### PR TITLE
fix(Rendering): add a glyph3d mapper

### DIFF
--- a/Sources/Rendering/Core/Glyph3DMapper/Constants.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/Constants.js
@@ -1,0 +1,15 @@
+export const OrientationModes = {
+  DIRECTION: 0,
+  ROTATION: 1,
+};
+
+export const ScaleModes = {
+  SCALE_BY_CONSTANT: 0,
+  SCALE_BY_MAGNITUDE: 1,
+  SCALE_BY_COMPONENTS: 2,
+};
+
+export default {
+  OrientationModes,
+  ScaleModes,
+};

--- a/Sources/Rendering/Core/Glyph3DMapper/example/controlPanel.html
+++ b/Sources/Rendering/Core/Glyph3DMapper/example/controlPanel.html
@@ -1,0 +1,14 @@
+<table>
+  <tr>
+    <td>X Resolution</td>
+    <td>
+      <input class='xResolution' type="range" min="1" max="25" step="1" value="10" />
+    </td>
+  </tr>
+  <tr>
+    <td>Y Resolution</td>
+    <td>
+      <input class='yResolution' type="range" min="1" max="25" step="1" value="10" />
+    </td>
+  </tr>
+</table>

--- a/Sources/Rendering/Core/Glyph3DMapper/example/index.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/example/index.js
@@ -1,0 +1,111 @@
+import 'vtk.js/Sources/favicon';
+
+import vtkActor                         from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkCalculator                    from 'vtk.js/Sources/Filters/General/Calculator';
+import vtkFullScreenRenderWindow        from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkPlaneSource                   from 'vtk.js/Sources/Filters/Sources/PlaneSource';
+import vtkConeSource                    from 'vtk.js/Sources/Filters/Sources/ConeSource';
+import vtkGlyph3DMapper                 from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
+
+import { AttributeTypes }               from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes }               from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
+
+import controlPanel from './controlPanel.html';
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({ background: [0, 0, 0] });
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+
+// ----------------------------------------------------------------------------
+// Example code
+// ----------------------------------------------------------------------------
+
+const planeSource = vtkPlaneSource.newInstance();
+const simpleFilter = vtkCalculator.newInstance();
+const mapper = vtkGlyph3DMapper.newInstance();
+const actor = vtkActor.newInstance();
+
+simpleFilter.setFormula({
+  getArrays: inputDataSets => ({
+    input: [
+      { location: FieldDataTypes.COORDINATE }], // Require point coordinates as input
+    output: [ // Generate two output arrays:
+      {
+        location: FieldDataTypes.POINT,   // This array will be point-data ...
+        name: 'pressure',                // ... with the given name ...
+        dataType: 'Float32Array',         // ... of this type ...
+        numberOfComponents: 3,            // ... with this many components ...
+      },
+      {
+        location: FieldDataTypes.POINT, // This array will be field data ...
+        name: 'temperature',                   // ... with the given name ...
+        dataType: 'Float32Array',         // ... of this type ...
+        attribute: AttributeTypes.SCALARS, // ... and will be marked as the default scalars.
+        numberOfComponents: 1,            // ... with this many components ...
+      },
+    ] }),
+  evaluate: (arraysIn, arraysOut) => {
+    // Convert in the input arrays of vtkDataArrays into variables
+    // referencing the underlying JavaScript typed-data arrays:
+    const [coords] = arraysIn.map(d => d.getData());
+    const [press, temp] = arraysOut.map(d => d.getData());
+
+    // Since we are passed coords as a 3-component array,
+    // loop over all the points and compute the point-data output:
+    for (let i = 0, sz = coords.length / 3; i < sz; ++i) {
+      press[i * 3] = ((coords[3 * i] - 0.5) * (coords[3 * i] - 0.5));
+      press[(i * 3) + 1] = (((coords[(3 * i) + 1] - 0.5) * (coords[(3 * i) + 1] - 0.5)) + 0.125) * 0.1;
+      press[(i * 3) + 2] = (((coords[3 * i] - 0.5) * (coords[3 * i] - 0.5)) + ((coords[(3 * i) + 1] - 0.5) * (coords[(3 * i) + 1] - 0.5)) + 0.125) * 0.1;
+      temp[i] = coords[(3 * i) + 1] * 0.1;
+    }
+    // Mark the output vtkDataArray as modified
+    arraysOut.forEach(x => x.modified());
+  },
+});
+
+// The generated 'temperature' array will become the default scalars, so the plane mapper will color by 'temperature':
+simpleFilter.setInputConnection(planeSource.getOutputPort());
+
+mapper.setInputConnection(simpleFilter.getOutputPort(), 0);
+
+const coneSource = vtkConeSource.newInstance();
+coneSource.setResolution(12);
+mapper.setInputConnection(coneSource.getOutputPort(), 1);
+mapper.setOrientationArray('pressure');
+mapper.setScalarRange(0.0, 0.1);
+
+actor.setMapper(mapper);
+
+renderer.addActor(actor);
+renderer.resetCamera();
+renderWindow.render();
+
+
+// -----------------------------------------------------------
+// UI control handling
+// -----------------------------------------------------------
+
+fullScreenRenderer.addController(controlPanel);
+['xResolution', 'yResolution'].forEach((propertyName) => {
+  document.querySelector(`.${propertyName}`).addEventListener('input', (e) => {
+    const value = Number(e.target.value);
+    planeSource.set({ [propertyName]: value });
+    renderWindow.render();
+  });
+});
+
+
+// -----------------------------------------------------------
+// Make some variables global so that you can inspect and
+// modify objects in your browser's developer console:
+// -----------------------------------------------------------
+
+global.planeSource = planeSource;
+global.mapper = mapper;
+global.actor = actor;
+global.renderer = renderer;
+global.renderWindow = renderWindow;

--- a/Sources/Rendering/Core/Glyph3DMapper/index.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.js
@@ -1,0 +1,325 @@
+import { mat3, mat4 } from 'gl-matrix';
+
+import Constants from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper/Constants';
+import macro     from 'vtk.js/Sources/macro';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkMath   from 'vtk.js/Sources/Common/Core/Math';
+
+const { OrientationModes, ScaleModes } = Constants;
+const { vtkErrorMacro } = macro;
+
+// ----------------------------------------------------------------------------
+// class methods
+// ----------------------------------------------------------------------------
+
+function vtkGlyph3DMapper(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkGlyph3DMapper');
+
+  /**
+   * An orientation array is a vtkDataArray with 3 components. The first
+   * component is the angle of rotation along the X axis. The second
+   * component is the angle of rotation along the Y axis. The third
+   * component is the angle of rotation along the Z axis. Orientation is
+   * specified in X,Y,Z order but the rotations are performed in Z,X an Y.
+   * This definition is compliant with SetOrientation method on vtkProp3D.
+   * By using vector or normal there is a degree of freedom or rotation
+   * left (underconstrained). With the orientation array, there is no degree of
+   * freedom left.
+   */
+  publicAPI.getOrientationModeAsString = () =>
+    macro.enumToString(OrientationModes, model.orientationMode);
+  publicAPI.setOrientationModeToDirection = () =>
+    publicAPI.setOrientationMode(OrientationModes.DIRECTION);
+  publicAPI.setOrientationModeToRotation = () =>
+    publicAPI.setOrientationMode(OrientationModes.ROTATION);
+  publicAPI.getOrientationArrayData = () => {
+    const idata = publicAPI.getInputData(0);
+    if (!idata || !idata.getPointData()) {
+      return null;
+    }
+    if (!model.orientationArray) {
+      return idata.getPointData().getVectors();
+    }
+    return idata.getPointData().getArray(model.orientationArray);
+  };
+
+  publicAPI.getScaleModeAsString = () =>
+    macro.enumToString(ScaleModes, model.scaleMode);
+  publicAPI.setScaleModeToScaleByMagnitude = () =>
+    publicAPI.setScaleMode(ScaleModes.SCALE_BY_MAGNITUDE);
+  publicAPI.setScaleModeToScaleByComponents = () =>
+    publicAPI.setScaleMode(ScaleModes.SCALE_BY_COMPONENTS);
+  publicAPI.setScaleModeToScaleByConstant = () =>
+    publicAPI.setScaleMode(ScaleModes.SCALE_BY_CONSTANT);
+  publicAPI.getScaleArrayData = () => {
+    const idata = publicAPI.getInputData(0);
+    if (!idata || !idata.getPointData()) {
+      return null;
+    }
+    if (!model.scaleArray) {
+      return idata.getPointData().getScalars();
+    }
+    return idata.getPointData().getArray(model.scaleArray);
+  };
+
+  publicAPI.getBounds = () => {
+    const idata = publicAPI.getInputData(0);
+    const gdata = publicAPI.getInputData(1);
+    if (!idata || !gdata) {
+      return vtkMath.createUninitializedBounds();
+    }
+    const ibounds = idata.getBounds();
+    const gbounds = gdata.getBounds();
+
+    const sArray = publicAPI.getScaleArrayData();
+
+    // either have to compute the full dataset result
+    // or use a heuristic. The basic gist is for the
+    // idata points, place a scaled and oriented glyph
+    // at that location and then compute the bounds.
+    // we instead take the input bounds, and add to them
+    // the maximum scaled glyph bounds for any orientation
+    // To get any orientation we treat the glyph as a
+    // sphere about the origin making it rotationally
+    // invarient
+    let radius = Math.abs(gbounds[0]);
+    for (let i = 1; i < 6; ++i) {
+      if (Math.abs(gbounds[i]) > radius) {
+        radius = gbounds[i];
+      }
+    }
+
+    // compute the max absolute scale
+    let scale = 1.0;
+    if (model.scaling) {
+      scale = model.scaleFactor;
+    }
+    if (sArray && model.scaleMode !== ScaleModes.SCALE_BY_CONSTANT) {
+      const numC = sArray.getNumberOfComponents();
+      let maxScale = 0.0;
+      for (let i = 0; i < numC; ++i) {
+        const srange = sArray.getRange(i);
+        if (-srange[0] > maxScale) {
+          maxScale = -srange[0];
+        }
+        if (srange[1] > maxScale) {
+          maxScale = srange[1];
+        }
+      }
+      scale *= maxScale;
+    }
+
+    // if orienting then use the radius
+    if (model.orienting) {
+      model.bounds[0] = ibounds[0] - (radius * scale);
+      model.bounds[1] = ibounds[1] + (radius * scale);
+      model.bounds[2] = ibounds[2] - (radius * scale);
+      model.bounds[3] = ibounds[3] + (radius * scale);
+      model.bounds[4] = ibounds[4] - (radius * scale);
+      model.bounds[5] = ibounds[5] + (radius * scale);
+    } else { // other wise use the actual glyph
+      model.bounds[0] = ibounds[0] + (gbounds[0] * scale);
+      model.bounds[1] = ibounds[1] + (gbounds[1] * scale);
+      model.bounds[2] = ibounds[2] + (gbounds[2] * scale);
+      model.bounds[3] = ibounds[3] + (gbounds[3] * scale);
+      model.bounds[4] = ibounds[4] + (gbounds[4] * scale);
+      model.bounds[5] = ibounds[5] + (gbounds[5] * scale);
+    }
+
+    return model.bounds;
+  };
+
+  publicAPI.buildArrays = () => {
+    // if the mtgime requires it, rebuild
+    const idata = publicAPI.getInputData(0);
+    if (model.buildTime.getMTime() < idata.getMTime() ||
+        model.buildTime.getMTime() < publicAPI.getMTime()) {
+      const pts = idata.getPoints().getData();
+      let sArray = publicAPI.getScaleArrayData();
+      let sData = null;
+      let numSComp = 0;
+      if (sArray) {
+        sData = sArray.getData();
+        numSComp = sArray.getNumberOfComponents();
+      }
+
+      if (model.scaling && sArray &&
+          model.scaleMode === ScaleModes.SCALE_BY_COMPONENTS &&
+          sArray.getNumberOfComponents() !== 3) {
+        vtkErrorMacro('Cannot scale by components since scale array does not have 3 components.');
+        sArray = null;
+      }
+
+      const oArray = publicAPI.getOrientationArrayData();
+
+      const identity = mat4.create();
+      const trans = [];
+      const scale = [];
+      const numPts = pts.length / 3;
+      model.matrixArray = new Float32Array(16 * numPts);
+      const mbuff = model.matrixArray.buffer;
+      model.normalArray = new Float32Array(9 * numPts);
+      const nbuff = model.normalArray.buffer;
+      const tuple = [];
+      for (let i = 0; i < numPts; ++i) {
+        const z = new Float32Array(mbuff, i * 64, 16);
+        trans[0] = pts[i * 3];
+        trans[1] = pts[(i * 3) + 1];
+        trans[2] = pts[(i * 3) + 2];
+        mat4.translate(z, identity, trans);
+
+        if (oArray) {
+          const orientation = [];
+          oArray.getTuple(i, orientation);
+          switch (model.orientationMode) {
+            case OrientationModes.ROTATION:
+              mat4.rotateZ(z, z, orientation[2] / 3.1415926);
+              mat4.rotateX(z, z, orientation[0] / 3.1415926);
+              mat4.rotateY(z, z, orientation[1] / 3.1415926);
+              break;
+
+            case OrientationModes.DIRECTION:
+              if (orientation[1] === 0.0 && orientation[2] === 0.0) {
+                if (orientation[0] < 0) {
+                  mat4.rotateY(z, z, 3.1415926);
+                }
+              } else {
+                const vMag = vtkMath.norm(orientation);
+                const vNew = [];
+                vNew[0] = (orientation[0] + vMag) / 2.0;
+                vNew[1] = orientation[1] / 2.0;
+                vNew[2] = orientation[2] / 2.0;
+                mat4.rotate(z, z, 3.1415926, vNew);
+              }
+              break;
+            default:
+              break;
+          }
+        }
+
+        // scale data if appropriate
+        if (model.scaling) {
+          scale[0] = 1.0;
+          scale[1] = 1.0;
+          scale[2] = 1.0;
+          // Get the scalar and vector data
+          if (sArray) {
+            switch (model.scaleMode) {
+              case ScaleModes.SCALE_BY_MAGNITUDE:
+                for (let t = 0; t < numSComp; ++t) {
+                  tuple[t] = sData[(i * numSComp) + t];
+                }
+                scale[0] = vtkMath.norm(tuple, numSComp);
+                scale[1] = scale[0];
+                scale[2] = scale[0];
+                break;
+              case ScaleModes.SCALE_BY_COMPONENTS:
+                scale[0] = tuple[0];
+                scale[1] = tuple[1];
+                scale[2] = tuple[2];
+                break;
+              case ScaleModes.SCALE_BY_CONSTANT:
+              default:
+                break;
+            }
+          }
+          if (scale[0] === 0.0) {
+            scale[0] = 1.0e-10;
+          }
+          if (scale[1] === 0.0) {
+            scale[1] = 1.0e-10;
+          }
+          if (scale[2] === 0.0) {
+            scale[2] = 1.0e-10;
+          }
+          mat4.scale(z, z, scale);
+        }
+
+        const n = new Float32Array(nbuff, i * 36, 9);
+        mat3.fromMat4(n, z);
+        mat3.invert(n, n);
+        mat3.transpose(n, n);
+      }
+
+      // map scalars as well
+      const scalars = publicAPI.getAbstractScalars(
+        idata, model.scalarMode,
+        model.arrayAccessMode,
+        model.arrayId,
+        model.colorByArrayName);
+
+      if (!model.useLookupTableScalarRange) {
+        publicAPI.getLookupTable().setRange(
+          model.scalarRange[0], model.scalarRange[1]);
+      }
+
+      model.colorArray = null;
+      const lut = publicAPI.getLookupTable();
+      if (lut) {
+        // Ensure that the lookup table is built
+        lut.build();
+        model.colorArray = lut.mapScalars(scalars, model.colorMode, 0);
+      }
+
+      model.buildTime.modified();
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  orient: true,
+  orientationMode: OrientationModes.DIRECTION,
+  orientationArray: null,
+  scaling: true,
+  scaleFactor: 1.0,
+  scaleMode: ScaleModes.SCALE_BY_MAGNITUDE,
+  scaleArray: null,
+  matrixArray: null,
+  normalArray: null,
+  colorArray: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkMapper.extend(publicAPI, model, initialValues);
+  macro.algo(publicAPI, model, 2, 0);
+
+  model.buildTime = {};
+  macro.obj(model.buildTime, { mtime: 0 });
+
+  macro.setGet(publicAPI, model, [
+    'orient',
+    'orientationArray',
+    'scaling',
+    'scaleFactor',
+    'scaleArray',
+  ]);
+
+  macro.get(publicAPI, model, [
+    'colorArray',
+    'matrixArray',
+    'normalArray',
+    'buildTime',
+  ]);
+
+  // Object methods
+  vtkGlyph3DMapper(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkGlyph3DMapper');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };
+

--- a/Sources/Rendering/Core/Mapper/Constants.js
+++ b/Sources/Rendering/Core/Mapper/Constants.js
@@ -13,13 +13,6 @@ export const ScalarMode = {
   USE_FIELD_DATA: 5,
 };
 
-export const MaterialMode = {
-  DEFAULT: 0,
-  AMBIENT: 1,
-  DIFFUSE: 2,
-  AMBIENT_AND_DIFFUSE: 3,
-};
-
 export const GetArray = {
   BY_ID: 0,
   BY_NAME: 1,
@@ -28,6 +21,5 @@ export const GetArray = {
 export default {
   ColorMode,
   GetArray,
-  MaterialMode,
   ScalarMode,
 };

--- a/Sources/Rendering/Core/Mapper/api.md
+++ b/Sources/Rendering/Core/Mapper/api.md
@@ -297,33 +297,6 @@ which comes from a vtkActor, etc.)
 }
 ```
 
-### scalarMaterialMode
-
-Set/Get the light-model color mode.
-
-```js
-// Other helper methods
-setScalarMaterialModeToDefault();
-setScalarMaterialModeToAmbient();
-setScalarMaterialModeToDiffuse();
-setScalarMaterialModeToAmbientAndDiffuse();
-```
-
-### getScalarMaterialModeAsString() : String
-
-Return the light-model color mode.
-
-```js
-const MaterialMode = {
-  DEFAULT: 0,
-  AMBIENT: 1,
-  DIFFUSE: 2,
-  AMBIENT_AND_DIFFUSE: 3,
-};
-
-console.log(getScalarMaterialModeAsString(3));
-```
-
 ### getIsOpaque() : Boolean
 
 Returns if the mapper does not expect to have translucent geometry. This

--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -10,7 +10,7 @@ import CoincidentTopologyHelper from 'vtk.js/Sources/Rendering/Core/Mapper/Coinc
 import otherStaticMethods       from 'vtk.js/Sources/Rendering/Core/Mapper/Static';
 import Constants                from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
 
-const { ColorMode, ScalarMode, MaterialMode, GetArray } = Constants;
+const { ColorMode, ScalarMode, GetArray } = Constants;
 const { VectorMode } = vtkScalarsToColors;
 
 // ----------------------------------------------------------------------------
@@ -409,12 +409,6 @@ function vtkMapper(publicAPI, model) {
     }
   };
 
-  publicAPI.setScalarMaterialModeToDefault = () => publicAPI.setScalarMaterialMode(MaterialMode.DEFAULT);
-  publicAPI.setScalarMaterialModeToAmbient = () => publicAPI.setScalarMaterialMode(MaterialMode.AMBIENT);
-  publicAPI.setScalarMaterialModeToDiffuse = () => publicAPI.setScalarMaterialMode(MaterialMode.DIFFUSE);
-  publicAPI.setScalarMaterialModeToAmbientAndDiffuse = () => publicAPI.setScalarMaterialMode(MaterialMode.AMBIENT_AND_DIFFUSE);
-  publicAPI.getScalarMaterialModeAsString = () => macro.enumToString(MaterialMode, model.scalarMaterialMode);
-
   publicAPI.getIsOpaque = () => {
     const lut = publicAPI.getLookupTable();
     if (lut) {
@@ -495,7 +489,6 @@ const DEFAULT_VALUES = {
 
   colorMode: 0,
   scalarMode: 0,
-  scalarMaterialMode: 0,
   arrayAccessMode: 1, // By_NAME
 
   renderTime: 0,
@@ -541,7 +534,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'lookupTable',
     'renderTime',
     'resolveCoincidentTopology',
-    'scalarMaterialMode',
     'scalarMode',
     'scalarVisibility',
     'static',

--- a/Sources/Rendering/Core/index.js
+++ b/Sources/Rendering/Core/index.js
@@ -7,6 +7,7 @@ import vtkCamera                  from './Camera';
 import vtkCellPicker              from './CellPicker';
 import vtkColorTransferFunction   from './ColorTransferFunction';
 import vtkCoordinate              from './Coordinate';
+import vtkGlyph3DMapper           from './Glyph3DMapper';
 import vtkImageMapper             from './ImageMapper';
 import vtkImageProperty           from './ImageProperty';
 import vtkImageSlice              from './ImageSlice';
@@ -42,6 +43,7 @@ export default {
   vtkCellPicker,
   vtkColorTransferFunction,
   vtkCoordinate,
+  vtkGlyph3DMapper,
   vtkImageMapper,
   vtkImageProperty,
   vtkImageSlice,

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -1,0 +1,388 @@
+import { mat3, mat4 }           from 'gl-matrix';
+// import { ObjectType }           from 'vtk.js/Sources/Rendering/OpenGL/BufferObject/Constants';
+
+import macro                    from 'vtk.js/Sources/macro';
+
+// import vtkBufferObject          from 'vtk.js/Sources/Rendering/OpenGL/BufferObject';
+import vtkProperty              from 'vtk.js/Sources/Rendering/Core/Property';
+import vtkOpenGLPolyDataMapper  from 'vtk.js/Sources/Rendering/OpenGL/PolyDataMapper';
+
+const { vtkErrorMacro } = macro;
+const { Representation } = vtkProperty;
+
+const StartEvent = { type: 'StartEvent' };
+const EndEvent = { type: 'EndEvent' };
+
+// ----------------------------------------------------------------------------
+// vtkOpenGLSphereMapper methods
+// ----------------------------------------------------------------------------
+
+function vtkOpenGLGlyph3DMapper(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkOpenGLGlyph3DMapper');
+
+  // Capture 'parentClass' api for internal use
+  const superClass = Object.assign({}, publicAPI);
+
+  publicAPI.renderPiece = (ren, actor) => {
+    publicAPI.invokeEvent(StartEvent);
+    if (!model.renderable.getStatic()) {
+      model.renderable.update();
+    }
+    model.currentInput = model.renderable.getInputData(1);
+    publicAPI.invokeEvent(EndEvent);
+
+    if (model.currentInput === null) {
+      vtkErrorMacro('No input!');
+      return;
+    }
+
+    // if there are no points then we are done
+    if (!model.currentInput.getPoints || !model.currentInput.getPoints().getNumberOfValues()) {
+      return;
+    }
+
+    // apply faceCulling
+    const gl = model.context;
+    const backfaceCulling = actor.getProperty().getBackfaceCulling();
+    const frontfaceCulling = actor.getProperty().getFrontfaceCulling();
+    if (!backfaceCulling && !frontfaceCulling) {
+      model.openGLRenderWindow.disableCullFace();
+    } else if (frontfaceCulling) {
+      model.openGLRenderWindow.enableCullFace();
+      gl.cullFace(gl.FRONT);
+    } else {
+      model.openGLRenderWindow.enableCullFace();
+      gl.cullFace(gl.BACK);
+    }
+
+    publicAPI.renderPieceStart(ren, actor);
+    publicAPI.renderPieceDraw(ren, actor);
+    publicAPI.renderPieceFinish(ren, actor);
+  };
+
+  publicAPI.multiply4x4WithOffset = (out, a, b, off) => {
+    const a00 = a[0];
+    const a01 = a[1];
+    const a02 = a[2];
+    const a03 = a[3];
+    const a10 = a[4];
+    const a11 = a[5];
+    const a12 = a[6];
+    const a13 = a[7];
+    const a20 = a[8];
+    const a21 = a[9];
+    const a22 = a[10];
+    const a23 = a[11];
+    const a30 = a[12];
+    const a31 = a[13];
+    const a32 = a[14];
+    const a33 = a[15];
+
+    // Cache only the current line of the second matrix
+    let b0 = b[off];
+    let b1 = b[off + 1];
+    let b2 = b[off + 2];
+    let b3 = b[off + 3];
+    out[0] = (b0 * a00) + (b1 * a10) + (b2 * a20) + (b3 * a30);
+    out[1] = (b0 * a01) + (b1 * a11) + (b2 * a21) + (b3 * a31);
+    out[2] = (b0 * a02) + (b1 * a12) + (b2 * a22) + (b3 * a32);
+    out[3] = (b0 * a03) + (b1 * a13) + (b2 * a23) + (b3 * a33);
+
+    b0 = b[off + 4]; b1 = b[off + 5]; b2 = b[off + 6]; b3 = b[off + 7];
+    out[4] = (b0 * a00) + (b1 * a10) + (b2 * a20) + (b3 * a30);
+    out[5] = (b0 * a01) + (b1 * a11) + (b2 * a21) + (b3 * a31);
+    out[6] = (b0 * a02) + (b1 * a12) + (b2 * a22) + (b3 * a32);
+    out[7] = (b0 * a03) + (b1 * a13) + (b2 * a23) + (b3 * a33);
+
+    b0 = b[off + 8]; b1 = b[off + 9]; b2 = b[off + 10]; b3 = b[off + 11];
+    out[8] = (b0 * a00) + (b1 * a10) + (b2 * a20) + (b3 * a30);
+    out[9] = (b0 * a01) + (b1 * a11) + (b2 * a21) + (b3 * a31);
+    out[10] = (b0 * a02) + (b1 * a12) + (b2 * a22) + (b3 * a32);
+    out[11] = (b0 * a03) + (b1 * a13) + (b2 * a23) + (b3 * a33);
+
+    b0 = b[off + 12]; b1 = b[off + 13]; b2 = b[off + 14]; b3 = b[off + 15];
+    out[12] = (b0 * a00) + (b1 * a10) + (b2 * a20) + (b3 * a30);
+    out[13] = (b0 * a01) + (b1 * a11) + (b2 * a21) + (b3 * a31);
+    out[14] = (b0 * a02) + (b1 * a12) + (b2 * a22) + (b3 * a32);
+    out[15] = (b0 * a03) + (b1 * a13) + (b2 * a23) + (b3 * a33);
+  };
+
+  publicAPI.updateGlyphShaderParameters = (
+    normalMatrixUsed,
+    mcvcMatrixUsed,
+    cellBO,
+    carray, garray, narray, p) => {
+    const program = cellBO.getProgram();
+
+    if (normalMatrixUsed) {
+      const a = model.normalMatrix;
+      const b = narray;
+      const ofs = p * 9;
+      const out = model.tmpMat3;
+
+      const a00 = a[0];
+      const a01 = a[1];
+      const a02 = a[2];
+      const a10 = a[3];
+      const a11 = a[4];
+      const a12 = a[5];
+      const a20 = a[6];
+      const a21 = a[7];
+      const a22 = a[8];
+
+      const b00 = b[ofs];
+      const b01 = b[ofs + 1];
+      const b02 = b[ofs + 2];
+      const b10 = b[ofs + 3];
+      const b11 = b[ofs + 4];
+      const b12 = b[ofs + 5];
+      const b20 = b[ofs + 6];
+      const b21 = b[ofs + 7];
+      const b22 = b[ofs + 8];
+
+      out[0] = (b00 * a00) + (b01 * a10) + (b02 * a20);
+      out[1] = (b00 * a01) + (b01 * a11) + (b02 * a21);
+      out[2] = (b00 * a02) + (b01 * a12) + (b02 * a22);
+
+      out[3] = (b10 * a00) + (b11 * a10) + (b12 * a20);
+      out[4] = (b10 * a01) + (b11 * a11) + (b12 * a21);
+      out[5] = (b10 * a02) + (b11 * a12) + (b12 * a22);
+
+      out[6] = (b20 * a00) + (b21 * a10) + (b22 * a20);
+      out[7] = (b20 * a01) + (b21 * a11) + (b22 * a21);
+      out[8] = (b20 * a02) + (b21 * a12) + (b22 * a22);
+
+      program.setUniformMatrix3x3('normalMatrix', model.tmpMat3);
+    }
+    publicAPI.multiply4x4WithOffset(model.tmpMat4, model.mcdcMatrix, garray, p * 16);
+    program.setUniformMatrix('MCDCMatrix', model.tmpMat4);
+    if (mcvcMatrixUsed) {
+      publicAPI.multiply4x4WithOffset(model.tmpMat4, model.mcvcMatrix, garray, p * 16);
+      program.setUniformMatrix('MCVCMatrix', model.tmpMat4);
+    }
+
+    // set color
+    if (carray) {
+      const cdata = carray.getData();
+      model.tmpColor[0] = cdata[p * 4] / 255.0;
+      model.tmpColor[1] = cdata[(p * 4) + 1] / 255.0;
+      model.tmpColor[2] = cdata[(p * 4) + 2] / 255.0;
+      program.setUniform3fArray('ambientColorUniform', model.tmpColor);
+      program.setUniform3fArray('diffuseColorUniform', model.tmpColor);
+    }
+  };
+
+  publicAPI.renderPieceDraw = (ren, actor) => {
+    const representation = actor.getProperty().getRepresentation();
+
+    const gl = model.context;
+
+    const drawSurfaceWithEdges =
+      (actor.getProperty().getEdgeVisibility() &&
+        representation === Representation.SURFACE);
+
+    // // [WMVD]C == {world, model, view, display} coordinates
+    // // E.g., WCDC == world to display coordinate transformation
+    const keyMats = model.openGLCamera.getKeyMatrices(ren);
+    const actMats = model.openGLActor.getKeyMatrices();
+
+    // precompute the actor+camera mats once
+    mat3.multiply(model.normalMatrix, keyMats.normalMatrix, actMats.normalMatrix);
+    mat4.multiply(model.mcdcMatrix, keyMats.wcdc, actMats.mcwc);
+    mat4.multiply(model.mcvcMatrix, keyMats.wcvc, actMats.mcwc);
+
+    const garray = model.renderable.getMatrixArray();
+    const narray = model.renderable.getNormalArray();
+    const carray = model.renderable.getColorArray();
+    const numPts = garray.length / 16;
+
+    // for every primitive type
+    for (let i = model.primTypes.Start; i < model.primTypes.End; i++) {
+      // if there are entries
+      const cabo = model.primitives[i].getCABO();
+      if (cabo.getElementCount()) {
+        // are we drawing edges
+        model.drawingEdges =
+          drawSurfaceWithEdges && (i === model.primTypes.TrisEdges
+          || i === model.primTypes.TriStripsEdges);
+        publicAPI.updateShaders(model.primitives[i], ren, actor);
+        const program = model.primitives[i].getProgram();
+
+        const mode = publicAPI.getOpenGLMode(representation, i);
+        const normalMatrixUsed = program.isUniformUsed('normalMatrix');
+        const mcvcMatrixUsed = program.isUniformUsed('MCVCMatrix');
+
+        // draw the array multiple times with different cam matrix
+        for (let p = 0; p < numPts; ++p) {
+          publicAPI.updateGlyphShaderParameters(
+            normalMatrixUsed,
+            mcvcMatrixUsed,
+            model.primitives[i], carray, garray, narray, p);
+          gl.drawArrays(mode, 0, cabo.getElementCount());
+        }
+
+        const stride = (mode === gl.POINTS ? 1 : (mode === gl.LINES ? 2 : 3));
+        model.primitiveIDOffset += cabo.getElementCount() / stride;
+      }
+    }
+  };
+
+  publicAPI.getNeedToRebuildBufferObjects = (ren, actor) => {
+    model.renderable.buildArrays();
+
+    // first do a coarse check
+    // Note that the actor's mtime includes it's properties mtime
+    const vmtime = model.VBOBuildTime.getMTime();
+    if (vmtime < model.renderable.getBuildTime().getMTime()) {
+      return true;
+    }
+    return superClass.getNeedToRebuildBufferObjects(ren, actor);
+  };
+
+  // publicAPI.buildBufferObjects = (ren, actor) => {
+  //   const poly = model.currentInput;
+
+  //   if (poly === null) {
+  //     return;
+  //   }
+
+  //   model.renderable.mapScalars(poly, 1.0);
+  //   const c = model.renderable.getColorMapColors();
+
+  //   const vbo = model.primitives[model.primTypes.Tris].getCABO();
+
+  //   const pointData = poly.getPointData();
+  //   const points = poly.getPoints();
+  //   const numPoints = points.getNumberOfPoints();
+  //   const pointArray = points.getData();
+
+  //   const pointSize = 5; // x,y,z,orientation1,orientation2
+  //   let scales = null;
+
+  //   if (model.renderable.getScaleArray() != null &&
+  //       pointData.hasArray(model.renderable.getScaleArray())) {
+  //     scales = pointData.getArray(model.renderable.getScaleArray()).getData();
+  //   }
+
+  //   let colorData = null;
+  //   let colorComponents = 0);
+  //   let packedUCVBO = null;
+  //   if (c) {
+  //     colorComponents = c.getNumberOfComponents();
+  //     vbo.setColorOffset(0);
+  //     vbo.setColorBOStride(4);
+  //     colorData = c.getData();
+  //     packedUCVBO = new Uint8Array(3 * numPoints * 4);
+  //     if (!vbo.getColorBO()) {
+  //       vbo.setColorBO(vtkBufferObject.newInstance());
+  //     }
+  //     vbo.getColorBO().setContext(model.context);
+  //   } else if (vbo.getColorBO()) {
+  //     vbo.setColorBO(null);
+  //   }
+  //   vbo.setColorComponents(colorComponents);
+
+  //   const packedVBO = new Float32Array(pointSize * numPoints * 3);
+
+  //   vbo.setStride(pointSize * 4);
+
+  //   const cos30 = Math.cos(vtkMath.radiansFromDegrees(30.0));
+  //   let pointIdx = 0);
+  //   let colorIdx = 0);
+
+  //   //
+  //   // Generate points and point data for sides
+  //   //
+  //   let vboIdx = 0);
+  //   let ucIdx = 0);
+  //   for (let i = 0); i < numPoints; ++i) {
+  //     let radius = model.renderable.getRadius();
+  //     if (scales) {
+  //       radius = scales[i];
+  //     }
+
+  //     pointIdx = i * 3;
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = -2.0 * radius * cos30);
+  //     packedVBO[vboIdx++] = -radius;
+  //     if (colorData) {
+  //       colorIdx = i * colorComponents;
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 1];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 2];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 3];
+  //     }
+
+  //     pointIdx = i * 3;
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = 2.0 * radius * cos30);
+  //     packedVBO[vboIdx++] = -radius;
+  //     if (colorData) {
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 1];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 2];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 3];
+  //     }
+
+  //     pointIdx = i * 3;
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = pointArray[pointIdx++];
+  //     packedVBO[vboIdx++] = 0.0);
+  //     packedVBO[vboIdx++] = 2.0 * radius;
+  //     if (colorData) {
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 1];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 2];
+  //       packedUCVBO[ucIdx++] = colorData[colorIdx + 3];
+  //     }
+  //   }
+
+  //   vbo.setElementCount(vboIdx / pointSize);
+  //   vbo.upload(packedVBO, ObjectType.ARRAY_BUFFER);
+  //   if (c) { vbo.getColorBO().upload(packedUCVBO, ObjectType.ARRAY_BUFFER); }
+
+  //   model.VBOBuildTime.modified();
+  // };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  normalMatrix: null,
+  mcdcMatrix: null,
+  mcwcMatrix: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkOpenGLPolyDataMapper.extend(publicAPI, model, initialValues);
+
+  model.tmpMat3 = mat3.create();
+  model.normalMatrix = mat3.create();
+  model.mcdcMatrix = mat4.create();
+  model.mcvcMatrix = mat4.create();
+  model.tmpColor = [];
+
+  // Object methods
+  vtkOpenGLGlyph3DMapper(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkOpenGLGlyph3DMapper');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Rendering/OpenGL/PolyDataMapper/test/testAddShaderReplacements.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/test/testAddShaderReplacements.js
@@ -91,7 +91,7 @@ test.onlyIfWebGL('Test Add Shader Replacements', (t) => {
       'Fragment',
       '//VTK::Normal::Impl',
       true,
-      '//VTK::Normal::Impl\n  diffuseColor = abs(myNormalMCVSOutput);\n',
+      '//VTK::Normal::Impl\n  diffuseColor = abs(myNormalMCVSOutput) / diffuse;\n',
       false,
     );
 

--- a/Sources/Rendering/OpenGL/ViewNodeFactory/index.js
+++ b/Sources/Rendering/OpenGL/ViewNodeFactory/index.js
@@ -4,6 +4,7 @@ import vtkViewNodeFactory      from 'vtk.js/Sources/Rendering/SceneGraph/ViewNod
 import vtkOpenGLActor          from 'vtk.js/Sources/Rendering/OpenGL/Actor';
 import vtkOpenGLActor2D        from 'vtk.js/Sources/Rendering/OpenGL/Actor2D';
 import vtkOpenGLCamera         from 'vtk.js/Sources/Rendering/OpenGL/Camera';
+import vtkOpenGLGlyph3DMapper  from 'vtk.js/Sources/Rendering/OpenGL/Glyph3DMapper';
 import vtkOpenGLImageMapper    from 'vtk.js/Sources/Rendering/OpenGL/ImageMapper';
 import vtkOpenGLImageSlice     from 'vtk.js/Sources/Rendering/OpenGL/ImageSlice';
 import vtkOpenGLPixelSpaceCallbackMapper from 'vtk.js/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper';
@@ -47,6 +48,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   publicAPI.registerOverride('vtkActor', vtkOpenGLActor.newInstance);
   publicAPI.registerOverride('vtkActor2D', vtkOpenGLActor2D.newInstance);
   publicAPI.registerOverride('vtkCamera', vtkOpenGLCamera.newInstance);
+  publicAPI.registerOverride('vtkGlyph3DMapper', vtkOpenGLGlyph3DMapper.newInstance);
   publicAPI.registerOverride('vtkImageMapper', vtkOpenGLImageMapper.newInstance);
   publicAPI.registerOverride('vtkImageSlice', vtkOpenGLImageSlice.newInstance);
   publicAPI.registerOverride('vtkMapper', vtkOpenGLPolyDataMapper.newInstance);

--- a/Sources/Rendering/OpenGL/index.js
+++ b/Sources/Rendering/OpenGL/index.js
@@ -4,6 +4,7 @@ import vtkBufferObject           from './BufferObject';
 import vtkCamera                 from './Camera';
 import vtkCellArrayBufferObject  from './CellArrayBufferObject';
 import vtkFramebuffer            from './Framebuffer';
+import vtkGlyph3DMapper          from './Glyph3DMapper';
 import vtkHardwareSelector       from './HardwareSelector';
 import vtkHelper                 from './Helper';
 import vtkImageMapper            from './ImageMapper';
@@ -30,6 +31,7 @@ export default {
   vtkCamera,
   vtkCellArrayBufferObject,
   vtkFramebuffer,
+  vtkGlyph3DMapper,
   vtkHardwareSelector,
   vtkHelper,
   vtkImageMapper,

--- a/Sources/Testing/Examples/ActorSerialization/example/actor.json
+++ b/Sources/Testing/Examples/ActorSerialization/example/actor.json
@@ -177,7 +177,6 @@
     "output": [],
     "renderTime": 0,
     "resolveCoincidentTopology": false,
-    "scalarMaterialMode": 0,
     "scalarMode": 0,
     "scalarRange": [0, 1],
     "scalarVisibility": true,


### PR DESCRIPTION
This is a first implementaiton of a glyph3d mapper
designed to more quickly render colored, scaled,
positioned, and oriented glyphs. This is a first
cut and will be followed quickly by an update that
adds a faster rendering path for implementations
that support instancing like webgl 2