### PR TITLE
fix(InteractorStyleTrackballCamera): Fix import of vtkInteractorStyle…

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -1,12 +1,13 @@
 import macro from 'vtk.js/Sources/macro';
 import vtkInteractorStyle from 'vtk.js/Sources/Rendering/Core/InteractorStyle';
+import vtkInteractorStyleConstants from 'vtk.js/Sources/Rendering/Core/InteractorStyle/Constants';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import {
   Device,
   Input,
 } from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor/Constants';
 
-const { States } = vtkInteractorStyle;
+const { States } = vtkInteractorStyleConstants;
 
 /* eslint-disable no-lonely-if */
 


### PR DESCRIPTION
… States

Addresses:

itkVtkImageViewer.js:61588 Uncaught TypeError: Cannot read property 'States' of undefined
   at Object.defineProperty.value (itkVtkImageViewer.js:61588)
var States = _InteractorStyle2.default.States;