### PR TITLE
fix(Rendering): support setValue(x,y) signature on coord

### DIFF
--- a/Sources/Rendering/Core/Coordinate/index.js
+++ b/Sources/Rendering/Core/Coordinate/index.js
@@ -1,6 +1,8 @@
 import macro          from 'vtk.js/Sources/macro';
 import { Coordinate } from 'vtk.js/Sources/Rendering/Core/Coordinate/Constants';
 
+const { vtkErrorMacro } = macro;
+
 // ----------------------------------------------------------------------------
 // vtkActor methods
 // ----------------------------------------------------------------------------
@@ -8,6 +10,42 @@ import { Coordinate } from 'vtk.js/Sources/Rendering/Core/Coordinate/Constants';
 function vtkCoordinate(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkCoordinate');
+
+  publicAPI.setValue = (...args) => {
+    if (model.deleted) {
+      vtkErrorMacro('instance deleted - cannot call any method');
+      return false;
+    }
+
+    let array = args;
+    // allow an array passed as a single arg.
+    if (array.length === 1 && Array.isArray(array[0])) {
+      array = array[0];
+    }
+
+    if (array.length === 2) {
+      publicAPI.setValue(array[0], array[1], 0.0);
+      return true;
+    }
+    if (array.length !== 3) {
+      throw new RangeError('Invalid number of values for array setter');
+    }
+    let changeDetected = false;
+    model.values.forEach((item, index) => {
+      if (item !== array[index]) {
+        if (changeDetected) {
+          return;
+        }
+        changeDetected = true;
+      }
+    });
+
+    if (changeDetected) {
+      model.values = [].concat(array);
+      publicAPI.modified();
+    }
+    return true;
+  };
 
   publicAPI.setCoordinateSystemToDisplay = () => {
     publicAPI.setCoordinateSystem(Coordinate.DISPLAY);
@@ -64,7 +102,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'viewport',
   ]);
 
-  macro.setGetArray(publicAPI, model, [
+  macro.getArray(publicAPI, model, [
     'value',
   ], 3);
 


### PR DESCRIPTION
Allow setValue(x,y) to work as well with an implicit z of 0.0