### PR TITLE
fix(Rendering): issue with textures after cube maps

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -62,7 +62,7 @@ function vtkOpenGLTexture(publicAPI, model) {
         const data = [];
         for (let i = 0; i < 6; ++i) {
           const indata = model.renderable.getInputData(i);
-          const scalars = indata.getPointData().getScalars().getData();
+          const scalars = indata ? indata.getPointData().getScalars().getData() : null;
           if (scalars) {
             data.push(scalars);
           }


### PR DESCRIPTION
The added support for cube maps caused an issue with
regular texture maps.