### PR TITLE
fix(Webpack): Fix webworker webpack release build

### DIFF
--- a/Sources/Interaction/Widgets/PiecewiseGaussianWidget/ComputeHistogram.worker.js
+++ b/Sources/Interaction/Widgets/PiecewiseGaussianWidget/ComputeHistogram.worker.js
@@ -1,11 +1,18 @@
 import registerWebworker from 'webworker-promise/lib/register';
 
-registerWebworker(({ array, min, max, numberOfBins }, emit) => {
-  const delta = max - min;
-  const histogram = new Float32Array(numberOfBins);
+/* eslint-disable */
+// prettier-ignore
+registerWebworker(function (message, emit) {
+  var array = message.array;
+  var min = message.min;
+  var max = message.max;
+  var numberOfBins = message.numberOfBins;
+  var delta = max - min;
+  var histogram = new Float32Array(numberOfBins);
   histogram.fill(0);
-  for (let i = 0, len = array.length; i < len; i++) {
-    const idx = Math.floor(
+  var len = array.length;
+  for (var i = 0; i < len; i++) {
+    var idx = Math.floor(
       (numberOfBins - 1) * (Number(array[i]) - min) / delta
     );
     histogram[idx] += 1;


### PR DESCRIPTION
This addresses builds with

  npm run build:release

Uglify bundled with Webpack does not support ES6, and chokes on ES6
constructs. Workarounds described:

  https://stackoverflow.com/questions/42633716/unexpected-token-punc-expected-punc-when-creating-chunk-from-uglifyjs
  https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/104

do not work reliably.

As described at https://github.com/webpack-contrib/uglifyjs-webpack-plugin

 webpack =< v3.0.0 currently contains v0.4.6 of this plugin under
 webpack.optimize.UglifyJsPlugin as an alias. For usage of the latest version
 (v1.0.0), please follow the instructions below. Aliasing v1.0.0 as
 webpack.optimize.UglifyJsPlugin is scheduled for webpack v4.0.0

So refactor the web workers to use ES5, and revert this patch after moving to
Webpack 4.

CC: @jourdain 