### PR TITLE
Fix function vtkRotate used inside JacobiN function

### DIFF
--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -629,8 +629,8 @@ function jacobiN(a, n, w, v) {
   const vtkROTATE = (aa, ii, jj, kk, ll) => {
     g = aa[ii][jj];
     h = aa[kk][ll];
-    a[ii][jj] = g - (s * (h + (g * tau)));
-    a[kk][ll] = h + (s * (g - (h * tau)));
+    aa[ii][jj] = g - (s * (h + (g * tau)));
+    aa[kk][ll] = h + (s * (g - (h * tau)));
   };
 
   // initialize


### PR DESCRIPTION
The vtkRotate fnction takes 5 arguments. In VTK, the first arguments is set inside the function. Actually, it's the first attribute of the JacobiN function which is set. So the first argument of thevtkRotate function is never set.