### PR TITLE
refactor(Common): Make use of tuple more consistent

### DIFF
--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -87,7 +87,8 @@ function vtkDataArray(publicAPI, model) {
   // Description:
   // Return the data component at the location specified by tupleIdx and
   // compIdx.
-  publicAPI.getComponent = (tupleIdx, compIdx = 0) => model.values[(tupleIdx * model.tuple) + compIdx];
+  publicAPI.getComponent = (tupleIdx, compIdx = 0) =>
+    model.values[(tupleIdx * model.numberOfComponents) + compIdx];
 
   // Description:
   // Set the data component at the location specified by tupleIdx and compIdx
@@ -96,8 +97,8 @@ function vtkDataArray(publicAPI, model) {
   //  NumberOfComponents. Make sure enough memory has been allocated
   // (use SetNumberOfTuples() and SetNumberOfComponents()).
   publicAPI.setComponent = (tupleIdx, compIdx, value) => {
-    if (value !== model.values[(tupleIdx * model.tuple) + compIdx]) {
-      model.values[(tupleIdx * model.tuple) + compIdx] = value;
+    if (value !== model.values[(tupleIdx * model.numberOfComponents) + compIdx]) {
+      model.values[(tupleIdx * model.numberOfComponents) + compIdx] = value;
       dataChange();
     }
   };
@@ -105,11 +106,11 @@ function vtkDataArray(publicAPI, model) {
   publicAPI.getData = () => model.values;
 
   publicAPI.getRange = (componentIndex = 0) => {
-    const rangeIdx = componentIndex < 0 ? model.tuple : componentIndex;
+    const rangeIdx = componentIndex < 0 ? model.numberOfComponents : componentIndex;
     let range = null;
 
     if (!model.ranges) {
-      model.ranges = insureRangeSize(model.ranges, model.tuple);
+      model.ranges = insureRangeSize(model.ranges, model.numberOfComponents);
     }
     range = model.ranges[rangeIdx];
 
@@ -125,15 +126,16 @@ function vtkDataArray(publicAPI, model) {
   publicAPI.getTupleLocation = (idx = 1) => idx * model.tuple;
 
   publicAPI.getBounds = () => {
-    if (model.tuple === 3) {
+    if (model.numberOfComponents === 3) {
       return [].concat(
         publicAPI.getRange(0),
         publicAPI.getRange(1),
         publicAPI.getRange(2));
     }
 
-    if (model.tuple !== 2) {
-      console.error('getBounds called on an array of tuple size', model.tuple, model);
+    if (model.numberOfComponents !== 2) {
+      console.error('getBounds called on an array with components of ',
+        model.numberOfComponents, model);
       return [1, -1, 1, -1, 1, -1];
     }
 
@@ -142,9 +144,9 @@ function vtkDataArray(publicAPI, model) {
         publicAPI.getRange(1));
   };
 
-  publicAPI.getNumberOfComponents = () => model.tuple;
+  publicAPI.getNumberOfComponents = () => model.numberOfComponents;
   publicAPI.getNumberOfValues = () => model.values.length;
-  publicAPI.getNumberOfTuples = () => model.values.length / model.tuple;
+  publicAPI.getNumberOfTuples = () => model.values.length / model.numberOfComponents;
   publicAPI.getDataType = () => model.dataType;
 
   publicAPI.getNumberOfCells = () => {
@@ -179,10 +181,10 @@ function vtkDataArray(publicAPI, model) {
     model.size = typedArray.length;
     model.dataType = getDataType(typedArray);
     if (numberOfComponents) {
-      model.tuple = numberOfComponents;
+      model.numberOfComponents = numberOfComponents;
     }
-    if (model.size % model.tuple !== 0) {
-      model.tuple = 1;
+    if (model.size % model.numberOfComponents !== 0) {
+      model.numberOfComponents = 1;
     }
     dataChange();
   };
@@ -199,7 +201,7 @@ function vtkDataArray(publicAPI, model) {
 const DEFAULT_VALUES = {
   type: 'vtkDataArray',
   name: '',
-  tuple: 1,
+  numberOfComponents: 1,
   size: 0,
   dataType: VTK_DEFAULT_DATATYPE,
   values: null,

--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -64,7 +64,7 @@ function vtkScalarsToColors(publicAPI, model) {
       const newscalars = {
         type: 'vtkDataArray',
         name: 'temp',
-        tuple: 4,
+        numberOfComponents: 4,
         dataType: VTK_DATATYPES.UNSIGNED_CHAR,
       };
 
@@ -181,7 +181,7 @@ function vtkScalarsToColors(publicAPI, model) {
       default:
       case VTK_VECTOR_MODE.MAGNITUDE: {
         const magValues =
-          vtkDataArray.newInstance({ tuple: 1, values: new Float32Array(input.getNumberOfTuples()) });
+          vtkDataArray.newInstance({numberOfComponents: 1, values: new Float32Array(input.getNumberOfTuples()) });
 
         publicAPI.mapVectorsToMagnitude(input, magValues, vectorSize);
         publicAPI.mapScalarsThroughTable(
@@ -279,7 +279,12 @@ function vtkScalarsToColors(publicAPI, model) {
       return colors;
     }
 
-    const newColors = vtkDataArray.newInstance({ tuple: 4, empty: true, size: 4 * numTuples, dataType: VTK_DATATYPES.UNSIGNED_CHAR });
+    const newColors = vtkDataArray.newInstance({
+      numberOfComponents: 4,
+      empty: true,
+      size: 4 * numTuples,
+      dataType: VTK_DATATYPES.UNSIGNED_CHAR,
+    });
 
     if (numTuples <= 0) {
       return newColors;

--- a/Sources/Common/DataModel/DataSet/index.js
+++ b/Sources/Common/DataModel/DataSet/index.js
@@ -24,7 +24,7 @@ function getBounds(dataset) {
       const array = ds.Points.values;
       const bbox = vtkBoundingBox.newInstance();
       const size = array.length;
-      const delta = ds.Points.tuple ? ds.Points.tuple : 3;
+      const delta = ds.Points.numberOfComponents ? ds.Points.numberOfComponents : 3;
       for (let idx = 0; idx < size; idx += delta) {
         bbox.addPoint(array[idx * delta], array[(idx * delta) + 1], array[(idx * delta) + 2]);
       }

--- a/Sources/Filters/General/WarpScalar/index.js
+++ b/Sources/Filters/General/WarpScalar/index.js
@@ -108,7 +108,7 @@ function vtkWarpScalar(publicAPI, model) {
         newPtsData[ptOffset + 1] = inPoints[ptOffset + 1] + (model.scaleFactor * s * n[1]);
         newPtsData[ptOffset + 2] = inPoints[ptOffset + 2] + (model.scaleFactor * s * n[2]);
       }
-      const newPts = vtkDataArray.newInstance({ values: newPtsData, tuple: 3 });
+      const newPts = vtkDataArray.newInstance({ values: newPtsData, numberOfComponents: 3 });
       const newDataSet = input.shallowCopy();
       newDataSet.setPoints(newPts);
       newDataSet.modified();

--- a/Sources/Filters/Sources/ConeSource/index.js
+++ b/Sources/Filters/Sources/ConeSource/index.js
@@ -31,13 +31,13 @@ export function vtkConeSource(publicAPI, model) {
           Points: {
             type: 'vtkDataArray',
             name: '_points',
-            tuple: 3,
+            numberOfComponents: 3,
             dataType: model.pointType,
           },
           Polys: {
             type: 'vtkDataArray',
             name: '_polys',
-            tuple: 1,
+            numberOfComponents: 1,
             dataType: 'Uint32Array',
           },
         },

--- a/Sources/Filters/Sources/ImageGridSource/index.js
+++ b/Sources/Filters/Sources/ImageGridSource/index.js
@@ -69,7 +69,7 @@ export function vtkImageGridSource(publicAPI, model) {
         }
       }
 
-      const da = vtkDataArray.newInstance({ tuple: 1, values: newArray });
+      const da = vtkDataArray.newInstance({ numberOfComponents: 1, values: newArray });
       da.setName('scalars');
 
       const cpd = id.getPointData();

--- a/Sources/Filters/Sources/SphereSource/index.js
+++ b/Sources/Filters/Sources/SphereSource/index.js
@@ -30,20 +30,20 @@ export function vtkSphereSource(publicAPI, model) {
           Points: {
             type: 'vtkDataArray',
             name: '_points',
-            tuple: 3,
+            numberOfComponents: 3,
             dataType: model.pointType,
           },
           Polys: {
             type: 'vtkDataArray',
             name: '_polys',
-            tuple: 1,
+            numberOfComponents: 1,
             dataType: 'Uint32Array',
           },
           PointData: {
             Normals: {
               type: 'vtkDataArray',
               name: 'Normals',
-              tuple: 3,
+              numberOfComponents: 3,
               dataType: 'Float32Array',
             },
           },

--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -359,7 +359,7 @@ function vtkMapper(publicAPI, model) {
       model.colorTextureMap.setExtent(
         0, numberOfColors - 1, 0, 1, 0, 0);
 
-      const tmp = vtkDataArray.newInstance({ tuple: 1, values: newArray });
+      const tmp = vtkDataArray.newInstance({ numberOfComponents: 1, values: newArray });
 
       model.colorTextureMap.getPointData().setScalars(
            model.lookupTable.mapScalars(tmp, model.colorMode, 0));
@@ -382,7 +382,7 @@ function vtkMapper(publicAPI, model) {
 
       // const fArray = new FloatArray(num * 2);
       model.colorCoordinates =
-        vtkDataArray.newInstance({ tuple: 2, values: new Float32Array(num * 2) });
+        vtkDataArray.newInstance({ numberOfComponents: 2, values: new Float32Array(num * 2) });
 
       let scalarComponent = model.lookupTable.getVectorComponent();
       // Although I like the feature of applying magnitude to single component

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -336,9 +336,9 @@ export function vtkOpenGLImageMapper(publicAPI, model) {
         tcoordArray[(i * 2) + 1] = (i > 1) ? 1.0 : 0.0;
       }
 
-      const points = vtkDataArray.newInstance({ tuple: 3, values: ptsArray });
+      const points = vtkDataArray.newInstance({ numberOfComponents: 3, values: ptsArray });
       points.setName('points');
-      const tcoords = vtkDataArray.newInstance({ tuple: 2, values: tcoordArray });
+      const tcoords = vtkDataArray.newInstance({ numberOfComponents: 2, values: tcoordArray });
       tcoords.setName('tcoords');
 
       const cellArray = new Uint16Array(8);
@@ -350,7 +350,7 @@ export function vtkOpenGLImageMapper(publicAPI, model) {
       cellArray[5] = 0;
       cellArray[6] = 3;
       cellArray[7] = 2;
-      const cells = vtkDataArray.newInstance({ tuple: 1, values: cellArray });
+      const cells = vtkDataArray.newInstance({ numberOfComponents: 1, values: cellArray });
 
       let cellOffset = 0;
       cellOffset += model.tris.getCABO().createVBO(cells,

--- a/Sources/Rendering/OpenGL/PolyDataMapper/test/testInterpolateScalarsBeforeMapping.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/test/testInterpolateScalarsBeforeMapping.js
@@ -88,7 +88,7 @@ test.onlyIfWebGL('Test Interpolate Scalars Before Colors', (t) => {
     }
   }
 
-  const da = vtkDataArray.newInstance({ tuple: 1, values: scalars });
+  const da = vtkDataArray.newInstance({ numberOfComponents: 1, values: scalars });
   pd.getPointData().setScalars(da);
 
   mapper.setInputData(pd);


### PR DESCRIPTION
tuple was used in a few places to represent the number
of components. This topic changes the wording to
use numberOfComponents instead.