### PR TITLE
refactor(Rendering): consolidate scalartocolors ranges

### DIFF
--- a/Sources/Common/Core/LookupTable/index.js
+++ b/Sources/Common/Core/LookupTable/index.js
@@ -105,7 +105,7 @@ function vtkLookupTable(publicAPI, model) {
       lookupFunc = publicAPI.indexedLookupFunction;
     }
 
-    const trange = publicAPI.getTableRange();
+    const trange = publicAPI.getMappingRange();
 
     const p = {
       maxIndex: publicAPI.getNumberOfColors() - 1,
@@ -230,9 +230,6 @@ function vtkLookupTable(publicAPI, model) {
     tptr[base + 3] = (model.nanColor[3] * 255.0) + 0.5;
   };
 
-  publicAPI.setRange = (min, max) => publicAPI.setTableRange(min, max);
-  publicAPI.getRange = () => publicAPI.getTableRange();
-
   publicAPI.build = () => {
     if (model.table.length < 1 ||
         publicAPI.getMTime() > model.buildTime.getMTime()) {
@@ -253,7 +250,6 @@ const DEFAULT_VALUES = {
   saturationRange: [1.0, 1.0],
   valueRange: [1.0, 1.0],
   alphaRange: [1.0, 1.0],
-  tableRange: [0.0, 1.0],
 
   nanColor: [0.5, 0.0, 0.0, 1.0],
   belowRangeColor: [0.0, 0.0, 0.0, 1.0],
@@ -305,7 +301,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'hueRange',
     'saturationRange',
     'valueRange',
-    'tableRange',
   ], 2);
 
   macro.setArray(publicAPI, model, [
@@ -319,7 +314,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'hueRange',
     'saturationRange',
     'valueRange',
-    'tableRange',
     'alphaRange',
     'nanColor',
     'belowRangeColor',

--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -461,8 +461,8 @@ function vtkScalarsToColors(publicAPI, model) {
 
   publicAPI.getNumberOfAvailableColors = () => 256 * 256 * 256;
 
-  publicAPI.setRange = (min, max) => publicAPI.setInputRange(min, max);
-  publicAPI.getRange = (min, max) => publicAPI.getInputRange();
+  publicAPI.setRange = (min, max) => publicAPI.setMappingRange(min, max);
+  publicAPI.getRange = (min, max) => publicAPI.getMappingRange();
 }
 
 // ----------------------------------------------------------------------------
@@ -474,7 +474,7 @@ const DEFAULT_VALUES = {
   vectorComponent: 0,
   vectorSize: -1,
   vectorMode: VectorMode.COMPONENT,
-  inputRange: [0, 255],
+  mappingRange: [0, 255],
   annotationArray: [],
   annotatedValueMap: [],
   indexedLookup: false,
@@ -499,12 +499,12 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Create set macros for array (needs to know size)
   macro.setArray(publicAPI, model, [
-    'inputRange',
+    'mappingRange',
   ], 2);
 
   // Create get macros for array
   macro.getArray(publicAPI, model, [
-    'inputRange',
+    'mappingRange',
   ]);
 
   // For more macro methods, see "Sources/macro.js"

--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -220,20 +220,20 @@ function vtkColorTransferFunction(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.updateRange = () => {
     const oldRange = [2];
-    oldRange[0] = model.range[0];
-    oldRange[1] = model.range[1];
+    oldRange[0] = model.mappingRange[0];
+    oldRange[1] = model.mappingRange[1];
 
     const size = model.nodes.length;
     if (size) {
-      model.range[0] = model.nodes[0].x;
-      model.range[1] = model.nodes[size - 1].x;
+      model.mappingRange[0] = model.nodes[0].x;
+      model.mappingRange[1] = model.nodes[size - 1].x;
     } else {
-      model.range[0] = 0;
-      model.range[1] = 0;
+      model.mappingRange[0] = 0;
+      model.mappingRange[1] = 0;
     }
 
     // If the range is the same, then no need to call Modified()
-    if (oldRange[0] === model.range[0] && oldRange[1] === model.range[1]) {
+    if (oldRange[0] === model.mappingRange[0] && oldRange[1] === model.mappingRange[1]) {
       return false;
     }
 
@@ -431,7 +431,7 @@ function vtkColorTransferFunction(publicAPI, model) {
     let usingLogScale = (model.scale === Scale.LOG10);
     if (usingLogScale) {
       // Note: This requires range[0] <= range[1].
-      usingLogScale = (model.range[0] > 0.0);
+      usingLogScale = (model.mappingRange[0] > 0.0);
     }
 
     let logStart = 0.0;
@@ -509,7 +509,7 @@ function vtkColorTransferFunction(publicAPI, model) {
       }
 
       // Are we at or past the end? If so, just use the last value
-      if (x > model.range[1]) {
+      if (x > model.mappingRange[1]) {
         table[tidx] = 0.0;
         table[tidx + 1] = 0.0;
         table[tidx + 2] = 0.0;
@@ -524,7 +524,7 @@ function vtkColorTransferFunction(publicAPI, model) {
             table[tidx + 2] = lastB;
           }
         }
-      } else if (x < model.range[0] || (vtkMath.isInf(x) && x < 0)) {
+      } else if (x < model.mappingRange[0] || (vtkMath.isInf(x) && x < 0)) {
         // we are before the first node? If so, duplicate this node's values.
         // We have to deal with -inf here
         table[tidx] = 0.0;
@@ -1093,11 +1093,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'useBelowRangeColor',
   ]);
 
-  // Create set macros for array (needs to know size)
-  macro.setArray(publicAPI, model, [
-    'range',
-  ], 2);
-
   macro.setArray(publicAPI, model, [
     'nanColor',
     'belowRangeColor',
@@ -1106,7 +1101,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Create get macros for array
   macro.getArray(publicAPI, model, [
-    'range',
     'nanColor',
     'belowRangeColor',
     'aboveRangeColor',


### PR DESCRIPTION
ScalarsToColors, LookupTable and ColorTransferFunction
had multiple definitions of the range to map. This topic
consolidates those to one set of ivars mappedRange for
clarity.