### PR TITLE
fix(RenderWindow): Allow render window to be unmount

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -90,7 +90,9 @@ export function vtkOpenGLRenderWindow(publicAPI, model) {
 
     if (model.el !== el) {
       model.el = el;
-      model.el.appendChild(model.canvas);
+      if (model.el) {
+        model.el.appendChild(model.canvas);
+      }
 
       // Trigger modified()
       publicAPI.modified();


### PR DESCRIPTION
setContainer() can take null or undefined to unmount the render window