### PR TITLE
perf(Texture): Only scale cube texture to power of two when not WebGL2

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -724,7 +724,11 @@ function vtkOpenGLTexture(publicAPI, model) {
     publicAPI.bind();
 
     const pixData = updateArrayDataType(dataType, data);
-    const scaledData = scaleTextureToHighestPowerOfTwo(pixData);
+
+    let scaledData = pixData;
+    if (!model.openGLRenderWindow.getWebgl2()) {
+      scaledData = scaleTextureToHighestPowerOfTwo(pixData);
+    }
 
     // Source texture data from the PBO.
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);


### PR DESCRIPTION
Co-authored-by: Ken Martin <ken.martin@kitware.com>