### PR TITLE
fix(Rendering): bad buffer free and rebuilding

### DIFF
--- a/Sources/Rendering/OpenGL/BufferObject/index.js
+++ b/Sources/Rendering/OpenGL/BufferObject/index.js
@@ -93,7 +93,7 @@ function vtkOpenGLBufferObject(publicAPI, model) {
   publicAPI.releaseGraphicsResources = () => {
     if (internalHandle !== null) {
       model.context.bindBuffer(convertType(internalType), null);
-      model.context.deleteBuffers(internalHandle);
+      model.context.deleteBuffer(internalHandle);
       internalHandle = null;
     }
   };

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1085,7 +1085,8 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
     }
 
     // Do we have normals?
-    let n = (actor.getProperty().getInterpolation() !== VTK_SHADING.FLAT) ? poly.getPointData().getNormals() : null;
+    let n = (actor.getProperty().getInterpolation() !== VTK_SHADING.FLAT)
+      ? poly.getPointData().getNormals() : null;
     if (n === null && poly.getCellData().getNormals()) {
       model.haveCellNormals = true;
       n = poly.getCelData().getNormals();
@@ -1099,7 +1100,9 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
     // parameters in the mapper
 
     const representation = actor.getProperty().getRepresentation();
-    const toString = `${poly.getMTime()}A${representation}B${poly.getMTime()}C${(n ? n.getMTime() : 1)}C${(model.colors ? model.colors.getMTime() : 1)}`;
+    const toString = `${poly.getMTime()}A${representation}B${poly.getMTime()}`
+      + `C${(n ? n.getMTime() : 1)}D${(model.colors ? model.colors.getMTime() : 1)}`
+      + `E${actor.getProperty().getEdgeVisibility()}`;
 
     let tcoords = poly.getPointData().getTCoords();
     if (!model.openGLActor.getActiveTextures().length) {


### PR DESCRIPTION
This topic fixes two issues. The first
When the setting of edge visibility changed the polydata
mapper for OpenGL was not rebuilding its buffers.
The second was that when freeing an old buffer the
method name was incorrect and caused an error.