### PR TITLE
fix(exports): Remove unwanted exports

### DIFF
--- a/Sources/Filters/General/MoleculeToRepresentation/index.js
+++ b/Sources/Filters/General/MoleculeToRepresentation/index.js
@@ -18,7 +18,7 @@ atomElem.atoms.forEach((a) => { ATOMS[a.atomicNumber] = a; });
 // vtkMoleculeToRepresentation methods
 // ----------------------------------------------------------------------------
 
-export function vtkMoleculeToRepresentation(publicAPI, model) {
+function vtkMoleculeToRepresentation(publicAPI, model) {
   const bondPositionData = [];
   const bondScaleData = [];
   const bondOrientationData = [];

--- a/Sources/Filters/Sources/ConeSource/index.js
+++ b/Sources/Filters/Sources/ConeSource/index.js
@@ -5,7 +5,7 @@ import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 // vtkConeSource methods
 // ----------------------------------------------------------------------------
 
-export function vtkConeSource(publicAPI, model) {
+function vtkConeSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkConeSource');
 

--- a/Sources/Filters/Sources/CubeSource/index.js
+++ b/Sources/Filters/Sources/CubeSource/index.js
@@ -6,7 +6,7 @@ import vtkPolyData  from 'vtk.js/Sources/Common/DataModel/PolyData';
 // vtkConeSource methods
 // ----------------------------------------------------------------------------
 
-export function vtkCubeSource(publicAPI, model) {
+function vtkCubeSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkCubeSource');
 

--- a/Sources/Filters/Sources/ImageGridSource/index.js
+++ b/Sources/Filters/Sources/ImageGridSource/index.js
@@ -6,7 +6,7 @@ import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 // vtkImageGridSource methods
 // ----------------------------------------------------------------------------
 
-export function vtkImageGridSource(publicAPI, model) {
+function vtkImageGridSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkImageGridSource');
 

--- a/Sources/Filters/Sources/LineSource/index.js
+++ b/Sources/Filters/Sources/LineSource/index.js
@@ -8,7 +8,7 @@ const { vtkWarningMacro } = macro;
 // vtkLineSource methods
 // ----------------------------------------------------------------------------
 
-export function vtkLineSource(publicAPI, model) {
+function vtkLineSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkLineSource');
 

--- a/Sources/Filters/Sources/PlaneSource/index.js
+++ b/Sources/Filters/Sources/PlaneSource/index.js
@@ -9,7 +9,7 @@ const { vtkWarningMacro } = macro;
 // vtkPlaneSource methods
 // ----------------------------------------------------------------------------
 
-export function vtkPlaneSource(publicAPI, model) {
+function vtkPlaneSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkPlaneSource');
 

--- a/Sources/Filters/Sources/PointSource/index.js
+++ b/Sources/Filters/Sources/PointSource/index.js
@@ -6,7 +6,7 @@ import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 // vtkPointSource methods
 // ----------------------------------------------------------------------------
 
-export function vtkPointSource(publicAPI, model) {
+function vtkPointSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkPointSource');
 

--- a/Sources/Filters/Sources/SphereSource/index.js
+++ b/Sources/Filters/Sources/SphereSource/index.js
@@ -6,7 +6,7 @@ import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 // vtkSphereSource methods
 // ----------------------------------------------------------------------------
 
-export function vtkSphereSource(publicAPI, model) {
+function vtkSphereSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkSphereSource');
 

--- a/Sources/IO/Core/HttpDataSetReader/index.js
+++ b/Sources/IO/Core/HttpDataSetReader/index.js
@@ -106,7 +106,7 @@ function processDataSet(publicAPI, model, dataset, fetchArray, resolve, reject, 
 // vtkHttpDataSetReader methods
 // ----------------------------------------------------------------------------
 
-export function vtkHttpDataSetReader(publicAPI, model) {
+function vtkHttpDataSetReader(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkHttpDataSetReader');
 

--- a/Sources/IO/Core/HttpSceneLoader/index.js
+++ b/Sources/IO/Core/HttpSceneLoader/index.js
@@ -75,7 +75,7 @@ const TYPE_MAPPING = {
 // vtkHttpSceneLoader methods
 // ----------------------------------------------------------------------------
 
-export function vtkHttpSceneLoader(publicAPI, model) {
+function vtkHttpSceneLoader(publicAPI, model) {
   const originalSceneParameters = {};
 
   // Set our className

--- a/Sources/IO/Misc/ElevationReader/index.js
+++ b/Sources/IO/Misc/ElevationReader/index.js
@@ -8,7 +8,7 @@ import DataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper';
 // vtkElevationReader methods
 // ----------------------------------------------------------------------------
 
-export function vtkElevationReader(publicAPI, model) {
+function vtkElevationReader(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkElevationReader');
 

--- a/Sources/IO/Misc/MTLReader/index.js
+++ b/Sources/IO/Misc/MTLReader/index.js
@@ -5,7 +5,7 @@ import DataAccessHelper from '../../Core/DataAccessHelper';
 // vtkMTLReader methods
 // ----------------------------------------------------------------------------
 
-export function vtkMTLReader(publicAPI, model) {
+function vtkMTLReader(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkMTLReader');
 

--- a/Sources/IO/Misc/OBJReader/index.js
+++ b/Sources/IO/Misc/OBJReader/index.js
@@ -164,7 +164,7 @@ function end(model) {
 // vtkOBJReader methods
 // ----------------------------------------------------------------------------
 
-export function vtkOBJReader(publicAPI, model) {
+function vtkOBJReader(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOBJReader');
 

--- a/Sources/IO/Misc/PDBReader/index.js
+++ b/Sources/IO/Misc/PDBReader/index.js
@@ -8,7 +8,7 @@ import ATOMS            from 'vtk.js/Utilities/XMLConverter/chemistry-mapper/ele
 // vtkPDBReader methods
 // ----------------------------------------------------------------------------
 
-export function vtkPDBReader(publicAPI, model) {
+function vtkPDBReader(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkPDBReader');
 

--- a/Sources/Rendering/Core/Light/index.js
+++ b/Sources/Rendering/Core/Light/index.js
@@ -9,7 +9,7 @@ export const LIGHT_TYPES = ['HeadLight', 'CameraLight', 'SceneLight'];
 // vtkLight methods
 // ----------------------------------------------------------------------------
 
-export function vtkLight(publicAPI, model) {
+function vtkLight(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkLight');
 

--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -4,7 +4,7 @@ import macro from 'vtk.js/Sources/macro';
 // vtkRenderWindow methods
 // ----------------------------------------------------------------------------
 
-export function vtkRenderWindow(publicAPI, model) {
+function vtkRenderWindow(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkRenderWindow');
 

--- a/Sources/Rendering/Core/Representation/index.js
+++ b/Sources/Rendering/Core/Representation/index.js
@@ -4,7 +4,7 @@ import * as macro from '../../../macro';
 // vtkRepresentation methods
 // ----------------------------------------------------------------------------
 
-export function vtkRepresentation(publicAPI, model) {
+function vtkRepresentation(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkRepresentation');
 

--- a/Sources/Rendering/Core/SphereMapper/index.js
+++ b/Sources/Rendering/Core/SphereMapper/index.js
@@ -5,7 +5,7 @@ import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 // vtkSphereMapper methods
 // ----------------------------------------------------------------------------
 
-export function vtkSphereMapper(publicAPI, model) {
+function vtkSphereMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkSphereMapper');
 }

--- a/Sources/Rendering/Core/StickMapper/index.js
+++ b/Sources/Rendering/Core/StickMapper/index.js
@@ -5,7 +5,7 @@ import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 // vtkStickMapper methods
 // ----------------------------------------------------------------------------
 
-export function vtkStickMapper(publicAPI, model) {
+function vtkStickMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkStickMapper');
 }

--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/index.js
@@ -228,7 +228,7 @@ function createSyncFunction(renderWindow, synchronizerContext) {
 // vtkSynchronizableRenderWindow methods
 // ----------------------------------------------------------------------------
 
-export function vtkSynchronizableRenderWindow(publicAPI, model) {
+function vtkSynchronizableRenderWindow(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkSynchronizableRenderWindow');
 

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -13,7 +13,7 @@ const { vtkErrorMacro } = macro;
 // vtkOpenGLHardwareSelector methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLHardwareSelector(publicAPI, model) {
+function vtkOpenGLHardwareSelector(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLHardwareSelector');
 

--- a/Sources/Rendering/OpenGL/Helper/index.js
+++ b/Sources/Rendering/OpenGL/Helper/index.js
@@ -7,7 +7,7 @@ import vtkVertexArrayObject     from 'vtk.js/Sources/Rendering/OpenGL/VertexArra
 // vtkOpenGLHelper methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLHelper(publicAPI, model) {
+function vtkOpenGLHelper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLHelper');
 

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -17,7 +17,7 @@ const { vtkErrorMacro } = macro;
 // vtkOpenGLImageMapper methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLImageMapper(publicAPI, model) {
+function vtkOpenGLImageMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLImageMapper');
 

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -33,7 +33,7 @@ const { vtkErrorMacro } = macro;
 // vtkOpenGLPolyDataMapper methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLPolyDataMapper(publicAPI, model) {
+function vtkOpenGLPolyDataMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLPolyDataMapper');
 

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -11,7 +11,7 @@ const { vtkErrorMacro } = macro;
 // vtkOpenGLRenderWindow methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLRenderWindow(publicAPI, model) {
+function vtkOpenGLRenderWindow(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLRenderWindow');
 

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -9,7 +9,7 @@ const { vtkDebugMacro } = macro;
 // ----------------------------------------------------------------------------
 /* eslint-disable no-bitwise */
 
-export function vtkOpenGLRenderer(publicAPI, model) {
+function vtkOpenGLRenderer(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLRenderer');
 

--- a/Sources/Rendering/OpenGL/Shader/index.js
+++ b/Sources/Rendering/OpenGL/Shader/index.js
@@ -8,7 +8,7 @@ const { vtkErrorMacro } = macro;
 // vtkShader methods
 // ----------------------------------------------------------------------------
 
-export function vtkShader(publicAPI, model) {
+function vtkShader(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkShader');
 

--- a/Sources/Rendering/OpenGL/ShaderProgram/index.js
+++ b/Sources/Rendering/OpenGL/ShaderProgram/index.js
@@ -25,7 +25,7 @@ export function substitute(source, search, replace, all = true) {
 // vtkShaderProgram methods
 // ----------------------------------------------------------------------------
 
-export function vtkShaderProgram(publicAPI, model) {
+function vtkShaderProgram(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkShaderProgram');
 

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -18,7 +18,7 @@ const { vtkErrorMacro } = macro;
 // vtkOpenGLSphereMapper methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLSphereMapper(publicAPI, model) {
+function vtkOpenGLSphereMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLSphereMapper');
 

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -17,7 +17,7 @@ const { vtkErrorMacro } = macro;
 // vtkOpenGLStickMapper methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLStickMapper(publicAPI, model) {
+function vtkOpenGLStickMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLStickMapper');
 

--- a/Sources/Rendering/OpenGL/ViewNodeFactory/index.js
+++ b/Sources/Rendering/OpenGL/ViewNodeFactory/index.js
@@ -18,7 +18,7 @@ import vtkOpenGLVolumeMapper   from 'vtk.js/Sources/Rendering/OpenGL/VolumeMappe
 // vtkOpenGLViewNodeFactory methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLViewNodeFactory(publicAPI, model) {
+function vtkOpenGLViewNodeFactory(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLViewNodeFactory');
 }

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -22,7 +22,7 @@ const { vtkWarningMacro, vtkErrorMacro } = macro;
 // vtkOpenGLVolumeMapper methods
 // ----------------------------------------------------------------------------
 
-export function vtkOpenGLVolumeMapper(publicAPI, model) {
+function vtkOpenGLVolumeMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLVolumeMapper');
 

--- a/Sources/Representation/Geometry/OBJRepresentation/index.js
+++ b/Sources/Representation/Geometry/OBJRepresentation/index.js
@@ -10,7 +10,7 @@ const { vtkDebugMacro } = macro;
 // vtkOBJRepresentation methods
 // ----------------------------------------------------------------------------
 
-export function vtkOBJRepresentation(publicAPI, model) {
+function vtkOBJRepresentation(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOBJRepresentation');
 


### PR DESCRIPTION
Exporting these named functions prevents us from importing things the way we want (or eslint complains). 
 And for the most part, we shouldn't use those methods from outside the modules anyway, instead we should rely on the default export for its newInstance method.