### PR TITLE
fix(InteractorStyleManipulator): properly register animation requesters

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -285,7 +285,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
         callData.pokedRenderer,
         callData.position
       );
-      model.interactor.requestAnimation(publicAPI);
+      model.interactor.requestAnimation(publicAPI.onButtonDown);
       publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     } else {
       vtkDebugMacro('No manipulator found');
@@ -353,7 +353,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       model.currentManipulator.onButtonUp(model.interactor);
       model.currentManipulator.endInteraction();
       model.currentManipulator = null;
-      model.interactor.cancelAnimation(publicAPI);
+      model.interactor.cancelAnimation(publicAPI.onButtonDown);
       publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
     }
   };
@@ -368,7 +368,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
         manipulator.startInteraction();
       }
     }
-    model.interactor.requestAnimation(publicAPI);
+    model.interactor.requestAnimation(publicAPI.handleStartMouseWheel);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
   };
 
@@ -382,7 +382,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
         manipulator.endInteraction();
       }
     }
-    model.interactor.cancelAnimation(publicAPI);
+    model.interactor.cancelAnimation(publicAPI.handleStartMouseWheel);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -269,6 +269,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       return;
     }
     if (animationRequesters.has(requestor)) {
+      vtkWarningMacro(`requester is already registered for animating`);
       return;
     }
     animationRequesters.add(requestor);


### PR DESCRIPTION
Do not use same key for animations due to mouse drag and due to mouse wheel
or the second event will not be registered as an animation requester, and
the animation will stop when the first event terminates.

@jourdain no rush to integrate it on my side, can be merged with anything else that comes up later.