### PR TITLE
fix(TrackballZoom): Fix broken zoom manipulator

### DIFF
--- a/Sources/Interaction/Manipulators/TrackballZoom/index.js
+++ b/Sources/Interaction/Manipulators/TrackballZoom/index.js
@@ -1,6 +1,8 @@
 import macro                from 'vtk.js/Sources/macro';
 import vtkCameraManipulator from 'vtk.js/Sources/Interaction/Manipulators/CameraManipulator';
 
+const { vtkWarningMacro } = macro;
+
 // ----------------------------------------------------------------------------
 // vtkTrackballZoom methods
 // ----------------------------------------------------------------------------
@@ -11,13 +13,17 @@ function vtkTrackballZoom(publicAPI, model) {
 
   publicAPI.onButtonDown = (interactor) => {
     const size = interactor.getView().getSize();
-    const camera = interactor.getActiveCamera();
 
-    if (camera.getParallelProjection()) {
-      model.zoomScale = 1.5 / size[1];
-    } else {
-      const range = camera.getClippingRange();
-      model.zoomScale = 1.5 * (range[1] / size[1]);
+    try {
+      const camera = interactor.getInteractorStyle().getCurrentRenderer().getActiveCamera();
+      if (camera.getParallelProjection()) {
+        model.zoomScale = 1.5 / size[1];
+      } else {
+        const range = camera.getClippingRange();
+        model.zoomScale = 1.5 * (range[1] / size[1]);
+      }
+    } catch (e) {
+      vtkWarningMacro('Unable to set model.zoomScale');
     }
   };
 


### PR DESCRIPTION
The `vtkRenderWindowInteractor` no longer has a `getActiveCamera()` method.  This fix allows the zoom manipulator to get its hands on the active camera via the current renderer belonging to the interactor style of the render window interactor. 