### PR TITLE
fix(BinaryHelper): Use latin1 for text decoding

### DIFF
--- a/Sources/IO/Core/BinaryHelper/index.js
+++ b/Sources/IO/Core/BinaryHelper/index.js
@@ -6,7 +6,7 @@
  */
 function arrayBufferToString(arrayBuffer) {
   if ('TextDecoder' in window) {
-    const decoder = new TextDecoder();
+    const decoder = new TextDecoder('latin1');
     return decoder.decode(arrayBuffer);
   }
   // fallback on platforms w/o TextDecoder


### PR DESCRIPTION
Latin1 is single byte encoding, which is what we want for a 1-to-1
conversion of the arraybuffer to a string.