### PR TITLE
fix(Rendering): fix alpha blending and point lighting

### DIFF
--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -597,8 +597,19 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
     const primType = cellBO.getPrimitiveType();
 
     let needLighting = true;
-    const haveNormals = false; // (model.currentInput.getPointData().getNormals() != null);
-    if (actor.getProperty().getRepresentation() === VTK_REPRESENTATION.POINTS) {
+
+    const poly = model.currentInput;
+
+    let n = (actor.getProperty().getInterpolation() !== VTK_SHADING.FLAT)
+      ? poly.getPointData().getNormals() : null;
+    if (n === null && poly.getCellData().getNormals()) {
+      n = poly.getCelData().getNormals();
+    }
+
+    const haveNormals = (n !== null);
+
+    if (actor.getProperty().getRepresentation() === VTK_REPRESENTATION.POINTS ||
+        primType === primTypes.Points) {
       needLighting = haveNormals;
     }
 

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -50,6 +50,11 @@ export function vtkOpenGLRenderWindow(publicAPI, model) {
       model.textureUnitManager = vtkOpenGLTextureUnitManager.newInstance();
       model.textureUnitManager.setContext(model.context);
       model.shaderCache.setContext(model.context);
+      // initialize blending for transparency
+      const gl = model.context;
+      gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA,
+                       gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+      gl.enable(gl.BLEND);
       model.initialized = true;
     }
   };


### PR DESCRIPTION
The blend function was not being set so translucent
objects appeared opaque.

When points were rendered in surface mode lighting was
being applied even if the points had no normals. Fixed
so that lighting is only applied on points with normals.