### PR TITLE
perf(Cell): Don't recreate vtkPoints when vtkCell is initialize

### DIFF
--- a/Sources/Common/DataModel/Cell/index.js
+++ b/Sources/Common/DataModel/Cell/index.js
@@ -11,15 +11,9 @@ function vtkCell(publicAPI, model) {
   model.classHierarchy.push('vtkCell');
 
   publicAPI.initialize = (npts, pointIdsList, pointList) => {
-    model.pointsIds = [];
-    model.points = vtkPoints.newInstance();
+    model.pointsIds = pointIdsList;
     model.points.setNumberOfPoints(npts);
-    const p = [];
-    for (let i = 0; i < npts; i++) {
-      pointList.getPoint(i, p);
-      model.pointsIds.push(pointIdsList[i]);
-      model.points.setPoint(i, p[0], p[1], p[2]);
-    }
+    model.points.setData(pointList.getData());
   };
 
   publicAPI.getBounds = () => {

--- a/Sources/Rendering/Core/CellPicker/index.js
+++ b/Sources/Rendering/Core/CellPicker/index.js
@@ -267,7 +267,7 @@ function vtkCellPicker(publicAPI, model) {
           }
         }
 
-        if (cellPicked.intersect && cellPicked.t <= (tMin + model.tolerance) &&
+        if (cellPicked.intersect === 1 && cellPicked.t <= (tMin + model.tolerance) &&
           cellPicked.t >= t1 && cellPicked.t <= t2) {
           const pDist = cell.getParametricDistance(pCoords);
           if (pDist < pDistMin || (pDist === pDistMin && cellPicked.t < tMin)) {


### PR DESCRIPTION
We don't want to recreate a vtkPoints when we call initialize on a vtkCell.
With the cellpicker and a mesh with 120000 cells, we pick on 4 sec. With this modification, we pick on 0.5sec.