### PR TITLE
perf(OBJReader): Filters faces if spaces have been added

### DIFF
--- a/Sources/IO/Misc/OBJReader/index.js
+++ b/Sources/IO/Misc/OBJReader/index.js
@@ -67,7 +67,7 @@ function parseLine(line) {
     }
     const cells = data.f[data.size - 1];
     tokens.shift();
-    const faces = tokens.filter((s) => s.length);
+    const faces = tokens.filter((s) => s.length > 0 && s !== '\r');
     const size = faces.length;
     cells.push(size);
     for (let i = 0; i < size; i++) {


### PR DESCRIPTION
If an obj file has spaces at the end of faces line, it adds a non existing point to the face
Example:
"f 10 10 10  " will create a face with 4 points and the last one will point to a memory adresse that doesn't exist. 