### PR TITLE
fix(RenderWindowInteractor): Bind event when mouse leave

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -136,6 +136,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     canvas.addEventListener('click', preventDefault);
     canvas.addEventListener('mousewheel', publicAPI.handleWheel);
     canvas.addEventListener('DOMMouseScroll', publicAPI.handleWheel);
+    canvas.addEventListener('mouseout', publicAPI.handleMouseOut);
 
     canvas.addEventListener('mousedown', publicAPI.handleMouseDown);
     document.querySelector('body').addEventListener('keypress', publicAPI.handleKeyPress);
@@ -153,6 +154,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     canvas.removeEventListener('click', preventDefault);
     canvas.removeEventListener('mousewheel', publicAPI.handleWheel);
     canvas.removeEventListener('DOMMouseScroll', publicAPI.handleWheel);
+    canvas.removeEventListener('mouseout', publicAPI.handleMouseOut);
 
     canvas.removeEventListener('mousedown', publicAPI.handleMouseDown);
     document.querySelector('body').removeEventListener('keypress', publicAPI.handleKeyPress);
@@ -278,6 +280,25 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     publicAPI.setScale(publicAPI.getScale() *
       Math.max(0.01, (wheelDelta + 1000.0) / 1000.0));
     publicAPI.pinchEvent();
+  };
+
+  publicAPI.handleMouseOut = (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    switch (event.which) {
+      case 1:
+        publicAPI.leftButtonReleaseEvent();
+        break;
+      case 2:
+        publicAPI.middleButtonReleaseEvent();
+        break;
+      case 3:
+        publicAPI.rightButtonReleaseEvent();
+        break;
+      default:
+        break;
+    }
   };
 
   publicAPI.handleMouseUp = (event) => {


### PR DESCRIPTION
If user clicks on the render window, then mouves out of the render window, releases the button and go back to the render window, then the moving is like the mouse was never released.
With this code, if the user clicks on the render window and then moves outside and go back to the render window, there is no moving. If the mouse leave the renderwindow, it's like if the user releases it.