### PR TITLE
fix(AnnotatedCubeActor): Vertically flip face textures

### DIFF
--- a/Sources/Rendering/Core/AnnotatedCubeActor/index.js
+++ b/Sources/Rendering/Core/AnnotatedCubeActor/index.js
@@ -71,6 +71,11 @@ function vtkAnnotatedCubeActor(publicAPI, model) {
 
     // set face rotation
     ctxt.save();
+
+    // vertical flip
+    ctxt.translate(0, canvas.height);
+    ctxt.scale(1, -1);
+
     ctxt.translate(canvas.width / 2, canvas.height / 2);
     ctxt.rotate(-Math.PI * (prop.faceRotation / 180.0));
 


### PR DESCRIPTION
Textures got inverted in 43ed0fb, so as a workaround we Y-flip the faces.  @agirault 