### PR TITLE
fix(Rendering): make sure scalar visibility works properly

### DIFF
--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -204,7 +204,6 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
     let packedUCVBO = null;
     if (c) {
       colorComponents = c.getNumberOfComponents();
-      vbo.setColorComponents(colorComponents);
       vbo.setColorOffset(0);
       vbo.setColorBOStride(4);
       colorData = c.getData();
@@ -213,7 +212,10 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
         vbo.setColorBO(vtkBufferObject.newInstance());
       }
       vbo.getColorBO().setContext(model.context);
+    } else if (vbo.getColorBO()) {
+      vbo.setColorBO(null);
     }
+    vbo.setColorComponents(colorComponents);
 
     const packedVBO = new Float32Array(pointSize * numPoints * 3);
 

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -320,11 +320,11 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     vbo.getColorBO().setContext(model.context);
     if (c) {
       colorComponents = c.getNumberOfComponents();
-      vbo.setColorComponents(colorComponents);
       vbo.setColorOffset(4);
       colorData = c.getData();
       vbo.setColorBOStride(8);
     }
+    vbo.setColorComponents(colorComponents);
 
     vbo.setStride(pointSize * 4);
 


### PR DESCRIPTION
For Stick and Sphere mappers turing scalar visibility on and
then off would leave the rendering in the on state.