### PR TITLE
fix(imageMapper): fix example by setting slicing mode

### DIFF
--- a/Sources/Rendering/Core/ImageMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageMapper/example/index.js
@@ -1,10 +1,13 @@
 import 'vtk.js/Sources/favicon';
 
+import Constants from 'vtk.js/Sources/Rendering/Core/ImageMapper/Constants';
 import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
 import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
 import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
 import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
 import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
+
+const { SlicingMode } = Constants;
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup
@@ -26,19 +29,37 @@ rtSource.setStandardDeviation(0.3);
 const mapper = vtkImageMapper.newInstance();
 mapper.setInputConnection(rtSource.getOutputPort());
 mapper.setSliceAtFocalPoint(true);
+mapper.setCurrentSlicingMode(SlicingMode.Z);
 // mapper.setZSlice(5);
 
 const actor = vtkImageSlice.newInstance();
 actor.getProperty().setColorWindow(255);
 actor.getProperty().setColorLevel(127);
 actor.setMapper(mapper);
+renderer.addActor(actor);
 
 const iStyle = vtkInteractorStyleImage.newInstance();
 iStyle.setInteractionMode('IMAGE_SLICING');
 renderWindow.getInteractor().setInteractorStyle(iStyle);
 
-renderer.getActiveCamera().setParallelProjection(true);
-renderer.addActor(actor);
+const camera = renderer.getActiveCamera();
+const position = camera.getFocalPoint();
+const axis = mapper.getCurrentSlicingMode();
+position[axis] += 1; // offset along the slicing axis
+camera.setPosition(...position);
+switch (axis) {
+  case SlicingMode.X:
+    camera.setViewUp([0, 1, 0]);
+    break;
+  case SlicingMode.Y:
+    camera.setViewUp([1, 0, 0]);
+    break;
+  case SlicingMode.Z:
+    camera.setViewUp([0, 1, 0]);
+    break;
+  default:
+}
+camera.setParallelProjection(true);
 renderer.resetCamera();
 renderWindow.render();
 


### PR DESCRIPTION
Default slice mode was `None`. Since d0bec193, the slicing from
camera focal point is based on the slicing mode. We therefore
use the slicing mode in this example as well as adjust the camera
orientation to face the slicing axis.