### PR TITLE
fix(Rendering): glyph3dmapper honors the composite_index pass

### DIFF
--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -38,7 +38,6 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
     model.openGLRenderer.clear();
     model.openGLRenderer.setSelector(publicAPI);
-    model.renderer.setPreserveDepthBuffer(1);
     model.hitProps = [];
     model.props = [];
     publicAPI.releasePixBuffers();
@@ -48,7 +47,6 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
   publicAPI.endSelection = () => {
     model.hitProps = [];
     model.openGLRenderer.setSelector(null);
-    model.renderer.setPreserveDepthBuffer(0);
     model.framebuffer.restorePreviousBindingsAndBuffers();
   };
 
@@ -162,8 +160,8 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.renderCompositeIndex = (index) => {
-    if (index > 0xffffff) {
-      vtkErrorMacro('Indices > 0xffffff are not supported.');
+    if (model.currentPass === PassTypes.COMPOSITE_INDEX_PASS) {
+      publicAPI.setPropColorValueFromInt(index + model.idOffset);
     }
   };
 
@@ -270,13 +268,15 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
       info.propID = actorid - model.idOffset;
       info.prop = publicAPI.getPropFromID(info.propID);
 
-      // let compositeID = publicAPI.convert(
-      //   displayPosition[0], displayPosition[1],
-      //   model.pixBuffer[PassTypes.COMPOSITE_INDEX_PASS]);
-      // if (compositeID < 0 || compositeID > 0xffffff) {
-      //   compositeID = 0;
-      // }
-      // info.compositeID = compositeID - model.idOffset;
+      let compositeID = publicAPI.convert(
+        displayPosition[0],
+        displayPosition[1],
+        model.pixBuffer[PassTypes.COMPOSITE_INDEX_PASS]
+      );
+      if (compositeID < 0 || compositeID > 0xffffff) {
+        compositeID = 0;
+      }
+      info.compositeID = compositeID - model.idOffset;
 
       // const low24 = publicAPI.convert(
       //   displayPosition[0], displayPosition[1], model.pixBuffer[PassTypes.ID_LOW24]);

--- a/Sources/Rendering/OpenGL/HardwareSelector/test/testHardwareSelectorGlyph.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/test/testHardwareSelectorGlyph.js
@@ -1,0 +1,124 @@
+import test from 'tape-catch';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
+import vtkOpenGLHardwareSelector from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector';
+import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
+import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
+import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+
+import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
+import {
+  FieldAssociations,
+  FieldDataTypes,
+} from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
+
+test.onlyIfWebGL('Test HardwareSelectorGlyph', (tapeContext) => {
+  const gc = testUtils.createGarbageCollector(tapeContext);
+  tapeContext.ok('rendering', 'TestHardwareSelectorGlyph');
+
+  // Create some control UI
+  const container = document.querySelector('body');
+  const renderWindowContainer = gc.registerDOMElement(
+    document.createElement('div')
+  );
+  container.appendChild(renderWindowContainer);
+
+  // create what we will view
+  const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+  const renderer = gc.registerResource(vtkRenderer.newInstance());
+  renderWindow.addRenderer(renderer);
+  renderer.setBackground(0.32, 0.34, 0.43);
+
+  const planeSource = vtkPlaneSource.newInstance();
+  const simpleFilter = vtkCalculator.newInstance();
+  const mapper = vtkGlyph3DMapper.newInstance();
+  const actor = vtkActor.newInstance();
+
+  simpleFilter.setFormula({
+    getArrays: (inputDataSets) => ({
+      input: [{ location: FieldDataTypes.COORDINATE }], // Require point coordinates as input
+      output: [
+        // Generate two output arrays:
+        {
+          location: FieldDataTypes.POINT, // This array will be point-data ...
+          name: 'pressure', // ... with the given name ...
+          dataType: 'Float32Array', // ... of this type ...
+          numberOfComponents: 3, // ... with this many components ...
+        },
+        {
+          location: FieldDataTypes.POINT, // This array will be field data ...
+          name: 'temperature', // ... with the given name ...
+          dataType: 'Float32Array', // ... of this type ...
+          attribute: AttributeTypes.SCALARS, // ... and will be marked as the default scalars.
+          numberOfComponents: 1, // ... with this many components ...
+        },
+      ],
+    }),
+    evaluate: (arraysIn, arraysOut) => {
+      // Convert in the input arrays of vtkDataArrays into variables
+      // referencing the underlying JavaScript typed-data arrays:
+      const [coords] = arraysIn.map((d) => d.getData());
+      const [press, temp] = arraysOut.map((d) => d.getData());
+
+      // Since we are passed coords as a 3-component array,
+      // loop over all the points and compute the point-data output:
+      for (let i = 0, sz = coords.length / 3; i < sz; ++i) {
+        press[i * 3] = (coords[3 * i] - 0.5) * (coords[3 * i] - 0.5);
+        press[i * 3 + 1] =
+          ((coords[3 * i + 1] - 0.5) * (coords[3 * i + 1] - 0.5) + 0.125) * 0.1;
+        press[i * 3 + 2] =
+          ((coords[3 * i] - 0.5) * (coords[3 * i] - 0.5) +
+            (coords[3 * i + 1] - 0.5) * (coords[3 * i + 1] - 0.5) +
+            0.125) *
+          0.1;
+        temp[i] = coords[3 * i + 1] * 0.1;
+      }
+      // Mark the output vtkDataArray as modified
+      arraysOut.forEach((x) => x.modified());
+    },
+  });
+
+  // The generated 'temperature' array will become the default scalars, so the plane mapper will color by 'temperature':
+  simpleFilter.setInputConnection(planeSource.getOutputPort());
+
+  mapper.setInputConnection(simpleFilter.getOutputPort(), 0);
+
+  const coneSource = vtkConeSource.newInstance();
+  coneSource.setResolution(12);
+  mapper.setInputConnection(coneSource.getOutputPort(), 1);
+  mapper.setOrientationArray('pressure');
+  mapper.setScalarRange(0.0, 0.1);
+  renderer.addActor(actor);
+  actor.setMapper(mapper);
+
+  // now create something to view it, in this case webgl
+  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  glwindow.setContainer(renderWindowContainer);
+  renderWindow.addView(glwindow);
+  glwindow.setSize(400, 400);
+  glwindow.traverseAllPasses();
+  renderer.getActiveCamera().zoom(1.4);
+
+  const sel = gc.registerResource(vtkOpenGLHardwareSelector.newInstance());
+  sel.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_POINTS);
+  sel.attach(glwindow, renderer);
+
+  sel.setArea(200, 200, 250, 300);
+  const res = sel.select();
+  console.log(res[0].get());
+  const allGood = res.length === 7 && res[0].getProperties().prop === actor;
+
+  tapeContext.ok(res.length === 7, 'Seven glyphs selected');
+  tapeContext.ok(
+    res[0].getProperties().compositeID === 71,
+    'glyph 71 was the first selected'
+  );
+  tapeContext.ok(allGood, 'Correct prop was selected');
+
+  gc.releaseResources();
+});

--- a/Sources/Rendering/OpenGL/glsl/vtkPolyDataVS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkPolyDataVS.glsl
@@ -41,6 +41,9 @@ attribute vec4 vertexMC;
 // Apple Bug
 //VTK::PrimID::Dec
 
+// picking support
+//VTK::Picking::Dec
+
 void main()
 {
   //VTK::Color::Impl
@@ -56,4 +59,6 @@ void main()
   //VTK::PositionVC::Impl
 
   //VTK::Light::Impl
+
+  //VTK::Picking::Impl
 }

--- a/Sources/tests.js
+++ b/Sources/tests.js
@@ -32,6 +32,7 @@ import './Rendering/Core/RenderWindow/test/testMultipleRenderers';
 import './Rendering/Core/SphereMapper/test/testDisableScalarColoring';
 import './Rendering/OpenGL/Actor/test/testRotate';
 import './Rendering/OpenGL/HardwareSelector/test/testHardwareSelector';
+import './Rendering/OpenGL/HardwareSelector/test/testHardwareSelectorGlyph';
 import './Rendering/OpenGL/ImageMapper/test/testImage';
 import './Rendering/OpenGL/ImageMapper/test/testImageColorTransferFunction';
 import './Rendering/OpenGL/PolyDataMapper/test/testAddShaderReplacements';


### PR DESCRIPTION
Now picking on a glyoph3dmapper should fill the composite id
of the glyphs that were picked.