### PR TITLE
fix(VolumeRepresentationProxy): remove useless get macro

### DIFF
--- a/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
@@ -332,7 +332,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   vtkAbstractRepresentationProxy.extend(publicAPI, model);
-  macro.setGet(publicAPI, model, ['lookupTable', 'piecewiseFunction']);
   macro.get(publicAPI, model, ['sampleDistance', 'edgeGradient']);
 
   // Object specific methods


### PR DESCRIPTION
To access the lookuptable, use:
`getLookupTableProxy(${arrayName}).getLookupTable()`
    
Same thing with piecewiseFunction.