### PR TITLE
Fix incorrect interpretation of last block size in zLib+appended vt* formats

### DIFF
--- a/Sources/IO/XML/XMLReader/index.js
+++ b/Sources/IO/XML/XMLReader/index.js
@@ -441,7 +441,13 @@ function vtkXMLReader(publicAPI, model) {
 
           let buffer = null;
           if (nbBlocks > 0) {
-            buffer = new ArrayBuffer(header[2] * (nbBlocks - 1) + header[3]);
+            // If the last block's size is labeled as 0, that means the last block
+            // really has size header[2].
+            if (header[3] === 0) {
+              buffer = new ArrayBuffer(header[2] * nbBlocks);
+            } else {
+              buffer = new ArrayBuffer(header[2] * (nbBlocks - 1) + header[3]);
+            }
           } else {
             // if there is no blocks, then default to a zero array of size 0.
             buffer = new ArrayBuffer(0);


### PR DESCRIPTION
This only affects data files whose data arrays' uncompressed sizes align with 32768 (or whatever the uncompressed block size is specified in the compression header).