### PR TITLE
perf(Math): Avoid Math.min, Math.max in vtkMath.arrayMin, vtkMath.arr…

### DIFF
--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -56,7 +56,7 @@ function arrayMin(arr) {
 function arrayMax(arr) {
   let maxValue = -Infinity;
   for (let i = 0, len = arr.length; i < len; ++i) {
-    if (arr[i] > maxValue) {
+    if (maxValue < arr[i]) {
       maxValue = arr[i];
     }
   }

--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -12,7 +12,6 @@ const { vtkErrorMacro, vtkWarningMacro } = macro;
 let randomSeedValue = 0;
 const VTK_MAX_ROTATIONS = 20;
 const VTK_SMALL_NUMBER = 1.0e-12;
-const MAX_FUNCTION_ARGUMENTS = 32768;
 
 function notImplemented(method) {
   return () => vtkErrorMacro(`vtkMath::${method} - NOT IMPLEMENTED`);
@@ -45,12 +44,10 @@ const { round, floor, ceil, min, max } = Math;
 
 function arrayMin(arr) {
   let minValue = Infinity;
-  for (let i = 0, len = arr.length; i < len; i += MAX_FUNCTION_ARGUMENTS) {
-    const submin = Math.min.apply(
-      null,
-      arr.slice(i, Math.min(i + MAX_FUNCTION_ARGUMENTS, len))
-    );
-    minValue = Math.min(submin, minValue);
+  for (let i = 0, len = arr.length; i < len; ++i) {
+    if (arr[i] < minValue) {
+      minValue = arr[i];
+    }
   }
 
   return minValue;
@@ -58,12 +55,10 @@ function arrayMin(arr) {
 
 function arrayMax(arr) {
   let maxValue = -Infinity;
-  for (let i = 0, len = arr.length; i < len; i += MAX_FUNCTION_ARGUMENTS) {
-    const submax = Math.max.apply(
-      null,
-      arr.slice(i, Math.min(i + MAX_FUNCTION_ARGUMENTS, len))
-    );
-    maxValue = Math.max(submax, maxValue);
+  for (let i = 0, len = arr.length; i < len; ++i) {
+    if (arr[i] > maxValue) {
+      maxValue = arr[i];
+    }
   }
 
   return maxValue;


### PR DESCRIPTION
…ayMax

Timings:

  Existing Math.min: ~210ms for arrayMin, ~2712ms for entire volume rendering initialization
  Comparison operator: ~35ms for arrayMin, ~2070ms for entire volume rendering initialization
  Ternary operator: ~37ms for arrayMin, ~2125ms for entire volume rendering initialization

CC: @martinken @jourdain @agirault 