### PR TITLE
fix(Rendering): use VAOs on webgl2 contexts

### DIFF
--- a/Sources/Rendering/OpenGL/Helper/index.js
+++ b/Sources/Rendering/OpenGL/Helper/index.js
@@ -11,10 +11,10 @@ function vtkOpenGLHelper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLHelper');
 
-  publicAPI.setContext = (ctx) => {
-    model.program.setContext(ctx);
-    model.VAO.setContext(ctx);
-    model.CABO.setContext(ctx);
+  publicAPI.setWindow = (win) => {
+    model.program.setContext(win.getContext());
+    model.VAO.setWindow(win);
+    model.CABO.setContext(win.getContext());
   };
 
   publicAPI.releaseGraphicsResources = (oglwin) => {

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -31,7 +31,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model.openGLRenderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       model.openGLRenderWindow = model.openGLRenderer.getParent();
       model.context = model.openGLRenderWindow.getContext();
-      model.tris.setContext(model.context);
+      model.tris.setWindow(model.openGLRenderWindow);
       model.openGLTexture.setWindow(model.openGLRenderWindow);
       model.openGLTexture.setContext(model.context);
       const ren = model.openGLRenderer.getRenderable();

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -79,7 +79,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     if (model.context !== ctx) {
       model.context = ctx;
       for (let i = primTypes.Start; i < primTypes.End; i++) {
-        model.primitives[i].setContext(ctx);
+        model.primitives[i].setWindow(model.openGLRenderWindow);
       }
     }
     const actor = model.openGLActor.getRenderable();

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -48,7 +48,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     if (prepass) {
       model.openGLRenderWindow = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderWindow');
       model.context = model.openGLRenderWindow.getContext();
-      model.tris.setContext(model.context);
+      model.tris.setWindow(model.openGLRenderWindow);
       model.scalarTexture.setWindow(model.openGLRenderWindow);
       model.scalarTexture.setContext(model.context);
       model.colorTexture.setWindow(model.openGLRenderWindow);
@@ -832,7 +832,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         const program = model.copyShader;
 
         model.copyVAO = vtkVertexArrayObject.newInstance();
-        model.copyVAO.setContext(model.context);
+        model.copyVAO.setWindow(model.openGLRenderWindow);
 
         model.tris.getCABO().bind();
         if (!model.copyVAO.addAttributeArray(


### PR DESCRIPTION
The old code was using emulation for webgl2 which
is slower and makes no sense.