### PR TITLE
perf(Rendering): Store colors etc as uchars instead of float

### DIFF
--- a/Sources/Common/Core/DynamicTypedArray/index.js
+++ b/Sources/Common/Core/DynamicTypedArray/index.js
@@ -20,6 +20,26 @@ export default class DynamicTypedArray {
     this.lastChunkItemCount += 1;
   }
 
+  pushBytes(srcview, srcoffset, numbytes) {
+    // numBytes must match ther underlying data type size
+    if (numbytes !== this.chunkContainer[0].BYTES_PER_ELEMENT) {
+      return;
+    }
+    if (this.lastChunkItemCount === this.chunkSize) {
+      this.chunkContainer.push(new this.ArrayConstructor(this.chunkSize));
+      this.lastChunkItemCount = 0;
+    }
+
+    const view = new DataView(
+      this.chunkContainer[this.chunkContainer.length - 1].buffer,
+      this.chunkContainer[0].BYTES_PER_ELEMENT * this.lastChunkItemCount,
+      this.chunkContainer[0].BYTES_PER_ELEMENT);
+    for (let j = 0; j < numbytes; j++) {
+      view.setUint8(j, srcview.getUint8(srcoffset + j));
+    }
+    this.lastChunkItemCount += 1;
+  }
+
   getNumberOfElements() {
     return ((this.chunkContainer.length - 1) * this.chunkSize) + this.lastChunkItemCount;
   }

--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -58,7 +58,7 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
     if (options.colors) {
       model.colorComponents = options.colors.getNumberOfComponents();
       model.colorOffset = 4 * model.blockSize;
-      model.blockSize += model.colorComponents;
+      model.blockSize += 1;
       colorData = options.colors.getData();
     }
     model.stride = 4 * model.blockSize;
@@ -68,6 +68,9 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
     let tcoordIdx = 0;
     let colorIdx = 0;
     let cellCount = 0;
+    const dataHelper = new ArrayBuffer(4);
+    const dataHelperView = new DataView(dataHelper, 0);
+    dataHelperView.setUint8(3, 255); // default alpha
 
     const addAPoint = function addAPoint(i) {
       // Vertices
@@ -101,10 +104,10 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
         } else {
           colorIdx = i * colorComponents;
         }
-
         for (let j = 0; j < colorComponents; ++j) {
-          packedVBO.push(colorData[colorIdx++] / 255.5);
+          dataHelperView.setUint8(j, colorData[colorIdx++]);
         }
+        packedVBO.pushBytes(dataHelperView, 0, 4);
       }
     };
 

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -751,7 +751,7 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
         if (!cellBO.getVAO().addAttributeArray(cellBO.getProgram(), cellBO.getCABO(),
                                            'vertexMC', cellBO.getCABO().getVertexOffset(),
                                            cellBO.getCABO().getStride(), model.context.FLOAT, 3,
-                                           model.context.FALSE)) {
+                                           false)) {
           vtkErrorMacro('Error setting vertexMC in shader VAO.');
         }
       }
@@ -761,7 +761,7 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
         if (!cellBO.getVAO().addAttributeArray(cellBO.getProgram(), cellBO.getCABO(),
                                            'normalMC', cellBO.getCABO().getNormalOffset(),
                                            cellBO.getCABO().getStride(), model.context.FLOAT, 3,
-                                           model.context.FALSE)) {
+                                           false)) {
           vtkErrorMacro('Error setting normalMC in shader VAO.');
         }
       }
@@ -771,7 +771,7 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
                                            'tcoordMC', cellBO.getCABO().getTCoordOffset(),
                                            cellBO.getCABO().getStride(), model.context.FLOAT,
                                            cellBO.getCABO().getTCoordComponents(),
-                                           model.context.FALSE)) {
+                                           false)) {
           vtkErrorMacro('Error setting tcoordMC in shader VAO.');
         }
       }
@@ -779,8 +779,8 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
           cellBO.getCABO().getColorComponents()) {
         if (!cellBO.getVAO().addAttributeArray(cellBO.getProgram(), cellBO.getCABO(),
                                            'scalarColor', cellBO.getCABO().getColorOffset(),
-                                           cellBO.getCABO().getStride(), model.context.FLOAT /* BYTE */,
-                                           cellBO.getCABO().getColorComponents(),
+                                           cellBO.getCABO().getStride(), model.context.UNSIGNED_BYTE,
+                                           4,
                                            true)) {
           vtkErrorMacro('Error setting scalarColor in shader VAO.');
         }

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -121,7 +121,7 @@ export function vtkOpenGLSphereMapper(publicAPI, model) {
       cellBO.getCABO().bind();
       if (!cellBO.getVAO().addAttributeArray(cellBO.getProgram(), cellBO.getCABO(),
           'offsetMC', 12, // 12:this->VBO->ColorOffset+sizeof(float)
-          cellBO.getCABO().getStride(), model.context.FLOAT, 2, model.context.FALSE)) {
+          cellBO.getCABO().getStride(), model.context.FLOAT, 2, false)) {
         vtkErrorMacro('Error setting \'offsetMC\' in shader VAO.');
       }
     }
@@ -193,7 +193,7 @@ export function vtkOpenGLSphereMapper(publicAPI, model) {
       colorComponents = c.getNumberOfComponents();
       vbo.setColorComponents(colorComponents);
       vbo.setColorOffset(4 * pointSize);
-      pointSize += colorComponents;
+      pointSize += 1;
       colorData = c.getData();
     }
 
@@ -202,6 +202,11 @@ export function vtkOpenGLSphereMapper(publicAPI, model) {
     const cos30 = Math.cos(vtkMath.radiansFromDegrees(30.0));
     let pointIdx = 0;
     let colorIdx = 0;
+    let colorView = null;
+    if (colorData) {
+      colorView = new DataView(colorData.buffer, 0);
+    }
+
   //
   // Generate points and point data for sides
   //
@@ -210,17 +215,16 @@ export function vtkOpenGLSphereMapper(publicAPI, model) {
       if (scales) {
         radius = scales[i];
       }
+
       pointIdx = i * 3;
       packedVBO.push(pointArray[pointIdx++]);
       packedVBO.push(pointArray[pointIdx++]);
       packedVBO.push(pointArray[pointIdx++]);
       packedVBO.push(-2.0 * radius * cos30);
       packedVBO.push(-radius);
-      colorIdx = i * colorComponents;
       if (colorData) {
-        for (let j = 0; j < colorComponents; ++j) {
-          packedVBO.push(colorData[colorIdx++] / 255.5);
-        }
+        colorIdx = i * colorComponents;
+        packedVBO.pushBytes(colorView, colorIdx, 4);
       }
 
       pointIdx = i * 3;
@@ -229,11 +233,8 @@ export function vtkOpenGLSphereMapper(publicAPI, model) {
       packedVBO.push(pointArray[pointIdx++]);
       packedVBO.push(2.0 * radius * cos30);
       packedVBO.push(-radius);
-      colorIdx = i * colorComponents;
       if (colorData) {
-        for (let j = 0; j < colorComponents; ++j) {
-          packedVBO.push(colorData[colorIdx++] / 255.5);
-        }
+        packedVBO.pushBytes(colorView, colorIdx, 4);
       }
 
       pointIdx = i * 3;
@@ -242,11 +243,8 @@ export function vtkOpenGLSphereMapper(publicAPI, model) {
       packedVBO.push(pointArray[pointIdx++]);
       packedVBO.push(0.0);
       packedVBO.push(2.0 * radius);
-      colorIdx = i * colorComponents;
       if (colorData) {
-        for (let j = 0; j < colorComponents; ++j) {
-          packedVBO.push(colorData[colorIdx++] / 255.5);
-        }
+        packedVBO.pushBytes(colorView, colorIdx, 4);
       }
     }
 


### PR DESCRIPTION
The original implementation only supported floats for
the VBO/CABO. This updates the code to use unsigned chars
by default for colors in the VBO. It also updates the stick
mapper to use unsigned chars for the offsets. The end result
is a 12 byte per point savings for color and an 8 byte per
point savings for offset.