### PR TITLE
fix(Pipeline): fix an issue with shouldUpdate

### DIFF
--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -404,15 +404,13 @@ export function algo(publicAPI, model, numberOfInputs, numberOfOutputs) {
     while (count--) {
       if (model.inputConnection[count] && model.inputConnection[count].filter.shouldUpdate()) {
         return true;
-      } else if (model.inputConnection[count] && model.inputConnection[count]() && model.inputConnection[count]().getMTime() > localMTime) {
-        return true;
       }
     }
 
-    const maxOutputMTime = Math.max(...model.output.filter(i => !!i).map(i => i.getMTime()));
+    const minOutputMTime = Math.min(...model.output.filter(i => !!i).map(i => i.getMTime()));
     count = numberOfInputs;
     while (count--) {
-      if (model.inputData[count] && model.inputData[count].getMTime() > maxOutputMTime) {
+      if (publicAPI.getInputData(count) && publicAPI.getInputData(count).getMTime() > minOutputMTime) {
         return true;
       }
     }
@@ -455,7 +453,9 @@ export function algo(publicAPI, model, numberOfInputs, numberOfOutputs) {
         count++;
       }
     }
-    publicAPI.requestData(ins, model.output);
+    if (publicAPI.shouldUpdate()) {
+      publicAPI.requestData(ins, model.output);
+    }
   };
 
   publicAPI.getNumberOfInputPorts = () => numberOfInputs;


### PR DESCRIPTION
The computation for when a filter should reexecute had
an issue that could cause it to always reexecute. This
change makes it so that a filter will always execute if
its inputs are more recent than its outputs or if its
mtime is more recent than its outputs. A filter is not
explicitly modified when executing and may have a mtime
that is lower than its inputs.