### PR TITLE
fix(Rendering): issue with interactor style image

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleImage/index.js
+++ b/Sources/Interaction/Style/InteractorStyleImage/index.js
@@ -60,7 +60,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
   };
 
   // Public API methods
-  publicAPI.superHandleMouseMove = publicAPI.handleMouseMove;
+  publicAPI.superHandleAnimation = publicAPI.handleAnimation;
   publicAPI.handleAnimation = () => {
     const pos = model.interactor.getEventPosition(model.interactor.getPointerIndex());
 
@@ -80,7 +80,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
       default:
         break;
     }
-    publicAPI.superHandleMouseMove();
+    publicAPI.superHandleAnimation();
   };
 
   //----------------------------------------------------------------------------

--- a/Sources/Rendering/Core/ImageMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageMapper/example/index.js
@@ -2,6 +2,7 @@ import vtkFullScreenRenderWindow  from 'vtk.js/Sources/Rendering/Misc/FullScreen
 import vtkImageGridSource         from 'vtk.js/Sources/Filters/Sources/ImageGridSource';
 import vtkImageMapper             from 'vtk.js/Sources/Rendering/Core/ImageMapper';
 import vtkImageSlice              from 'vtk.js/Sources/Rendering/Core/ImageSlice';
+import vtkInteractorStyleImage    from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup
@@ -27,6 +28,9 @@ const actor = vtkImageSlice.newInstance();
 actor.getProperty().setColorWindow(255);
 actor.getProperty().setColorLevel(127);
 actor.setMapper(mapper);
+
+const iStyle = vtkInteractorStyleImage.newInstance();
+renderWindow.getInteractor().setInteractorStyle(iStyle);
 
 renderer.addActor(actor);
 renderer.resetCamera();

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testIntermixed.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testIntermixed.js
@@ -91,7 +91,7 @@ test.onlyIfWebGL('Test Composite Volume Rendering', (t) => {
       const image = glwindow.captureImage();
       testUtils.compareImages(image, [baseline],
         'Rendering/OpenGL/VolumeMapper/testComposite',
-        t, 1.5, gc.releaseResources);
+        t, 1.8, gc.releaseResources);
     });
   });
 });


### PR DESCRIPTION
There was an old method signature causing the interactor style
image to not work. Modified the ImageMapper example to use
that interactor style.