### PR TITLE
fix(Rendering): Do not use key event positions

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -227,16 +227,22 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
     const size = rwi.getView().getViewportSize(model.currentRenderer);
 
-    const deltaElevation = -20.0 / size[1];
-    const deltaAzimuth = -20.0 / size[0];
+    let deltaElevation = -0.1;
+    let deltaAzimuth = -0.1;
+    if (size[0] && size[1]) {
+      deltaElevation = -20.0 / size[1];
+      deltaAzimuth = -20.0 / size[0];
+    }
 
     const rxf = dx * deltaAzimuth * model.motionFactor;
     const ryf = dy * deltaElevation * model.motionFactor;
 
     const camera = model.currentRenderer.getActiveCamera();
-    camera.azimuth(rxf);
-    camera.elevation(ryf);
-    camera.orthogonalizeViewUp();
+    if (!isNaN(rxf) && !isNaN(ryf)) {
+      camera.azimuth(rxf);
+      camera.elevation(ryf);
+      camera.orthogonalizeViewUp();
+    }
 
     if (model.autoAdjustCameraClippingRange) {
       model.currentRenderer.resetCameraClippingRange();
@@ -264,16 +270,17 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
     const camera = model.currentRenderer.getActiveCamera();
     const center = rwi.getView().getViewportCenter(model.currentRenderer);
 
-    const newAngle =
-      vtkMath.degreesFromRadians(Math.atan2(pos.y - center[1],
-                                          pos.x - center[0]));
-
     const oldAngle =
       vtkMath.degreesFromRadians(Math.atan2(lastPos.y - center[1],
                                           lastPos.x - center[0]));
+    const newAngle =
+      vtkMath.degreesFromRadians(Math.atan2(pos.y - center[1],
+                                          pos.x - center[0])) - oldAngle;
 
-    camera.roll(newAngle - oldAngle);
-    camera.orthogonalizeViewUp();
+    if (!isNaN(newAngle)) {
+      camera.roll(newAngle - oldAngle);
+      camera.orthogonalizeViewUp();
+    }
 
     rwi.render();
   };
@@ -348,7 +355,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.dollyByFactor = (factor) => {
-    if (model.currentRenderer === null) {
+    if (model.currentRenderer === null || isNaN(factor)) {
       return;
     }
 

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -148,7 +148,6 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   };
 
   publicAPI.handleKeyPress = (event) => {
-    publicAPI.setEventPosition(event.clientX, model.canvas.clientHeight - event.clientY + 1, 0, 0);
     model.controlKey = event.ctrlKey;
     model.altKey = event.altKey;
     model.shiftKey = event.shiftKey;


### PR DESCRIPTION
Pressing a key while interacting could populate the
camera with NaNs as the keyboard events position
is NaN. Do not use the position of a keyboard event.