### PR TITLE
fix(Rendering): Handle LookupTable Mtime in Mapper

### DIFF
--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -450,6 +450,15 @@ function vtkMapper(publicAPI, model) {
     return model.lookupTable;
   };
 
+  publicAPI.getMTime = () => {
+    let mt = model.mtime;
+    if (model.lookupTable !== null) {
+      const time = model.lookupTable.getMTime();
+      mt = (time > mt ? time : mt);
+    }
+    return mt;
+  };
+
   publicAPI.acquireInvertibleLookupTable = notImplemented('AcquireInvertibleLookupTable');
   publicAPI.valueToColor = notImplemented('ValueToColor');
   publicAPI.colorToValue = notImplemented('ColorToValue');


### PR DESCRIPTION
The mapper was not considering its LookupTable when
computing it mtime causing changes in the LookupTable
to be ignored.