### PR TITLE
fix(OpenGLImageMapper): shader modification to create a vec4

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -144,9 +144,9 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           '//VTK::TCoord::Impl',
           [
             'vec4 tcolor = scale*texture2D(texture1, tcoordVCVSOutput.st) + shift;',
-            'gl_FragData[0] = vec4(texture2D(colorTexture1, vec2(tcolor.r,0.5)),',
-            '  texture2D(colorTexture1, vec2(tcolor.g,0.5)),',
-            '  texture2D(colorTexture1, vec2(tcolor.b,0.5)), tcolor.a);',
+            'gl_FragData[0] = vec4(texture2D(colorTexture1, vec2(tcolor.r,0.5)).r,',
+            '  texture2D(colorTexture1, vec2(tcolor.g,0.5)).r,',
+            '  texture2D(colorTexture1, vec2(tcolor.b,0.5)).r, tcolor.a);',
           ]
         ).result;
     }


### PR DESCRIPTION
When trying to add an actor with an image with 4 components, the shader can't build. It seemed that the vec4 constructor wasn't good. 
Does @martinken can confirm ?