### PR TITLE
Fix orientations + XYZ slicing

### DIFF
--- a/Examples/Volume/MultiSliceImageMapper/controlPanel.html
+++ b/Examples/Volume/MultiSliceImageMapper/controlPanel.html
@@ -1,20 +1,20 @@
 <table>
     <tr>
-        <td>Slice X</td>
+        <td>Slice I</td>
         <td>
-            <input class='sliceX' type="range" min="0" max="2.0" step="1" value="1" />
+            <input class='sliceI' type="range" min="0" max="2.0" step="1" value="1" />
         </td>
     </tr>
     <tr>
-        <td>Slice Y</td>
+        <td>Slice J</td>
         <td>
-            <input class='sliceY' type="range" min="0" max="2.0" step="1" value="1" />
+            <input class='sliceJ' type="range" min="0" max="2.0" step="1" value="1" />
         </td>
     </tr>
     <tr>
-        <td>Slice Z</td>
+        <td>Slice K</td>
         <td>
-            <input class='sliceZ' type="range" min="0" max="100" step="1" value="1" />
+            <input class='sliceK' type="range" min="0" max="100" step="1" value="1" />
         </td>
     </tr>
     <tr>

--- a/Examples/Volume/MultiSliceImageMapper/index.js
+++ b/Examples/Volume/MultiSliceImageMapper/index.js
@@ -57,17 +57,17 @@ reader
 
     const imageMapperZ = vtkImageMapper.newInstance();
     imageMapperZ.setInputData(data);
-    imageMapperZ.setZSliceIndex(30);
+    imageMapperZ.setZSlice(30);
     imageActorZ.setMapper(imageMapperZ);
 
     const imageMapperY = vtkImageMapper.newInstance();
     imageMapperY.setInputData(data);
-    imageMapperY.setYSliceIndex(30);
+    imageMapperY.setYSlice(30);
     imageActorY.setMapper(imageMapperY);
 
     const imageMapperX = vtkImageMapper.newInstance();
     imageMapperX.setInputData(data);
-    imageMapperX.setXSliceIndex(30);
+    imageMapperX.setXSlice(30);
     imageActorX.setMapper(imageMapperX);
 
     renderer.resetCamera();
@@ -93,17 +93,17 @@ reader
   });
 
 document.querySelector('.sliceX').addEventListener('input', (e) => {
-  imageActorX.getMapper().setXSliceIndex(Number(e.target.value));
+  imageActorX.getMapper().setXSlice(Number(e.target.value));
   renderWindow.render();
 });
 
 document.querySelector('.sliceY').addEventListener('input', (e) => {
-  imageActorY.getMapper().setYSliceIndex(Number(e.target.value));
+  imageActorY.getMapper().setYSlice(Number(e.target.value));
   renderWindow.render();
 });
 
 document.querySelector('.sliceZ').addEventListener('input', (e) => {
-  imageActorZ.getMapper().setZSliceIndex(Number(e.target.value));
+  imageActorZ.getMapper().setZSlice(Number(e.target.value));
   renderWindow.render();
 });
 

--- a/Examples/Volume/MultiSliceImageMapper/index.js
+++ b/Examples/Volume/MultiSliceImageMapper/index.js
@@ -14,21 +14,21 @@ const renderWindow = fullScreenRenderWindow.getRenderWindow();
 const renderer = fullScreenRenderWindow.getRenderer();
 fullScreenRenderWindow.addController(controlPanel);
 
-const imageActorX = vtkImageSlice.newInstance();
-const imageActorY = vtkImageSlice.newInstance();
-const imageActorZ = vtkImageSlice.newInstance();
+const imageActorI = vtkImageSlice.newInstance();
+const imageActorJ = vtkImageSlice.newInstance();
+const imageActorK = vtkImageSlice.newInstance();
 
-renderer.addActor(imageActorZ);
-renderer.addActor(imageActorY);
-renderer.addActor(imageActorX);
+renderer.addActor(imageActorK);
+renderer.addActor(imageActorJ);
+renderer.addActor(imageActorI);
 
 function updateColorLevel(e) {
   const colorLevel = Number(
     (e ? e.target : document.querySelector('.colorLevel')).value
   );
-  imageActorX.getProperty().setColorLevel(colorLevel);
-  imageActorY.getProperty().setColorLevel(colorLevel);
-  imageActorZ.getProperty().setColorLevel(colorLevel);
+  imageActorI.getProperty().setColorLevel(colorLevel);
+  imageActorJ.getProperty().setColorLevel(colorLevel);
+  imageActorK.getProperty().setColorLevel(colorLevel);
   renderWindow.render();
 }
 
@@ -36,9 +36,9 @@ function updateColorWindow(e) {
   const colorLevel = Number(
     (e ? e.target : document.querySelector('.colorWindow')).value
   );
-  imageActorX.getProperty().setColorWindow(colorLevel);
-  imageActorY.getProperty().setColorWindow(colorLevel);
-  imageActorZ.getProperty().setColorWindow(colorLevel);
+  imageActorI.getProperty().setColorWindow(colorLevel);
+  imageActorJ.getProperty().setColorWindow(colorLevel);
+  imageActorK.getProperty().setColorWindow(colorLevel);
   renderWindow.render();
 }
 
@@ -55,26 +55,26 @@ reader
       .getRange();
     const extent = data.getExtent();
 
-    const imageMapperZ = vtkImageMapper.newInstance();
-    imageMapperZ.setInputData(data);
-    imageMapperZ.setZSlice(30);
-    imageActorZ.setMapper(imageMapperZ);
+    const imageMapperK = vtkImageMapper.newInstance();
+    imageMapperK.setInputData(data);
+    imageMapperK.setKSlice(30);
+    imageActorK.setMapper(imageMapperK);
 
-    const imageMapperY = vtkImageMapper.newInstance();
-    imageMapperY.setInputData(data);
-    imageMapperY.setYSlice(30);
-    imageActorY.setMapper(imageMapperY);
+    const imageMapperJ = vtkImageMapper.newInstance();
+    imageMapperJ.setInputData(data);
+    imageMapperJ.setJSlice(30);
+    imageActorJ.setMapper(imageMapperJ);
 
-    const imageMapperX = vtkImageMapper.newInstance();
-    imageMapperX.setInputData(data);
-    imageMapperX.setXSlice(30);
-    imageActorX.setMapper(imageMapperX);
+    const imageMapperI = vtkImageMapper.newInstance();
+    imageMapperI.setInputData(data);
+    imageMapperI.setISlice(30);
+    imageActorI.setMapper(imageMapperI);
 
     renderer.resetCamera();
     renderer.resetCameraClippingRange();
     renderWindow.render();
 
-    ['.sliceX', '.sliceY', '.sliceZ'].forEach((selector, idx) => {
+    ['.sliceI', '.sliceJ', '.sliceK'].forEach((selector, idx) => {
       const el = document.querySelector(selector);
       el.setAttribute('min', extent[idx * 2 + 0]);
       el.setAttribute('max', extent[idx * 2 + 1]);
@@ -92,18 +92,18 @@ reader
     updateColorWindow();
   });
 
-document.querySelector('.sliceX').addEventListener('input', (e) => {
-  imageActorX.getMapper().setXSlice(Number(e.target.value));
+document.querySelector('.sliceI').addEventListener('input', (e) => {
+  imageActorI.getMapper().setISlice(Number(e.target.value));
   renderWindow.render();
 });
 
-document.querySelector('.sliceY').addEventListener('input', (e) => {
-  imageActorY.getMapper().setYSlice(Number(e.target.value));
+document.querySelector('.sliceJ').addEventListener('input', (e) => {
+  imageActorJ.getMapper().setJSlice(Number(e.target.value));
   renderWindow.render();
 });
 
-document.querySelector('.sliceZ').addEventListener('input', (e) => {
-  imageActorZ.getMapper().setZSlice(Number(e.target.value));
+document.querySelector('.sliceK').addEventListener('input', (e) => {
+  imageActorK.getMapper().setKSlice(Number(e.target.value));
   renderWindow.render();
 });
 
@@ -115,6 +115,6 @@ document
   .addEventListener('input', updateColorWindow);
 
 global.fullScreen = fullScreenRenderWindow;
-global.imageActorX = imageActorX;
-global.imageActorY = imageActorY;
-global.imageActorZ = imageActorZ;
+global.imageActorI = imageActorI;
+global.imageActorJ = imageActorJ;
+global.imageActorK = imageActorK;

--- a/Sources/Common/DataModel/ITKHelper/index.js
+++ b/Sources/Common/DataModel/ITKHelper/index.js
@@ -37,8 +37,9 @@ function convertItkToVtkImage(itkImage, options = {}) {
     vtkImage.spacing[idx] = itkImage.spacing[idx];
     dimensions[idx] = itkImage.size[idx];
     for (let col = 0; col < itkImage.imageType.dimension; ++col) {
+      // Transpose direction matrix
       direction[col + idx * 3] =
-        itkImage.direction.data[col + idx * itkImage.imageType.dimension];
+        itkImage.direction.data[idx + col * itkImage.imageType.dimension];
     }
   }
 

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
@@ -29,7 +29,7 @@ rtSource.setStandardDeviation(0.3);
 
 const mapper = vtkImageMapper.newInstance();
 mapper.setInputConnection(rtSource.getOutputPort());
-mapper.setCurrentSlicingMode(SlicingMode.K);
+mapper.setSlicingMode(SlicingMode.K);
 
 const actor = vtkImageSlice.newInstance();
 actor.getProperty().setColorWindow(100);

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
@@ -8,6 +8,8 @@ import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/Inte
 
 import Manipulators from 'vtk.js/Sources/Interaction/Manipulators';
 
+const { SlicingMode } = vtkImageMapper;
+
 // ----------------------------------------------------------------------------
 // Standard rendering code setup
 // ----------------------------------------------------------------------------
@@ -27,6 +29,7 @@ rtSource.setStandardDeviation(0.3);
 
 const mapper = vtkImageMapper.newInstance();
 mapper.setInputConnection(rtSource.getOutputPort());
+mapper.setCurrentSlicingMode(SlicingMode.K);
 
 const actor = vtkImageSlice.newInstance();
 actor.getProperty().setColorWindow(100);
@@ -46,11 +49,11 @@ const lMin = range[0];
 const lMax = range[1];
 const lGet = actor.getProperty().getColorLevel;
 const lSet = actor.getProperty().setColorLevel;
-const bounds = data.getBounds();
-const zMin = bounds[4];
-const zMax = bounds[5];
-const zGet = mapper.getZSlice;
-const zSet = mapper.setZSlice;
+const extent = data.getExtent();
+const kMin = extent[4];
+const kMax = extent[5];
+const kGet = mapper.getSlice;
+const kSet = mapper.setSlice;
 
 const rangeManipulator = Manipulators.vtkMouseRangeManipulator.newInstance({
   button: 1,
@@ -58,7 +61,7 @@ const rangeManipulator = Manipulators.vtkMouseRangeManipulator.newInstance({
 });
 rangeManipulator.setVerticalListener(wMin, wMax, 1, wGet, wSet);
 rangeManipulator.setHorizontalListener(lMin, lMax, 1, lGet, lSet);
-rangeManipulator.setScrollListener(zMin, zMax, 1, zGet, zSet);
+rangeManipulator.setScrollListener(kMin, kMax, 1, kGet, kSet);
 
 const iStyle = vtkInteractorStyleManipulator.newInstance();
 iStyle.addMouseManipulator(rangeManipulator);

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/controlPanel.html
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/controlPanel.html
@@ -1,29 +1,29 @@
 <table>
     <tr>
-        <td>Slice X</td>
+        <td>Slice I</td>
         <td>
-            <input class='sliceX' type="range" min="0" max="2.0" step="1" value="1" />
+            <input class='sliceI' type="range" min="0" max="2.0" step="1" value="1" />
         </td>
     </tr>
     <tr>
-        <td>Slice Y</td>
+        <td>Slice J</td>
         <td>
-            <input class='sliceY' type="range" min="0" max="2.0" step="1" value="1" />
+            <input class='sliceJ' type="range" min="0" max="2.0" step="1" value="1" />
         </td>
     </tr>
     <tr>
-        <td>Slice Z</td>
+        <td>Slice K</td>
         <td>
-            <input class='sliceZ' type="range" min="0" max="100" step="1" value="1" />
+            <input class='sliceK' type="range" min="0" max="100" step="1" value="1" />
         </td>
     </tr>
     <tr>
         <td>View axis</td>
         <td>
             <select class='viewAxis'>
-              <option name='X'>X</option>
-              <option name='Y'>Y</option>
-              <option name='Z'>Z</option>
+              <option name='I'>I</option>
+              <option name='J'>J</option>
+              <option name='K'>K</option>
             </select>
         </td>
     </tr>

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
@@ -31,9 +31,9 @@ interactorStyle2D.setCurrentImageNumber(0);
 
 function setupControlPanel(data, imageMapper) {
   const sliceInputs = [
-    document.querySelector('.sliceX'),
-    document.querySelector('.sliceY'),
-    document.querySelector('.sliceZ'),
+    document.querySelector('.sliceI'),
+    document.querySelector('.sliceJ'),
+    document.querySelector('.sliceK'),
   ];
   const viewAxisInput = document.querySelector('.viewAxis');
 
@@ -46,22 +46,23 @@ function setupControlPanel(data, imageMapper) {
     el.setAttribute('value', (upperExtent - lowerExtent) / 2);
   });
 
-  viewAxisInput.value = ['X', 'Y', 'Z'][imageMapper.getSlicingMode()];
+  viewAxisInput.value = 'IJKXYZ'[imageMapper.getSlicingMode()];
 
   sliceInputs.forEach((el, idx) => {
     el.addEventListener('input', (ev) => {
-      const sliceNormal = ['X', 'Y', 'Z'][idx];
-      imageMapper[`set${sliceNormal}Slice`](Number(ev.target.value));
-
-      renderWindow.render();
+      const sliceMode = sliceInputs.indexOf(el);
+      if (imageMapper.getSlicingMode() === sliceMode) {
+        imageMapper.setSlice(Number(ev.target.value));
+        renderWindow.render();
+      }
     });
   });
 
   viewAxisInput.addEventListener('input', (ev) => {
-    const sliceMode = ['X', 'Y', 'Z'].indexOf(ev.target.value);
+    const sliceMode = 'IJKXYZ'.indexOf(ev.target.value);
     imageMapper.setSlicingMode(sliceMode);
     const slice = sliceInputs[sliceMode].value;
-    imageMapper[`set${ev.target.value}Slice`](slice);
+    imageMapper.setSlice(slice);
 
     const camPosition = renderer
       .getActiveCamera()
@@ -102,8 +103,7 @@ function setupWidget(volumeMapper, imageMapper) {
   imageMapper.onModified(() => {
     // update slice and slice orientation
     const sliceMode = imageMapper.getSlicingMode();
-    const sliceNormal = ['X', 'Y', 'Z'][sliceMode];
-    const slice = imageMapper[`get${sliceNormal}Slice`]();
+    const slice = imageMapper.getSlice();
     widget.setSlice(slice);
     widget.setSliceOrientation(sliceMode);
   });
@@ -136,12 +136,11 @@ reader
 
     // After creating our cropping widget, we can now update our image mapper
     // with default slice orientation/mode and camera view.
-    const sliceMode = 2;
+    const sliceMode = vtkImageMapper.SlicingMode.K;
     const viewUp = [0, 1, 0];
 
-    const sliceNormal = ['X', 'Y', 'Z'][sliceMode];
     imageMapper.setSlicingMode(sliceMode);
-    imageMapper[`set${sliceNormal}Slice`](0);
+    imageMapper.setSlice(0);
 
     const camPosition = renderer
       .getActiveCamera()

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
@@ -46,7 +46,7 @@ function setupControlPanel(data, imageMapper) {
     el.setAttribute('value', (upperExtent - lowerExtent) / 2);
   });
 
-  viewAxisInput.value = ['X', 'Y', 'Z'][imageMapper.getCurrentSlicingMode()];
+  viewAxisInput.value = ['X', 'Y', 'Z'][imageMapper.getSlicingMode()];
 
   sliceInputs.forEach((el, idx) => {
     el.addEventListener('input', (ev) => {
@@ -59,7 +59,7 @@ function setupControlPanel(data, imageMapper) {
 
   viewAxisInput.addEventListener('input', (ev) => {
     const sliceMode = ['X', 'Y', 'Z'].indexOf(ev.target.value);
-    imageMapper.setCurrentSlicingMode(sliceMode);
+    imageMapper.setSlicingMode(sliceMode);
     const slice = sliceInputs[sliceMode].value;
     imageMapper[`set${ev.target.value}Slice`](slice);
 
@@ -101,7 +101,7 @@ function setupWidget(volumeMapper, imageMapper) {
 
   imageMapper.onModified(() => {
     // update slice and slice orientation
-    const sliceMode = imageMapper.getCurrentSlicingMode();
+    const sliceMode = imageMapper.getSlicingMode();
     const sliceNormal = ['X', 'Y', 'Z'][sliceMode];
     const slice = imageMapper[`get${sliceNormal}Slice`]();
     widget.setSlice(slice);
@@ -140,7 +140,7 @@ reader
     const viewUp = [0, 1, 0];
 
     const sliceNormal = ['X', 'Y', 'Z'][sliceMode];
-    imageMapper.setCurrentSlicingMode(sliceMode);
+    imageMapper.setSlicingMode(sliceMode);
     imageMapper[`set${sliceNormal}Slice`](0);
 
     const camPosition = renderer

--- a/Sources/Proxy/Core/AbstractRepresentationProxy/index.js
+++ b/Sources/Proxy/Core/AbstractRepresentationProxy/index.js
@@ -12,9 +12,8 @@ function vtkAbstractRepresentationProxy(publicAPI, model) {
 
   function updateConnectivity() {
     if (model.input) {
-      let count = model.sourceDependencies.length;
-      while (count--) {
-        model.sourceDependencies[count].setInputData(model.input.getDataset());
+      for (let i = 0; i < model.sourceDependencies.length; ++i) {
+        model.sourceDependencies[i].setInputData(model.input.getDataset());
       }
     }
   }

--- a/Sources/Proxy/Core/View2DProxy/index.js
+++ b/Sources/Proxy/Core/View2DProxy/index.js
@@ -28,10 +28,7 @@ function vtkView2DProxy(publicAPI, model) {
 
   // Setup default corner annotation
   /* eslint-disable no-template-curly-in-string */
-  publicAPI.setCornerAnnotation(
-    'nw',
-    'Orientation ${axis}<br>Slice ${sliceIndex}'
-  );
+  publicAPI.setCornerAnnotation('nw', 'Orientation ${axis}<br>Slice ${slice}');
   publicAPI.setCornerAnnotation('se', 'CW ${colorWindow}<br>CL ${colorLevel}');
   /* eslint-enable no-template-curly-in-string */
 

--- a/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
@@ -89,9 +89,20 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
 
     // Init slice location
     const extent = inputDataset.getExtent();
-    publicAPI.setXSlice(Math.floor(mean(extent[0], extent[1])));
-    publicAPI.setYSlice(Math.floor(mean(extent[2], extent[3])));
-    publicAPI.setZSlice(Math.floor(mean(extent[4], extent[5])));
+    const { ijkMode } = model.mapper.getClosestIJKSlice();
+    switch (ijkMode) {
+      case vtkImageMapper.SlicingMode.I:
+        publicAPI.setSlice(Math.floor(mean(extent[0], extent[1])));
+        break;
+      case vtkImageMapper.SlicingMode.J:
+        publicAPI.setSlice(Math.floor(mean(extent[2], extent[3])));
+        break;
+      case vtkImageMapper.SlicingMode.K:
+        publicAPI.setSlice(Math.floor(mean(extent[4], extent[5])));
+        break;
+      default:
+        break;
+    }
   }
 
   // Keep things updated
@@ -99,12 +110,6 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
   model.sourceDependencies.push({ setInputData });
 
   // API ----------------------------------------------------------------------
-
-  publicAPI.setSliceIndex = (index) =>
-    model.mapper[`set${model.slicingMode}Slice`](index);
-
-  publicAPI.getSliceIndex = () =>
-    model.slicingMode ? model.mapper[`get${model.slicingMode}Slice`]() : 0;
 
   publicAPI.setSlicingMode = (mode) => {
     if (!mode) {
@@ -172,9 +177,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     visibility: { modelKey: 'actor', property: 'visibility' },
     colorWindow: { modelKey: 'property', property: 'colorWindow' },
     colorLevel: { modelKey: 'property', property: 'colorLevel' },
-    xSlice: { modelKey: 'mapper', property: 'xSlice' },
-    ySlice: { modelKey: 'mapper', property: 'ySlice' },
-    zSlice: { modelKey: 'mapper', property: 'zSlice' },
+    sliceIndex: { modelKey: 'mapper', property: 'slice' },
   });
 }
 

--- a/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
@@ -122,7 +122,7 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
     // Init slice location
     const bounds = inputDataset.getBounds();
     const extent = inputDataset.getExtent();
-    switch (model.mapper.getCurrentSlicingMode()) {
+    switch (model.mapper.getSlicingMode()) {
       case vtkImageMapper.SlicingMode.I:
         publicAPI.setSlice(Math.floor(mean(extent[0], extent[1])));
         break;
@@ -160,7 +160,7 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
     if (model.slicingMode !== mode) {
       // Update Mode
       model.slicingMode = mode;
-      model.mapper.setCurrentSlicingMode(vtkImageMapper.SlicingMode[mode]);
+      model.mapper.setSlicingMode(vtkImageMapper.SlicingMode[mode]);
 
       if (model.input) {
         // Update domains for UI...

--- a/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
@@ -18,17 +18,48 @@ function mean(...array) {
 
 // ----------------------------------------------------------------------------
 
-function updateDomains(dataset, dataArray, { slicingMode }, updateProp) {
+function updateDomains(dataset, dataArray, model, updateProp) {
   const dataRange = dataArray.getRange();
+  const spacing = dataset.getSpacing();
+  const bounds = dataset.getBounds();
   const extent = dataset.getExtent();
-  const axisIndex = 'XYZ'.indexOf(slicingMode);
+
+  let sliceMin;
+  let sliceMax;
+  let stepVal;
+  let axisIndex;
+  const sliceMode = model.mapper.getSlicingMode();
+  const sliceModeLabel = 'IJKXYZ'[sliceMode];
+  switch (sliceMode) {
+    case vtkImageMapper.SlicingMode.I:
+    case vtkImageMapper.SlicingMode.J:
+    case vtkImageMapper.SlicingMode.K:
+      axisIndex = 'IJK'.indexOf(sliceModeLabel);
+      sliceMin = extent[axisIndex * 2];
+      sliceMax = extent[axisIndex * 2 + 1];
+      stepVal = 1;
+      break;
+    case vtkImageMapper.SlicingMode.X:
+    case vtkImageMapper.SlicingMode.Y:
+    case vtkImageMapper.SlicingMode.Z:
+      {
+        axisIndex = 'XYZ'.indexOf(sliceModeLabel);
+        sliceMin = bounds[axisIndex * 2];
+        sliceMax = bounds[axisIndex * 2 + 1];
+        const { ijkMode } = model.mapper.getClosestIJKAxis();
+        stepVal = spacing[ijkMode];
+      }
+      break;
+    default:
+      break;
+  }
 
   const propToUpdate = {
-    sliceIndex: {
+    slice: {
       domain: {
-        min: extent[axisIndex * 2],
-        max: extent[axisIndex * 2 + 1],
-        step: 1,
+        min: sliceMin,
+        max: sliceMax,
+        step: stepVal,
       },
     },
     colorWindow: {
@@ -47,11 +78,12 @@ function updateDomains(dataset, dataArray, { slicingMode }, updateProp) {
     },
   };
 
-  updateProp('sliceIndex', propToUpdate.sliceIndex);
+  updateProp('slice', propToUpdate.slice);
   updateProp('colorWindow', propToUpdate.colorWindow);
   updateProp('colorLevel', propToUpdate.colorLevel);
 
   return {
+    slice: mean(propToUpdate.slice.domain.min, propToUpdate.slice.domain.max),
     colorWindow: propToUpdate.colorWindow.domain.max,
     colorLevel: Math.floor(
       mean(
@@ -88,9 +120,9 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
     publicAPI.set(state);
 
     // Init slice location
+    const bounds = inputDataset.getBounds();
     const extent = inputDataset.getExtent();
-    const { ijkMode } = model.mapper.getClosestIJKSlice();
-    switch (ijkMode) {
+    switch (model.mapper.getCurrentSlicingMode()) {
       case vtkImageMapper.SlicingMode.I:
         publicAPI.setSlice(Math.floor(mean(extent[0], extent[1])));
         break;
@@ -99,6 +131,15 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
         break;
       case vtkImageMapper.SlicingMode.K:
         publicAPI.setSlice(Math.floor(mean(extent[4], extent[5])));
+        break;
+      case vtkImageMapper.SlicingMode.X:
+        publicAPI.setSlice(mean(bounds[0], bounds[1]));
+        break;
+      case vtkImageMapper.SlicingMode.Y:
+        publicAPI.setSlice(mean(bounds[2], bounds[3]));
+        break;
+      case vtkImageMapper.SlicingMode.Z:
+        publicAPI.setSlice(mean(bounds[4], bounds[5]));
         break;
       default:
         break;
@@ -116,33 +157,35 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
       console.log('skip setSlicingMode', mode);
       return;
     }
-    if (model.input && model.slicingMode !== mode) {
+    if (model.slicingMode !== mode) {
       // Update Mode
       model.slicingMode = mode;
       model.mapper.setCurrentSlicingMode(vtkImageMapper.SlicingMode[mode]);
 
-      // Update domains for UI...
-      const state = updateDomains(
-        publicAPI.getInputDataSet(),
-        publicAPI.getDataArray(),
-        model,
-        publicAPI.updateProxyProperty
-      );
-      publicAPI.set(state);
+      if (model.input) {
+        // Update domains for UI...
+        const state = updateDomains(
+          publicAPI.getInputDataSet(),
+          publicAPI.getDataArray(),
+          model,
+          publicAPI.updateProxyProperty
+        );
+        publicAPI.set(state);
+      }
     }
   };
 
   // Used for UI
-  publicAPI.getSliceIndexValues = () => {
+  publicAPI.getSliceValues = () => {
     const ds = publicAPI.getInputDataSet();
     if (!ds) {
       return [];
     }
     const values = [];
-    const extent = ds.getExtent();
+    const bds = ds.getBounds();
     const axisIndex = 'XYZ'.indexOf(model.slicingMode);
-    const endValue = extent[axisIndex * 2 + 1];
-    let currentValue = extent[axisIndex * 2];
+    const endValue = bds[axisIndex * 2 + 1];
+    let currentValue = bds[axisIndex * 2];
     while (currentValue <= endValue) {
       values.push(currentValue);
       currentValue++;
@@ -177,7 +220,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     visibility: { modelKey: 'actor', property: 'visibility' },
     colorWindow: { modelKey: 'property', property: 'colorWindow' },
     colorLevel: { modelKey: 'property', property: 'colorLevel' },
-    sliceIndex: { modelKey: 'mapper', property: 'slice' },
+    slice: { modelKey: 'mapper', property: 'slice' },
   });
 }
 

--- a/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
@@ -316,9 +316,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Object specific methods
   vtkVolumeRepresentationProxy(publicAPI, model);
   macro.proxyPropertyMapping(publicAPI, model, {
-    xSliceIndex: { modelKey: 'mapperX', property: 'xSlice' },
-    ySliceIndex: { modelKey: 'mapperY', property: 'ySlice' },
-    zSliceIndex: { modelKey: 'mapperZ', property: 'zSlice' },
+    xSliceIndex: { modelKey: 'mapperX', property: 'slice' },
+    ySliceIndex: { modelKey: 'mapperY', property: 'slice' },
+    zSliceIndex: { modelKey: 'mapperZ', property: 'slice' },
     colorWindow: { modelKey: 'propertySlices', property: 'colorWindow' },
     colorLevel: { modelKey: 'propertySlices', property: 'colorLevel' },
     useShadow: { modelKey: 'property', property: 'shade' },

--- a/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
@@ -21,30 +21,35 @@ function mean(...array) {
 
 // ----------------------------------------------------------------------------
 
-function updateDomains(dataset, dataArray, updateProp) {
+function updateDomains(dataset, dataArray, model, updateProp) {
   const dataRange = dataArray.getRange();
-  const extent = dataset.getExtent();
+  const spacing = dataset.getSpacing();
+  const bounds = dataset.getBounds();
+
+  const { xIJKAxis } = model.mapperX.getClosestIJKAxis();
+  const { yIJKAxis } = model.mapperY.getClosestIJKAxis();
+  const { zIJKAxis } = model.mapperZ.getClosestIJKAxis();
 
   const propToUpdate = {
-    xSliceIndex: {
+    xSlice: {
       domain: {
-        min: extent[0],
-        max: extent[1],
-        step: 1,
+        min: bounds[0],
+        max: bounds[1],
+        step: spacing[xIJKAxis],
       },
     },
-    ySliceIndex: {
+    ySlice: {
       domain: {
-        min: extent[2],
-        max: extent[3],
-        step: 1,
+        min: bounds[2],
+        max: bounds[3],
+        step: spacing[yIJKAxis],
       },
     },
-    zSliceIndex: {
+    zSlice: {
       domain: {
-        min: extent[4],
-        max: extent[5],
-        step: 1,
+        min: bounds[4],
+        max: bounds[5],
+        step: spacing[zIJKAxis],
       },
     },
     colorWindow: {
@@ -63,30 +68,24 @@ function updateDomains(dataset, dataArray, updateProp) {
     },
   };
 
-  updateProp('xSliceIndex', propToUpdate.xSliceIndex);
-  updateProp('ySliceIndex', propToUpdate.ySliceIndex);
-  updateProp('zSliceIndex', propToUpdate.zSliceIndex);
+  updateProp('xSlice', propToUpdate.xSlice);
+  updateProp('ySlice', propToUpdate.ySlice);
+  updateProp('zSlice', propToUpdate.zSlice);
   updateProp('colorWindow', propToUpdate.colorWindow);
   updateProp('colorLevel', propToUpdate.colorLevel);
 
   return {
-    xSliceIndex: Math.floor(
-      mean(
-        propToUpdate.xSliceIndex.domain.min,
-        propToUpdate.xSliceIndex.domain.max
-      )
+    xSlice: mean(
+      propToUpdate.xSlice.domain.min,
+      propToUpdate.xSlice.domain.max
     ),
-    ySliceIndex: Math.floor(
-      mean(
-        propToUpdate.ySliceIndex.domain.min,
-        propToUpdate.ySliceIndex.domain.max
-      )
+    ySlice: mean(
+      propToUpdate.ySlice.domain.min,
+      propToUpdate.ySlice.domain.max
     ),
-    zSliceIndex: Math.floor(
-      mean(
-        propToUpdate.zSliceIndex.domain.min,
-        propToUpdate.zSliceIndex.domain.max
-      )
+    zSlice: mean(
+      propToUpdate.zSlice.domain.min,
+      propToUpdate.zSlice.domain.max
     ),
     colorWindow: propToUpdate.colorWindow.domain.max,
     colorLevel: Math.floor(
@@ -212,6 +211,7 @@ function vtkVolumeRepresentationProxy(publicAPI, model) {
     const state = updateDomains(
       inputDataset,
       publicAPI.getDataArray(),
+      model,
       publicAPI.updateProxyProperty
     );
     publicAPI.set(state);
@@ -316,9 +316,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Object specific methods
   vtkVolumeRepresentationProxy(publicAPI, model);
   macro.proxyPropertyMapping(publicAPI, model, {
-    xSliceIndex: { modelKey: 'mapperX', property: 'slice' },
-    ySliceIndex: { modelKey: 'mapperY', property: 'slice' },
-    zSliceIndex: { modelKey: 'mapperZ', property: 'slice' },
+    xSlice: { modelKey: 'mapperX', property: 'slice' },
+    ySlice: { modelKey: 'mapperY', property: 'slice' },
+    zSlice: { modelKey: 'mapperZ', property: 'slice' },
     colorWindow: { modelKey: 'propertySlices', property: 'colorWindow' },
     colorLevel: { modelKey: 'propertySlices', property: 'colorLevel' },
     useShadow: { modelKey: 'property', property: 'shade' },

--- a/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
@@ -153,19 +153,19 @@ function vtkVolumeRepresentationProxy(publicAPI, model) {
 
   // Slices
   model.mapperX = vtkImageMapper.newInstance({
-    currentSlicingMode: vtkImageMapper.SlicingMode.X,
+    slicingMode: vtkImageMapper.SlicingMode.X,
   });
   model.actorX = vtkImageSlice.newInstance({ visibility: false });
   model.propertySlices = model.actorX.getProperty();
   model.mapperY = vtkImageMapper.newInstance({
-    currentSlicingMode: vtkImageMapper.SlicingMode.Y,
+    slicingMode: vtkImageMapper.SlicingMode.Y,
   });
   model.actorY = vtkImageSlice.newInstance({
     visibility: false,
     property: model.propertySlices,
   });
   model.mapperZ = vtkImageMapper.newInstance({
-    currentSlicingMode: vtkImageMapper.SlicingMode.Z,
+    slicingMode: vtkImageMapper.SlicingMode.Z,
   });
   model.actorZ = vtkImageSlice.newInstance({
     visibility: false,

--- a/Sources/Rendering/Core/ImageMapper/Constants.js
+++ b/Sources/Rendering/Core/ImageMapper/Constants.js
@@ -1,8 +1,11 @@
 export const SlicingMode = {
   NONE: -1,
-  X: 0,
-  Y: 1,
-  Z: 2,
+  I: 0,
+  J: 1,
+  K: 2,
+  X: 3,
+  Y: 4,
+  Z: 5,
 };
 
 export default {

--- a/Sources/Rendering/Core/ImageMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageMapper/example/index.js
@@ -29,7 +29,7 @@ rtSource.setStandardDeviation(0.3);
 const mapper = vtkImageMapper.newInstance();
 mapper.setInputConnection(rtSource.getOutputPort());
 mapper.setSliceAtFocalPoint(true);
-mapper.setCurrentSlicingMode(SlicingMode.Z);
+mapper.setSlicingMode(SlicingMode.Z);
 // mapper.setZSlice(5);
 
 const actor = vtkImageSlice.newInstance();
@@ -50,7 +50,7 @@ position[0] += normal[0];
 position[1] += normal[1];
 position[2] += normal[2];
 camera.setPosition(...position);
-switch (mapper.getCurrentSlicingMode()) {
+switch (mapper.getSlicingMode()) {
   case SlicingMode.X:
     camera.setViewUp([0, 1, 0]);
     break;

--- a/Sources/Rendering/Core/ImageMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageMapper/example/index.js
@@ -44,10 +44,13 @@ renderWindow.getInteractor().setInteractorStyle(iStyle);
 
 const camera = renderer.getActiveCamera();
 const position = camera.getFocalPoint();
-const axis = mapper.getCurrentSlicingMode();
-position[axis] += 1; // offset along the slicing axis
+// offset along the slicing axis
+const normal = mapper.getSlicingModeNormal();
+position[0] += normal[0];
+position[1] += normal[1];
+position[2] += normal[2];
 camera.setPosition(...position);
-switch (axis) {
+switch (mapper.getCurrentSlicingMode()) {
   case SlicingMode.X:
     camera.setViewUp([0, 1, 0]);
     break;

--- a/Sources/Rendering/Core/ImageMapper/index.js
+++ b/Sources/Rendering/Core/ImageMapper/index.js
@@ -82,6 +82,36 @@ function vtkImageMapper(publicAPI, model) {
 
   publicAPI.setKSlice = (id) => publicAPI.setSlice(id, SlicingMode.K);
 
+  publicAPI.getSlicingModeNormal = () => {
+    const out = [0, 0, 0];
+    const a = publicAPI.getInputData().getDirection();
+    const mat3 = [[a[0], a[1], a[2]], [a[3], a[4], a[5]], [a[6], a[7], a[8]]];
+
+    switch (publicAPI.getCurrentSlicingMode()) {
+      case SlicingMode.X:
+        out[0] = 1;
+        break;
+      case SlicingMode.Y:
+        out[1] = 1;
+        break;
+      case SlicingMode.Z:
+        out[2] = 1;
+        break;
+      case SlicingMode.I:
+        vtkMath.multiply3x3_vect3(mat3, [1, 0, 0], out);
+        break;
+      case SlicingMode.J:
+        vtkMath.multiply3x3_vect3(mat3, [0, 1, 0], out);
+        break;
+      case SlicingMode.K:
+        vtkMath.multiply3x3_vect3(mat3, [0, 0, 1], out);
+        break;
+      default:
+        break;
+    }
+    return out;
+  };
+
   publicAPI.findClosestIJK = (inVec3, t = 0.99) => {
     // Project vec3 onto direction cosines
     const out = [0, 0, 0];

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -473,18 +473,23 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       }
     }
 
-    // rebuild the VBO if the data has changed
-    let nSlice = model.renderable.getZSlice();
+    // Find what IJK axis and what direction to slice along
+    const { ijkMode, nSlice } = model.renderable.getClosestIJKSlice();
+
+    // Find sliceOffset
     const ext = image.getExtent();
-    let sliceOffset = nSlice - ext[4];
-    if (model.renderable.getCurrentSlicingMode() === SlicingMode.X) {
-      nSlice = model.renderable.getXSlice();
+    let sliceOffset;
+    if (ijkMode === SlicingMode.I) {
       sliceOffset = nSlice - ext[0];
     }
-    if (model.renderable.getCurrentSlicingMode() === SlicingMode.Y) {
-      nSlice = model.renderable.getYSlice();
+    if (ijkMode === SlicingMode.J) {
       sliceOffset = nSlice - ext[2];
     }
+    if (ijkMode === SlicingMode.K || ijkMode === SlicingMode.NONE) {
+      sliceOffset = nSlice - ext[4];
+    }
+
+    // rebuild the VBO if the data has changed
     const toString = `${nSlice}A${image.getMTime()}A${image
       .getPointData()
       .getScalars()
@@ -525,7 +530,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         .getData();
       let scalars = null;
       // Get right scalars according to slicing mode
-      if (model.renderable.getCurrentSlicingMode() === SlicingMode.X) {
+      if (ijkMode === SlicingMode.I) {
         scalars = [];
         for (let k = 0; k < dims[2]; k++) {
           for (let j = 0; j < dims[1]; j++) {
@@ -548,7 +553,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         ptsArray[9] = nSlice;
         ptsArray[10] = ext[3];
         ptsArray[11] = ext[5];
-      } else if (model.renderable.getCurrentSlicingMode() === SlicingMode.Y) {
+      } else if (ijkMode === SlicingMode.J) {
         scalars = [];
         for (let k = 0; k < dims[2]; k++) {
           for (let i = 0; i < dims[0]; i++) {
@@ -570,7 +575,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         ptsArray[9] = ext[1];
         ptsArray[10] = nSlice;
         ptsArray[11] = ext[5];
-      } else {
+      } else if (ijkMode === SlicingMode.K || ijkMode === SlicingMode.NONE) {
         scalars = basicScalars.subarray(
           sliceOffset * sliceSize,
           (sliceOffset + 1) * sliceSize
@@ -587,6 +592,8 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         ptsArray[9] = ext[1];
         ptsArray[10] = ext[3];
         ptsArray[11] = nSlice;
+      } else {
+        vtkErrorMacro('Reformat slicing not yet supported.');
       }
 
       model.openGLTexture.create2DFromRaw(

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -478,7 +478,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
     // Find the IJK slice
     let nSlice = model.renderable.getSlice();
-    if (ijkMode !== model.renderable.getCurrentSlicingMode()) {
+    if (ijkMode !== model.renderable.getSlicingMode()) {
       // If not IJK slicing, get the IJK slice from the XYZ position/slice
       nSlice = model.renderable.getSliceAtPosition(nSlice);
     }
@@ -500,7 +500,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     const toString = `${nSlice}A${image.getMTime()}A${image
       .getPointData()
       .getScalars()
-      .getMTime()}B${publicAPI.getMTime()}C${model.renderable.getCurrentSlicingMode()}`;
+      .getMTime()}B${publicAPI.getMTime()}C${model.renderable.getSlicingMode()}`;
     if (model.VBOBuildString !== toString) {
       // Build the VBOs
       const dims = image.getDimensions();

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -474,7 +474,14 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     }
 
     // Find what IJK axis and what direction to slice along
-    const { ijkMode, nSlice } = model.renderable.getClosestIJKSlice();
+    const { ijkMode } = model.renderable.getClosestIJKAxis();
+
+    // Find the IJK slice
+    let nSlice = model.renderable.getSlice();
+    if (ijkMode !== model.renderable.getCurrentSlicingMode()) {
+      // If not IJK slicing, get the IJK slice from the XYZ position/slice
+      nSlice = model.renderable.getSliceAtPosition(nSlice);
+    }
 
     // Find sliceOffset
     const ext = image.getExtent();


### PR DESCRIPTION
- [x] Use proper orientation matrix in ITKHelper
  - Needed to transpose it from ITK to VTK.
  - Tested with numerous datasets with orientation matrices different than identity.
- [x] Add X,Y,Z slicing (and rename previous IJK slicing for data space slicing)
  - Only supports it if X, Y, Z are orthogonal to I, J, K axis for now (aka flips and permutations). Will still do it if one of those component is > 0.99 (so with a small tilt). All world axis that do not perfectly align one of IJK axis should require a reformat to compute the slice, but this will be added in future work (@martinken promised :clinking_glasses: )
  - Still use indexes for X, Y, Z for now (instead of world coordinates) since they currently still map to IJK. In the future, X, Y, Z or any world axis slicing (ex: normal to the camera or to a plane widget...) should be in world coordinates (based on imagedata spacing/bounds).

