### PR TITLE
feat(Rendering): add hardware selector and framebuffers

### DIFF
--- a/Sources/Common/DataModel/DataSet/Constants.js
+++ b/Sources/Common/DataModel/DataSet/Constants.js
@@ -22,6 +22,18 @@ export const FieldDataTypes = {
   ROW_DATA: 6,             // to match VTK
 };
 
+export const FieldAssociations = {
+  FIELD_ASSOCIATION_POINTS: 0,
+  FIELD_ASSOCIATION_CELLS: 1,
+  FIELD_ASSOCIATION_NONE: 2,
+  FIELD_ASSOCIATION_POINTS_THEN_CELLS: 3,
+  FIELD_ASSOCIATION_VERTICES: 4,
+  FIELD_ASSOCIATION_EDGES: 5,
+  FIELD_ASSOCIATION_ROWS: 6,
+  NUMBER_OF_ASSOCIATIONS: 7,
+};
+
 export default {
   FieldDataTypes,
+  FieldAssociations,
 };

--- a/Sources/Common/DataModel/SelectionNode/Constants.js
+++ b/Sources/Common/DataModel/SelectionNode/Constants.js
@@ -1,0 +1,43 @@
+/**
+ * The (primary) property that describes the content of a selection
+ * node's data. Other auxiliary description properties follow.
+ * GLOBALIDS means that the selection list contains values from the
+ * vtkDataSetAttribute array of the same name.
+ * PEDIGREEIDS means that the selection list contains values from the
+ * vtkDataSetAttribute array of the same name.
+ * VALUES means the the selection list contains values from an
+ * arbitrary attribute array (ignores any globalids attribute)
+ * INDICES means that the selection list contains indexes into the
+ * cell or point arrays.
+ * FRUSTUM means the set of points and cells inside a frustum
+ * LOCATIONS means the set of points and cells near a set of positions
+ * THRESHOLDS means the points and cells with values within a set of ranges
+ * getContentType() returns -1 if the content type is not set.
+ */
+
+// Specify how data arrays can be used by data objects
+export const SelectionContent = {
+  GLOBALIDS: 0,
+  PEDIGREEIDS: 1,
+  VALUES: 2,
+  INDICES: 3,
+  FRUSTUM: 4,
+  LOCATIONS: 5,
+  THRESHOLDS: 6,
+  BLOCKS: 7,
+  QUERY: 8,
+};
+
+export const SelectionField = {
+  CELL: 0,
+  POINT: 1,
+  FIELD: 2,
+  VERTEX: 3,
+  EDGE: 4,
+  ROW: 5,
+};
+
+export default {
+  SelectionContent,
+  SelectionField,
+};

--- a/Sources/Common/DataModel/SelectionNode/index.js
+++ b/Sources/Common/DataModel/SelectionNode/index.js
@@ -1,0 +1,54 @@
+import * as macro   from '../../../macro';
+
+// ----------------------------------------------------------------------------
+// Global methods
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// vtkPointSet methods
+// ----------------------------------------------------------------------------
+
+function vtkSelectionNode(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkSelectionNode');
+
+  publicAPI.getBounds = () => model.points.getBounds();
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  contentType: -1,
+  fieldType: -1,
+  properties: null,
+  selectionList: [],
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  macro.obj(publicAPI, model);
+  model.properties = {};
+  macro.setGet(publicAPI, model, [
+    'contentType',
+    'fieldType',
+    'properties',
+    'selectionList',
+  ]);
+
+  // Object specific methods
+  vtkSelectionNode(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkSelectionNode');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -118,7 +118,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkViewNode.extend(publicAPI, model, initialValues);
 
   model.keyMatrixTime = {};
-  macro.obj(model.keyMatrixTime);
+  macro.obj(model.keyMatrixTime, { mtime: 0 });
   model.normalMatrix = mat3.create();
   model.MCWCMatrix = mat4.create();
 

--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -1,0 +1,133 @@
+import * as macro     from '../../../macro';
+import vtkOpenGLTexture from '../Texture';
+import { VtkDataTypes } from '../../../Common/Core/DataArray/Constants';
+
+// ----------------------------------------------------------------------------
+// vtkFramebuffer methods
+// ----------------------------------------------------------------------------
+function vtkFramebuffer(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkFramebuffer');
+
+  publicAPI.getBothMode = () => model.context.FRAMEBUFFER;
+  // publicAPI.getDrawMode = () => model.context.DRAW_FRAMEBUFFER;
+  // publicAPI.getReadMode = () => model.context.READ_FRAMEBUFFER;
+
+  publicAPI.saveCurrentBindingsAndBuffers = (modeIn) => {
+    const mode = (typeof modeIn !== 'undefined') ? modeIn : publicAPI.getBothMode();
+    publicAPI.saveCurrentBindings(mode);
+    publicAPI.saveCurrentBuffers(mode);
+  };
+
+  publicAPI.saveCurrentBindings = (modeIn) => {
+    const gl = model.context;
+    model.previousDrawBinding = gl.getParameter(model.context.FRAMEBUFFER_BINDING);
+  };
+
+  publicAPI.saveCurrentBuffers = (modeIn) => {
+    // noop on webgl 1
+  };
+
+  publicAPI.restorePreviousBindingsAndBuffers = (modeIn) => {
+    const mode = (typeof modeIn !== 'undefined') ? modeIn : publicAPI.getBothMode();
+    publicAPI.restorePreviousBindings(mode);
+    publicAPI.restorePreviousBuffers(mode);
+  };
+
+  publicAPI.restorePreviousBindings = (modeIn) => {
+    const gl = model.context;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, model.previousDrawBinding);
+  };
+
+  publicAPI.restorePreviousBuffers = (modeIn) => {
+    // currently a noop on webgl1
+  };
+
+  publicAPI.bind = () => {
+    model.context.bindFramebuffer(
+      model.context.FRAMEBUFFER, model.glFramebuffer);
+    if (model.colorTexture) {
+      model.colorTexture.bind();
+    }
+  };
+
+  publicAPI.create = (width, height) => {
+    model.glFramebuffer = model.context.createFramebuffer();
+    model.glFramebuffer.width = width;
+    model.glFramebuffer.height = height;
+  };
+
+  publicAPI.setColorBuffer = (texture, mode) => {
+    const gl = model.context;
+    model.colorTexture = texture;
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture.getHandle(), 0);
+  };
+
+  // publicAPI.setDepthBuffer = (texture, mode) => {
+  //   const gl = model.context;
+  //   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, texture.getHandle(), 0);
+  // };
+
+  publicAPI.setWindow = (win) => {
+    model.window = win;
+    model.context = win.getContext();
+  };
+
+  publicAPI.populateFramebuffer = () => {
+    publicAPI.bind();
+    const gl = model.context;
+
+    const texture = vtkOpenGLTexture.newInstance();
+    texture.setWindow(model.window);
+    texture.setContext(model.context);
+    texture.create2DFromRaw(
+      model.glFramebuffer.width,
+      model.glFramebuffer.height, 4, VtkDataTypes.UNSIGNED_CHAR, null);
+    publicAPI.setColorBuffer(texture);
+
+    // for now do not count of having a depth buffer texture
+    // as they are not standard webgl 1
+    model.depthTexture = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, model.depthTexture);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16,
+      model.glFramebuffer.width, model.glFramebuffer.height);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, model.depthTexture);
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+const DEFAULT_VALUES = {
+  window: null,
+  context: null,
+  glFramebuffer: null,
+  colorTexture: null,
+  depthTexture: null,
+  previousDrawBinding: 0,
+  previousReadBinding: 0,
+  previousDrawBuffer: 0,
+  previousReadBuffer: 0,
+};
+
+// ----------------------------------------------------------------------------
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Build VTK API
+  macro.obj(publicAPI, model);
+
+  macro.setGet(publicAPI, model, [
+    'context',
+  ]);
+
+  // For more macro methods, see "Sources/macro.js"
+  // Object specific methods
+  vtkFramebuffer(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+export const newInstance = macro.newInstance(extend, 'vtkFramebuffer');
+
+// ----------------------------------------------------------------------------
+export default Object.assign({ newInstance, extend });

--- a/Sources/Rendering/OpenGL/HardwareSelector/Constants.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/Constants.js
@@ -1,0 +1,11 @@
+export const PassTypes = {
+  MIN_KNOWN_PASS: 0,
+  ACTOR_PASS: 0,
+  COMPOSITE_INDEX_PASS: 1,
+  ID_LOW24: 2,
+  MAX_KNOWN_PASS: 2,
+};
+
+export default {
+  PassTypes,
+};

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -1,0 +1,437 @@
+import * as macro from '../../../macro';
+import { PassTypes } from './Constants';
+import vtkOpenGLFramebuffer from '../../../Rendering/OpenGL/Framebuffer';
+import vtkSelectionNode from '../../../Common/DataModel/SelectionNode';
+import { SelectionContent, SelectionField } from '../../../Common/DataModel/SelectionNode/Constants';
+import { FieldAssociations } from '../../../Common/DataModel/DataSet/Constants';
+
+// ----------------------------------------------------------------------------
+
+export function vtkOpenGLHardwareSelector(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkOpenGLHardwareSelector');
+
+  //----------------------------------------------------------------------------
+  publicAPI.releasePixBuffers = () => {
+    model.pixBuffer = [];
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.beginSelection = () => {
+    model.oglrenderer = model.oglwindow.getViewNodeFor(model.renderer);
+    model.maxAttributeId = 0;
+
+    model.framebuffer = vtkOpenGLFramebuffer.newInstance();
+    model.framebuffer.setWindow(model.oglwindow);
+    model.framebuffer.saveCurrentBindingsAndBuffers();
+    const size = model.oglwindow.getSize();
+    model.framebuffer.create(size[0], size[1]);
+    model.framebuffer.populateFramebuffer();
+
+    model.oglrenderer.clear();
+    model.oglrenderer.setSelector(publicAPI);
+    model.renderer.setPreserveDepthBuffer(1);
+    model.hitProps = [];
+    model.props = [];
+    publicAPI.releasePixBuffers();
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.endSelection = () => {
+    model.hitProps = [];
+    model.oglrenderer.setSelector(null);
+    model.renderer.setPreserveDepthBuffer(0);
+    model.framebuffer.restorePreviousBindingsAndBuffers();
+  };
+
+  publicAPI.preCapturePass = () => {
+  };
+
+  publicAPI.postCapturePass = () => {
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.select = () => {
+    let sel = null;
+    if (publicAPI.captureBuffers()) {
+      sel = publicAPI.generateSelection(
+        model.area[0], model.area[1],
+        model.area[2], model.area[3]);
+      publicAPI.releasePixBuffers();
+    }
+    return sel;
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.captureBuffers = () => {
+    if (!model.renderer || !model.oglwindow) {
+      vtkErrorMacro('Renderer and view must be set before calling Select.');
+      return false;
+    }
+
+    model.oglrenderer = model.oglwindow.getViewNodeFor(model.renderer);
+
+    // int rgba[4];
+    // rwin.getColorBufferSizes(rgba);
+    // if (rgba[0] < 8 || rgba[1] < 8 || rgba[2] < 8) {
+    //   vtkErrorMacro("Color buffer depth must be atleast 8 bit. "
+    //     "Currently: " << rgba[0] << ", " << rgba[1] << ", " <<rgba[2]);
+    //   return false;
+    // }
+    publicAPI.invokeEvent({ type: 'StartEvent' });
+
+    // Initialize renderer for selection.
+    // change the renderer's background to black, which will indicate a miss
+    model.originalBackground = model.renderer.getBackground();
+    model.renderer.setBackground(0.0, 0.0, 0.0);
+
+    publicAPI.beginSelection();
+    for (model.currentPass = PassTypes.MIN_KNOWN_PASS;
+      model.currentPass <= PassTypes.MAX_KNOWN_PASS; model.currentPass++) {
+      if (publicAPI.passRequired(model.currentPass)) {
+        publicAPI.preCapturePass(model.currentPass);
+        model.oglwindow.traverseAllPasses();
+        publicAPI.postCapturePass(model.currentPass);
+
+        publicAPI.savePixelBuffer(model.currentPass);
+      }
+    }
+    publicAPI.endSelection();
+
+    // restore original background
+    model.renderer.setBackground(model.originalBackground);
+    publicAPI.invokeEvent({ type: 'EndEvent' });
+
+    // restore image
+    model.oglwindow.traverseAllPasses();
+    return true;
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.passRequired = pass => true;
+
+  //----------------------------------------------------------------------------
+  publicAPI.savePixelBuffer = (passNo) => {
+    model.pixBuffer[passNo] = model.oglwindow.getPixelData(
+      model.area[0], model.area[1], model.area[2], model.area[3]);
+    if (passNo === PassTypes.ACTOR_PASS) {
+      publicAPI.buildPropHitList(model.pixBuffer[passNo]);
+    }
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.buildPropHitList = (pixelbuffer) => {
+    for (let yy = 0; yy <= model.area[3] - model.area[1]; yy++) {
+      for (let xx = 0; xx <= model.area[2] - model.area[0]; xx++) {
+        let val = publicAPI.convert(xx, yy, pixelbuffer);
+        if (val > 0) {
+          val--;
+          if (model.hitProps.indexOf(val) === -1) {
+            model.hitProps.push(val);
+          }
+        }
+      }
+    }
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.renderProp = (prop) => {
+    if (model.currentPass === PassTypes.ACTOR_PASS) {
+      publicAPI.setPropColorValueFromInt(
+        model.props.length + model.idOffset);
+      model.props.push(prop);
+    }
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.renderCompositeIndex = (index) => {
+    if (index > 0xffffff) {
+      vtkErrorMacro('Indices > 0xffffff are not supported.');
+      return;
+    }
+  };
+
+  //----------------------------------------------------------------------------
+  // TODO: make inline
+  publicAPI.renderAttributeId = (attribid) => {
+    if (attribid < 0) {
+      // negative attribid is valid. It happens when rendering higher order
+      // elements where new points are added for rendering smooth surfaces.
+      return;
+    }
+
+    model.maxAttributeId = (attribid > model.maxAttributeId)
+      ? attribid : model.maxAttributeId;
+
+    if (model.currentPass < PassTypes.ID_LOW24) {
+      return;
+    }
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.getPropFromID = (id) => {
+    if (id >= 0 && id < model.props.length) {
+      return model.props[id];
+    }
+    return null;
+  };
+
+  //----------------------------------------------------------------------------
+  publicAPI.passTypeToString = type => macro.enumToString(PassTypes, type);
+
+  //----------------------------------------------------------------------------
+  publicAPI.isPropHit = id => model.hitProps.hasKey(id);
+
+  publicAPI.convert = (xx, yy, pb) => {
+    if (!pb) {
+      return 0;
+    }
+    const offset = ((yy * (model.area[2] - model.area[0] + 1)) + xx) * 4;
+    const rgb = [];
+    rgb[0] = pb[offset];
+    rgb[1] = pb[offset + 1];
+    rgb[2] = pb[offset + 2];
+    let val = rgb[2];
+    val *= 256;
+    val += rgb[1];
+    val *= 256;
+    val += rgb[0];
+    return val;
+  };
+
+  publicAPI.setPropColorValueFromInt = (val) => {
+    model.propColorValue[0] = (val % 256) / 255.0;
+    model.propColorValue[1] = ((val / 256) % 256) / 255.0;
+    model.propColorValue[2] = ((val / 65536) % 256) / 255.0;
+  };
+
+  // info has
+  //   valid
+  //   propId
+  //   prop
+  //   compositeID
+  //   attributeID
+
+  //----------------------------------------------------------------------------
+  publicAPI.getPixelInformation = (
+    inDisplayPosition,
+    maxDistance,
+    outSelectedPosition) => {
+    // Base case
+    const maxDist = (maxDistance < 0) ? 0 : maxDistance;
+    if (maxDist === 0) {
+      outSelectedPosition[0] = inDisplayPosition[0];
+      outSelectedPosition[1] = inDisplayPosition[1];
+      if (inDisplayPosition[0] < model.area[0] || inDisplayPosition[0] > model.area[2] ||
+        inDisplayPosition[1] < model.area[1] || inDisplayPosition[1] > model.area[3]) {
+        return null;
+      }
+
+      // offset inDisplayPosition based on the lower-left-corner of the Area.
+      const displayPosition = [
+        inDisplayPosition[0] - model.area[0],
+        inDisplayPosition[1] - model.area[1]];
+
+      const actorid = publicAPI.convert(
+        displayPosition[0], displayPosition[1], model.pixBuffer[PassTypes.ACTOR_PASS]);
+      if (actorid <= 0) {
+        // the pixel did not hit any actor.
+        return null;
+      }
+
+      const info = {};
+      info.valid = true;
+
+      info.propID = actorid - model.idOffset;
+      info.prop = publicAPI.getPropFromID(info.propID);
+
+      // let compositeID = publicAPI.convert(
+      //   displayPosition[0], displayPosition[1],
+      //   model.pixBuffer[PassTypes.COMPOSITE_INDEX_PASS]);
+      // if (compositeID < 0 || compositeID > 0xffffff) {
+      //   compositeID = 0;
+      // }
+      // info.compositeID = compositeID - model.idOffset;
+
+      // const low24 = publicAPI.convert(
+      //   displayPosition[0], displayPosition[1], model.pixBuffer[PassTypes.ID_LOW24]);
+
+      // // id 0 is reserved for nothing present.
+      // info.attributeID = low24 - model.idOffset;
+      // if (info.attributeID < 0) {
+      //   // the pixel did not hit any cell.
+      //   return null;
+      // }
+      return info;
+    }
+
+    // Iterate over successively growing boxes.
+    // They recursively call the base case to handle single pixels.
+    const dispPos = [inDisplayPosition[0], inDisplayPosition[1]];
+    const curPos = [0, 0];
+    let info = publicAPI.getPixelInformation(inDisplayPosition, 0, outSelectedPosition);
+    if (info && info.valid) {
+      return info;
+    }
+    for (let dist = 1; dist < maxDist; ++dist) {
+      // Vertical sides of box.
+      for (let y = ((dispPos[1] > dist) ? (dispPos[1] - dist) : 0); y <= dispPos[1] + dist; ++y) {
+        curPos[1] = y;
+        if (dispPos[0] >= dist) {
+          curPos[0] = dispPos[0] - dist;
+          info = publicAPI.getPixelInformation(curPos, 0, outSelectedPosition);
+          if (info && info.valid) {
+            return info;
+          }
+        }
+        curPos[0] = dispPos[0] + dist;
+        info = publicAPI.getPixelInformation(curPos, 0, outSelectedPosition);
+        if (info && info.valid) {
+          return info;
+        }
+      }
+      // Horizontal sides of box.
+      for (let x = ((dispPos[0] >= dist) ? (dispPos[0] - (dist - 1)) : 0); x <= dispPos[0] + (dist - 1); ++x) {
+        curPos[0] = x;
+        if (dispPos[1] >= dist) {
+          curPos[1] = dispPos[1] - dist;
+          info = publicAPI.getPixelInformation(curPos, 0, outSelectedPosition);
+          if (info && info.valid) {
+            return info;
+          }
+        }
+        curPos[1] = dispPos[1] + dist;
+        info = publicAPI.getPixelInformation(curPos, 0, outSelectedPosition);
+        if (info && info.valid) {
+          return info;
+        }
+      }
+    }
+
+    // nothing hit.
+    outSelectedPosition[0] = inDisplayPosition[0];
+    outSelectedPosition[1] = inDisplayPosition[1];
+    return null;
+  };
+
+  //-----------------------------------------------------------------------------
+  publicAPI.convertSelection = (
+    fieldassociation, dataMap) => {
+    const sel = [];
+
+    let count = 0;
+    dataMap.forEach((value, key) => {
+      const child = vtkSelectionNode.newInstance();
+      child.setContentType(SelectionContent.INDICES);
+      switch (fieldassociation) {
+        case FieldAssociations.FIELD_ASSOCIATION_CELLS:
+          child.setFieldType(SelectionField.CELL);
+          break;
+        case FieldAssociations.FIELD_ASSOCIATION_POINTS:
+          child.setFieldType(SelectionField.POINT);
+          break;
+        default:
+          vtkErrorMacro('Unknown field association');
+      }
+      child.getProperties().propID = value.info.propID;
+      child.getProperties().prop = value.info.prop;
+      child.getProperties().compositeID = value.info.compositeID;
+      child.getProperties().pixelCount = value.pixelCount;
+
+      child.setSelectionList(value.attributeIDs);
+      sel[count] = child;
+      count++;
+    });
+
+    return sel;
+  };
+
+  publicAPI.getInfoHash = info => `${info.propID} ${info.compositeID}`;
+
+  //----------------------------------------------------------------------------
+  publicAPI.generateSelection = (
+    x1, y1,
+    x2, y2) => {
+    const dataMap = new Map();
+
+    const outSelectedPosition = [0, 0];
+
+    for (let yy = y1; yy <= y2; yy++) {
+      for (let xx = x1; xx <= x2; xx++) {
+        const pos = [xx, yy];
+        const info = publicAPI.getPixelInformation(pos, 0, outSelectedPosition);
+        if (info && info.valid) {
+          const hash = publicAPI.getInfoHash(info);
+          if (!dataMap.has(hash)) {
+            dataMap.set(hash, { info, pixelCount: 1, attributeIDs: [info.attributeID] });
+          } else {
+            dataMap.get(hash).pixelCount++;
+            if (dataMap.get(hash).attributeIDs.indexOf(info.attributeID) === -1) {
+              dataMap.get(hash).attributeIDs.push(info.attributeID);
+            }
+          }
+        }
+      }
+    }
+    return publicAPI.convertSelection(model.fieldAssociation, dataMap);
+  };
+
+  publicAPI.attach = (w, r) => {
+    model.oglwindow = w;
+    model.renderer = r;
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  fieldAssociation: FieldAssociations.FIELD_ASSOCIATION_CELLS,
+  renderer: null,
+  area: null,
+  oglwindow: null,
+  oglrenderer: null,
+  currentPass: -1,
+  propColorValue: null,
+  props: null,
+  idOffset: 1,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Build VTK API
+  macro.obj(publicAPI, model);
+
+  model.area = [0, 0, 0, 0];
+  model.propColorValue = [0, 0, 0];
+  model.props = [];
+
+  macro.setGet(publicAPI, model, [
+    'fieldAssociation',
+    'renderer',
+    'currentPass',
+  ]);
+
+  macro.setGetArray(publicAPI, model, [
+    'area',
+  ], 4);
+  macro.setGetArray(publicAPI, model, [
+    'propColorValue',
+  ], 3);
+  macro.event(publicAPI, model, 'event');
+
+  // Object methods
+  vtkOpenGLHardwareSelector(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkOpenGLHardwareSelector');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Rendering/OpenGL/HardwareSelector/test/testHardwareSelector.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/test/testHardwareSelector.js
@@ -1,0 +1,75 @@
+import test from 'tape-catch';
+
+import vtkOpenGLRenderWindow from '../../../../Rendering/OpenGL/RenderWindow';
+import vtkOpenGLHardwareSelector from '../../../../Rendering/OpenGL/HardwareSelector';
+import vtkRenderWindow from '../../../../Rendering/Core/RenderWindow';
+import vtkRenderer from '../../../../Rendering/Core/Renderer';
+import vtkActor from '../../../../Rendering/Core/Actor';
+import vtkMapper from '../../../../Rendering/Core/Mapper';
+import vtkPlaneSource from '../../../../Filters/Sources/PlaneSource';
+import vtkSphereSource from '../../../../Filters/Sources/SphereSource';
+import { FieldAssociations } from '../../../../Common/DataModel/DataSet/Constants';
+
+test.onlyIfWebGL('Test HardwareSelector', (tapeContext) => {
+  tapeContext.ok('rendering', 'vtkOpenGLHardwareSelector TestHardwareSelector');
+
+  // Create some control UI
+  const container = document.querySelector('body');
+  const renderWindowContainer = document.createElement('div');
+  container.appendChild(renderWindowContainer);
+
+  // create what we will view
+  const renderWindow = vtkRenderWindow.newInstance();
+  const renderer = vtkRenderer.newInstance();
+  renderWindow.addRenderer(renderer);
+  renderer.setBackground(0.32, 0.34, 0.43);
+
+  const actor = vtkActor.newInstance();
+  renderer.addActor(actor);
+
+  const mapper = vtkMapper.newInstance();
+  actor.setMapper(mapper);
+
+  const PlaneSource = vtkPlaneSource.newInstance({ xResolution: 5, yResolution: 10 });
+  mapper.setInputConnection(PlaneSource.getOutputPort());
+
+  const actor2 = vtkActor.newInstance();
+  renderer.addActor(actor2);
+
+  const mapper2 = vtkMapper.newInstance();
+  actor2.setMapper(mapper2);
+
+  const SphereSource = vtkSphereSource.newInstance();
+  mapper2.setInputConnection(SphereSource.getOutputPort());
+
+  const actor3 = vtkActor.newInstance();
+  actor3.getProperty().setEdgeVisibility(true);
+  actor3.getProperty().setEdgeColor(1.0, 0.5, 0.5);
+  actor3.getProperty().setDiffuseColor(0.5, 1.0, 0.5);
+  actor3.setPosition(1.0, 1.0, 1.0);
+  renderer.addActor(actor3);
+  const mapper3 = vtkMapper.newInstance();
+  actor3.setMapper(mapper3);
+  mapper3.setInputConnection(SphereSource.getOutputPort());
+
+  // now create something to view it, in this case webgl
+  const glwindow = vtkOpenGLRenderWindow.newInstance();
+  glwindow.setContainer(renderWindowContainer);
+  renderWindow.addView(glwindow);
+  glwindow.setSize(400, 400);
+  glwindow.traverseAllPasses();
+
+  const sel = vtkOpenGLHardwareSelector.newInstance();
+  sel.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_POINTS);
+  sel.attach(glwindow, renderer);
+
+  sel.setArea(200, 200, 300, 300);
+  const res = sel.select();
+  const allGood = (res.length === 2 &&
+    res[0].getProperties().prop === actor &&
+    res[1].getProperties().prop === actor3);
+
+  tapeContext.ok(res.length === 2, 'Two props selected');
+  tapeContext.ok(allGood, 'Correct props were selected');
+  tapeContext.end();
+});

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -124,6 +124,16 @@ export function vtkOpenGLRenderWindow(publicAPI, model) {
   publicAPI.normalizedDisplayToDisplay = (x, y, z) =>
     [x * (model.size[0] - 1), y * (model.size[1] - 1), z];
 
+  publicAPI.getPixelData = (x1, y1, x2, y2) => {
+    const pixels = new Uint8Array((x2 - x1 + 1) * (y2 - y1 + 1) * 4);
+    model.context.readPixels(
+      x1, y1, x2 - x1 + 1, y2 - y1 + 1,
+      model.context.RGBA,
+      model.context.UNSIGNED_BYTE,
+      pixels);
+    return pixels;
+  };
+
   publicAPI.get2DContext = () => model.canvas.getContext('2d');
 
   publicAPI.get3DContext = (options = { preserveDrawingBuffer: true, premultipliedAlpha: false }) =>
@@ -235,7 +245,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
 // ----------------------------------------------------------------------------
 
-export const newInstance = macro.newInstance(extend);
+export const newInstance = macro.newInstance(extend, 'vtkOpenGLRenderWindow');
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -139,6 +139,7 @@ export function vtkOpenGLRenderer(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   context: null,
+  selector: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -154,6 +155,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   macro.setGet(publicAPI, model, [
     'context',
+    'selector',
   ]);
 
   // Object methods
@@ -162,7 +164,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
 // ----------------------------------------------------------------------------
 
-export const newInstance = macro.newInstance(extend);
+export const newInstance = macro.newInstance(extend, 'vtkOpenGLRenderer');
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Rendering/OpenGL/Shader/index.js
+++ b/Sources/Rendering/OpenGL/Shader/index.js
@@ -97,7 +97,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
 // ----------------------------------------------------------------------------
 
-export const newInstance = macro.newInstance(extend);
+export const newInstance = macro.newInstance(extend, 'vtkShader');
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Rendering/OpenGL/ShaderCache/index.js
+++ b/Sources/Rendering/OpenGL/ShaderCache/index.js
@@ -193,7 +193,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
 // ----------------------------------------------------------------------------
 
-export const newInstance = macro.newInstance(extend);
+export const newInstance = macro.newInstance(extend, 'vtkShaderCache');
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Rendering/OpenGL/ShaderProgram/index.js
+++ b/Sources/Rendering/OpenGL/ShaderProgram/index.js
@@ -414,7 +414,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
 // ----------------------------------------------------------------------------
 
-export const newInstance = macro.newInstance(extend);
+export const newInstance = macro.newInstance(extend, 'vtkShaderprogram');
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -477,6 +477,50 @@ function vtkOpenGLTexture(publicAPI, model) {
   };
 
   //----------------------------------------------------------------------------
+  publicAPI.createDepthFromRaw = (width, height, dataType, data) => {
+    // Now determine the texture parameters using the arguments.
+    publicAPI.getOpenGLDataType(dataType);
+    model.format = model.context.DEPTH_COMPONENT;
+    model.internalFormat = model.context.DEPTH_COMPONENT;
+
+    if (!model.internalFormat || !model.format || !model.openGLDataType) {
+      vtkErrorMacro('Failed to determine texture parameters.');
+      return false;
+    }
+
+    model.target = model.context.TEXTURE_2D;
+    model.components = 1;
+    model.width = width;
+    model.height = height;
+    model.depth = 1;
+    model.numberOfDimensions = 2;
+    model.window.activateTexture(publicAPI);
+    publicAPI.createTexture();
+    publicAPI.bind();
+
+    // Source texture data from the PBO.
+    // model.context.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+    model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
+
+    model.context.texImage2D(
+          model.target,
+          0,
+          model.internalFormat,
+          model.width, model.height,
+          0,
+          model.format,
+          model.openGLDataType,
+          data);
+
+    if (model.generateMipmap) {
+      model.context.generateMipmap(model.target);
+    }
+
+    publicAPI.deactivate();
+    return true;
+  };
+
+  //----------------------------------------------------------------------------
   publicAPI.create2DFromImage = (image) => {
     // Now determine the texture parameters using the arguments.
     publicAPI.getOpenGLDataType(VtkDataTypes.UNSIGNED_CHAR);
@@ -588,6 +632,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   macro.get(publicAPI, model, [
     'components',
+    'handle',
   ]);
 
   // Object methods

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -31,7 +31,7 @@ export function getStateArrayMapFunc(item) {
 
 export function obj(publicAPI = {}, model = {}) {
   const callbacks = [];
-  model.mtime = model.mtime || ++globalMTime;
+  model.mtime = (Number.isInteger(model.mtime) ? model.mtime : ++globalMTime);
   model.classHierarchy = ['vtkObject'];
 
   function off(index) {

--- a/Sources/tests.js
+++ b/Sources/tests.js
@@ -10,6 +10,7 @@ import './Filters/Sources/PointSource/test/testPointSource';
 import './IO/Misc/PDBReader/test/testMolecule';
 import './Rendering/Core/ColorTransferFunction/test/testColorTransferFunction';
 import './Rendering/Core/Mapper/test/testEdgeVisibility';
+import './Rendering/OpenGL/HardwareSelector/test/testHardwareSelector';
 import './Rendering/OpenGL/PolyDataMapper/test/testInterpolateScalarsBeforeMapping';
 import './Rendering/OpenGL/SphereMapper/test/testSphere';
 import './Rendering/OpenGL/StickMapper/test/testStick';


### PR DESCRIPTION
This topic adds a hardwareslector class that can be used
to perform hardware picks and return the prop and propid.
In the future we can extend it to support the other passes
such as composite id and attribute id.

To support this we added a SelectionNode class that contains
information and properties about a selection.

Since webgl doesn't really have an option to turn of bufferswapping
we add a framebuffer class so that the hardware picking can take
place in the framebuffer instead of the visible buffer. The
framebuffer class will of course be useful for a lot of other
cases.

Fixed a bug where is a class initialized mtime to zero it
would not be honored and would instead use the global mtime.