### PR TITLE
fix(Rendering): fix an issue with textures of short/int

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -189,7 +189,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   publicAPI.getDefaultTextureInternalFormat = (vtktype, numComps, useFloat) => {
     if (model.webgl2) {
       switch (vtktype) {
-        default:
         case VtkDataTypes.UNSIGNED_CHAR:
           switch (numComps) {
             case 1: return model.context.R8;
@@ -199,6 +198,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
             default:
               return model.context.RGBA8;
           }
+        default:
         case VtkDataTypes.FLOAT:
           switch (numComps) {
             case 1: return model.context.R16F;


### PR DESCRIPTION
There was a mismatch in the code for Webgl2 that caused
issues when using data types other than float/uchar in
textures