### PR TITLE
fix(Renderer): allow a transparent clear color

### DIFF
--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -20,6 +20,10 @@ function notImplemented(method) {
 function vtkRenderer(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkRenderer');
+  // make sure background has 4 entries. Default to opaque black
+  if (!model.background) model.background = [0, 0, 0, 1];
+  while (model.background.length < 3) model.background.push(0);
+  if (model.background.length === 3) model.background.push(1);
 
   publicAPI.updateCamera = () => {
     if (!model.activeCamera) {
@@ -597,7 +601,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'pass',
   ]);
   macro.getArray(publicAPI, model, ['actors', 'volumes', 'lights']);
-  macro.setGetArray(publicAPI, model, ['background'], [3, 4]);
+  macro.setGetArray(publicAPI, model, ['background'], 4, 1.0);
 
   // Object methods
   vtkRenderer(publicAPI, model);

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -597,7 +597,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'pass',
   ]);
   macro.getArray(publicAPI, model, ['actors', 'volumes', 'lights']);
-  macro.setGetArray(publicAPI, model, ['background'], 3);
+  macro.setGetArray(publicAPI, model, ['background'], [3, 4]);
 
   // Object methods
   vtkRenderer(publicAPI, model);

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -136,7 +136,8 @@ function vtkOpenGLRenderer(publicAPI, model) {
 
     if (!model.renderable.getTransparent()) {
       const background = model.renderable.getBackground();
-      model.context.clearColor(background[0], background[1], background[2], 1.0);
+      if (background.length === 3) background.push(1.0);
+      model.context.clearColor(...background);
       clearMask |= gl.COLOR_BUFFER_BIT;
     }
 

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -136,7 +136,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
 
     if (!model.renderable.getTransparent()) {
       const background = model.renderable.getBackground();
-      if (background.length === 3) background.push(1.0);
+      // renderable ensures that background has 4 entries.
       model.context.clearColor(...background);
       clearMask |= gl.COLOR_BUFFER_BIT;
     }

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -360,7 +360,11 @@ export function setArray(publicAPI, model, fieldNames, size) {
         array = array[0];
       }
 
-      if (array.length !== size) {
+      if (Array.isArray(size)) {
+        if (!size.includes(array.length)) {
+          throw new RangeError('Invalid number of values for array setter');
+        }
+      } else if (array.length !== size) {
         throw new RangeError('Invalid number of values for array setter');
       }
       let changeDetected = false;

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -344,9 +344,10 @@ export function getArray(publicAPI, model, fieldNames) {
 
 // ----------------------------------------------------------------------------
 // setXXX: add setter for object of type array
+// if 'defaultVal' is supplied, shorter arrays will be padded to 'size' with 'defaultVal'
 // ----------------------------------------------------------------------------
 
-export function setArray(publicAPI, model, fieldNames, size) {
+export function setArray(publicAPI, model, fieldNames, size, defaultVal = undefined) {
   fieldNames.forEach((field) => {
     publicAPI[`set${capitalize(field)}`] = (...args) => {
       if (model.deleted) {
@@ -360,12 +361,13 @@ export function setArray(publicAPI, model, fieldNames, size) {
         array = array[0];
       }
 
-      if (Array.isArray(size)) {
-        if (!size.includes(array.length)) {
+      if (array.length !== size) {
+        if (array.length < size && defaultVal !== undefined) {
+          array = [].concat(array);
+          while (array.length < size) array.push(defaultVal);
+        } else {
           throw new RangeError('Invalid number of values for array setter');
         }
-      } else if (array.length !== size) {
-        throw new RangeError('Invalid number of values for array setter');
       }
       let changeDetected = false;
       model[field].forEach((item, index) => {
@@ -377,7 +379,7 @@ export function setArray(publicAPI, model, fieldNames, size) {
         }
       });
 
-      if (changeDetected) {
+      if (changeDetected || model[field].length !== array.length) {
         model[field] = [].concat(array);
         publicAPI.modified();
       }
@@ -390,9 +392,9 @@ export function setArray(publicAPI, model, fieldNames, size) {
 // set/get XXX: add setter and getter for object of type array
 // ----------------------------------------------------------------------------
 
-export function setGetArray(publicAPI, model, fieldNames, size) {
+export function setGetArray(publicAPI, model, fieldNames, size, defaultVal = undefined) {
   getArray(publicAPI, model, fieldNames);
-  setArray(publicAPI, model, fieldNames, size);
+  setArray(publicAPI, model, fieldNames, size, defaultVal);
 }
 
 // ----------------------------------------------------------------------------

--- a/Utilities/ParaView/export-scene-macro.py
+++ b/Utilities/ParaView/export-scene-macro.py
@@ -224,7 +224,7 @@ def writeDataSet(filePath, dataset, outputDir, colorArrayInfo, newDSName = None,
   if writer:
     writer(datasetDir, dataDir, dataset, colorArrayInfo, root, compress)
   else:
-    print dataObject.GetClassName(), 'is not supported'
+    print (dataObject.GetClassName(), 'is not supported')
 
   with open(os.path.join(datasetDir, "index.json"), 'w') as f:
     f.write(json.dumps(root, indent=2))
@@ -280,10 +280,10 @@ scDirs = []
 sceneComponents = []
 componentIndex = 0
 
-for rIdx in xrange(renderers.GetNumberOfItems()):
+for rIdx in range(renderers.GetNumberOfItems()):
   renderer = renderers.GetItemAsObject(rIdx)
   renProps = renderer.GetViewProps()
-  for rpIdx in xrange(renProps.GetNumberOfItems()):
+  for rpIdx in range(renProps.GetNumberOfItems()):
     renProp = renProps.GetItemAsObject(rpIdx)
     if not renProp.GetVisibility():
       continue
@@ -421,4 +421,4 @@ finally:
 
 shutil.rmtree(outputDir)
 
-print 'Finished exporting dataset to: ',sceneFileName
+print ('Finished exporting dataset to: ',sceneFileName)


### PR DESCRIPTION
Expand the setArray macro to allow mulitple array sizes.
Allow a background color of 3 or 4. If it's length 3, assume opaque.

Also fix export-scene-macro.py to be Py3 compatible.

@martinken @scottwittenburg Here's the change that allows a background image/div to show through.