### PR TITLE
fix(vtkMath): Update the name of a function

### DIFF
--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -1898,7 +1898,7 @@ const isFinite = Number.isFinite;
 
 // JavaScript - add-on ----------------------
 
-function createUninitializedBouds() {
+function createUninitializedBounds() {
   return [].concat([
     Number.MAX_VALUE, Number.MIN_VALUE, // X
     Number.MAX_VALUE, Number.MIN_VALUE, // Y
@@ -2001,5 +2001,5 @@ export default {
   isFinite,
 
   // JS add-on
-  createUninitializedBouds,
+  createUninitializedBounds,
 };

--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -45,7 +45,7 @@ function vtkMapper(publicAPI, model) {
   publicAPI.getBounds = () => {
     const input = publicAPI.getInputData();
     if (!input) {
-      model.bounds = vtkMath.createUninitializedBouds();
+      model.bounds = vtkMath.createUninitializedBounds();
     } else {
       if (!model.static) {
         publicAPI.update();

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -528,7 +528,7 @@ const DEFAULT_VALUES = {
   preserveColorBuffer: false,
   preserveDepthBuffer: false,
 
-  computeVisiblePropBounds: vtkMath.createUninitializedBouds(),
+  computeVisiblePropBounds: vtkMath.createUninitializedBounds(),
 
   interactive: true,
 

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -12,7 +12,7 @@ function vtkVolumeMapper(publicAPI, model) {
   publicAPI.getBounds = () => {
     const input = publicAPI.getInputData();
     if (!input) {
-      model.bounds = vtkMath.createUninitializedBouds();
+      model.bounds = vtkMath.createUninitializedBounds();
     } else {
       if (!model.static) {
         publicAPI.update();


### PR DESCRIPTION
`createUninitializedBounds ` was called by ImageMapper but it crashed during execution. The real function was defined under the name `createUninitializedBouds`.