### PR TITLE
feat(Rendering): Add initial support for WebVR

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
   // ],
   globals: {
     __BASE_PATH__: false,
+    VRFrameData: true,
   },
   'settings': {
     'import/resolver': 'webpack'

--- a/Examples/Geometry/VR/controller.html
+++ b/Examples/Geometry/VR/controller.html
@@ -1,0 +1,21 @@
+<table>
+  <tr>
+    <td>
+      <button class='vrbutton' style="width: 100%">Send To VR</button>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <select class='representations' style="width: 100%">
+        <option value='0'>Points</option>
+        <option value='1'>Wireframe</option>
+        <option value='2' selected>Surface</option>
+      </select>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <input class='resolution' type='range' min='4' max='80' value='6' />
+    </td>
+  </tr>
+</table>

--- a/Examples/Geometry/VR/index.js
+++ b/Examples/Geometry/VR/index.js
@@ -1,0 +1,101 @@
+import 'vtk.js/Sources/favicon';
+
+import vtkActor                  from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkCalculator             from 'vtk.js/Sources/Filters/General/Calculator';
+import vtkConeSource             from 'vtk.js/Sources/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper                 from 'vtk.js/Sources/Rendering/Core/Mapper';
+import { AttributeTypes }        from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes }        from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
+
+import controlPanel from './controller.html';
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({ background: [0, 0, 0] });
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+
+// ----------------------------------------------------------------------------
+// Example code
+// ----------------------------------------------------------------------------
+// create a filter on the fly, sort of cool, this is a random scalars
+// filter we create inline, for a simple cone you would not need
+// this
+// ----------------------------------------------------------------------------
+
+const coneSource = vtkConeSource.newInstance({ height: 100.0, radius: 50.0 });
+// const coneSource = vtkConeSource.newInstance({ height: 1.0, radius: 0.5 });
+const filter = vtkCalculator.newInstance();
+
+filter.setInputConnection(coneSource.getOutputPort());
+// filter.setFormulaSimple(FieldDataTypes.CELL, [], 'random', () => Math.random());
+filter.setFormula({
+  getArrays: inputDataSets => ({
+    input: [],
+    output: [
+      { location: FieldDataTypes.CELL, name: 'Random', dataType: 'Float32Array', attribute: AttributeTypes.SCALARS },
+    ],
+  }),
+  evaluate: (arraysIn, arraysOut) => {
+    const [scalars] = arraysOut.map(d => d.getData());
+    for (let i = 0; i < scalars.length; i++) {
+      scalars[i] = Math.random();
+    }
+  },
+});
+
+const mapper = vtkMapper.newInstance();
+mapper.setInputConnection(filter.getOutputPort());
+
+const actor = vtkActor.newInstance();
+actor.setMapper(mapper);
+actor.setPosition(20.0, 0.0, 0.0);
+
+renderer.addActor(actor);
+renderer.resetCamera();
+renderWindow.render();
+
+// -----------------------------------------------------------
+// UI control handling
+// -----------------------------------------------------------
+
+fullScreenRenderer.addController(controlPanel);
+const representationSelector = document.querySelector('.representations');
+const resolutionChange = document.querySelector('.resolution');
+const vrbutton = document.querySelector('.vrbutton');
+
+representationSelector.addEventListener('change', (e) => {
+  const newRepValue = Number(e.target.value);
+  actor.getProperty().setRepresentation(newRepValue);
+  renderWindow.render();
+});
+
+resolutionChange.addEventListener('input', (e) => {
+  const resolution = Number(e.target.value);
+  coneSource.setResolution(resolution);
+  renderWindow.render();
+});
+
+vrbutton.addEventListener('click', (e) => {
+  if (vrbutton.textContent === 'Send To VR') {
+    fullScreenRenderer.getOpenGLRenderWindow().startVR();
+    vrbutton.textContent = 'Return From VR';
+  } else {
+    fullScreenRenderer.getOpenGLRenderWindow().stopVR();
+    vrbutton.textContent = 'Send To VR';
+  }
+});
+
+// -----------------------------------------------------------
+// Make some variables global so that you can inspect and
+// modify objects in your browser's developer console:
+// -----------------------------------------------------------
+
+global.source = coneSource;
+global.mapper = mapper;
+global.actor = actor;
+global.renderer = renderer;
+global.renderWindow = renderWindow;

--- a/Sources/Rendering/Core/InteractorStyle/Constants.js
+++ b/Sources/Rendering/Core/InteractorStyle/Constants.js
@@ -12,6 +12,7 @@ export const States = {
   IS_FORWARDFLY: 8,
   IS_REVERSEFLY: 9,
   IS_TWO_POINTER: 10,
+  IS_CAMERA_POSE: 11,
 
   IS_ANIM_OFF: 0,
   IS_ANIM_ON: 1,

--- a/Sources/Rendering/Core/InteractorStyle/index.js
+++ b/Sources/Rendering/Core/InteractorStyle/index.js
@@ -21,6 +21,7 @@ const stateNames = {
   Timer: States.IS_TIMER,
   TwoPointer: States.IS_TWO_POINTER,
   UniformScale: States.IS_USCALE,
+  CameraPose: States.IS_CAMERA_POSE,
 };
 
 const events = [
@@ -49,6 +50,8 @@ const events = [
   'Tap',
   'LongTap',
   'Swipe',
+  'Button3D',
+  'Move3D',
 ];
 
 // ----------------------------------------------------------------------------
@@ -77,9 +80,9 @@ function vtkInteractorStyle(publicAPI, model) {
     if (i) {
       events.forEach((eventName) => {
         model.unsubscribes.push(
-        i[`on${eventName}`](() => {
+        i[`on${eventName}`]((data) => {
           if (publicAPI[`handle${eventName}`]) {
-            publicAPI[`handle${eventName}`]();
+            publicAPI[`handle${eventName}`](data);
           }
         }));
       });

--- a/Sources/Rendering/Core/RenderWindowInteractor/Constants.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/Constants.js
@@ -1,0 +1,18 @@
+export const Device = {
+  Unknown: 0,
+  LeftController: 1,
+  RightController: 2,
+};
+
+export const Input = {
+  Unknown: 0,
+  Trigger: 1,
+  TrackPad: 2,
+  Grip: 3,
+  ApplicationMenu: 4,
+};
+
+export default {
+  Device,
+  Input,
+};

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -45,10 +45,6 @@ function vtkRenderer(publicAPI, model) {
       vtkDebugMacro('No cameras are on, creating one.');
       // the get method will automagically create a camera
       // and reset it since one hasn't been specified yet.
-      // If is very unlikely that this can occur - if this
-      // renderer is part of a vtkRenderWindow, the camera
-      // will already have been created as part of the
-      // DoStereoRender() method.
       publicAPI.getActiveCameraAndResetIfCreated();
     }
 
@@ -393,6 +389,10 @@ function vtkRenderer(publicAPI, model) {
 
     // setup default parallel scale
     model.activeCamera.setParallelScale(parallelScale);
+
+    // update reasonable world to physical values
+    model.activeCamera.setPhysicalScale(1.0 / radius);
+    model.activeCamera.setPhysicalTranslation(-center[0], -center[1], -center[2]);
 
     // Here to let parallel/distributed compositing intercept
     // and do the right thing.

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
@@ -62,13 +62,13 @@ function vtkFullScreenRenderWindow(publicAPI, model) {
   model.renderWindow.addRenderer(model.renderer);
 
   // OpenGlRenderWindow
-  model.openGlRenderWindow = vtkOpenGLRenderWindow.newInstance();
-  model.openGlRenderWindow.setContainer(model.container);
-  model.renderWindow.addView(model.openGlRenderWindow);
+  model.openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
+  model.openGLRenderWindow.setContainer(model.container);
+  model.renderWindow.addView(model.openGLRenderWindow);
 
   // Interactor
   model.interactor = vtkRenderWindowInteractor.newInstance();
-  model.interactor.setView(model.openGlRenderWindow);
+  model.interactor.setView(model.openGLRenderWindow);
   model.interactor.initialize();
   model.interactor.bindEvents(model.container);
 
@@ -115,7 +115,7 @@ function vtkFullScreenRenderWindow(publicAPI, model) {
   // Handle window resize
   publicAPI.resize = () => {
     const dims = model.container.getBoundingClientRect();
-    model.openGlRenderWindow.setSize(Math.floor(dims.width), Math.floor(dims.height));
+    model.openGLRenderWindow.setSize(Math.floor(dims.width), Math.floor(dims.height));
     if (model.resizeCallback) {
       model.resizeCallback(dims);
     }
@@ -155,7 +155,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.get(publicAPI, model, [
     'renderWindow',
     'renderer',
-    'openGlRenderWindow',
+    'openGLRenderWindow',
     'interactor',
     'container',
     'controlContainer',


### PR DESCRIPTION
Tested on Firefox with the Vive. Supports the notion
of WorldToPhysical coordinate systems and uses the
gamepad API to poll controller events. Currently the
right controller trackpad is used to control movement.

ResetCamera will compute reasonable values for PhysicalScale
and PhysicalTranslation.

Still needs to be tested against DayDream and other VR
systems. Support for their gamepads needs to be added.