### PR TITLE
fix(RenderWindowInteractor): Disable mouse/touch event listener

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -528,6 +528,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
             controlKey: false,
           };
           publicAPI.leftButtonReleaseEvent(callData);
+          interactionRegistration(false);
         } else {
           // If more than one finger released, recognize touchend
           const positions = getTouchEventPositionsFor(event.changedTouches);


### PR DESCRIPTION
Fix the problem in mobile device when user touches renderWindow, release touches and then use GUI component. The mouse/touch event weren't removed.