### PR TITLE
fix(Rendering): instanced glyphs, cleanup, fix imaging

### DIFF
--- a/Sources/Rendering/OpenGL/BufferObject/index.js
+++ b/Sources/Rendering/OpenGL/BufferObject/index.js
@@ -100,6 +100,18 @@ function vtkOpenGLBufferObject(publicAPI, model) {
     }
   };
 
+  publicAPI.setOpenGLRenderWindow = (rw) => {
+    if (model.openGLRenderWindow === rw) {
+      return;
+    }
+    publicAPI.releaseGraphicsResources();
+    model.openGLRenderWindow = rw;
+    model.context = null;
+    if (rw) {
+      model.context = model.openGLRenderWindow.getContext();
+    }
+  };
+
   publicAPI.getError = () => error;
 }
 
@@ -109,6 +121,7 @@ function vtkOpenGLBufferObject(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   objectType: ObjectType.ARRAY_BUFFER,
+  openGLRenderWindow: null,
   context: null,
 };
 
@@ -120,8 +133,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Object methods
   macro.obj(publicAPI, model);
 
-  macro.setGet(publicAPI, model, [
-    'context',
+  macro.get(publicAPI, model, [
+    'openGLRenderWindow',
   ]);
 
   vtkOpenGLBufferObject(publicAPI, model);

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -13,16 +13,16 @@ function vtkOpenGLCamera(publicAPI, model) {
 
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model.renderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.renderWindow = model.renderer.getParent();
-      model.context = model.renderWindow.getContext();
+      model.openGLRenderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
+      model.openGLRenderWindow = model.openGLRenderer.getParent();
+      model.context = model.openGLRenderWindow.getContext();
     }
   };
 
   // Renders myself
   publicAPI.opaquePass = (prepass) => {
     if (prepass) {
-      const tsize = model.renderer.getTiledSizeAndOrigin();
+      const tsize = model.openGLRenderer.getTiledSizeAndOrigin();
       model.context.viewport(tsize.lowerLeftU, tsize.lowerLeftV, tsize.usize, tsize.vsize);
       model.context.scissor(tsize.lowerLeftU, tsize.lowerLeftV, tsize.usize, tsize.vsize);
     }
@@ -34,7 +34,7 @@ function vtkOpenGLCamera(publicAPI, model) {
   publicAPI.getKeyMatrices = (ren) => {
     // has the camera changed?
     if (ren !== model.lastRenderer ||
-      model.renderWindow.getMTime() > model.keyMatrixTime.getMTime() ||
+      model.openGLRenderWindow.getMTime() > model.keyMatrixTime.getMTime() ||
       publicAPI.getMTime() > model.keyMatrixTime.getMTime() ||
       ren.getMTime() > model.keyMatrixTime.getMTime()) {
       mat4.copy(model.keyMatrices.wcvc, model.renderable.getViewTransformMatrix());
@@ -43,7 +43,7 @@ function vtkOpenGLCamera(publicAPI, model) {
       mat3.invert(model.keyMatrices.normalMatrix, model.keyMatrices.normalMatrix);
       mat4.transpose(model.keyMatrices.wcvc, model.keyMatrices.wcvc);
 
-      const aspectRatio = model.renderer.getAspectRatio();
+      const aspectRatio = model.openGLRenderer.getAspectRatio();
 
       mat4.copy(model.keyMatrices.vcdc, model.renderable.getProjectionTransformMatrix(
                            aspectRatio, -1, 1));

--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -60,7 +60,7 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
       if (!model.colorBO) {
         model.colorBO = vtkBufferObject.newInstance();
       }
-      model.colorBO.setContext(model.context);
+      model.colorBO.setOpenGLRenderWindow(model.openGLRenderWindow);
     } else {
       model.colorBO = null;
     }

--- a/Sources/Rendering/OpenGL/ForwardPass/index.js
+++ b/Sources/Rendering/OpenGL/ForwardPass/index.js
@@ -39,7 +39,7 @@ function vtkForwardPass(publicAPI, model) {
       if (model.framebuffer === null) {
         model.framebuffer = vtkOpenGLFramebuffer.newInstance();
       }
-      model.framebuffer.setWindow(viewNode);
+      model.framebuffer.setOpenGLRenderWindow(viewNode);
       model.framebuffer.saveCurrentBindingsAndBuffers();
       const fbSize = model.framebuffer.getSize();
       if (fbSize === null ||

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -24,18 +24,18 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.beginSelection = () => {
-    model.oglrenderer = model.oglwindow.getViewNodeFor(model.renderer);
+    model.openGLRenderer = model.openGLRenderWindow.getViewNodeFor(model.renderer);
     model.maxAttributeId = 0;
 
     model.framebuffer = vtkOpenGLFramebuffer.newInstance();
-    model.framebuffer.setWindow(model.oglwindow);
+    model.framebuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
     model.framebuffer.saveCurrentBindingsAndBuffers();
-    const size = model.oglwindow.getSize();
+    const size = model.openGLRenderWindow.getSize();
     model.framebuffer.create(size[0], size[1]);
     model.framebuffer.populateFramebuffer();
 
-    model.oglrenderer.clear();
-    model.oglrenderer.setSelector(publicAPI);
+    model.openGLRenderer.clear();
+    model.openGLRenderer.setSelector(publicAPI);
     model.renderer.setPreserveDepthBuffer(1);
     model.hitProps = [];
     model.props = [];
@@ -45,7 +45,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.endSelection = () => {
     model.hitProps = [];
-    model.oglrenderer.setSelector(null);
+    model.openGLRenderer.setSelector(null);
     model.renderer.setPreserveDepthBuffer(0);
     model.framebuffer.restorePreviousBindingsAndBuffers();
   };
@@ -70,12 +70,12 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.captureBuffers = () => {
-    if (!model.renderer || !model.oglwindow) {
+    if (!model.renderer || !model.openGLRenderWindow) {
       vtkErrorMacro('Renderer and view must be set before calling Select.');
       return false;
     }
 
-    model.oglrenderer = model.oglwindow.getViewNodeFor(model.renderer);
+    model.openGLRenderer = model.openGLRenderWindow.getViewNodeFor(model.renderer);
 
     // int rgba[4];
     // rwin.getColorBufferSizes(rgba);
@@ -96,7 +96,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
       model.currentPass <= PassTypes.MAX_KNOWN_PASS; model.currentPass++) {
       if (publicAPI.passRequired(model.currentPass)) {
         publicAPI.preCapturePass(model.currentPass);
-        model.oglwindow.traverseAllPasses();
+        model.openGLRenderWindow.traverseAllPasses();
         publicAPI.postCapturePass(model.currentPass);
 
         publicAPI.savePixelBuffer(model.currentPass);
@@ -109,7 +109,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
     publicAPI.invokeEvent({ type: 'EndEvent' });
 
     // restore image
-    model.oglwindow.traverseAllPasses();
+    model.openGLRenderWindow.traverseAllPasses();
     return true;
   };
 
@@ -118,7 +118,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.savePixelBuffer = (passNo) => {
-    model.pixBuffer[passNo] = model.oglwindow.getPixelData(
+    model.pixBuffer[passNo] = model.openGLRenderWindow.getPixelData(
       model.area[0], model.area[1], model.area[2], model.area[3]);
     if (passNo === PassTypes.ACTOR_PASS) {
       publicAPI.buildPropHitList(model.pixBuffer[passNo]);
@@ -382,7 +382,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
   };
 
   publicAPI.attach = (w, r) => {
-    model.oglwindow = w;
+    model.openGLRenderWindow = w;
     model.renderer = r;
   };
 }
@@ -395,8 +395,8 @@ const DEFAULT_VALUES = {
   fieldAssociation: FieldAssociations.FIELD_ASSOCIATION_CELLS,
   renderer: null,
   area: null,
-  oglwindow: null,
-  oglrenderer: null,
+  openGLRenderWindow: null,
+  openGLRenderer: null,
   currentPass: -1,
   propColorValue: null,
   props: null,

--- a/Sources/Rendering/OpenGL/Helper/index.js
+++ b/Sources/Rendering/OpenGL/Helper/index.js
@@ -11,10 +11,10 @@ function vtkOpenGLHelper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLHelper');
 
-  publicAPI.setWindow = (win) => {
+  publicAPI.setOpenGLRenderWindow = (win) => {
     model.program.setContext(win.getContext());
-    model.VAO.setWindow(win);
-    model.CABO.setContext(win.getContext());
+    model.VAO.setOpenGLRenderWindow(win);
+    model.CABO.setOpenGLRenderWindow(win);
   };
 
   publicAPI.releaseGraphicsResources = (oglwin) => {

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -32,11 +32,9 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model.openGLRenderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       model.openGLRenderWindow = model.openGLRenderer.getParent();
       model.context = model.openGLRenderWindow.getContext();
-      model.tris.setWindow(model.openGLRenderWindow);
-      model.openGLTexture.setWindow(model.openGLRenderWindow);
-      model.openGLTexture.setContext(model.context);
-      model.colorTexture.setWindow(model.openGLRenderWindow);
-      model.colorTexture.setContext(model.context);
+      model.tris.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.openGLTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.colorTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
       const ren = model.openGLRenderer.getRenderable();
       model.openGLCamera = model.openGLRenderer.getViewNodeFor(ren.getActiveCamera());
       // is zslice set by the camera
@@ -344,6 +342,10 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           cTable[i] = 255.0 * cfTable[i];
         }
         model.colorTextureString = cfunToString;
+        model.colorTexture.setMinificationFilter(Filter.LINEAR);
+        model.colorTexture.setMagnificationFilter(Filter.LINEAR);
+        model.colorTexture.create2DFromRaw(cWidth, 1, 3,
+          VtkDataTypes.UNSIGNED_CHAR, cTable);
       }
     } else {
       const cfunToString = '0';
@@ -354,12 +356,12 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           cTable[i + 2] = 255.0 * i / ((cWidth - 1) * 3);
         }
         model.colorTextureString = cfunToString;
+        model.colorTexture.setMinificationFilter(Filter.LINEAR);
+        model.colorTexture.setMagnificationFilter(Filter.LINEAR);
+        model.colorTexture.create2DFromRaw(cWidth, 1, 3,
+          VtkDataTypes.UNSIGNED_CHAR, cTable);
       }
     }
-    model.colorTexture.setMinificationFilter(Filter.LINEAR);
-    model.colorTexture.setMagnificationFilter(Filter.LINEAR);
-    model.colorTexture.create2DFromRaw(cWidth, 1, 3,
-      VtkDataTypes.UNSIGNED_CHAR, cTable);
 
     // rebuild the VBO if the data has changed
     let nSlice = model.renderable.getZSlice();
@@ -496,7 +498,6 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  context: null,
   VBOBuildTime: 0,
   VBOBuildString: null,
   openGLTexture: null,
@@ -521,7 +522,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Build VTK API
   macro.setGet(publicAPI, model, [
-    'context',
   ]);
 
   model.VBOBuildTime = {};

--- a/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
+++ b/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
@@ -13,11 +13,10 @@ function vtkOpenGLPixelSpaceCallbackMapper(publicAPI, model) {
   model.classHierarchy.push('vtkOpenGLPixelSpaceCallbackMapper');
 
   publicAPI.opaquePass = (prepass, renderPass) => {
-    const oglren = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-    const aspectRatio = oglren.getAspectRatio();
-    const ren = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-    const camera = ren ? ren.getRenderable().getActiveCamera() : null;
-    const tsize = ren.getTiledSizeAndOrigin();
+    model.openGLRenderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
+    const aspectRatio = model.openGLRenderer.getAspectRatio();
+    const camera = model.openGLRenderer ? model.openGLRenderer.getRenderable().getActiveCamera() : null;
+    const tsize = model.openGLRenderer.getTiledSizeAndOrigin();
     let texels = null;
 
     if (model.renderable.getUseZValues()) {

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -79,7 +79,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     if (model.context !== ctx) {
       model.context = ctx;
       for (let i = primTypes.Start; i < primTypes.End; i++) {
-        model.primitives[i].setWindow(model.openGLRenderWindow);
+        model.primitives[i].setOpenGLRenderWindow(model.openGLRenderWindow);
       }
     }
     const actor = model.openGLActor.getRenderable();
@@ -171,12 +171,12 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       'uniform float diffuse;',
       'uniform float specular;',
       'uniform float opacityUniform; // the fragment opacity',
-      'uniform vec3 ambientColorUniform; // intensity weighted color',
-      'uniform vec3 diffuseColorUniform; // intensity weighted color'];
+      'uniform vec3 ambientColorUniform;',
+      'uniform vec3 diffuseColorUniform;'];
     // add more for specular
     if (lastLightComplexity) {
       colorDec = colorDec.concat([
-        'uniform vec3 specularColorUniform; // intensity weighted color',
+        'uniform vec3 specularColorUniform;',
         'uniform float specularPowerUniform;']);
     }
 
@@ -1458,8 +1458,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       tex.setMagnificationFilter(Filter.NEAREST);
       tex.setWrapS(Wrap.CLAMP_TO_EDGE);
       tex.setWrapT(Wrap.CLAMP_TO_EDGE);
-      tex.setWindow(model.openGLRenderWindow);
-      tex.setContext(model.openGLRenderWindow.getContext());
+      tex.setOpenGLRenderWindow(model.openGLRenderWindow);
 
       const input = model.renderable.getColorTextureMap();
       const ext = input.getExtent();

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -47,7 +47,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
       publicAPI.initialize();
       model.children.forEach((child) => {
-        child.setContext(model.context);
+        child.setOpenGLRenderWindow(publicAPI);
       });
     }
   };

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -158,6 +158,24 @@ function vtkOpenGLRenderer(publicAPI, model) {
     gl.enable(gl.DEPTH_TEST);
     /* eslint-enable no-bitwise */
   };
+
+  publicAPI.releaseGraphicsResources = () => {
+    if (model.selector !== null) {
+      model.selector.releaseGraphicsResources();
+    }
+  };
+
+  publicAPI.setOpenGLRenderWindow = (rw) => {
+    if (model.openGLRenderWindow === rw) {
+      return;
+    }
+    publicAPI.releaseGraphicsResources();
+    model.openGLRenderWindow = rw;
+    model.context = null;
+    if (rw) {
+      model.context = model.openGLRenderWindow.getContext();
+    }
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -166,6 +184,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   context: null,
+  openGLRenderWindow: null,
   selector: null,
 };
 
@@ -181,7 +200,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.get(publicAPI, model, ['shaderCache']);
 
   macro.setGet(publicAPI, model, [
-    'context',
     'selector',
   ]);
 

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -210,7 +210,7 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
       if (!vbo.getColorBO()) {
         vbo.setColorBO(vtkBufferObject.newInstance());
       }
-      vbo.getColorBO().setContext(model.context);
+      vbo.getColorBO().setOpenGLRenderWindow(model.openGLRenderWindow);
     } else if (vbo.getColorBO()) {
       vbo.setColorBO(null);
     }

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -316,7 +316,7 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     if (!vbo.getColorBO()) {
       vbo.setColorBO(vtkBufferObject.newInstance());
     }
-    vbo.getColorBO().setContext(model.context);
+    vbo.getColorBO().setOpenGLRenderWindow(model.openGLRenderWindow);
     if (c) {
       colorComponents = c.getNumberOfComponents();
       vbo.setColorOffset(4);

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -18,10 +18,10 @@ function vtkOpenGLTexture(publicAPI, model) {
   model.classHierarchy.push('vtkOpenGLTexture');
   // Renders myself
   publicAPI.render = () => {
-    const oglren = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
+    model.openGLRenderer = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
     // sync renderable properties
-    model.window = oglren.getParent();
-    model.context = model.window.getContext();
+    model.openGLRenderWindow = model.openGLRenderer.getParent();
+    model.context = model.openGLRenderWindow.getContext();
     if (model.renderable.getInterpolate()) {
       if (model.generateMipmap) {
         publicAPI.setMinificationFilter(Filter.LINEAR_MIPMAP_LINEAR);
@@ -142,8 +142,8 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //---------------------------------------------------------------------------
   publicAPI.getTextureUnit = () => {
-    if (model.window) {
-      return model.window.getTextureUnitForTexture(publicAPI);
+    if (model.openGLRenderWindow) {
+      return model.openGLRenderWindow.getTextureUnitForTexture(publicAPI);
     }
     return -1;
   };
@@ -151,16 +151,14 @@ function vtkOpenGLTexture(publicAPI, model) {
   //---------------------------------------------------------------------------
   publicAPI.activate = () => {
     // activate a free texture unit for this texture
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.bind();
   };
 
   //---------------------------------------------------------------------------
   publicAPI.deactivate = () => {
-    if (model.window) {
-      model.window.activateTexture(publicAPI);
-      publicAPI.unBind();
-      model.window.deactivateTexture(publicAPI);
+    if (model.openGLRenderWindow) {
+      model.openGLRenderWindow.deactivateTexture(publicAPI);
     }
   };
 
@@ -170,7 +168,6 @@ function vtkOpenGLTexture(publicAPI, model) {
       rwin.makeCurrent();
 
       rwin.activateTexture(publicAPI);
-      publicAPI.unBind();
       rwin.deactivateTexture(publicAPI);
       model.context.deleteTexture(model.handle);
       model.handle = 0;
@@ -199,13 +196,6 @@ function vtkOpenGLTexture(publicAPI, model) {
   };
 
   //----------------------------------------------------------------------------
-  publicAPI.unBind = () => {
-    if (model.target) {
-      model.context.bindTexture(model.target, null);
-    }
-  };
-
-  //----------------------------------------------------------------------------
   publicAPI.isBound = () => {
     let result = false;
     if (model.context && model.handle) {
@@ -230,7 +220,7 @@ function vtkOpenGLTexture(publicAPI, model) {
       publicAPI.getOpenGLWrapMode(model.wrapS));
     model.context.texParameteri(model.target, model.context.TEXTURE_WRAP_T,
       publicAPI.getOpenGLWrapMode(model.wrapT));
-    if (model.window.getWebgl2()) {
+    if (model.openGLRenderWindow.getWebgl2()) {
       model.context.texParameteri(model.target, model.context.TEXTURE_WRAP_R,
         publicAPI.getOpenGLWrapMode(model.wrapR));
     }
@@ -274,14 +264,14 @@ function vtkOpenGLTexture(publicAPI, model) {
     let result = 0;
 
     // try default next
-    result = model.window.getDefaultTextureInternalFormat(
+    result = model.openGLRenderWindow.getDefaultTextureInternalFormat(
       vtktype, numComps, false);
     if (result) {
       return result;
     }
 
     // try floating point
-    result = this.window.getDefaultTextureInternalFormat(
+    result = this.openGLRenderWindow.getDefaultTextureInternalFormat(
       vtktype, numComps, true);
 
     if (!result) {
@@ -311,7 +301,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.getDefaultFormat = (vtktype, numComps) => {
-    if (model.window.getWebgl2()) {
+    if (model.openGLRenderWindow.getWebgl2()) {
       switch (numComps) {
         case 1:
           return model.context.RED;
@@ -350,7 +340,7 @@ function vtkOpenGLTexture(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.getDefaultDataType = (vtkScalarType) => {
     // DON'T DEAL with VTK_CHAR as this is platform dependent.
-    if (model.window.getWebgl2()) {
+    if (model.openGLRenderWindow.getWebgl2()) {
       switch (vtkScalarType) {
         // case VtkDataTypes.SIGNED_CHAR:
         //   return model.context.BYTE;
@@ -608,7 +598,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -657,7 +647,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -703,7 +693,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -747,7 +737,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = image.height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -800,7 +790,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = depth;
     model.numberOfDimensions = 3;
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -854,7 +844,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     if (dataType === VtkDataTypes.UNSIGNED_CHAR) {
       model.volumeInfo.min = 0.0;
       model.volumeInfo.max = 255.0;
-    } else if (model.window.getWebgl2() ||
+    } else if (model.openGLRenderWindow.getWebgl2() ||
         (model.context.getExtension('OES_texture_float') &&
          model.context.getExtension('OES_texture_float_linear'))) {
       dataTypeToUse = VtkDataTypes.FLOAT;
@@ -878,7 +868,7 @@ function vtkOpenGLTexture(publicAPI, model) {
       };
     }
 
-    if (model.window.getWebgl2()) {
+    if (model.openGLRenderWindow.getWebgl2()) {
       if (dataType !== VtkDataTypes.UNSIGNED_CHAR) {
         const newArray = new Float32Array(numPixelsIn);
         for (let i = 0; i < numPixelsIn; ++i) {
@@ -923,7 +913,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     model.width = targetWidth;
     model.height = targetHeight;
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -1042,7 +1032,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.volumeInfo = { min: minMag, max: maxMag };
     let outIdx = 0;
 
-    if (model.window.getWebgl2()) {
+    if (model.openGLRenderWindow.getWebgl2()) {
       const numPixelsIn = width * height * depth;
       const newArray = new Uint8Array(numPixelsIn * 4);
       for (let p = 0; p < numPixelsIn; ++p) {
@@ -1103,7 +1093,7 @@ function vtkOpenGLTexture(publicAPI, model) {
       }
     }
 
-    model.window.activateTexture(publicAPI);
+    model.openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -1125,6 +1115,18 @@ function vtkOpenGLTexture(publicAPI, model) {
     return true;
   };
 
+  publicAPI.setOpenGLRenderWindow = (rw) => {
+    if (model.openGLRenderWindow === rw) {
+      return;
+    }
+    publicAPI.releaseGraphicsResources();
+    model.openGLRenderWindow = rw;
+    model.context = null;
+    if (rw) {
+      model.context = model.openGLRenderWindow.getContext();
+    }
+  };
+
   //----------------------------------------------------------------------------
   publicAPI.getMaximumTextureSize = (ctx) => {
     if (ctx && ctx.isCurrent()) {
@@ -1140,7 +1142,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  window: null,
+  openGLRenderWindow: null,
   context: null,
   handle: 0,
   sendParametersTime: null,
@@ -1187,8 +1189,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
 
   macro.setGet(publicAPI, model, [
-    'window',
-    'context',
     'keyMatrixTime',
     'minificationFilter',
     'magnificationFilter',

--- a/Sources/Rendering/OpenGL/VertexArrayObject/index.js
+++ b/Sources/Rendering/OpenGL/VertexArrayObject/index.js
@@ -15,7 +15,9 @@ function vtkOpenGLVertexArrayObject(publicAPI, model) {
   };
 
   publicAPI.initialize = () => {
-    if (!model.forceEmulation && model.openGLWindow && model.openGLWindow.getWebgl2()) {
+    if (!model.forceEmulation &&
+         model.openGLRenderWindow &&
+         model.openGLRenderWindow.getWebgl2()) {
       model.extension = null;
       model.supported = true;
       model.handleVAO = model.context.createVertexArray();
@@ -160,7 +162,6 @@ function vtkOpenGLVertexArrayObject(publicAPI, model) {
     attribs.index = gl.getAttribLocation(model.handleProgram, name);
     attribs.offset = offset;
     attribs.stride = stride;
-  //    attribs.type = convertTypeToGL(elementType);
     attribs.type = elementType;
     attribs.size = elementTupleSize;
     attribs.normalize = normalize;
@@ -230,7 +231,6 @@ function vtkOpenGLVertexArrayObject(publicAPI, model) {
 
     for (let i = 1; i < elementTupleSize; i++) {
       gl.enableVertexAttribArray(index + i);
-//      gl.vertexAttribPointer(index + i, elementTupleSize, convertTypeToGL(elementType),
       gl.vertexAttribPointer(index + i, elementTupleSize, elementType,
                             normalize, stride,
                             offset + ((stride * i) / elementTupleSize));
@@ -267,9 +267,16 @@ function vtkOpenGLVertexArrayObject(publicAPI, model) {
     return true;
   };
 
-  publicAPI.setWindow = (win) => {
-    model.openGLWindow = win;
-    model.context = win.getContext();
+  publicAPI.setOpenGLRenderWindow = (rw) => {
+    if (model.openGLRenderWindow === rw) {
+      return;
+    }
+    publicAPI.releaseGraphicsResources();
+    model.openGLRenderWindow = rw;
+    model.context = null;
+    if (rw) {
+      model.context = model.openGLRenderWindow.getContext();
+    }
   };
 }
 
@@ -284,7 +291,7 @@ const DEFAULT_VALUES = {
   supported: true,
   buffers: null,
   context: null,
-  openGLWindow: null,
+  openGLRenderWindow: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -48,18 +48,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     if (prepass) {
       model.openGLRenderWindow = publicAPI.getFirstAncestorOfType('vtkOpenGLRenderWindow');
       model.context = model.openGLRenderWindow.getContext();
-      model.tris.setWindow(model.openGLRenderWindow);
-      model.scalarTexture.setWindow(model.openGLRenderWindow);
-      model.scalarTexture.setContext(model.context);
-      model.colorTexture.setWindow(model.openGLRenderWindow);
-      model.colorTexture.setContext(model.context);
-      model.opacityTexture.setWindow(model.openGLRenderWindow);
-      model.opacityTexture.setContext(model.context);
-      model.lightingTexture.setWindow(model.openGLRenderWindow);
-      model.lightingTexture.setContext(model.context);
-      model.jitterTexture.setWindow(model.openGLRenderWindow);
-      model.jitterTexture.setContext(model.context);
-      model.framebuffer.setWindow(model.openGLRenderWindow);
+      model.tris.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.scalarTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.colorTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.opacityTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.lightingTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.jitterTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.framebuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
 
       model.openGLVolume = publicAPI.getFirstAncestorOfType('vtkOpenGLVolume');
       const actor = model.openGLVolume.getRenderable();


### PR DESCRIPTION
Add support for instanced rendering for webgl2 glyphs

Fix an issue with image mapper not redrawing correctly
after a modification.

Cleanup the use of window versus olgwindow versus
openGLRenderWindow naming to be more consistent.

Move more towards setting the window as opposed to the context.