### PR TITLE
fix(Rendering): fix the matrix calc for parallel projection

### DIFF
--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -316,8 +316,7 @@ function vtkCamera(publicAPI, model) {
       const ymin = (model.windowCenter[1] - 1.0) * height;
       const ymax = (model.windowCenter[1] + 1.0) * height;
 
-      // mat4.ortho(out, left, right, bottom, top, near, far)
-      mat4.ortho(projectionMatrix, xmin, xmax, ymin, ymax, nearz, farz);
+      mat4.ortho(projectionMatrix, xmin, xmax, ymin, ymax, cRange[0], cRange[1]);
       mat4.transpose(projectionMatrix, projectionMatrix);
     } else if (model.useOffAxisProjection) {
       throw new Error('Off-Axis projection is not supported at this time');


### PR DESCRIPTION
The clipping range was applied correctly resulting in
bad clippinig of the data.