### PR TITLE
fix(Rendering): fix world to view conversions

### DIFF
--- a/Sources/Rendering/Core/InteractorObserver/index.js
+++ b/Sources/Rendering/Core/InteractorObserver/index.js
@@ -58,10 +58,8 @@ function vtkInteractorObserver(publicAPI, model) {
       return null;
     }
 
-    const ndp =
-      model.interactor.getView().displayToNormalizedDisplay(x, y, z);
-
-    return model.currentRenderer.normalizedDisplayToWorld(ndp[0], ndp[1], ndp[2]);
+    return model.interactor.getView().displayToWorld(
+      x, y, z, model.currentRenderer);
   };
 
   //----------------------------------------------------------------------------
@@ -72,9 +70,8 @@ function vtkInteractorObserver(publicAPI, model) {
       return null;
     }
 
-    const ndp = model.currentRenderer.worldToNormalizedDisplay(x, y, z);
-
-    return model.interactor.getView().normalizedDisplayToDisplay(ndp[0], ndp[1], ndp[2]);
+    return model.interactor.getView().worldToDisplay(
+      x, y, z, model.currentRenderer);
   };
 
   //----------------------------------------------------------------------------

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -200,20 +200,23 @@ function vtkRenderer(publicAPI, model) {
     model.createdLight.setFocalPoint(publicAPI.getActiveCamera().getFocalPoint());
   };
 
-  publicAPI.normalizedDisplayToWorld = (x, y, z) => {
+  // requires the aspect ratio of the viewport as X/Y
+  publicAPI.normalizedDisplayToWorld = (x, y, z, aspect) => {
     const vpd = publicAPI.normalizedDisplayToView(x, y, z);
 
-    return publicAPI.viewToWorld(vpd[0], vpd[1], vpd[2]);
+    return publicAPI.viewToWorld(vpd[0], vpd[1], vpd[2], aspect);
   };
 
-  publicAPI.worldToNormalizedDisplay = (x, y, z) => {
+  // requires the aspect ratio of the viewport as X/Y
+  publicAPI.worldToNormalizedDisplay = (x, y, z, aspect) => {
     const vpd = publicAPI.worldToView(x, y, z);
 
-    return publicAPI.viewToNormalizedDisplay(vpd[0], vpd[1], vpd[2]);
+    return publicAPI.viewToNormalizedDisplay(vpd[0], vpd[1], vpd[2], aspect);
   };
 
 
-  publicAPI.viewToWorld = (x, y, z) => {
+  // requires the aspect ratio of the viewport as X/Y
+  publicAPI.viewToWorld = (x, y, z, aspect) => {
     if (model.activeCamera === null) {
       vtkErrorMacro('ViewToWorld: no active camera, cannot compute view to world, returning 0,0,0');
       return [0, 0, 0];
@@ -221,8 +224,7 @@ function vtkRenderer(publicAPI, model) {
 
     // get the perspective transformation from the active camera
     const matrix = model.activeCamera
-      .getCompositeProjectionTransformMatrix(1.0, 0, 1);
-//                    publicAPI.getTiledAspectRatio(), 0, 1);
+      .getCompositeProjectionTransformMatrix(aspect, -1.0, 1.0);
 
     mat4.invert(matrix, matrix);
     mat4.transpose(matrix, matrix);
@@ -234,7 +236,8 @@ function vtkRenderer(publicAPI, model) {
   };
 
   // Convert world point coordinates to view coordinates.
-  publicAPI.worldToView = (x, y, z) => {
+  // requires the aspect ratio of the viewport as X/Y
+  publicAPI.worldToView = (x, y, z, aspect) => {
     if (model.activeCamera === null) {
       vtkErrorMacro('ViewToWorld: no active camera, cannot compute view to world, returning 0,0,0');
       return [0, 0, 0];
@@ -242,8 +245,7 @@ function vtkRenderer(publicAPI, model) {
 
     // get the perspective transformation from the active camera
     const matrix = model.activeCamera
-      .getCompositeProjectionTransformMatrix(1.0, 0, 1);
-//                    publicAPI.getTiledAspectRatio(), 0, 1);
+      .getCompositeProjectionTransformMatrix(aspect, -1.0, 1.0);
     mat4.transpose(matrix, matrix);
 
     const result = vec3.fromValues(x, y, z);

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -120,6 +120,28 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   publicAPI.normalizedDisplayToDisplay = (x, y, z) =>
     [x * model.size[0], y * model.size[1], z];
 
+  publicAPI.worldToView = (x, y, z, renderer) => {
+    const dims = publicAPI.getViewportSize(renderer);
+    return renderer.worldToView(y, y, z, dims[0] / dims[1]);
+  };
+
+  publicAPI.viewToWorld = (x, y, z, renderer) => {
+    const dims = publicAPI.getViewportSize(renderer);
+    return renderer.viewToWorld(y, y, z, dims[0] / dims[1]);
+  };
+
+  publicAPI.worldToDisplay = (x, y, z, renderer) => {
+    const val = publicAPI.worldToView(x, y, z, renderer);
+    const val2 = renderer.viewToNormalizedDisplay(val[0], val[1], val[2]);
+    return publicAPI.normalizedDisplayToDisplay(val2[0], val2[1], val2[2]);
+  };
+
+  publicAPI.displayToWorld = (x, y, z, renderer) => {
+    const val = publicAPI.displayToNormalized(x, y, z);
+    const val2 = renderer.normalizedDisplayToView(val[0], val[1], val[2]);
+    return publicAPI.viewToWorld(val2[0], val2[1], val2[2], renderer);
+  };
+
   publicAPI.getPixelData = (x1, y1, x2, y2) => {
     const pixels = new Uint8Array((x2 - x1 + 1) * (y2 - y1 + 1) * 4);
     model.context.readPixels(


### PR DESCRIPTION
The world to view conversions in Renderer were hardcoded to
a 1.0 aspect ratio and an incorrect zvalue range. This change
requires the aspect ratio to be passed in. As a convinience
when doing conversions that involve world -- view methods
have been added on the view (OpenGL/RenderWindow). These
methods take the renderer as an argument and include display -- world
and view -- world conversions.