### PR TITLE
fix(Picker): Deep copy matrix to not modify original matrix

### DIFF
--- a/Sources/Rendering/Core/CellPicker/index.js
+++ b/Sources/Rendering/Core/CellPicker/index.js
@@ -136,6 +136,7 @@ function vtkCellPicker(publicAPI, model) {
   };
 
   publicAPI.pick = (selection, renderer) => {
+    publicAPI.initialize();
     const pickResult = superClass.pick(selection, renderer);
     if (pickResult) {
       const camera = renderer.getActiveCamera();

--- a/Sources/Rendering/Core/Picker/index.js
+++ b/Sources/Rendering/Core/Picker/index.js
@@ -244,7 +244,7 @@ function vtkPicker(publicAPI, model) {
       }
 
       if (pickable) {
-        model.transformMatrix = prop.getMatrix();
+        model.transformMatrix = prop.getMatrix().slice(0);
         // Webgl need a transpose matrix but we need the untransposed one to project world points
         // into the right referential
         mat4.transpose(model.transformMatrix, model.transformMatrix);


### PR DESCRIPTION
getMatrix() function returns a reference to the matrix. As we revert the matrix, it modifies the original which is not requested.