### PR TITLE
Update webpack.loaders.js to webpack 2

### DIFF
--- a/Utilities/config/webpack.loaders.js
+++ b/Utilities/config/webpack.loaders.js
@@ -26,16 +26,16 @@ module.exports = [
     loader: 'url-loader?limit=1048576',
   }, {
     test: /\.css$/,
-    loader: 'style!css!postcss',
+    loader: 'style-loader!css-loader!postcss-loader',
   }, {
     test: /\.mcss$/,
-    loader: 'style!css?modules&importLoaders=1&localIdentName=[name]_[local]_[hash:base64:5]!postcss',
+    loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[name]_[local]_[hash:base64:5]!postcss-loader',
   }, {
     test: /\.c$/i,
-    loader: 'shader',
+    loader: 'shader-loader',
   }, {
     test: /\.glsl$/i,
-    loader: 'shader',
+    loader: 'shader-loader',
   }, {
     test: /\.json$/,
     loader: 'json-loader',
@@ -48,10 +48,10 @@ module.exports = [
   }, {
     test: /\.js$/,
     include: /node_modules(\/|\\)vtk\.js(\/|\\)/,
-    loader: `babel?presets[]=es2015,presets[]=react!string-replace?${replaceConfig}`,
+    loader: `babel-loader?presets[]=es2015,presets[]=react!string-replace-loader?${replaceConfig}`,
   }, {
     test: /\.js$/,
     exclude: /node_modules/,
-    loader: `babel?presets[]=es2015,presets[]=react!string-replace?${replaceConfig}`,
+    loader: `babel-loader?presets[]=es2015,presets[]=react!string-replace-loader?${replaceConfig}`,
   },
 ];


### PR DESCRIPTION
This is not a complete pull request as it misses documentation but I would like to let you know that I was able to use vtk.js with webpack 2.2.1 by making these changes. Feel free to close this PR as I also don't know if the changes are backward compatible to webpack 1, I guess not.

My `webpack.config.js`:

```javascript
const path = require('path');
const webpack = require('webpack');
const merge = require('webpack-merge');
const parts = require('./webpack.parts');
const pkg = require('./package.json');

const loaders = require('./node_modules/vtk.js/Utilities/config/webpack.loaders.js');

const commonConfig = merge([
  {
    entry: {
      app: pkg.paths.src.js + 'app.js'
    output: {
      path: pkg.paths.dist.js,
      filename: 'bundle.js'
    },
    module: {
        rules: [
            {
              test: require.resolve("./src/js/app.js"),
              loader: "expose-loader?MyWebApp"
            }
        ].concat(loaders),
      },
    // postcss: [
      // require('autoprefixer')({ browsers: ['last 2 versions'] }),
    // ],
  }
]);

const productionConfig = merge([
  parts.productionEnv(),
  parts.minifyJavaScript({ useSourceMap: true })
]);

const developmentConfig = merge([
  {
    // plugins: [
      // new webpack.NamedModulesPlugin(),
    // ],
  }
]);

module.exports = function(env) {
  if (env === 'production') {
    return merge(commonConfig, productionConfig);
  }

  return merge(commonConfig, developmentConfig);
};
``` 

My `webpack.parts.js`:

```javascript
const webpack = require('webpack');

exports.minifyJavaScript = function({ useSourceMap }) {
  return {
    plugins: [
      new webpack.optimize.UglifyJsPlugin({
        // sourceMap: useSourceMap,
        compress: {
          warnings: false,
        },
      }),
    ],
  };
};

exports.productionEnv = function() {
  return {
    plugins: [
      new webpack.DefinePlugin({
        "process.env": {
            NODE_ENV: JSON.stringify("production"),
        },
      })
    ]
  }
}
```