### PR TITLE
Abstract widget events handling

### DIFF
--- a/Sources/Interaction/Widgets/AbstractWidget/api.md
+++ b/Sources/Interaction/Widgets/AbstractWidget/api.md
@@ -21,8 +21,10 @@ It defines the representation of the widget
 
 ## listenEvents()
 
-Virtual method, needs to be overrides in derived class.
-It defined which methods will be invoked for each event (see vtkHandleWidget)
+Attaches interactor events to callbacks. Events are defined in
+vtkRenderWindowInteractor.handledEvents, and callbacks need to be formatted
+as handle${eventToHandle} and implemented in derived classes.
+example: handleMouseMove, handleLeftButtonPress...
 
 ## render()
 

--- a/Sources/Interaction/Widgets/HandleWidget/api.md
+++ b/Sources/Interaction/Widgets/HandleWidget/api.md
@@ -8,7 +8,7 @@ General widget for moving handles (translate and scale)
 
 ## Caught events
 
-List of event catch by the widget :
+List of events caught by the widget :
 - MouseMove
 - LeftButtonPress
 - LeftButtonRelease
@@ -20,13 +20,6 @@ List of event catch by the widget :
 ## createDefaultRepresentation()
 
 Create a vtkSphereHandleRepresentation as a default representation.
-
-## listenEvents()
-
-For each events, define a method called when event is caught :
-- onMouseMove then call handleMouseMove
-- onLeftButtonPress then call handleLeftButtonPress
-- ...
 
 ## allowHandleResize (set/get bool)
 

--- a/Sources/Interaction/Widgets/HandleWidget/index.js
+++ b/Sources/Interaction/Widgets/HandleWidget/index.js
@@ -6,21 +6,10 @@ import Constants from 'vtk.js/Sources/Interaction/Widgets/HandleWidget/Constants
 
 const { InteractionState } = vtkHandleRepresentation;
 const { WidgetState } = Constants;
-const { vtkErrorMacro } = macro;
 
 // ----------------------------------------------------------------------------
 // vtkHandleWidget methods
 // ----------------------------------------------------------------------------
-
-const events = [
-  'MouseMove',
-  'LeftButtonPress',
-  'LeftButtonRelease',
-  'MiddleButtonPress',
-  'MiddleButtonRelease',
-  'RightButtonPress',
-  'RightButtonRelease',
-];
 
 function vtkHandleWidget(publicAPI, model) {
   // Set our className
@@ -50,42 +39,6 @@ function vtkHandleWidget(publicAPI, model) {
   publicAPI.createDefaultRepresentation = () => {
     if (!model.widgetRep) {
       model.widgetRep = vtkSphereHandleRepresentation.newInstance();
-    }
-  };
-
-  // Implemented method
-  publicAPI.listenEvents = () => {
-    if (!model.interactor) {
-      vtkErrorMacro('The interactor must be set before listening events');
-      return;
-    }
-    events.forEach((eventName) => {
-      model.unsubscribes.push(
-        model.interactor[`on${eventName}`](() => {
-          if (publicAPI[`handle${eventName}`]) {
-            publicAPI[`handle${eventName}`]();
-          }
-        })
-      );
-    });
-  };
-
-  publicAPI.setInteractor = (i) => {
-    if (i === model.interactor) {
-      return;
-    }
-
-    // if we already have an Interactor then stop observing it
-    if (model.interactor) {
-      while (model.unsubscribes.length) {
-        model.unsubscribes.pop().unsubscribe();
-      }
-    }
-
-    model.interactor = i;
-
-    if (i) {
-      publicAPI.listenEvents();
     }
   };
 

--- a/Sources/Interaction/Widgets/HandleWidget/index.js
+++ b/Sources/Interaction/Widgets/HandleWidget/index.js
@@ -4,6 +4,7 @@ import vtkSphereHandleRepresentation from 'vtk.js/Sources/Interaction/Widgets/Sp
 import vtkHandleRepresentation from 'vtk.js/Sources/Interaction/Widgets/HandleRepresentation';
 import Constants from 'vtk.js/Sources/Interaction/Widgets/HandleWidget/Constants';
 
+const { VOID, EVENT_ABORT } = macro;
 const { InteractionState } = vtkHandleRepresentation;
 const { WidgetState } = Constants;
 
@@ -42,33 +43,19 @@ function vtkHandleWidget(publicAPI, model) {
     }
   };
 
-  publicAPI.handleMouseMove = () => {
-    publicAPI.moveAction();
-  };
+  publicAPI.handleMouseMove = () => publicAPI.moveAction();
 
-  publicAPI.handleLeftButtonPress = () => {
-    publicAPI.selectAction();
-  };
+  publicAPI.handleLeftButtonPress = () => publicAPI.selectAction();
 
-  publicAPI.handleLeftButtonRelease = () => {
-    publicAPI.endSelectAction();
-  };
+  publicAPI.handleLeftButtonRelease = () => publicAPI.endSelectAction();
 
-  publicAPI.handleMiddleButtonPress = () => {
-    publicAPI.translateAction();
-  };
+  publicAPI.handleMiddleButtonPress = () => publicAPI.translateAction();
 
-  publicAPI.handleMiddleButtonRelease = () => {
-    publicAPI.endSelectAction();
-  };
+  publicAPI.handleMiddleButtonRelease = () => publicAPI.endSelectAction();
 
-  publicAPI.handleRightButtonPress = () => {
-    publicAPI.scaleAction();
-  };
+  publicAPI.handleRightButtonPress = () => publicAPI.scaleAction();
 
-  publicAPI.handleRightButtonRelease = () => {
-    publicAPI.endSelectAction();
-  };
+  publicAPI.handleRightButtonRelease = () => publicAPI.endSelectAction();
 
   publicAPI.selectAction = () => {
     const pos = model.interactor.getEventPosition(
@@ -83,13 +70,13 @@ function vtkHandleWidget(publicAPI, model) {
     ];
     model.widgetRep.computeInteractionState(position);
     if (model.widgetRep.getInteractionState() === InteractionState.OUTSIDE) {
-      return;
+      return VOID;
     }
-
     model.widgetRep.startComplexWidgetInteraction(position);
     model.widgetState = WidgetState.ACTIVE;
     model.widgetRep.setInteractionState(InteractionState.SELECTING);
     genericAction();
+    return EVENT_ABORT;
   };
 
   publicAPI.translateAction = () => {
@@ -105,43 +92,47 @@ function vtkHandleWidget(publicAPI, model) {
     ];
     model.widgetRep.startComplexWidgetInteraction(position);
     if (model.widgetRep.getInteractionState() === InteractionState.OUTSIDE) {
-      return;
+      return VOID;
     }
     model.widgetState = WidgetState.ACTIVE;
     model.widgetRep.setInteractionState(InteractionState.TRANSLATING);
     genericAction();
+    return EVENT_ABORT;
   };
 
   publicAPI.scaleAction = () => {
-    if (model.allowHandleResize) {
-      const pos = model.interactor.getEventPosition(
-        model.interactor.getPointerIndex()
-      );
-      const boundingContainer = model.interactor
-        .getCanvas()
-        .getBoundingClientRect();
-      const position = [
-        pos.x - boundingContainer.left,
-        pos.y + boundingContainer.top,
-      ];
-      model.widgetRep.startComplexWidgetInteraction(position);
-      if (model.widgetRep.getInteractionState() === InteractionState.OUTSIDE) {
-        return;
-      }
-      model.widgetState = WidgetState.ACTIVE;
-      model.widgetRep.setInteractionState(InteractionState.SCALING);
-      genericAction();
+    if (!model.allowHandleResize) {
+      return VOID;
     }
+    const pos = model.interactor.getEventPosition(
+      model.interactor.getPointerIndex()
+    );
+    const boundingContainer = model.interactor
+      .getCanvas()
+      .getBoundingClientRect();
+    const position = [
+      pos.x - boundingContainer.left,
+      pos.y + boundingContainer.top,
+    ];
+    model.widgetRep.startComplexWidgetInteraction(position);
+    if (model.widgetRep.getInteractionState() === InteractionState.OUTSIDE) {
+      return VOID;
+    }
+    model.widgetState = WidgetState.ACTIVE;
+    model.widgetRep.setInteractionState(InteractionState.SCALING);
+    genericAction();
+    return EVENT_ABORT;
   };
 
   publicAPI.endSelectAction = () => {
     if (model.widgetState !== WidgetState.ACTIVE) {
-      return;
+      return VOID;
     }
     model.widgetState = WidgetState.START;
     model.widgetRep.highlight(0);
     publicAPI.invokeEndInteractionEvent();
     publicAPI.render();
+    return EVENT_ABORT;
   };
 
   publicAPI.moveAction = () => {
@@ -165,12 +156,13 @@ function vtkHandleWidget(publicAPI, model) {
       ) {
         publicAPI.render();
       }
-      return;
+      return VOID;
     }
 
     model.widgetRep.complexWidgetInteraction(position);
     publicAPI.invokeInteractionEvent();
     publicAPI.render();
+    return EVENT_ABORT;
   };
 }
 

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -6,16 +6,6 @@ import Constants from 'vtk.js/Sources/Interaction/Widgets/ImageCroppingRegionsWi
 const { vtkErrorMacro, VOID, EVENT_ABORT } = macro;
 const { WidgetState, CropWidgetEvents, Orientation } = Constants;
 
-const events = [
-  'MouseMove',
-  'LeftButtonPress',
-  'LeftButtonRelease',
-  'MiddleButtonPress',
-  'MiddleButtonRelease',
-  'RightButtonPress',
-  'RightButtonRelease',
-];
-
 // ----------------------------------------------------------------------------
 // vtkImageCroppingRegionsWidget methods
 // ----------------------------------------------------------------------------
@@ -62,45 +52,6 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
 
       publicAPI.updateRepresentation();
     }
-  };
-
-  // Implemented method
-  publicAPI.listenEvents = () => {
-    if (!model.interactor) {
-      vtkErrorMacro('The interactor must be set before listening events');
-      return;
-    }
-    events.forEach((eventName) => {
-      model.unsubscribes.push(
-        model.interactor[`on${eventName}`](() => {
-          if (publicAPI[`handle${eventName}`]) {
-            return publicAPI[`handle${eventName}`]();
-          }
-          return true;
-        }, model.priority)
-      );
-    });
-  };
-
-  publicAPI.setInteractor = (i) => {
-    if (i === model.interactor) {
-      return;
-    }
-
-    // if we already have an Interactor then stop observing it
-    if (model.interactor) {
-      while (model.unsubscribes.length) {
-        model.unsubscribes.pop().unsubscribe();
-      }
-    }
-
-    model.interactor = i;
-
-    if (i) {
-      publicAPI.listenEvents();
-    }
-
-    publicAPI.modified();
   };
 
   publicAPI.setVolumeMapper = (volumeMapper) => {

--- a/Sources/Interaction/Widgets/LineWidget/index.js
+++ b/Sources/Interaction/Widgets/LineWidget/index.js
@@ -6,23 +6,12 @@ import vtkLineRepresentation from 'vtk.js/Sources/Interaction/Widgets/LineRepres
 import { State } from 'vtk.js/Sources/Interaction/Widgets/LineRepresentation/Constants';
 import Constants from './Constants';
 
-const { vtkErrorMacro } = macro;
 const { WidgetState } = Constants;
 const { InteractionState } = HandleRepConstants;
 
 // ----------------------------------------------------------------------------
 // vtkHandleWidget methods
 // ----------------------------------------------------------------------------
-
-const events = [
-  'MouseMove',
-  'LeftButtonPress',
-  'LeftButtonRelease',
-  'MiddleButtonPress',
-  'MiddleButtonRelease',
-  'RightButtonPress',
-  'RightButtonRelease',
-];
 
 function vtkLineWidget(publicAPI, model) {
   // Set our className
@@ -41,42 +30,6 @@ function vtkLineWidget(publicAPI, model) {
       }
     }
   }
-
-  // Implemented method
-  publicAPI.listenEvents = () => {
-    if (!model.interactor) {
-      vtkErrorMacro('The interactor must be set before listening events');
-      return;
-    }
-    events.forEach((eventName) => {
-      model.unsubscribes.push(
-        model.interactor[`on${eventName}`](() => {
-          if (publicAPI[`handle${eventName}`]) {
-            publicAPI[`handle${eventName}`]();
-          }
-        })
-      );
-    });
-  };
-
-  publicAPI.setInteractor = (i) => {
-    if (i === model.interactor) {
-      return;
-    }
-
-    // if we already have an Interactor then stop observing it
-    if (model.interactor) {
-      while (model.unsubscribes.length) {
-        model.unsubscribes.pop().unsubscribe();
-      }
-    }
-
-    model.interactor = i;
-
-    if (i) {
-      publicAPI.listenEvents();
-    }
-  };
 
   publicAPI.setEnable = (enabling) => {
     const enable = model.enabled;

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -19,7 +19,7 @@ const deviceInputMap = {
   ],
 };
 
-const eventsWeHandle = [
+const handledEvents = [
   'Animation',
   'Enter',
   'Leave',
@@ -581,7 +581,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   };
 
   // create the generic Event methods
-  eventsWeHandle.forEach((eventName) => {
+  handledEvents.forEach((eventName) => {
     const lowerFirst = eventName.charAt(0).toLowerCase() + eventName.slice(1);
     publicAPI[`${lowerFirst}Event`] = (arg) => {
       if (!model.enabled) {
@@ -927,7 +927,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.obj(publicAPI, model);
 
   macro.event(publicAPI, model, 'RenderEvent');
-  eventsWeHandle.forEach((eventName) =>
+  handledEvents.forEach((eventName) =>
     macro.event(publicAPI, model, eventName)
   );
 
@@ -981,4 +981,4 @@ export const newInstance = macro.newInstance(
 
 // ----------------------------------------------------------------------------
 
-export default Object.assign({ newInstance, extend }, Constants);
+export default Object.assign({ newInstance, extend, handledEvents }, Constants);

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -736,8 +736,11 @@ export function event(publicAPI, model, eventName) {
       return;
     }
     /* eslint-disable prefer-rest-params */
-    for (let index = 0; index < callbacks.length; ++index) {
-      const [, cb, priority] = callbacks[index];
+    // Go through a copy of the callbacks array in case new callbacks
+    // get prepended within previous callbacks
+    const currentCallbacks = callbacks.slice();
+    for (let index = 0; index < currentCallbacks.length; ++index) {
+      const [, cb, priority] = currentCallbacks[index];
       if (priority < 0) {
         setTimeout(() => cb.apply(publicAPI, arguments), 1 - priority);
       } else if (cb) {


### PR DESCRIPTION
- [x] rename `eventsWeHandle` to `handledEvents` and expose them from the interactor
- [x] consolidate `setInteractor` and `listenEvents` in AbstractWidget
- [x] abort events when needed in HandleWidget
- [x] fix callback infinite loop in `macro.invoke`
- [x] ensure callbacks are not stored twice