### PR TITLE
fix(Rendering): microsoft edge was not working

### DIFF
--- a/Sources/Rendering/OpenGL/ShaderCache/index.js
+++ b/Sources/Rendering/OpenGL/ShaderCache/index.js
@@ -51,7 +51,7 @@ function vtkShaderCache(publicAPI, model) {
     ]).result;
 
     const nVSSource = vtkShaderProgram.substitute(VSSource, '//VTK::System::Dec', [
-      `${version}\n#extension GL_OES_standard_derivatives : enable\n`,
+      `${version}\n`,
       '#ifdef GL_FRAGMENT_PRECISION_HIGH',
       'precision highp float;',
       'precision highp int;',


### PR DESCRIPTION
We were requesting the derivatives extension for
the vertex shader when we only need it on the
fragment shader. On edge this resulted in a failed
shader compilation.