### PR TITLE
Misc fixes

### DIFF
--- a/Sources/Common/DataModel/PolyData/index.js
+++ b/Sources/Common/DataModel/PolyData/index.js
@@ -15,11 +15,7 @@ function vtkPolyData(publicAPI, model) {
 
   function camelize(str) {
     return str
-      .replace(
-        /(?:^\w|[A-Z]|\b\w)/g,
-        (letter, index) =>
-          index === 0 ? letter.toLowerCase() : letter.toUpperCase()
-      )
+      .replace(/(?:^\w|[A-Z]|\b\w)/g, (letter) => letter.toUpperCase())
       .replace(/\s+/g, '');
   }
 

--- a/Sources/IO/XML/XMLImageDataReader/index.js
+++ b/Sources/IO/XML/XMLImageDataReader/index.js
@@ -54,7 +54,7 @@ function vtkXMLImageDataReader(publicAPI, model) {
       );
 
       // Add new output
-      model.output[outputIndex++] = imageData;
+      model.output[outputIndex] = imageData;
     }
   };
 

--- a/Sources/IO/XML/XMLPolyDataReader/index.js
+++ b/Sources/IO/XML/XMLPolyDataReader/index.js
@@ -123,7 +123,7 @@ function vtkXMLPolyDataReader(publicAPI, model) {
       );
 
       // Add new output
-      model.output[outputIndex++] = polydata;
+      model.output[outputIndex] = polydata;
     }
   };
 

--- a/Sources/Rendering/Core/Glyph3DMapper/index.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.js
@@ -265,7 +265,7 @@ function vtkGlyph3DMapper(publicAPI, model) {
     }
   };
 
-  publicAPI.getPrimativeCount = () => {
+  publicAPI.getPrimitiveCount = () => {
     const glyph = publicAPI.getInputData(1);
     const mult =
       publicAPI

--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -501,7 +501,7 @@ function vtkMapper(publicAPI, model) {
     return mt;
   };
 
-  publicAPI.getPrimativeCount = () => {
+  publicAPI.getPrimitiveCount = () => {
     const input = publicAPI.getInputData();
     const pcount = {
       points: input.getPoints().getNumberOfValues() / 3,

--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -68,8 +68,8 @@ function vtkRenderWindow(publicAPI, model) {
         if (prop.getVisibility()) {
           results.propCount += 1;
           const mpr = prop.getMapper();
-          if (mpr && mpr.getPrimativeCount) {
-            const pcount = mpr.getPrimativeCount();
+          if (mpr && mpr.getPrimitiveCount) {
+            const pcount = mpr.getPrimitiveCount();
             Object.keys(pcount).forEach((keyName) => {
               if (!results[keyName]) {
                 results[keyName] = 0;


### PR DESCRIPTION
`getNumberOf*` methods on polydata were incorrectly capitalized as `getNumberOfverts`, when it should be `getNumberOfVerts`, and so forth.

Other minor changes and spelling changes.