### PR TITLE
perf(Rendering): improve volume rendering perf on some devices

### DIFF
--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -172,9 +172,19 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     // We do a break so most systems will gracefully
     // early terminate, but it is always possible
     // a system will execute every step regardless
+
+    const ext = model.currentInput.getExtent();
+    const spc = model.currentInput.getSpacing();
+    const vsize = vec3.create();
+    vec3.set(vsize,
+      (ext[1] - ext[0]) * spc[0],
+      (ext[3] - ext[2]) * spc[1],
+      (ext[5] - ext[4]) * spc[2]);
+    const maxSamples = vec3.length(vsize) / model.renderable.getSampleDistance();
+
     FSSource = vtkShaderProgram.substitute(FSSource,
       '//VTK::MaximumSamplesValue',
-      `${model.renderable.getMaximumSamplesPerRay()}`).result;
+      `${Math.ceil(maxSamples)}`).result;
 
     // if we have a ztexture then declare it and use it
     if (model.zBufferTexture !== null) {

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -197,7 +197,6 @@ void main()
 
     // start slightly inside
     vpos = vpos + vdelta*0.1;
-    bool done = false;
     vec4 color = vec4(0.0, 0.0, 0.0, 0.0);
     int count = int(numSteps - 0.2); // end slightly inside
 


### PR DESCRIPTION
On some systems it seems glsl breaking out of a for loop is
not improving the performance so the full loop count
is being executed. So we tighten up the loop count so that
we have the minimum count required for the step size.