### PR TITLE
fix(Rendering): fix for prop3d isIdentity and more perf fixes

### DIFF
--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -270,46 +270,52 @@ function vtkRenderer(publicAPI, model) {
   };
 
   publicAPI.computeVisiblePropBounds = () => {
-    const allBounds = [].concat(INIT_BOUNDS);
+    model.allBounds[0] = INIT_BOUNDS[0];
+    model.allBounds[1] = INIT_BOUNDS[1];
+    model.allBounds[2] = INIT_BOUNDS[2];
+    model.allBounds[3] = INIT_BOUNDS[3];
+    model.allBounds[4] = INIT_BOUNDS[4];
+    model.allBounds[5] = INIT_BOUNDS[5];
     let nothingVisible = true;
 
     publicAPI.invokeEvent(COMPUTE_VISIBLE_PROP_BOUNDS_EVENT);
 
     // loop through all props
-    model.props.forEach((prop) => {
+    for (let index = 0; index < model.props.length; ++index) {
+      const prop = model.props[index];
       if (prop.getVisibility() && prop.getUseBounds()) {
         const bounds = prop.getBounds();
         if (bounds && vtkMath.areBoundsInitialized(bounds)) {
           nothingVisible = false;
 
-          if (bounds[0] < allBounds[0]) {
-            allBounds[0] = bounds[0];
+          if (bounds[0] < model.allBounds[0]) {
+            model.allBounds[0] = bounds[0];
           }
-          if (bounds[1] > allBounds[1]) {
-            allBounds[1] = bounds[1];
+          if (bounds[1] > model.allBounds[1]) {
+            model.allBounds[1] = bounds[1];
           }
-          if (bounds[2] < allBounds[2]) {
-            allBounds[2] = bounds[2];
+          if (bounds[2] < model.allBounds[2]) {
+            model.allBounds[2] = bounds[2];
           }
-          if (bounds[3] > allBounds[3]) {
-            allBounds[3] = bounds[3];
+          if (bounds[3] > model.allBounds[3]) {
+            model.allBounds[3] = bounds[3];
           }
-          if (bounds[4] < allBounds[4]) {
-            allBounds[4] = bounds[4];
+          if (bounds[4] < model.allBounds[4]) {
+            model.allBounds[4] = bounds[4];
           }
-          if (bounds[5] > allBounds[5]) {
-            allBounds[5] = bounds[5];
+          if (bounds[5] > model.allBounds[5]) {
+            model.allBounds[5] = bounds[5];
           }
         }
       }
-    });
+    }
 
     if (nothingVisible) {
-      vtkMath.uninitializeBounds(allBounds);
+      vtkMath.uninitializeBounds(model.allBounds);
       vtkDebugMacro('Can\'t compute bounds, no 3D props are visible');
     }
 
-    return allBounds;
+    return model.allBounds;
   };
 
   publicAPI.resetCamera = (bounds = null) => {
@@ -528,6 +534,7 @@ const DEFAULT_VALUES = {
   pickedProp: null,
   activeCamera: null,
 
+  allBounds: [],
   ambient: [1, 1, 1],
 
   allocatedRenderTime: 100,

--- a/Sources/Rendering/Core/Viewport/index.js
+++ b/Sources/Rendering/Core/Viewport/index.js
@@ -37,11 +37,12 @@ function vtkViewport(publicAPI, model) {
   // this method get all the props including any nested props
   publicAPI.getViewPropsWithNestedProps = () => {
     model.allprops = model.props;
-    model.props.forEach((prop) => {
+    for (let index = 0; index < model.props.length; ++index) {
+      const prop = model.props[index];
       if (prop.getNestedProps()) {
         model.allprops = model.allprops.concat(prop.getProps());
       }
-    });
+    }
     return model.allprops;
   };
 

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -294,6 +294,34 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       publicAPI.invokeImageReady(getCanvasDataURL());
     }
   };
+
+  publicAPI.disableDepthMask = () => {
+    if (model.depthMaskEnabled) {
+      model.context.depthMask(false);
+      model.depthMaskEnabled = false;
+    }
+  };
+
+  publicAPI.enableDepthMask = () => {
+    if (!model.depthMaskEnabled) {
+      model.context.depthMask(true);
+      model.depthMaskEnabled = true;
+    }
+  };
+
+  publicAPI.disableCullFace = () => {
+    if (model.cullFaceEnabled) {
+      model.context.disable(model.context.CULL_FACE);
+      model.cullFaceEnabled = false;
+    }
+  };
+
+  publicAPI.enableCullFace = () => {
+    if (!model.cullFaceEnabled) {
+      model.context.enable(model.context.CULL_FACE);
+      model.cullFaceEnabled = true;
+    }
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -301,6 +329,8 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  cullFaceEnabled: false,
+  depthMaskEnabled: true,
   shaderCache: null,
   initialized: false,
   context: null,

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -137,7 +137,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
     if (!model.renderable.getTransparent()) {
       const background = model.renderable.getBackgroundByReference();
       // renderable ensures that background has 4 entries.
-      model.context.clearColor(...background);
+      model.context.clearColor(background[0], background[1], background[2], background[3]);
       clearMask |= gl.COLOR_BUFFER_BIT;
     }
 

--- a/Sources/Rendering/OpenGL/ShaderProgram/index.js
+++ b/Sources/Rendering/OpenGL/ShaderProgram/index.js
@@ -515,6 +515,10 @@ function vtkShaderProgram(publicAPI, model) {
     model.geometryShader.setContext(ctx);
   };
 
+  publicAPI.setLastCameraMTime = (mtime) => {
+    model.lastCameraMTime = mtime;
+  };
+
   // publicAPI.enableAttributeArray = (name) => {
   //   const location = publicAPI.findAttributeArray(name);
   //   if (location === -1) {
@@ -558,6 +562,7 @@ const DEFAULT_VALUES = {
   uniformLocs: null,
   md5Hash: 0,
   context: null,
+  lastCameraMTime: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -577,6 +582,9 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Build VTK API
   macro.obj(publicAPI, model);
+  macro.get(publicAPI, model, [
+    'lastCameraMTime',
+  ]);
   macro.setGet(publicAPI, model, [
     'error',
     'handle',

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -52,10 +52,14 @@ function vtkViewNode(publicAPI, model) {
       return publicAPI;
     }
 
-    return model.children.find((child) => {
+    for (let index = 0; index < model.children.length; ++index) {
+      const child = model.children[index];
       const vn = child.getViewNodeFor(dataObject);
-      return !!vn;
-    });
+      if (vn) {
+        return vn;
+      }
+    }
+    return undefined;
   };
 
   publicAPI.getFirstAncestorOfType = (type) => {

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -138,7 +138,17 @@ export function obj(publicAPI = {}, model = {}) {
 
   publicAPI.getMTime = () => model.mtime;
 
-  publicAPI.isA = className => (model.classHierarchy.indexOf(className) !== -1);
+  publicAPI.isA = (className) => {
+    let count = model.classHierarchy.length;
+    // we go backwards as that is more likely for
+    // early termination
+    while (count--) {
+      if (model.classHierarchy[count] === className) {
+        return true;
+      }
+    }
+    return false;
+  };
 
   publicAPI.getClassName = (depth = 0) => model.classHierarchy[model.classHierarchy.length - 1 - depth];
 
@@ -608,7 +618,12 @@ export function event(publicAPI, model, eventName) {
       return;
     }
     /* eslint-disable prefer-rest-params */
-    callbacks.forEach(callback => callback && callback.apply(publicAPI, arguments));
+    for (let index = 0; index < callbacks.length; ++index) {
+      const cb = callbacks[index];
+      if (cb) {
+        cb.apply(publicAPI, arguments);
+      }
+    }
     /* eslint-enable prefer-rest-params */
   }
 


### PR DESCRIPTION
prop3d was reporting not identity all the time

More reduction in heap allocations.

Cache a couple frequently made opengl calls to avoid
unnecc webgl calls.