### PR TITLE
fix(OpenGLRenderWindow): Call the right function to convert display coord

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -137,7 +137,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   };
 
   publicAPI.displayToWorld = (x, y, z, renderer) => {
-    const val = publicAPI.displayToNormalized(x, y, z);
+    const val = publicAPI.displayToNormalizedDisplay(x, y, z);
     const val2 = renderer.normalizedDisplayToView(val[0], val[1], val[2]);
     return publicAPI.viewToWorld(val2[0], val2[1], val2[2], renderer);
   };


### PR DESCRIPTION
@martinken , is this PR is relevant ? Because I have an error when I press shift + mouse click and move.