### PR TITLE
fix(XMLReader): Buffer length may not fit the typed array

### DIFF
--- a/Sources/IO/XML/XMLReader/index.js
+++ b/Sources/IO/XML/XMLReader/index.js
@@ -470,7 +470,8 @@ function vtkXMLReader(publicAPI, model) {
           );
           // set length header
           // TODO this does not work for lengths that are greater than the max Uint32 value.
-          new TYPED_ARRAY[headerType](data.buffer)[0] = uncompressed.length;
+          new TYPED_ARRAY[headerType](data.buffer, 0, 1)[0] =
+            uncompressed.length;
           data.set(uncompressed, TYPED_ARRAY_BYTES[headerType]);
 
           dataArrays[arrayidx] = data;


### PR DESCRIPTION
Since we only need to set the first several bytes as the length header,
simply create an array view that has length 1.