### PR TITLE
style(Rendering): clean some camera method names

### DIFF
--- a/Sources/Rendering/Core/Camera/api.md
+++ b/Sources/Rendering/Core/Camera/api.md
@@ -180,33 +180,20 @@ calculation. Default is (0.5, -0.5, -0.5).
 Set/Get top right corner point of the screen. This will be used only for offaxis frustum
 calculation. Default is (0.5, 0.5, -0.5).
 
-### getViewTransformMatrix()
+### getViewMatrix()
 
 Return the matrix of the view transform. The ViewTransform depends on only three ivars:  the
 Position, the FocalPoint, and the ViewUp vector. All the other methods are there simply for
 the sake of the users' convenience.
 
-### getViewTransformObject()
-
-Return the view transform. The ViewTransform depends on only three ivars: the Position, the
-FocalPoint, and the ViewUp vector. All the other methods are there simply for the sake of the
-users' convenience.
-
-### getProjectionTransformMatrix(aspect, nearz, farz)
+### getProjectionMatrix(aspect, nearz, farz)
 
 Return the projection transform matrix, which converts from camera coordinates to viewport
 coordinates. The 'aspect' is the width/height for the viewport, and the nearz and farz are
 the Z-buffer values that map to the near and far clipping planes. The viewport coordinates of
 a point located inside the frustum are in the range ([-1,+1],[-1,+1],[nearz,farz]).
 
-### getProjectionTransformObject(aspect, nearz, farz)
-
-Return the projection transform matrix, which converts from camera coordinates to viewport
-coordinates. The 'aspect' is the width/height for the viewport, and the nearz and farz are
-the Z-buffer values that map to the near and far clipping planes. The viewport coordinates
-of a point located inside the frustum are in the range ([-1,+1],[-1,+1],[nearz,farz]).
-
-### getCompositeProjectionTransformMatrix(aspect, nearz, farz)
+### getCompositeProjectionMatrix(aspect, nearz, farz)
 
 Return the concatenation of the ViewTransform and the ProjectionTransform. This transform
 will convert world coordinates to viewport coordinates. The 'aspect' is the width/height
@@ -214,23 +201,11 @@ for the viewport, and the nearz and farz are the Z-buffer values that map to the
 far clipping planes. The viewport coordinates of a point located inside the frustum are
 in the range ([-1,+1],[-1,+1],[nearz,farz]).
 
-### getProjectionTransformMatrix(renderer)
+### getProjectionMatrix(renderer)
 
 Given a vtkRenderer, return the projection transform matrix, which converts from camera
 coordinates to viewport coordinates. This method computes the aspect, nearz and farz,
 then calls the more specific signature of GetCompositeProjectionTransformMatrix.
-
-### userViewTransform
-
-In addition to the instance variables such as position and orientation, you can add an
-additional transformation for your own use. This transformation is concatenated to the
-camera's ViewTransform.
-
-### userTransform
-
-In addition to the instance variables such as position and orientation, you can add an
-additional transformation for your own use. This transformation is concatenated to the
-camera's ProjectionTransform.
 
 ### render(renderer)
 

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -37,7 +37,7 @@ function vtkCamera(publicAPI, model) {
   const tmpvec3 = vec3.create();
 
   publicAPI.orthogonalizeViewUp = () => {
-    const vt = publicAPI.getViewTransformMatrix();
+    const vt = publicAPI.getViewMatrix();
     model.viewUp[0] = vt[4];
     model.viewUp[1] = vt[5];
     model.viewUp[2] = vt[6];
@@ -58,7 +58,6 @@ function vtkCamera(publicAPI, model) {
 
     // recompute the focal distance
     publicAPI.computeDistance();
-    // publicAPI.computeCameraLightTransform();
 
     publicAPI.modified();
   };
@@ -76,7 +75,6 @@ function vtkCamera(publicAPI, model) {
 
     // recompute the focal distance
     publicAPI.computeDistance();
-    // publicAPI.computeCameraLightTransform();
 
     publicAPI.modified();
   };
@@ -226,7 +224,7 @@ function vtkCamera(publicAPI, model) {
     const newPosition = vec3.create();
     const fp = model.focalPoint;
 
-    const vt = publicAPI.getViewTransformMatrix();
+    const vt = publicAPI.getViewMatrix();
     const axis = [-vt[0], -vt[1], -vt[2]];
 
     const trans = mat4.create();
@@ -248,7 +246,7 @@ function vtkCamera(publicAPI, model) {
     const newFocalPoint = vec3.create();
     const position = model.position;
 
-    const vt = publicAPI.getViewTransformMatrix();
+    const vt = publicAPI.getViewMatrix();
     const axis = [vt[0], vt[1], vt[2]];
 
     const trans = mat4.create();
@@ -363,7 +361,7 @@ function vtkCamera(publicAPI, model) {
     publicAPI.setDistance(oldDist);
   };
 
-  publicAPI.getViewTransformMatrix = () => {
+  publicAPI.getViewMatrix = () => {
     const eye = model.position;
     const at = model.focalPoint;
     const up = model.viewUp;
@@ -384,7 +382,7 @@ function vtkCamera(publicAPI, model) {
     model.projectionMatrix = mat;
   };
 
-  publicAPI.getProjectionTransformMatrix = (aspect, nearz, farz) => {
+  publicAPI.getProjectionMatrix = (aspect, nearz, farz) => {
     const result = mat4.create();
 
     if (model.projectionMatrix) {
@@ -456,17 +454,13 @@ function vtkCamera(publicAPI, model) {
     return result;
   };
 
-  publicAPI.getCompositeProjectionTransformMatrix = (aspect, nearz, farz) => {
-    const vMat = publicAPI.getViewTransformMatrix();
-    const pMat = publicAPI.getProjectionTransformMatrix(aspect, nearz, farz);
+  publicAPI.getCompositeProjectionMatrix = (aspect, nearz, farz) => {
+    const vMat = publicAPI.getViewMatrix();
+    const pMat = publicAPI.getProjectionMatrix(aspect, nearz, farz);
     const result = mat4.create();
     mat4.multiply(result, vMat, pMat);
     return result;
   };
-
-  // publicAPI.getProjectionTransformMatrix = renderer => {
-  //   // return glmatrix object
-  // };
 
   publicAPI.getFrustumPlanes = (aspect) => {
     // Return array of 24 params (4 params for each of 6 plane equations)
@@ -563,26 +557,6 @@ function vtkCamera(publicAPI, model) {
     publicAPI.setDirectionOfProjection(newdop[0], newdop[1], newdop[2]);
     publicAPI.setViewUp(newvup[0], newvup[1], newvup[2]);
     publicAPI.modified();
-  };
-
-  publicAPI.getCameraLightTransformMatrix = () => {
-
-  };
-
-  publicAPI.updateViewport = () => {
-
-  };
-
-  publicAPI.shallowCopy = (sourceCamera) => {
-
-  };
-
-  publicAPI.setScissorRect = (rect) => {
-    // rect is a vtkRect
-  };
-
-  publicAPI.getScissorRect = () => {
-
   };
 }
 

--- a/Sources/Rendering/Core/PixelSpaceCallbackMapper/index.js
+++ b/Sources/Rendering/Core/PixelSpaceCallbackMapper/index.js
@@ -19,7 +19,7 @@ function vtkPixelSpaceCallbackMapper(publicAPI, model) {
       return;
     }
 
-    const matrix = camera.getCompositeProjectionTransformMatrix(aspect, -1, 1);
+    const matrix = camera.getCompositeProjectionMatrix(aspect, -1, 1);
     mat4.transpose(matrix, matrix);
 
     const dataPoints = dataset.getPoints();

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -59,7 +59,6 @@ function vtkRenderer(publicAPI, model) {
     // this lights.  That allows one renderer to view the lights that
     // another renderer is setting up.
     const camera = publicAPI.getActiveCameraAndResetIfCreated();
-    const lightMatrix = camera.getCameraLightTransformMatrix();
 
     model.lights.forEach((light) => {
       if (light.lightTypeIsSceneLight()) {
@@ -72,7 +71,7 @@ function vtkRenderer(publicAPI, model) {
         light.setFocalPointFrom(camera.getFocalPointByReference());
         light.modified(camera.getMTime());
       } else if (light.lightTypeIsCameraLight()) {
-        light.setTransformMatrix(lightMatrix);
+        vtkErrorMacro('camera lights not supported yet', light);
       } else {
         vtkErrorMacro('light has unknown light type', light);
       }
@@ -236,7 +235,7 @@ function vtkRenderer(publicAPI, model) {
 
     // get the perspective transformation from the active camera
     const matrix = model.activeCamera
-      .getCompositeProjectionTransformMatrix(aspect, -1.0, 1.0);
+      .getCompositeProjectionMatrix(aspect, -1.0, 1.0);
 
     mat4.invert(matrix, matrix);
     mat4.transpose(matrix, matrix);
@@ -257,7 +256,7 @@ function vtkRenderer(publicAPI, model) {
 
     // get the perspective transformation from the active camera
     const matrix = model.activeCamera
-      .getCompositeProjectionTransformMatrix(aspect, -1.0, 1.0);
+      .getCompositeProjectionMatrix(aspect, -1.0, 1.0);
     mat4.transpose(matrix, matrix);
 
     const result = vec3.fromValues(x, y, z);

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -37,7 +37,7 @@ function vtkOpenGLCamera(publicAPI, model) {
       model.openGLRenderWindow.getMTime() > model.keyMatrixTime.getMTime() ||
       publicAPI.getMTime() > model.keyMatrixTime.getMTime() ||
       ren.getMTime() > model.keyMatrixTime.getMTime()) {
-      mat4.copy(model.keyMatrices.wcvc, model.renderable.getViewTransformMatrix());
+      mat4.copy(model.keyMatrices.wcvc, model.renderable.getViewMatrix());
 
       mat3.fromMat4(model.keyMatrices.normalMatrix, model.keyMatrices.wcvc);
       mat3.invert(model.keyMatrices.normalMatrix, model.keyMatrices.normalMatrix);
@@ -45,12 +45,11 @@ function vtkOpenGLCamera(publicAPI, model) {
 
       const aspectRatio = model.openGLRenderer.getAspectRatio();
 
-      mat4.copy(model.keyMatrices.vcdc, model.renderable.getProjectionTransformMatrix(
+      mat4.copy(model.keyMatrices.vcdc, model.renderable.getProjectionMatrix(
                            aspectRatio, -1, 1));
       mat4.transpose(model.keyMatrices.vcdc, model.keyMatrices.vcdc);
 
       mat4.multiply(model.keyMatrices.wcdc, model.keyMatrices.vcdc, model.keyMatrices.wcvc);
-//      mat4.multiply(model.WCDCMatrix, model.WCVCMatrix, model.VCDCMatrix);
 
       model.keyMatrixTime.modified();
       model.lastRenderer = ren;

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1121,7 +1121,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
 
     // for lightkit case there are some parameters to set
     const cam = ren.getActiveCamera();
-    const viewTF = cam.getViewTransformMatrix();
+    const viewTF = cam.getViewMatrix();
     mat4.transpose(viewTF, viewTF);
 
     numberOfLights = 0;


### PR DESCRIPTION
Remove the Transform from some method names as we do not
have a Transform class. The old names were returning the
Transform's matrix. The vtk.js methods have no transform
so the name doesn't really make sense. We are just returning
the matrix.