### PR TITLE
Add widget notion (+ widget representation)

### DIFF
--- a/Sources/Interaction/Widgets/AbstractWidget/api.md
+++ b/Sources/Interaction/Widgets/AbstractWidget/api.md
@@ -1,0 +1,35 @@
+## Introduction
+
+AbstractWidget define the API for widget. It can't be instanciated.
+
+## See Also
+
+[vtkHandleWidget]
+
+## widgetRep (set/get vtkWidgetRepresentation)
+
+Set the representation of the widget. The object needs to be inherited from vtkWidgetRepresentation
+
+## parent (set/get vtkAbstractWidget)
+
+Specifying a parent to this widget is used when creating composite widgets.
+
+## createDefaultRepresentation()
+
+Virtual method, needs to be overrides in derived class.
+It defines the representation of the widget
+
+## listenEvents()
+
+Virtual method, needs to be overrides in derived class.
+It defined which methods will be invoked for each event (see vtkHandleWidget)
+
+## render()
+
+Render the interactor.
+
+## setEnable(bool)
+
+Enable or disable the widget.
+When the widget is enabled, then the default representation is created.
+

--- a/Sources/Interaction/Widgets/AbstractWidget/index.js
+++ b/Sources/Interaction/Widgets/AbstractWidget/index.js
@@ -1,0 +1,115 @@
+import macro                 from 'vtk.js/Sources/macro';
+import vtkInteractorObserver from 'vtk.js/Sources/Rendering/Core/InteractorObserver';
+
+const { vtkErrorMacro } = macro;
+
+// ----------------------------------------------------------------------------
+// vtkAbstractWidget methods
+// ----------------------------------------------------------------------------
+
+function vtkAbstractWidget(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkAbstractWidget');
+
+  // Virtual method
+  publicAPI.createDefaultRepresentation = () => {
+  };
+
+  // Virtual method
+  publicAPI.listenEvents = () => {
+  };
+
+  publicAPI.render = () => {
+    if (!model.parent && model.interactor) {
+      model.interactor.render();
+    }
+  };
+
+  publicAPI.setEnable = (enable) => {
+    if (enable) {
+      if (model.enabled) { // widget already enabled
+        return;
+      }
+      if (!model.interactor) {
+        vtkErrorMacro('The interactor must be set prior to enabling the widget');
+        return;
+      }
+
+      const eventPosition = model.interactor.getEventPosition();
+      let X = 0;
+      let Y = 0;
+      if (eventPosition) {
+        X = eventPosition[0];
+        Y = eventPosition[1];
+      }
+
+      if (!model.currentRenderer) {
+        model.currentRenderer = model.interactor.findPokedRenderer(X, Y);
+        if (!model.currentRenderer) {
+          return;
+        }
+      }
+      model.enabled = 1;
+      publicAPI.createDefaultRepresentation();
+      model.widgetRep.setRenderer(model.currentRenderer);
+
+      // Enable listening events
+      publicAPI.listenEvents();
+
+      model.widgetRep.buildRepresentation();
+      model.currentRenderer.addViewProp(model.widgetRep);
+    } else {
+      if (!model.enabled) { // already
+        return;
+      }
+      model.enabled = 0;
+
+      // Don't listen events
+      while (model.unsubscribes.length) {
+        model.unsubscribes.pop().unsubscribe();
+      }
+
+      if (model.currentRenderer) {
+        model.currentRenderer.removeViewProp(model.widgetRep);
+      }
+      model.currentRenderer = null;
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  widgetRep: null,
+  parent: null,
+  unsubscribes: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkInteractorObserver.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, [
+    'widgetRep',
+    'parent',
+  ]);
+
+  model.unsubscribes = [];
+
+  // Object methods
+  vtkAbstractWidget(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkAbstractWidget');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Widgets/HandleRepresentation/Constants.js
+++ b/Sources/Interaction/Widgets/HandleRepresentation/Constants.js
@@ -1,0 +1,11 @@
+export const InteractionState = {
+  OUTSIDE: 0,
+  NEARBY: 1,
+  SELECTING: 2,
+  TRANSLATING: 3,
+  SCALING: 4,
+};
+
+export default {
+  InteractionState,
+};

--- a/Sources/Interaction/Widgets/HandleRepresentation/api.md
+++ b/Sources/Interaction/Widgets/HandleRepresentation/api.md
@@ -1,0 +1,23 @@
+## Introduction
+
+Class use to convert coordinate for widgetRepresentation
+
+## See also
+
+[vtkWidgetRepresentation]
+
+## setDisplayPosition(position)
+
+Set the current display position that will be converted
+
+## getDisplayPosition
+
+Return the display position
+
+## setWorldPosition(position)
+
+Set the current world position that will be converted
+
+## getWorldPosition
+
+Return the world position

--- a/Sources/Interaction/Widgets/HandleRepresentation/index.js
+++ b/Sources/Interaction/Widgets/HandleRepresentation/index.js
@@ -1,0 +1,98 @@
+import macro                   from 'vtk.js/Sources/macro';
+import Constants               from 'vtk.js/Sources/Interaction/Widgets/HandleRepresentation/Constants';
+import vtkCoordinate           from 'vtk.js/Sources/Rendering/Core/Coordinate';
+import vtkPointPlacer          from 'vtk.js/Sources/Interaction/Widgets/PointPlacer';
+import vtkWidgetRepresentation from 'vtk.js/Sources/Interaction/Widgets/WidgetRepresentation';
+
+const { InteractionState } = Constants;
+
+// ----------------------------------------------------------------------------
+// vtkHandleRepresentation methods
+// ----------------------------------------------------------------------------
+
+function vtkHandleRepresentation(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkHandleRepresentation');
+
+  publicAPI.setDisplayPosition = (displayPos) => {
+    if (model.renderer && model.pointPlacer) {
+      const worldPos = [];
+      if (model.pointPlacer.computeWorldPosition(model.renderer, displayPos, worldPos)) {
+        model.displayPosition.setValue(displayPos);
+        model.worldPosition.setValue(worldPos);
+      }
+    } else {
+      model.displayPosition.setValue(displayPos);
+    }
+  };
+
+  publicAPI.getDisplayPosition = (pos) => {
+    if (model.renderer) {
+      const p = model.worldPosition.getComputedDisplayValue(model.renderer);
+      model.displayPosition.setValue(p[0], p[1], 0.0);
+    }
+    pos[0] = model.displayPosition.getValue()[0];
+    pos[1] = model.displayPosition.getValue()[1];
+    pos[2] = model.displayPosition.getValue()[2];
+  };
+
+  publicAPI.getDisplayPosition = () => {
+    if (model.renderer) {
+      const p = model.worldPosition.getComputedDisplayValue(model.renderer);
+      model.displayPosition.setValue(p[0], p[1], 0.0);
+    }
+    return model.displayPosition.getValue();
+  };
+
+  publicAPI.setWorldPosition = (pos) => {
+    model.worldPosition.setValue(pos);
+  };
+
+  publicAPI.getWorldPosition = (pos) => {
+    model.worldPosition.getValue(pos);
+  };
+
+  publicAPI.getWorldPosition = () => model.worldPosition.getValue();
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  displayPosition: null,
+  worldPosition: null,
+  tolerance: 15,
+  activeRepresentation: 0,
+  constrained: 0,
+  pointPlacer: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkWidgetRepresentation.extend(publicAPI, model, initialValues);
+
+  model.displayPosition = vtkCoordinate.newInstance();
+  model.displayPosition.setCoordinateSystemToDisplay();
+  model.worldPosition = vtkCoordinate.newInstance();
+  model.worldPosition.setCoordinateSystemToWorld();
+  model.pointPlacer = vtkPointPlacer.newInstance();
+  model.interactionState = InteractionState.OUTSIDE;
+
+  macro.setGet(publicAPI, model, ['activeRepresentation']);
+
+  // Object methods
+  vtkHandleRepresentation(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkHandleRepresentation');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Widgets/HandleWidget/Constants.js
+++ b/Sources/Interaction/Widgets/HandleWidget/Constants.js
@@ -1,0 +1,8 @@
+export const WidgetState = {
+  START: 0,
+  ACTIVE: 1,
+};
+
+export default {
+  WidgetState,
+};

--- a/Sources/Interaction/Widgets/HandleWidget/api.md
+++ b/Sources/Interaction/Widgets/HandleWidget/api.md
@@ -1,0 +1,33 @@
+## Introduction
+
+General widget for moving handles (translate and scale)
+
+## See Also
+
+[vtkAbstractWidget]
+
+## Caught events
+
+List of event catch by the widget :
+- MouseMove
+- LeftButtonPress
+- LeftButtonRelease
+- MiddleButtonPress
+- MiddleButtonRelease
+- RightButtonPress
+- RightButtonRelease
+
+## createDefaultRepresentation()
+
+Create a vtkSphereHandleRepresentation as a default representation.
+
+## listenEvents()
+
+For each events, define a method called when event is caught :
+- onMouseMove then call handleMouseMove
+- onLeftButtonPress then call handleLeftButtonPress
+- ...
+
+## allowHandleResize (set/get bool)
+
+Define if the widget representation can be resized (default is true)

--- a/Sources/Interaction/Widgets/HandleWidget/example/index.js
+++ b/Sources/Interaction/Widgets/HandleWidget/example/index.js
@@ -1,0 +1,35 @@
+import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkHandleWidget           from 'vtk.js/Sources/Interaction/Widgets/HandleWidget';
+
+// ----------------------------------------------------------------------------
+// USER AVAILABLE INTERACTIONS
+// ----------------------------------------------------------------------------
+// Sphere can be translated by clicking with mouse left on it
+// Sphere can be scaled by clicking with mouse right
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance();
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+renderWindow.getInteractor().setInteractorStyle(null);
+
+// ----------------------------------------------------------------------------
+// Create widget
+// ----------------------------------------------------------------------------
+const widget = vtkHandleWidget.newInstance();
+widget.setInteractor(renderWindow.getInteractor());
+widget.setEnable(1);
+
+renderWindow.render();
+
+// -----------------------------------------------------------
+// Make some variables global so that you can inspect and
+// modify objects in your browser's developer console:
+// -----------------------------------------------------------
+
+global.renderer = renderer;
+global.renderWindow = renderWindow;
+global.widget = widget;

--- a/Sources/Interaction/Widgets/HandleWidget/index.js
+++ b/Sources/Interaction/Widgets/HandleWidget/index.js
@@ -1,0 +1,220 @@
+import macro                         from 'vtk.js/Sources/macro';
+import vtkAbstractWidget             from 'vtk.js/Sources/Interaction/Widgets/AbstractWidget';
+import vtkSphereHandleRepresentation from 'vtk.js/Sources/Interaction/Widgets/SphereHandleRepresentation';
+
+import { InteractionState }          from '../HandleRepresentation/Constants';
+import { WidgetState }               from './Constants';
+
+const { vtkErrorMacro } = macro;
+
+// ----------------------------------------------------------------------------
+// vtkHandleWidget methods
+// ----------------------------------------------------------------------------
+
+const events = [
+  'MouseMove',
+  'LeftButtonPress',
+  'LeftButtonRelease',
+  'MiddleButtonPress',
+  'MiddleButtonRelease',
+  'RightButtonPress',
+  'RightButtonRelease',
+];
+
+function vtkHandleWidget(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkHandleWidget');
+
+  function setCursor(state) {
+    switch (state) {
+      case InteractionState.OUTSIDE: {
+        model.interactor.getView().setCursor('default');
+        break;
+      }
+      default: {
+        model.interactor.getView().setCursor('pointer');
+      }
+    }
+  }
+
+  function genericAction() {
+    setCursor(model.widgetRep.getInteractionState());
+    model.widgetRep.highlight(1);
+    // publicAPI.startInteraction();
+    publicAPI.invokeStartInteractionEvent();
+    publicAPI.render();
+  }
+
+  // Overriden method
+  publicAPI.createDefaultRepresentation = () => {
+    if (!model.widgetRep) {
+      model.widgetRep = vtkSphereHandleRepresentation.newInstance();
+    }
+  };
+
+  // Implemented method
+  publicAPI.listenEvents = () => {
+    if (!model.interactor) {
+      vtkErrorMacro('The interactor must be set before listening events');
+      return;
+    }
+    events.forEach((eventName) => {
+      model.unsubscribes.push(
+      model.interactor[`on${eventName}`](() => {
+        if (publicAPI[`handle${eventName}`]) {
+          publicAPI[`handle${eventName}`]();
+        }
+      }));
+    });
+  };
+
+  publicAPI.setInteractor = (i) => {
+    if (i === model.interactor) {
+      return;
+    }
+
+    // if we already have an Interactor then stop observing it
+    if (model.interactor) {
+      while (model.unsubscribes.length) {
+        model.unsubscribes.pop().unsubscribe();
+      }
+    }
+
+    model.interactor = i;
+
+    if (i) {
+      publicAPI.listenEvents();
+    }
+  };
+
+  publicAPI.handleMouseMove = () => {
+    publicAPI.moveAction();
+  };
+
+  publicAPI.handleLeftButtonPress = () => {
+    publicAPI.selectAction();
+  };
+
+  publicAPI.handleLeftButtonRelease = () => {
+    publicAPI.endSelectAction();
+  };
+
+  publicAPI.handleMiddleButtonPress = () => {
+    publicAPI.translateAction();
+  };
+
+  publicAPI.handleMiddleButtonRelease = () => {
+    publicAPI.endSelectAction();
+  };
+
+  publicAPI.handleRightButtonPress = () => {
+    publicAPI.scaleAction();
+  };
+
+  publicAPI.handleRightButtonRelease = () => {
+    publicAPI.endSelectAction();
+  };
+
+  publicAPI.selectAction = () => {
+    const pos = model.interactor.getEventPosition(model.interactor.getPointerIndex());
+    const boundingContainer = model.interactor.getCanvas().getBoundingClientRect();
+    const position = [pos.x - boundingContainer.left, pos.y + boundingContainer.top];
+    model.widgetRep.computeInteractionState(position);
+    if (model.widgetRep.getInteractionState() === InteractionState.OUTSIDE) {
+      return;
+    }
+
+    model.widgetRep.startComplexWidgetInteraction(position);
+    model.widgetState = WidgetState.ACTIVE;
+    model.widgetRep.setInteractionState(InteractionState.SELECTING);
+    genericAction();
+  };
+
+  publicAPI.translateAction = () => {
+    const pos = model.interactor.getEventPosition(model.interactor.getPointerIndex());
+    const boundingContainer = model.interactor.getCanvas().getBoundingClientRect();
+    const position = [pos.x - boundingContainer.left, pos.y + boundingContainer.top];
+    model.widgetRep.startComplexWidgetInteraction(position);
+    if (model.widgetRep.getInteractionState() === InteractionState.OUTSIDE) {
+      return;
+    }
+    model.widgetState = WidgetState.ACTIVE;
+    model.widgetRep.setInteractionState(InteractionState.TRANSLATING);
+    genericAction();
+  };
+
+  publicAPI.scaleAction = () => {
+    if (model.allowHandleResize) {
+      const pos = model.interactor.getEventPosition(model.interactor.getPointerIndex());
+      const boundingContainer = model.interactor.getCanvas().getBoundingClientRect();
+      const position = [pos.x - boundingContainer.left, pos.y + boundingContainer.top];
+      model.widgetRep.startComplexWidgetInteraction(position);
+      if (model.widgetRep.getInteractionState() === InteractionState.OUTSIDE) {
+        return;
+      }
+      model.widgetState = WidgetState.ACTIVE;
+      model.widgetRep.setInteractionState(InteractionState.SCALING);
+      genericAction();
+    }
+  };
+
+  publicAPI.endSelectAction = () => {
+    if (model.widgetState !== WidgetState.ACTIVE) {
+      return;
+    }
+    model.widgetState = WidgetState.START;
+    model.widgetRep.highlight(0);
+    publicAPI.invokeEndInteractionEvent();
+    publicAPI.render();
+  };
+
+  publicAPI.moveAction = () => {
+    const pos = model.interactor.getEventPosition(model.interactor.getPointerIndex());
+    const boundingContainer = model.interactor.getCanvas().getBoundingClientRect();
+    const position = [pos.x - boundingContainer.left, pos.y + boundingContainer.top];
+    if (model.widgetState === WidgetState.START) {
+      const state = model.widgetRep.getInteractionState();
+      model.widgetRep.computeInteractionState(position);
+      setCursor(model.widgetRep.getInteractionState());
+      if (model.widgetRep.getActiveRepresentation() && state !== model.widgetRep.getInteractionState()) {
+        publicAPI.render();
+      }
+      return;
+    }
+
+    model.widgetRep.complexWidgetInteraction(position);
+    publicAPI.invokeInteractionEvent();
+    publicAPI.render();
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  allowHandleResize: 1,
+  widgetState: WidgetState.START,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkAbstractWidget.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, ['allowHandleResize']);
+
+  // Object methods
+  vtkHandleWidget(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkHandleWidget');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Widgets/PointPlacer/api.md
+++ b/Sources/Interaction/Widgets/PointPlacer/api.md
@@ -1,0 +1,18 @@
+## Introduction
+
+Abstract interface to translate 2D display positions to world coordinates
+
+## pixelTolerance (set/get Number)
+
+Define the pixel tolerance (default = 5)
+
+## worldTolerance (set/get Number)
+
+Define the worls tolerance (default = 0.001)
+
+## computeWorkdPositon(renderer, displayPos, worldPos)
+
+- renderer : vtkRenderer
+- displayPos : 2D position
+- worldPos : computed world position filled in the function
+Return 1 if success to convert position, else 0

--- a/Sources/Interaction/Widgets/PointPlacer/index.js
+++ b/Sources/Interaction/Widgets/PointPlacer/index.js
@@ -1,0 +1,55 @@
+import macro         from 'vtk.js/Sources/macro';
+import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
+
+// ----------------------------------------------------------------------------
+// vtkPointPlacer methods
+// ----------------------------------------------------------------------------
+
+function vtkPointPlacer(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkPointPlacer');
+
+  publicAPI.computeWorldPosition = (renderer, displayPos, worldPos) => {
+    if (renderer) {
+      const dPos = vtkCoordinate.newInstance();
+      dPos.setCoordinateSystemToDisplay();
+      dPos.setValue(displayPos[0], displayPos[1]);
+      worldPos[0] = dPos.getComputedWorldValue(renderer)[0];
+      worldPos[1] = dPos.getComputedWorldValue(renderer)[1];
+      worldPos[2] = dPos.getComputedWorldValue(renderer)[2];
+      return 1;
+    }
+    return 0;
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  pixelTolerance: 5,
+  worldTolerance: 0.001,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Build VTK API
+  macro.obj(publicAPI, model);
+
+  macro.setGet(publicAPI, model, ['pixelTolerance', 'worldTolerance']);
+
+  // Object methods
+  vtkPointPlacer(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkPointPlacer');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Widgets/SphereHandleRepresentation/api.md
+++ b/Sources/Interaction/Widgets/SphereHandleRepresentation/api.md
@@ -1,0 +1,78 @@
+## Introduction
+
+A spherical rendition of point in 3D space
+
+## See also
+
+[vtkHandleRepresentation] [vtkHandleWidget]
+
+## getActors()
+
+Return actors use in the representation. Here, only one actor is used : sphere
+
+## placeWidget(bounds)
+
+Place the widget inside bounds
+
+## setSphereRadius(radius)
+
+Change the radius of the sphere
+
+## getSphereRadius()
+
+Return the current radius of the sphere
+
+## getBounds()
+
+Return the bounds of the widget.
+Here it's the bounds of the sphere.
+
+## setWorldPosition(position)
+
+Set the world position [vtkHandleRepresentation]
+
+## setDisplayPosition(position)
+
+Set the display position [vtkHandleRepresentation]
+
+## setHandleSize (size)
+
+Change the size of the handle
+
+## computeInteractionState(pos)
+
+Compute the current interaction state according to the mouse position
+Returns `InteractionState` enum :
+- OUTSIDE
+- NEARBY
+- SELECTING
+- TRANSLATING
+- SCALING
+
+## determineConstraintAxis(constraint, x)
+
+Determine which axis is constraint
+
+## moveFocus(p1, p2)
+
+Method called if the current interaction state is SELECTING
+
+## translate(p1, p2)
+
+Method called if the current interaction state is TRANSLATING
+
+## sizeBounds()
+
+Update the sphere radius
+
+## scale(p1, p2, eventPos)
+
+Method called if the current interaction state is SCALING
+
+## highlight(highlight)
+
+Change the coloration of the sphere when user clicks on it
+
+## buildRepresentation()
+
+Initialize the sphere radius.

--- a/Sources/Interaction/Widgets/SphereHandleRepresentation/index.js
+++ b/Sources/Interaction/Widgets/SphereHandleRepresentation/index.js
@@ -1,0 +1,349 @@
+import macro                   from 'vtk.js/Sources/macro';
+import vtkActor                from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkCellPicker           from 'vtk.js/Sources/Rendering/Core/CellPicker';
+import vtkHandleRepresentation from 'vtk.js/Sources/Interaction/Widgets/HandleRepresentation';
+import vtkInteractorObserver   from 'vtk.js/Sources/Rendering/Core/InteractorObserver';
+import vtkMapper               from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkMath                 from 'vtk.js/Sources/Common/Core/Math';
+import vtkProperty             from 'vtk.js/Sources/Rendering/Core/Property';
+import vtkSphereSource         from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import { InteractionState }    from '../HandleRepresentation/Constants';
+
+// ----------------------------------------------------------------------------
+// vtkSphereHandleRepresentation methods
+// ----------------------------------------------------------------------------
+
+function vtkSphereHandleRepresentation(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkSphereHandleRepresentation');
+
+  const superClass = Object.assign({}, publicAPI);
+
+  publicAPI.getActors = () => model.actor;
+
+  publicAPI.placeWidget = (...bounds) => {
+    let boundsArray = [];
+
+    if (Array.isArray(bounds[0])) {
+      boundsArray = bounds[0];
+    } else {
+      for (let i = 0; i < bounds.length; i++) {
+        boundsArray.push(bounds[i]);
+      }
+    }
+
+    if (boundsArray.length !== 6) {
+      return;
+    }
+
+    const newBounds = [];
+    const center = [];
+    publicAPI.adjustBounds(boundsArray, newBounds, center);
+    publicAPI.setWorldPosition(center);
+    for (let i = 0; i < 6; i++) {
+      model.initialBounds[i] = newBounds[i];
+    }
+    model.initialLength = Math.sqrt(
+        ((newBounds[1] - newBounds[0]) * (newBounds[1] - newBounds[0])) +
+        ((newBounds[3] - newBounds[2]) * (newBounds[3] - newBounds[2])) +
+        ((newBounds[5] - newBounds[4]) * (newBounds[5] - newBounds[4])));
+  };
+
+  publicAPI.setSphereRadius = (radius) => {
+    model.sphere.setRadius(radius);
+    model.modified();
+  };
+
+  publicAPI.getSphereRadius = () => model.sphere.getRadius();
+
+  publicAPI.getBounds = () => {
+    const radius = model.sphere.getRadius();
+    const center = model.sphere.getCenter();
+    const bounds = [];
+    bounds[0] = model.placeFactor * (center[0] - radius);
+    bounds[1] = model.placeFactor * (center[0] + radius);
+    bounds[2] = model.placeFactor * (center[1] - radius);
+    bounds[3] = model.placeFactor * (center[1] + radius);
+    bounds[4] = model.placeFactor * (center[2] - radius);
+    bounds[5] = model.placeFactor * (center[2] + radius);
+    return bounds;
+  };
+
+  publicAPI.setWorldPosition = (position) => {
+    model.sphere.setCenter(position);
+    superClass.setWorldPosition(model.sphere.getCenter());
+  };
+
+  publicAPI.setDisplayPosition = (position) => {
+    superClass.setDisplayPosition(position);
+    publicAPI.setWorldPosition(model.worldPosition.getValue());
+  };
+
+  publicAPI.setHandleSize = (size) => {
+    superClass.setHandleSize(size);
+    model.currentHandleSize = model.handleSize;
+  };
+
+  publicAPI.computeInteractionState = (pos) => {
+    model.visibility = 1;
+    const pos3d = [pos[0], pos[1], 0.0];
+    model.cursorPicker.pick(pos3d, model.renderer);
+    const pickedActor = model.cursorPicker.getDataSet();
+    if (pickedActor) {
+      model.interactionState = InteractionState.SELECTING;
+    } else {
+      model.interactionState = InteractionState.OUTSIDE;
+      if (model.activeRepresentation) {
+        model.visibility = 0;
+      }
+    }
+    return model.interactionState;
+  };
+
+  publicAPI.determineConstraintAxis = (constraint, x) => {
+    // Look for trivial cases
+    if (!model.constrained) {
+      return -1;
+    } else if (constraint >= 0 && constraint < 3) {
+      return constraint;
+    }
+    // Okay, figure out constraint. First see if the choice is
+    // outside the hot spot
+    if (!model.waitingForMotion) {
+      const pickedPosition = model.cursorPicker.getPickPosition();
+      const d2 = vtkMath.distance2BetweenPoints(pickedPosition, model.startEventPosition);
+      const tol = model.hotSpotSize * model.initialLength;
+      if (d2 > (tol * tol)) {
+        model.waitingForMotion = 0;
+        return model.cursorPicker.getCellId();
+      }
+      model.waitingForMotion = 1;
+      model.waitCount = 0;
+      return -1;
+    } else if (model.waitingForMotion && x) {
+      model.waitingForMotion = 0;
+      const v = [];
+      v[0] = Math.abs(x[0] - model.startEventPosition[0]);
+      v[1] = Math.abs(x[1] - model.startEventPosition[1]);
+      v[2] = Math.abs(x[2] - model.startEventPosition[2]);
+      return (v[0] > v[1] ? (v[0] > v[2] ? 0 : 2) : (v[1] > v[2] ? 1 : 2));
+    }
+    return -1;
+  };
+
+  publicAPI.startComplexWidgetInteraction = (startEventPos) => {
+    // Record the current event position, and the rectilinear wipe position.
+    model.startEventPosition[0] = startEventPos[0];
+    model.startEventPosition[1] = startEventPos[1];
+    model.startEventPosition[2] = 0.0;
+
+    model.lastEventPosition[0] = startEventPos[0];
+    model.lastEventPosition[1] = startEventPos[1];
+
+    const pos = [startEventPos[0], startEventPos[1], 0];
+    model.cursorPicker.pick(pos, model.renderer);
+    const pickedActor = model.cursorPicker.getDataSet();
+    if (pickedActor) {
+      model.interactionState = InteractionState.SELECTING;
+      model.constraintAxis = publicAPI.determineConstraintAxis(-1, null);
+      model.lastPickPosition = model.cursorPicker.getPickPosition();
+    } else {
+      model.interactionState = InteractionState.OUTSIDE;
+      model.constraintAxis = -1;
+    }
+  };
+
+  publicAPI.complexWidgetInteraction = (eventPos) => {
+    const focalPoint = vtkInteractorObserver.computeDisplayToWorld(model.renderer,
+        model.lastPickPosition[0], model.lastPickPosition[1], model.lastPickPosition[2]);
+    const z = focalPoint[2];
+    const prevPickPoint = vtkInteractorObserver.computeDisplayToWorld(model.renderer,
+        model.lastEventPosition[0], model.lastEventPosition[1], z);
+    const pickPoint = vtkInteractorObserver.computeDisplayToWorld(model.renderer,
+        eventPos[0], eventPos[1], z);
+
+    if (model.interactionState === InteractionState.SELECTING ||
+      model.interactionState === InteractionState.TRANSLATING) {
+      if (!model.waitingForMotion || model.waitCount++ > 3) {
+        model.constraintAxis = publicAPI.determineConstraintAxis(model.constraintAxis, pickPoint);
+        if (model.interactionState === InteractionState.SELECTING && !model.translationMode) {
+          publicAPI.moveFocus(prevPickPoint, pickPoint);
+        } else {
+          publicAPI.translate(prevPickPoint, pickPoint);
+        }
+      }
+    } else if (model.interactionState === InteractionState.SCALING) {
+      publicAPI.scale(prevPickPoint, pickPoint, eventPos);
+    }
+
+    model.lastEventPosition[0] = eventPos[0];
+    model.lastEventPosition[1] = eventPos[1];
+    publicAPI.modified();
+  };
+
+  publicAPI.moveFocus = (p1, p2) => {
+    // get the motion vector
+    const v = [];
+    v[0] = p2[0] - p1[0];
+    v[1] = p2[1] - p1[1];
+    v[2] = p2[2] - p1[2];
+
+    const focus = model.sphere.getCenter();
+    if (model.constraintAxis >= 0) {
+      focus[model.constraintAxis] += v[model.constraintAxis];
+    } else {
+      focus[0] += v[0];
+      focus[1] += v[1];
+      focus[2] += v[2];
+    }
+
+    publicAPI.setWorldPosition(focus);
+  };
+
+  publicAPI.translate = (p1, p2) => {
+    // get the motion vector
+    const v = [];
+    v[0] = p2[0] - p1[0];
+    v[1] = p2[1] - p1[1];
+    v[2] = p2[2] - p1[2];
+
+    const pos = model.sphere.getCenter();
+    if (model.constraintAxis >= 0) {
+      // move along axis
+      for (let i = 0; i < 3; i++) {
+        if (i !== model.constraintAxis) {
+          v[i] = 0.0;
+        }
+      }
+    }
+
+    const newFocus = [];
+    for (let i = 0; i < 3; i++) {
+      newFocus[i] = pos[i] + v[i];
+    }
+    publicAPI.setWorldPosition(newFocus);
+
+    let radius = publicAPI.sizeHandlesInPixels(1.0, newFocus);
+    radius *= model.currentHandleSize / model.handleSize;
+    model.sphere.setRadius(radius);
+  };
+
+  publicAPI.sizeBounds = () => {
+    const center = model.sphere.getCenter();
+    let radius = publicAPI.sizeHandlesInPixels(1.0, center);
+    radius *= model.currentHandleSize / model.handleSize;
+    model.sphere.setRadius(radius);
+  };
+
+  publicAPI.scale = (p1, p2, eventPos) => {
+    // get the motion vector
+    const v = [];
+    v[0] = p2[0] - p1[0];
+    v[1] = p2[1] - p1[1];
+    v[2] = p2[2] - p1[2];
+
+    const bounds = publicAPI.getBounds();
+
+    // Compute the scale factor
+    let sf = vtkMath.norm(v) /
+        Math.sqrt(((bounds[1] - bounds[0]) * (bounds[1] - bounds[0])) +
+            ((bounds[3] - bounds[2]) * (bounds[3] - bounds[2])) +
+            ((bounds[5] - bounds[4]) * (bounds[5] - bounds[4])));
+
+    if (eventPos[1] > model.lastEventPosition[1]) {
+      sf += 1.0;
+    } else {
+      sf = 1.0 - sf;
+    }
+
+    model.currentHandleSize *= sf;
+    model.currentHandleSize = (model.currentHandleSize < 0.001 ? 0.001 : model.currentHandleSize);
+    publicAPI.sizeBounds();
+  };
+
+  publicAPI.highlight = (highlight) => {
+    if (highlight) {
+      model.actor.setProperty(model.selectProperty);
+    } else {
+      model.actor.setProperty(model.property);
+    }
+  };
+
+  publicAPI.buildRepresentation = () => {
+    if (model.renderer) {
+      if (!model.placed) {
+        model.validPick = 1;
+        model.placed = 1;
+      }
+
+      publicAPI.sizeBounds();
+      model.sphere.update();
+      publicAPI.modified();
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  actor: null,
+  mapper: null,
+  sphere: null,
+  cursorPicker: null,
+  lastPickPosition: [0, 0, 0],
+  lastEventPosition: [0, 0],
+  constraintAxis: -1,
+  translationMode: 1,
+  property: null,
+  selectProperty: null,
+  placeFactor: 1,
+  waitingForMotion: 0,
+  hotSpotSize: 0.05,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkHandleRepresentation.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, ['translationMode']);
+  macro.get(publicAPI, model, ['actor']);
+
+  model.sphere = vtkSphereSource.newInstance();
+  model.sphere.setThetaResolution(16);
+  model.sphere.setPhiResolution(8);
+  model.mapper = vtkMapper.newInstance();
+  model.mapper.setInputConnection(model.sphere.getOutputPort());
+  model.actor = vtkActor.newInstance();
+  model.actor.setMapper(model.mapper);
+
+  publicAPI.setHandleSize(15);
+  model.currentHandleSize = model.handleSize;
+
+  model.cursorPicker = vtkCellPicker.newInstance();
+  model.cursorPicker.setPickFromList(1);
+  model.cursorPicker.initializePickList();
+  model.cursorPicker.addPickList(model.actor);
+
+  model.property = vtkProperty.newInstance();
+  model.property.setColor(1, 1, 1);
+  model.selectProperty = vtkProperty.newInstance();
+  model.selectProperty.setColor(0, 1, 0);
+  model.actor.setProperty(model.property);
+
+  // Object methods
+  vtkSphereHandleRepresentation(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkSphereHandleRepresentation');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Widgets/WidgetRepresentation/api.md
+++ b/Sources/Interaction/Widgets/WidgetRepresentation/api.md
@@ -1,0 +1,23 @@
+## Introduction
+
+Abstract class defined interface between widget and widget representation
+
+## See also
+
+[vtkHandleRepresentation]
+
+## getPickedActor(x, y, z, picker)
+
+Find the actor picked by the user (x, y, and z are display coordinate)
+
+## adjustBounds(bounds, newBounds, center)
+
+Recompute the `newBounds` from bounds, center and scale factor (class attributes)
+
+## sizeHandlesInPixels(factor, pos)
+
+Compute the size handles in pixels
+
+## sizeHandlesRelativeToViewport
+
+Compute the size handles relative to viewport

--- a/Sources/Interaction/Widgets/WidgetRepresentation/index.js
+++ b/Sources/Interaction/Widgets/WidgetRepresentation/index.js
@@ -1,0 +1,134 @@
+import macro                 from 'vtk.js/Sources/macro';
+import vtkInteractorObserver from 'vtk.js/Sources/Rendering/Core/InteractorObserver';
+import vtkProp               from 'vtk.js/Sources/Rendering/Core/Prop';
+
+const { vtkErrorMacro } = macro;
+
+// ----------------------------------------------------------------------------
+// vtkWidgetRepresentation methods
+// ----------------------------------------------------------------------------
+
+function vtkWidgetRepresentation(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkWidgetRepresentation');
+
+  publicAPI.getPickedActor = (x, y, z, picker) => {
+    picker.pick(x, y, z, model.renderer);
+    return picker.getActors[0];
+  };
+
+  publicAPI.adjustBounds = (bounds, newBounds, center) => {
+    if (bounds.length !== 6) {
+      vtkErrorMacro("vtkWidgetRepresentation::adjustBounds Can't process bounds, not enough values...");
+      return;
+    }
+
+    center[0] = (bounds[0] + bounds[1]) / 2.0;
+    center[1] = (bounds[2] + bounds[3]) / 2.0;
+    center[2] = (bounds[4] + bounds[5]) / 2.0;
+
+    newBounds[0] = center[0] + (model.placeFactor * (bounds[0] - center[0]));
+    newBounds[1] = center[0] + (model.placeFactor * (bounds[1] - center[0]));
+    newBounds[2] = center[1] + (model.placeFactor * (bounds[2] - center[1]));
+    newBounds[3] = center[1] + (model.placeFactor * (bounds[3] - center[1]));
+    newBounds[4] = center[2] + (model.placeFactor * (bounds[4] - center[2]));
+    newBounds[5] = center[2] + (model.placeFactor * (bounds[5] - center[2]));
+  };
+
+  publicAPI.sizeHandlesInPixels = (factor, pos) => {
+    const renderer = model.renderer;
+    if (!model.validPick || !renderer || !renderer.getActiveCamera()) {
+      return (model.handleSize * factor * model.initialLength);
+    }
+
+    const focalPoint = vtkInteractorObserver.computeWorldToDisplay(renderer, pos[0], pos[1], pos[2]);
+    const z = focalPoint[2];
+
+    let x = focalPoint[0] - (model.handleSize / 2.0);
+    let y = focalPoint[1] - (model.handleSize / 2.0);
+    const lowerLeft = vtkInteractorObserver.computeDisplayToWorld(renderer, x, y, z);
+
+    x = focalPoint[0] + (model.handleSize / 2.0);
+    y = focalPoint[1] + (model.handleSize / 2.0);
+    const upperRight = vtkInteractorObserver.computeDisplayToWorld(renderer, x, y, z);
+
+    let radius = 0.0;
+    for (let i = 0; i < 3; i++) {
+      radius += (upperRight[i] - lowerLeft[i]) * (upperRight[i] - lowerLeft[i]);
+    }
+    return (factor * (Math.sqrt(radius) / 2.0));
+  };
+
+  publicAPI.sizeHandlesRelativeToViewport = (factor, pos) => {
+    const renderer = model.renderer;
+    if (!model.validPick || !renderer || !renderer.getActiveCamera()) {
+      return (model.handleSize * factor * model.initialLength);
+    }
+
+    const viewport = renderer.getViewport();
+    const view = renderer.getRenderWindow().getViews()[0];
+    const winSize = view.getViewportSize(renderer);
+
+    const focalPoint = vtkInteractorObserver.computeWorldToDisplay(renderer, pos[0], pos[1], pos[2]);
+    const z = focalPoint[2];
+
+    let x = winSize[0] * viewport[0];
+    let y = winSize[1] * viewport[1];
+    const windowLowerLeft = vtkInteractorObserver.computeDisplayToWorld(renderer, x, y, z);
+
+    x = winSize[0] * viewport[2];
+    y = winSize[1] * viewport[3];
+    const windowUpperRight = vtkInteractorObserver.computeDisplayToWorld(renderer, x, y, z);
+
+    let radius = 0.0;
+    for (let i = 0; i < 3; i++) {
+      radius += (windowUpperRight[i] - windowLowerLeft[i]) * (windowUpperRight[i] - windowLowerLeft[i]);
+    }
+    return (factor * (Math.sqrt(radius) / 2.0));
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  renderer: null,
+  interactionState: 0,
+  startEventPosition: [0.0, 0.0, 0.0],
+  placeFactor: 0.5,
+  placed: 0,
+  handleSize: 0.05,
+  validPick: 0,
+  initialBounds: [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+  initialLength: 0.0,
+  needToRender: 0,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkProp.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, [
+    'renderer',
+    'handleSize',
+    'placeFactor',
+    'needToRender',
+    'interactionState',
+  ]);
+
+  // Object methods
+  vtkWidgetRepresentation(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkWidgetRepresentation');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Widgets/index.js
+++ b/Sources/Interaction/Widgets/index.js
@@ -1,5 +1,17 @@
+import vtkAbstractWidget from './AbstractWidget';
+import vtkHandleRepresentation from './HandleRepresentation';
+import vtkHandleWidget from './HandleWidget';
 import vtkPiecewiseGaussianWidget from './PiecewiseGaussianWidget';
+import vtkPointPlacer from './PointPlacer';
+import vtkSphereHandleRepresentation from './SphereHandleRepresentation';
+import vtkWidgetRepresentation from './WidgetRepresentation';
 
 export default {
+  vtkAbstractWidget,
+  vtkHandleRepresentation,
+  vtkHandleWidget,
   vtkPiecewiseGaussianWidget,
+  vtkPointPlacer,
+  vtkSphereHandleRepresentation,
+  vtkWidgetRepresentation,
 };

--- a/Sources/Rendering/Core/Coordinate/index.js
+++ b/Sources/Rendering/Core/Coordinate/index.js
@@ -411,6 +411,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Build VTK API
   macro.set(publicAPI, model, ['property']);
+  macro.get(publicAPI, model, ['value']);
   macro.setGet(publicAPI, model, [
     'coordinateSystem',
     'referenceCoordinate',

--- a/Sources/Rendering/Core/InteractorObserver/index.js
+++ b/Sources/Rendering/Core/InteractorObserver/index.js
@@ -8,7 +8,7 @@ import macro from 'vtk.js/Sources/macro';
 // Description:
 // Transform from world to display coordinates.
 function computeWorldToDisplay(renderer, x, y, z) {
-  const view = renderer.getRenderWindow().getView()[0];
+  const view = renderer.getRenderWindow().getViews()[0];
   return view.worldToDisplay(x, y, z, renderer);
 }
 
@@ -16,7 +16,7 @@ function computeWorldToDisplay(renderer, x, y, z) {
 // Description:
 // Transform from display to world coordinates.
 function computeDisplayToWorld(renderer, x, y, z) {
-  const view = renderer.getRenderWindow().getView()[0];
+  const view = renderer.getRenderWindow().getViews()[0];
   return view.displayToWorld(x, y, z, renderer);
 }
 

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -737,6 +737,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Create get-only macros
   macro.get(publicAPI, model, [
     'initialized',
+    'canvas',
     'enabled',
     'enableRender',
     'scale',

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -356,6 +356,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'renderPasses',
     'notifyImageReady',
     'defaultToWebgl2',
+    'cursor',
   ]);
 
   macro.setGetArray(publicAPI, model, [

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -28,9 +28,6 @@ function vtkOpenGLRenderer(publicAPI, model) {
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getActiveCamera());
       publicAPI.addMissingPropNodes(model.renderable.getViewProps());
-      publicAPI.addMissingNodes(model.renderable.getActors());
-      publicAPI.addMissingNodes(model.renderable.getActors2D());
-      publicAPI.addMissingNodes(model.renderable.getVolumes());
       publicAPI.removeUnusedNodes();
     }
   };

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -27,6 +27,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
       publicAPI.updateLights();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getActiveCamera());
+      publicAPI.addMissingPropNodes(model.renderable.getViewProps());
       publicAPI.addMissingNodes(model.renderable.getActors());
       publicAPI.addMissingNodes(model.renderable.getActors2D());
       publicAPI.addMissingNodes(model.renderable.getVolumes());

--- a/Sources/Rendering/OpenGL/ViewNodeFactory/index.js
+++ b/Sources/Rendering/OpenGL/ViewNodeFactory/index.js
@@ -1,4 +1,5 @@
 import macro                   from 'vtk.js/Sources/macro';
+import vtkGenericWidgetRepresentation from 'vtk.js/Sources/Rendering/SceneGraph/GenericWidgetRepresentation';
 import vtkViewNodeFactory      from 'vtk.js/Sources/Rendering/SceneGraph/ViewNodeFactory';
 import vtkOpenGLActor          from 'vtk.js/Sources/Rendering/OpenGL/Actor';
 import vtkOpenGLActor2D        from 'vtk.js/Sources/Rendering/OpenGL/Actor2D';
@@ -57,6 +58,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   publicAPI.registerOverride('vtkTexture', vtkOpenGLTexture.newInstance);
   publicAPI.registerOverride('vtkVolume', vtkOpenGLVolume.newInstance);
   publicAPI.registerOverride('vtkVolumeMapper', vtkOpenGLVolumeMapper.newInstance);
+  publicAPI.registerOverride('vtkWidgetRepresentation', vtkGenericWidgetRepresentation.newInstance);
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/SceneGraph/GenericWidgetRepresentation/index.js
+++ b/Sources/Rendering/SceneGraph/GenericWidgetRepresentation/index.js
@@ -1,0 +1,38 @@
+import macro       from 'vtk.js/Sources/macro';
+import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
+
+// ----------------------------------------------------------------------------
+// vtkOpenGLActor methods
+// ----------------------------------------------------------------------------
+
+function vtkGenericWidgetRepresentation(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkGenericWidgetRepresentation');
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkViewNode.extend(publicAPI, model, initialValues);
+
+  // Object methods
+  vtkGenericWidgetRepresentation(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Rendering/SceneGraph/ViewNodeFactory/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNodeFactory/index.js
@@ -15,10 +15,24 @@ function vtkViewNodeFactory(publicAPI, model) {
     if (dataObject.isDeleted()) {
       return null;
     }
-    if (Object.keys(model.overrides).indexOf(dataObject.getClassName()) === -1) {
+    // if (Object.keys(model.overrides).indexOf(dataObject.getClassName()) === -1) {
+    //   return null;
+    // }
+
+    const hierarchy = dataObject.getHierarchy();
+    let isObject = false;
+    let className = '';
+    for (let i = hierarchy.length - 1; i > 0; i--) {
+      if (Object.keys(model.overrides).indexOf(hierarchy[i]) !== -1) {
+        isObject = true;
+        className = hierarchy[i];
+        break;
+      }
+    }
+    if (!isObject) {
       return null;
     }
-    const vn = model.overrides[dataObject.getClassName()]();
+    const vn = model.overrides[className]();
     vn.setMyFactory(publicAPI);
     return vn;
   };

--- a/Sources/Rendering/SceneGraph/ViewNodeFactory/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNodeFactory/index.js
@@ -15,20 +15,19 @@ function vtkViewNodeFactory(publicAPI, model) {
     if (dataObject.isDeleted()) {
       return null;
     }
-    // if (Object.keys(model.overrides).indexOf(dataObject.getClassName()) === -1) {
-    //   return null;
-    // }
 
-    const hierarchy = dataObject.getHierarchy();
+    let cpt = 0;
+    let className = dataObject.getClassName(cpt++);
     let isObject = false;
-    let className = '';
-    for (let i = hierarchy.length - 1; i > 0; i--) {
-      if (Object.keys(model.overrides).indexOf(hierarchy[i]) !== -1) {
+    const keys = Object.keys(model.overrides);
+    while (className && !isObject) {
+      if (keys.indexOf(className) !== -1) {
         isObject = true;
-        className = hierarchy[i];
-        break;
+      } else {
+        className = dataObject.getClassName(cpt++);
       }
     }
+
     if (!isObject) {
       return null;
     }

--- a/Sources/Rendering/SceneGraph/index.js
+++ b/Sources/Rendering/SceneGraph/index.js
@@ -1,8 +1,10 @@
-import vtkRenderPass      from './RenderPass';
-import vtkViewNode        from './ViewNode';
-import vtkViewNodeFactory from './ViewNodeFactory';
+import vtkGenericWidgetRepresentation from './GenericWidgetRepresentation';
+import vtkRenderPass                  from './RenderPass';
+import vtkViewNode                    from './ViewNode';
+import vtkViewNodeFactory             from './ViewNodeFactory';
 
 export default {
+  vtkGenericWidgetRepresentation,
   vtkRenderPass,
   vtkViewNode,
   vtkViewNodeFactory,

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -233,6 +233,8 @@ export function obj(publicAPI = {}, model = {}) {
 
     publicAPI.modified();
   };
+
+  publicAPI.getHierarchy = () => model.classHierarchy;
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -136,7 +136,7 @@ export function obj(publicAPI = {}, model = {}) {
 
   publicAPI.isA = className => (model.classHierarchy.indexOf(className) !== -1);
 
-  publicAPI.getClassName = () => model.classHierarchy.slice(-1)[0];
+  publicAPI.getClassName = (depth = 0) => model.classHierarchy[model.classHierarchy.length - 1 - depth];
 
   publicAPI.set = (map = {}, noWarning = false, noFunction = false) => {
     let ret = false;
@@ -233,8 +233,6 @@ export function obj(publicAPI = {}, model = {}) {
 
     publicAPI.modified();
   };
-
-  publicAPI.getHierarchy = () => model.classHierarchy;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR add the possibility to create widget.
A handleWidget have been implemented (+ an using example)

Some modifications needs to be added and should be reviewed :
- [vtkCoordinate] the value should be get
- [vtkRenderWindowInteractor] A macro `get ` has been added to the `canvas` because some attributes of the `clientBoundingRect `are used to change 2D picking position. If we don't modify it, then there's a shift when mouse move (cf vtkHandleWidget when we get the event position)
- [vtkOpenGLRenderWindow/vtkViewNode] In VTK, a WidgetRepresentation can have several actors. To avoid adding each actor as actor in the renderer (`addActor`), we would like to only add the representation which will render it's child = actors. So we add a new method which get ViewProps and create a sceneGraph with the representation as a node, and its actors as subnode. (If it's not clear, please tell me)
- [SceneGraphViewNodeFactory/macro] : Instead of testing only the class name to create a node, we check the whole hierarchy. So we change the macro.js file to allow vtkObject to get its all hierarchy.
- A new generic file for the widget representation has been added in order to allow the view node creation of widgetRepresentation. (SceneGraphGenericWidgetRepresentation). Maybe an other name could be set to this file.

@martinken @jourdain We modified a lot of files because we need it and we didn't find an other solution. So don't hesitate to tell us if there's an other way to di it.