### PR TITLE
fix(Rendering): some fixes and performance improvements

### DIFF
--- a/Sources/Common/Core/Points/index.js
+++ b/Sources/Common/Core/Points/index.js
@@ -4,6 +4,8 @@ import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 
 const { vtkErrorMacro } = macro;
 
+const INVALID_BOUNDS = [1, -1, 1, -1, 1, -1];
+
 // ----------------------------------------------------------------------------
 // vtkPoints methods
 // ----------------------------------------------------------------------------
@@ -35,21 +37,34 @@ function vtkPoints(publicAPI, model) {
 
   publicAPI.getBounds = () => {
     if (publicAPI.getNumberOfComponents() === 3) {
-      return [].concat(
-        publicAPI.getRange(0),
-        publicAPI.getRange(1),
-        publicAPI.getRange(2));
+      const xRange = publicAPI.getRange(0);
+      model.bounds[0] = xRange[0];
+      model.bounds[1] = xRange[1];
+      const yRange = publicAPI.getRange(1);
+      model.bounds[2] = yRange[0];
+      model.bounds[3] = yRange[1];
+      const zRange = publicAPI.getRange(2);
+      model.bounds[4] = zRange[0];
+      model.bounds[5] = zRange[1];
+      return model.bounds;
     }
 
     if (publicAPI.getNumberOfComponents() !== 2) {
       vtkErrorMacro(`getBounds called on an array with components of
         ${publicAPI.getNumberOfComponents()}`);
-      return [1, -1, 1, -1, 1, -1];
+      return INVALID_BOUNDS;
     }
 
-    return [].concat(
-      publicAPI.getRange(0),
-      publicAPI.getRange(1));
+    const xRange = publicAPI.getRange(0);
+    model.bounds[0] = xRange[0];
+    model.bounds[1] = xRange[1];
+    const yRange = publicAPI.getRange(1);
+    model.bounds[2] = yRange[0];
+    model.bounds[3] = yRange[1];
+    model.bounds[4] = 0;
+    model.bounds[5] = 0;
+
+    return model.bounds;
   };
 
   // Trigger the computation of bounds
@@ -64,6 +79,7 @@ const DEFAULT_VALUES = {
   empty: true,
   numberOfComponents: 3,
   dataType: VtkDataTypes.FLOAT,
+  bounds: [1, -1, 1, -1, 1, -1],
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -79,23 +79,23 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
   publicAPI.handleLeftButtonRelease = () => {
     switch (model.state) {
       case States.IS_DOLLY:
-        publicAPI.setAnimationStateOff();
         publicAPI.endDolly();
+        publicAPI.setAnimationStateOff();
         break;
 
       case States.IS_PAN:
-        publicAPI.setAnimationStateOff();
         publicAPI.endPan();
+        publicAPI.setAnimationStateOff();
         break;
 
       case States.IS_SPIN:
-        publicAPI.setAnimationStateOff();
         publicAPI.endSpin();
+        publicAPI.setAnimationStateOff();
         break;
 
       case States.IS_ROTATE:
-        publicAPI.setAnimationStateOff();
         publicAPI.endRotate();
+        publicAPI.setAnimationStateOff();
         break;
 
       default:

--- a/Sources/Interaction/Widgets/SphereHandleRepresentation/index.js
+++ b/Sources/Interaction/Widgets/SphereHandleRepresentation/index.js
@@ -20,6 +20,7 @@ function vtkSphereHandleRepresentation(publicAPI, model) {
   const superClass = Object.assign({}, publicAPI);
 
   publicAPI.getActors = () => model.actor;
+  publicAPI.getProps = () => model.actor;
 
   publicAPI.placeWidget = (...bounds) => {
     let boundsArray = [];

--- a/Sources/Rendering/Core/InteractorStyle/index.js
+++ b/Sources/Rendering/Core/InteractorStyle/index.js
@@ -194,8 +194,6 @@ function vtkInteractorStyle(publicAPI, model) {
   publicAPI.startState = (state) => {
     model.state = state;
     if (model.animationState === States.IS_ANIM_OFF) {
-      // const rwi = model.interactor;
-      // rwi.getRenderWindow().setDesiredUpdateRate(rwi.getDesiredUpdateRate());
       publicAPI.invokeStartInteractionEvent({ type: 'StartInteractionEvent' });
     }
   };
@@ -204,7 +202,6 @@ function vtkInteractorStyle(publicAPI, model) {
     model.state = States.IS_NONE;
     if (model.animationState === States.IS_ANIM_OFF) {
       const rwi = model.interactor;
-      // rwi.getRenderWindow().setDesiredUpdateRate(rwi.getStillUpdateRate());
       publicAPI.invokeEndInteractionEvent({ type: 'EndInteractionEvent' });
       rwi.render();
     }

--- a/Sources/Rendering/Core/Prop/index.js
+++ b/Sources/Rendering/Core/Prop/index.js
@@ -17,6 +17,7 @@ function vtkProp(publicAPI, model) {
       Math.max(val.getMTime(), acc)
     , 0));
 
+  publicAPI.getProps = () => publicAPI;
   publicAPI.getActors = () => null;
   publicAPI.getActors2D = () => null;
   publicAPI.getVolumes = () => null;

--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -53,7 +53,11 @@ function vtkRenderWindow(publicAPI, model) {
   publicAPI.hasView = view => model.views.indexOf(view) !== -1;
 
   publicAPI.render = () => {
-    model.views.forEach(view => view.traverseAllPasses());
+    if (model.interactor) {
+      model.interactor.render();
+    } else {
+      model.views.forEach(view => view.traverseAllPasses());
+    }
   };
 
   publicAPI.getStatistics = () => {

--- a/Sources/Rendering/Core/Viewport/index.js
+++ b/Sources/Rendering/Core/Viewport/index.js
@@ -34,6 +34,15 @@ function vtkViewport(publicAPI, model) {
     model.props = [];
   };
 
+  // this method get all the props including any nested props
+  publicAPI.getViewPropsWithNestedProps = () => {
+    model.allprops = [];
+    model.props.forEach((prop) => {
+      model.allprops = model.allprops.concat(prop.getProps());
+    });
+    return model.allprops;
+  };
+
   publicAPI.addActor2D = publicAPI.addViewProp;
   publicAPI.removeActor2D = (prop) => {
     // VTK way: model.actors2D.RemoveItem(prop);

--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -14,6 +14,7 @@ function vtkOpenGLActor(publicAPI, model) {
   // Builds myself.
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
+      model.context = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderWindow').getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNodes(model.renderable.getTextures());
       publicAPI.addMissingNode(model.renderable.getMapper());
@@ -90,7 +91,6 @@ function vtkOpenGLActor(publicAPI, model) {
 
   publicAPI.opaquePass = (prepass, renderPass) => {
     if (prepass) {
-      model.context = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderWindow').getContext();
       model.context.depthMask(true);
       publicAPI.activateTextures();
     } else {
@@ -104,7 +104,6 @@ function vtkOpenGLActor(publicAPI, model) {
   // Renders myself
   publicAPI.translucentPass = (prepass, renderPass) => {
     if (prepass) {
-      model.context = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderWindow').getContext();
       model.context.depthMask(false);
       publicAPI.activateTextures();
     } else {

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -27,13 +27,13 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderWindow');
+      model.openGLImageSlice = publicAPI.getFirstAncestorOfType('vtkOpenGLImageSlice');
+      model.openGLRenderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
+      model.openGLRenderWindow = model.openGLRenderer.getParent();
       model.context = model.openGLRenderWindow.getContext();
       model.tris.setContext(model.context);
       model.openGLTexture.setWindow(model.openGLRenderWindow);
       model.openGLTexture.setContext(model.context);
-      model.openGLImageSlice = publicAPI.getFirstAncestorOfType('vtkOpenGLImageSlice');
-      model.openGLRenderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       const ren = model.openGLRenderer.getRenderable();
       model.openGLCamera = model.openGLRenderer.getViewNodeFor(ren.getActiveCamera());
       // is zslice set by the camera

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -27,7 +27,8 @@ function vtkOpenGLRenderer(publicAPI, model) {
       publicAPI.updateLights();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getActiveCamera());
-      publicAPI.addMissingPropNodes(model.renderable.getViewProps());
+      publicAPI.addMissingNodes(
+        model.renderable.getViewPropsWithNestedProps());
       publicAPI.removeUnusedNodes();
     }
   };


### PR DESCRIPTION
Clean up some of the rendering interaction code to better
manage animating and to ignore render calls when in the
middle of interacting. Also remove some calls that were
rendering the still image twice.

Also some code cleanup to improve performance some. Still a ways
to go in cases with hundreds of actors.