### PR TITLE
feat(Rendering): add jitter to volume rendering

### DIFF
--- a/Examples/Applications/VolumeViewer/index.js
+++ b/Examples/Applications/VolumeViewer/index.js
@@ -110,7 +110,8 @@ function createViewer(container, fileContentAsText) {
   mapper.setSampleDistance(sampleDistance);
   actor.getProperty().setRGBTransferFunction(0, lookupTable);
   actor.getProperty().setScalarOpacity(0, piecewiseFunction);
-  actor.getProperty().setInterpolationTypeToFastLinear();
+  // actor.getProperty().setInterpolationTypeToFastLinear();
+  actor.getProperty().setInterpolationTypeToLinear();
 
   // For better looking volume rendering
   // - distance in world coordinates a scalar opacity of 1.0

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -50,6 +50,9 @@ uniform sampler2D ctexture;
 uniform float cshift;
 uniform float cscale;
 
+// jitter texture
+uniform sampler2D jtexture;
+
 // some 3D texture values
 uniform sampler2D texture1;
 uniform float sampleDistance;
@@ -195,8 +198,9 @@ void main()
     float numSteps = length(vdelta) / sampleDistance;
     vdelta = vdelta / numSteps;
 
-    // start slightly inside
-    vpos = vpos + vdelta*0.1;
+    // start slightly inside and apply some jitter
+    float jitter = texture2D(jtexture, gl_FragCoord.xy/32.0).r;
+    vpos = vpos + vdelta*(0.01 + 0.98*jitter);
     vec4 color = vec4(0.0, 0.0, 0.0, 0.0);
     int count = int(numSteps - 0.2); // end slightly inside
 

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS2.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS2.glsl
@@ -50,6 +50,9 @@ uniform sampler2D ctexture;
 uniform float cshift;
 uniform float cscale;
 
+// jitter texture
+uniform sampler2D jtexture;
+
 // some 3D texture values
 uniform highp sampler3D texture1;
 uniform float sampleDistance;
@@ -164,8 +167,9 @@ void main()
     float numSteps = length(vdelta) / sampleDistance;
     vdelta = vdelta / numSteps;
 
-    // start slightly inside
-    vpos = vpos + vdelta*0.1;
+    // start slightly inside and apply some jitter
+    float jitter = texture2D(jtexture, gl_FragCoord.xy/32.0).r;
+    vpos = vpos + vdelta*(0.01 + 0.98*jitter);
     vec4 color = vec4(0.0, 0.0, 0.0, 0.0);
 
     vec3 ijk = vpos * vVCToIJK;


### PR DESCRIPTION
By default volume rendering will use a jitter texture
to reduce banding when the sample distance is too
large to the rate of changhe in the data.