### PR TITLE
Performance improvements (& windows fixes)

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/ComputeGradients.worker.js
+++ b/Sources/Rendering/OpenGL/Texture/ComputeGradients.worker.js
@@ -10,6 +10,8 @@ registerWebworker(
     message,
     emit
   ) {
+    // have to compute the gradient to get the normal
+    // and magnitude
     var width = message.width;
     var height = message.height;
     var depth = message.depth;
@@ -19,10 +21,13 @@ registerWebworker(
     var depthStart = message.depthStart;
     var depthEnd = message.depthEnd;
 
-    // have to compute the gradient to get the normal
-    // and magnitude
+    // only compute gradient for last slice of the web worker
+    // if it is the last slice of the volume data
+    if (depthEnd !== depth - 1) {
+      depthEnd--;
+    }
     var depthLength = depthEnd - depthStart + 1;
-    var gradients = new Float32Array(width * height * depthLength * 4);
+    var gradients = new Uint8Array(width * height * depthLength * 3);
     var gradientMagnitudes = new Float32Array(width * height * depthLength);
 
     var sliceSize = width * height;
@@ -37,7 +42,7 @@ registerWebworker(
     );
     var minMag = vec3.length(grad);
     var maxMag = -1.0;
-    for (var z = depthStart; z < depthEnd + 1; ++z) {
+    for (var z = depthStart; z <= depthEnd; ++z) {
       var zedge = 0;
       if (z === depth - 1) {
         zedge = -sliceSize;
@@ -61,12 +66,10 @@ registerWebworker(
 
           var mag = vec3.length(grad);
           vec3.normalize(grad, grad);
-          gradients[outPtr++] = grad[0];
-          gradients[outPtr++] = grad[1];
-          gradients[outPtr++] = grad[2];
-          gradients[outPtr++] = mag;
-          gradientMagnitudes[inPtr] = mag;
-          inPtr++;
+          gradients[outPtr++] = 127.5 + 127.5 * grad[0];
+          gradients[outPtr++] = 127.5 + 127.5 * grad[1];
+          gradients[outPtr++] = 127.5 + 127.5 * grad[2];
+          gradientMagnitudes[inPtr++] = mag;
         }
       }
     }
@@ -77,9 +80,11 @@ registerWebworker(
 
     var result = {
       subGradients: gradients,
+      subMagnitudes: gradientMagnitudes,
       subMinMag: minMag,
       subMaxMag: maxMag,
       subDepthStart: depthStart,
+      subDepthEnd: depthEnd,
     };
     return Promise.resolve(
       new registerWebworker.TransferableResponse(

--- a/Sources/Rendering/OpenGL/Texture/ComputeGradients.worker.js
+++ b/Sources/Rendering/OpenGL/Texture/ComputeGradients.worker.js
@@ -66,6 +66,7 @@ registerWebworker(
 
           var mag = vec3.length(grad);
           vec3.normalize(grad, grad);
+          // Compact normal encoding (from [-1.0, 1.0] to [0, 255])
           gradients[outPtr++] = 127.5 + 127.5 * grad[0];
           gradients[outPtr++] = 127.5 + 127.5 * grad[1];
           gradients[outPtr++] = 127.5 + 127.5 * grad[2];

--- a/Sources/Rendering/OpenGL/Texture/ComputeGradients.worker.js
+++ b/Sources/Rendering/OpenGL/Texture/ComputeGradients.worker.js
@@ -89,7 +89,7 @@ registerWebworker(
     return Promise.resolve(
       new registerWebworker.TransferableResponse(
         result,
-        [result.subGradients.buffer]
+        [result.subGradients.buffer, result.subMagnitudes.buffer]
       )
     );
   }

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1022,7 +1022,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     // MAX_TEXTURE_SIZE gives the max dimensions that can be supported by the GPU,
     // but it doesn't mean it will fit in memory. If we have to use a float data type
     // or 4 components, there are good chances that the texture size will blow up
-    // and coud not fit in the GPU memory. Use a smaller texture size in that case,
+    // and could not fit in the GPU memory. Use a smaller texture size in that case,
     // which will force a downsampling of the dataset.
     // That problem does not occur when using webGL2 since we can pack the data in
     // denser textures based on our data type.

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1135,17 +1135,149 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     const haveWebgl2 = model.openGLRenderWindow.getWebgl2();
 
+    let reformatGradientsFunction;
+    if (haveWebgl2) {
+      reformatGradientsFunction = (workerResults) => {
+        const numVoxelsIn = width * height * depth;
+        const reformattedGradients = new Uint8Array(numVoxelsIn * 4);
+        const maxMag = model.volumeInfo.max;
+
+        workerResults.forEach(
+          ({
+            subGradients,
+            subMagnitudes,
+            subMinMag,
+            subMaxMag,
+            subDepthStart,
+            subDepthEnd,
+          }) => {
+            let inIdx = 0;
+            let inMagIdx = 0;
+            let outIdx = subDepthStart * width * height * 4;
+            // start and end depths are inclusive
+            const numWorkerVoxels =
+              width * height * (subDepthEnd - subDepthStart + 1);
+            for (let vp = 0; vp < numWorkerVoxels; ++vp) {
+              reformattedGradients[outIdx++] = subGradients[inIdx++];
+              reformattedGradients[outIdx++] = subGradients[inIdx++];
+              reformattedGradients[outIdx++] = subGradients[inIdx++];
+              reformattedGradients[outIdx++] =
+                255.0 * Math.sqrt(subMagnitudes[inMagIdx++] / maxMag);
+            }
+          }
+        );
+
+        return publicAPI.create3DFromRaw(
+          width,
+          height,
+          depth,
+          4,
+          VtkDataTypes.UNSIGNED_CHAR,
+          reformattedGradients
+        );
+      };
+    } else {
+      // Now determine the texture parameters using the arguments.
+      publicAPI.getOpenGLDataType(VtkDataTypes.UNSIGNED_CHAR);
+      publicAPI.getInternalFormat(VtkDataTypes.UNSIGNED_CHAR, 4);
+      publicAPI.getFormat(VtkDataTypes.UNSIGNED_CHAR, 4);
+
+      if (!model.internalFormat || !model.format || !model.openGLDataType) {
+        vtkErrorMacro('Failed to determine texture parameters.');
+        return;
+      }
+
+      model.target = model.context.TEXTURE_2D;
+      model.components = 4;
+      model.depth = 1;
+      model.numberOfDimensions = 2;
+      model.width = scalarTexture.getWidth();
+      model.height = scalarTexture.getHeight();
+
+      reformatGradientsFunction = (workerResults) => {
+        // now store the computed values into the packed 2D
+        // texture using the same packing as volumeInfo
+        const reformattedGradients = new Uint8Array(
+          model.width * model.height * 4
+        );
+        const maxMag = model.volumeInfo.max;
+
+        workerResults.forEach(
+          ({
+            subGradients,
+            subMagnitudes,
+            subMinMag,
+            subMaxMag,
+            subDepthStart,
+            subDepthEnd,
+          }) => {
+            // start and end depths are inclusive
+            for (let zpin = subDepthStart; zpin <= subDepthEnd; ++zpin) {
+              // map xyz to 2d x y
+              let zyout = Math.floor(zpin / vinfo.xreps); // y offset in reps
+              let zxout = zpin - zyout * vinfo.xreps; // x offset in reps
+              zxout *= Math.floor(width / vinfo.xstride); // in pixels
+              zyout *= Math.floor(height / vinfo.ystride); // in pixels
+              let ypout = zyout;
+              for (
+                let ypin = 0;
+                ypin < height;
+                ypin += vinfo.ystride, ypout++
+              ) {
+                let outIdx = (ypout * model.width + zxout) * 4;
+                let inMagIdx = ((zpin - subDepthStart) * height + ypin) * width;
+                let inIdx = inMagIdx * 3;
+                for (let xpin = 0; xpin < width; xpin += vinfo.xstride) {
+                  reformattedGradients[outIdx++] = subGradients[inIdx];
+                  reformattedGradients[outIdx++] = subGradients[inIdx + 1];
+                  reformattedGradients[outIdx++] = subGradients[inIdx + 2];
+                  reformattedGradients[outIdx++] =
+                    255.0 * Math.sqrt(subMagnitudes[inMagIdx] / maxMag);
+                  inMagIdx += vinfo.xstride;
+                  inIdx += 3 * vinfo.xstride;
+                }
+              }
+            }
+          }
+        );
+
+        model.openGLRenderWindow.activateTexture(publicAPI);
+        publicAPI.createTexture();
+        publicAPI.bind();
+
+        // Source texture data from the PBO.
+        // model.context.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+        model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
+
+        model.context.texImage2D(
+          model.target,
+          0,
+          model.internalFormat,
+          model.width,
+          model.height,
+          0,
+          model.format,
+          model.openGLDataType,
+          reformattedGradients
+        );
+
+        publicAPI.deactivate();
+        return true;
+      };
+    }
+
     const maxNumberOfWorkers = 4;
-    const depthStride = Math.floor(depth / maxNumberOfWorkers) || 1;
+    const depthStride = Math.ceil(depth / maxNumberOfWorkers);
     const workers = [];
     let depthIndex = 0;
-    while (depthIndex < depth) {
+    while (depthIndex < depth - 1) {
       const worker = new ComputeGradientsWorker();
       const workerPromise = new WebworkerPromise(worker);
       const depthStart = depthIndex;
-      const depthEnd = Math.min(depthIndex + depthStride, depth - 1);
+      let depthEnd = depthIndex + depthStride; // no -1 to include one more slice to compute gradient
+      depthEnd = Math.min(depthEnd, depth - 1);
       const subData = new data.constructor(
-        data.slice(depthStart * width * height, (depthEnd + 1) * width * height)
+        data.slice(depthStart * width * height, (depthEnd + 1) * width * height) // +1 to include data from slice at depthEnd
       );
       workers.push(
         workerPromise.postMessage(
@@ -1165,14 +1297,18 @@ function vtkOpenGLTexture(publicAPI, model) {
       depthIndex += depthStride;
     }
     Promise.all(workers).then((workerResults) => {
-      const gradients = new Float32Array(width * height * depth * 4);
+      // compute min/max across all workers
       let minMag = Infinity;
       let maxMag = -Infinity;
-
       workerResults.forEach(
-        ({ subGradients, subMinMag, subMaxMag, subDepthStart }) => {
-          const start = subDepthStart * width * height * 4;
-          gradients.set(subGradients, start);
+        ({
+          subGradients,
+          subMagnitudes,
+          subMinMag,
+          subMaxMag,
+          subDepthStart,
+          subDepthEnd,
+        }) => {
           minMag = Math.min(subMinMag, minMag);
           maxMag = Math.max(subMaxMag, maxMag);
         }
@@ -1181,108 +1317,12 @@ function vtkOpenGLTexture(publicAPI, model) {
       // store the information, we will need it later
       model.volumeInfo = { min: minMag, max: maxMag };
 
-      const numPixelsIn = width * height * depth;
-      if (haveWebgl2) {
-        const reformattedGradients = new Uint8Array(numPixelsIn * 4);
-        let outIdx = 0;
-        for (let p = 0; p < numPixelsIn; ++p) {
-          const pp = p * 4;
-          reformattedGradients[outIdx++] = 127.5 + 127.5 * gradients[pp];
-          reformattedGradients[outIdx++] = 127.5 + 127.5 * gradients[pp + 1];
-          reformattedGradients[outIdx++] = 127.5 + 127.5 * gradients[pp + 2];
-          // we encode gradient magnitude using sqrt so that
-          // we have nonlinear resolution
-          reformattedGradients[outIdx++] =
-            255.0 * Math.sqrt(gradients[pp + 3] / maxMag);
-        }
-
-        const create3DFromRawReturn = publicAPI.create3DFromRaw(
-          width,
-          height,
-          depth,
-          4,
-          VtkDataTypes.UNSIGNED_CHAR,
-          reformattedGradients
-        );
-        model.computedGradients = true;
+      // copy the data and create the texture
+      model.computedGradients = reformatGradientsFunction(workerResults);
+      if (model.computedGradients) {
         model.gradientsBuildTime.modified();
-        return create3DFromRawReturn;
       }
-
-      // Now determine the texture parameters using the arguments.
-      publicAPI.getOpenGLDataType(VtkDataTypes.UNSIGNED_CHAR);
-      publicAPI.getInternalFormat(VtkDataTypes.UNSIGNED_CHAR, 4);
-      publicAPI.getFormat(VtkDataTypes.UNSIGNED_CHAR, 4);
-
-      if (!model.internalFormat || !model.format || !model.openGLDataType) {
-        vtkErrorMacro('Failed to determine texture parameters.');
-        return false;
-      }
-
-      model.target = model.context.TEXTURE_2D;
-      model.components = 4;
-      model.depth = 1;
-      model.numberOfDimensions = 2;
-
-      // now store the computed values into the packed 2D
-      // texture using the same packing as volumeInfo
-      model.width = scalarTexture.getWidth();
-      model.height = scalarTexture.getHeight();
-      const reformattedGradients = new Uint8Array(
-        model.width * model.height * 4
-      );
-
-      let outIdx = 0;
-      for (let yRep = 0; yRep < vinfo.yreps; yRep++) {
-        const xrepsThisRow = Math.min(vinfo.xreps, depth - yRep * vinfo.xreps);
-        const outXContIncr =
-          model.width - xrepsThisRow * Math.floor(width / vinfo.xstride);
-        for (let inY = 0; inY < height; inY += vinfo.ystride) {
-          for (let xRep = 0; xRep < xrepsThisRow; xRep++) {
-            const inOffset =
-              4 * ((yRep * vinfo.xreps + xRep) * width * height + inY * width);
-            for (let inX = 0; inX < width; inX += vinfo.xstride) {
-              // copy value
-              reformattedGradients[outIdx++] =
-                127.5 + 127.5 * gradients[inOffset + inX * 4];
-              reformattedGradients[outIdx++] =
-                127.5 + 127.5 * gradients[inOffset + inX * 4 + 1];
-              reformattedGradients[outIdx++] =
-                127.5 + 127.5 * gradients[inOffset + inX * 4 + 2];
-              // we encode gradient magnitude using sqrt so that
-              // we have nonlinear resolution
-              reformattedGradients[outIdx++] =
-                255.0 * Math.sqrt(gradients[inOffset + inX * 4 + 3] / maxMag);
-            }
-          }
-          outIdx += outXContIncr * 4;
-        }
-      }
-
-      model.openGLRenderWindow.activateTexture(publicAPI);
-      publicAPI.createTexture();
-      publicAPI.bind();
-
-      // Source texture data from the PBO.
-      // model.context.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-      model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
-
-      model.context.texImage2D(
-        model.target,
-        0,
-        model.internalFormat,
-        model.width,
-        model.height,
-        0,
-        model.format,
-        model.openGLDataType,
-        reformattedGradients
-      );
-
-      publicAPI.deactivate();
-      model.computedGradients = true;
-      model.gradientsBuildTime.modified();
-      return true;
+      return model.computedGradients;
     });
   };
 


### PR DESCRIPTION
- [x] Reduce CPU memory footprint for gradients computation (~50%)
- [x] Avoid crash in webgl1 by limiting textures size
- [x] Transfer magnitudes sub array from worker to main thread (instead of copy)
- [x] Terminate web workers adequately

cc: @martinken, @thewtex