### PR TITLE
fix(Rendering): fix surface with edges failure

### DIFF
--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -16,9 +16,9 @@ function notImplemented(method) {
 /* eslint-disable arrow-body-style */
 
 const staticOffsetModel = {
-  Polygon: { factor: 2, unit: 2 },
-  Line: { factor: 1, unit: 1 },
-  Point: { factor: 0, unit: 0 },
+  Polygon: { factor: 2, offset: 0 },
+  Line: { factor: 1, offset: -1 },
+  Point: { factor: 0, offset: -2 },
 };
 const staticOffsetAPI = {};
 
@@ -89,9 +89,9 @@ function vtkMapper(publicAPI, model) {
   // Relative metods
   /* eslint-disable arrow-body-style */
   model.topologyOffset = {
-    Polygon: { factor: 0, unit: 0 },
-    Line: { factor: 0, unit: 0 },
-    Point: { factor: 0, unit: 0 },
+    Polygon: { factor: 0, offset: 0 },
+    Line: { factor: 0, offset: 0 },
+    Point: { factor: 0, offset: 0 },
   };
   CoincidentTopologyHelper.addCoincidentTopologyMethods(
     publicAPI,
@@ -106,7 +106,7 @@ function vtkMapper(publicAPI, model) {
     const localValue = publicAPI.getRelativeCoincidentTopologyPolygonOffsetParameters();
     return {
       factor: globalValue.factor + localValue.factor,
-      units: globalValue.units + localValue.units,
+      offset: globalValue.offset + localValue.offset,
     };
   };
 
@@ -115,7 +115,7 @@ function vtkMapper(publicAPI, model) {
     const localValue = publicAPI.getRelativeCoincidentTopologyLineOffsetParameters();
     return {
       factor: globalValue.factor + localValue.factor,
-      units: globalValue.units + localValue.units,
+      offset: globalValue.offset + localValue.offset,
     };
   };
 
@@ -124,7 +124,7 @@ function vtkMapper(publicAPI, model) {
     const localValue = publicAPI.getRelativeCoincidentTopologyPointOffsetParameters();
     return {
       factor: globalValue.factor + localValue.factor,
-      units: globalValue.units + localValue.units,
+      offset: globalValue.offset + localValue.offset,
     };
   };
 

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -378,8 +378,9 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
               '  if (gl_FrontFacing == false) { normalVCVSOutput = -normalVCVSOutput; }']
             ).result;
         } else {
-          if (model.lastBoundBO.getPrimitiveType() === primTypes.Lines ||
-              actor.getProperty().getRepresentation() === Representation.WIREFRAME) {
+          if (publicAPI.getOpenGLMode(
+            actor.getProperty().getRepresentation(),
+            model.lastBoundBO.getPrimitiveType()) === model.context.LINES) {
             // generate a normal for lines, it will be perpendicular to the line
             // and maximally aligned with the camera view direction
             // no clue if this is the best way to do this.
@@ -580,7 +581,7 @@ export function vtkOpenGLPolyDataMapper(publicAPI, model) {
           primType === primTypes.TriStripsEdges) {
         cp = model.renderable.getCoincidentTopologyPolygonOffsetParameters();
         cp.factor /= 2.0;
-        cp.units /= 2.0;
+        cp.offset /= 2.0;
       }
     }
 


### PR DESCRIPTION
Two issues. There was a typo between unit and units in
the offset code. Renamed all to offset.

The code to compute lighting on edges was not triggering
resulting in odd lighting.