### PR TITLE
PiecewiseFunctionProxy modes

### DIFF
--- a/Sources/Common/DataModel/PiecewiseFunction/index.js
+++ b/Sources/Common/DataModel/PiecewiseFunction/index.js
@@ -149,8 +149,8 @@ function vtkPiecewiseFunction(publicAPI, model) {
 
     val[0] = model.nodes[index].x;
     val[1] = model.nodes[index].y;
-    val[2] = model.nodes[index].Midpoint;
-    val[3] = model.nodes[index].Sharpness;
+    val[2] = model.nodes[index].midpoint;
+    val[3] = model.nodes[index].sharpness;
 
     return 1;
   };
@@ -167,8 +167,8 @@ function vtkPiecewiseFunction(publicAPI, model) {
     const oldX = model.nodes[index].x;
     model.nodes[index].x = val[0];
     model.nodes[index].y = val[1];
-    model.nodes[index].Midpoint = val[2];
-    model.nodes[index].Sharpness = val[3];
+    model.nodes[index].midpoint = val[2];
+    model.nodes[index].sharpness = val[3];
 
     if (oldX !== val[0]) {
       // The point has been moved, the order of points or the range might have

--- a/Sources/Proxy/Core/PiecewiseFunctionProxy/Constants.js
+++ b/Sources/Proxy/Core/PiecewiseFunctionProxy/Constants.js
@@ -1,0 +1,19 @@
+const Defaults = {
+  Gaussians: [{ position: 0.5, height: 1, width: 0.5, xBias: 0.5, yBias: 0.5 }],
+  Points: [[0, 0], [1, 1]],
+  Nodes: [
+    { x: 0, y: 0, midpoint: 0.5, sharpness: 0 },
+    { x: 1, y: 1, midpoint: 0.5, sharpness: 0 },
+  ],
+};
+
+const Mode = {
+  Gaussians: 0,
+  Points: 1,
+  Nodes: 2,
+};
+
+export default {
+  Defaults,
+  Mode,
+};

--- a/Sources/Proxy/Core/PiecewiseFunctionProxy/test/testPiecewiseFunctionProxy.js
+++ b/Sources/Proxy/Core/PiecewiseFunctionProxy/test/testPiecewiseFunctionProxy.js
@@ -1,0 +1,93 @@
+import test from 'tape-catch';
+
+import vtkPiecewiseFunctionProxy from 'vtk.js/Sources/Proxy/Core/PiecewiseFunctionProxy';
+import Constants from 'vtk.js/Sources/Proxy/Core/PiecewiseFunctionProxy/Constants';
+
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+const { Mode, Defaults } = Constants;
+const { arrayEquals, objEquals } = testUtils;
+
+function listEquals(a, b, equality = 'array') {
+  const equals = equality === 'array' ? arrayEquals : objEquals;
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; ++i) {
+    if (!equals(a, b)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validatePwf(pwf, expected) {
+  for (let i = 0; i < expected.length; ++i) {
+    const val = Array(4);
+    pwf.getNodeValue(i, val);
+    if (!arrayEquals(val, expected[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getRange(points) {
+  let min = Infinity;
+  let max = -Infinity;
+  points.forEach(([x, y]) => {
+    min = Math.min(x, min);
+    max = Math.max(x, max);
+  });
+
+  return [min, max];
+}
+
+function normalize(points, range) {
+  const width = range[1] - range[0];
+  return points.map(([x, y]) => [(x - range[0]) / width, y]);
+}
+
+test('Test vtkPiecewiseFunctionProxy', (t) => {
+  const pwfProxy = vtkPiecewiseFunctionProxy.newInstance();
+  const pwf = pwfProxy.getPiecewiseFunction();
+
+  const points = [[-30, 0], [20, 0.3], [50, 0.5], [80, 1.0]];
+  // adds midpoint=0.5, sharpness=0
+  const expected = points.map((p) => [].concat(p, [0.5, 0]));
+
+  const range = getRange(points);
+  pwfProxy.setPoints(normalize(points, range));
+  pwfProxy.setDataRange(...range);
+
+  t.ok(
+    !validatePwf(pwf, expected),
+    'Custom points should not be active in Gaussian mode'
+  );
+
+  pwfProxy.setMode(Mode.Points);
+  t.ok(
+    validatePwf(pwf, expected),
+    'Custom points should be active in Points mode'
+  );
+
+  pwfProxy.setGaussians(null);
+  t.ok(
+    listEquals(pwfProxy.getGaussians(), Defaults.Gaussians, 'object'),
+    'Default nodes'
+  );
+
+  pwfProxy.setPoints(null);
+  t.ok(
+    listEquals(pwfProxy.getPoints(), Defaults.Points, 'array'),
+    'Default points'
+  );
+
+  pwfProxy.setNodes(null);
+  t.ok(
+    listEquals(pwfProxy.getNodes(), Defaults.Nodes, 'object'),
+    'Default nodes'
+  );
+
+  t.end();
+});

--- a/Sources/Proxy/Core/index.js
+++ b/Sources/Proxy/Core/index.js
@@ -1,4 +1,5 @@
 import vtkAbstractRepresentationProxy from './AbstractRepresentationProxy';
+import vtkPiecewiseFunctionProxy from './PiecewiseFunctionProxy';
 import vtkProxyManager from './ProxyManager';
 import vtkSourceProxy from './SourceProxy';
 import vtkView2DProxy from './View2DProxy';
@@ -6,6 +7,7 @@ import vtkViewProxy from './ViewProxy';
 
 export default {
   vtkAbstractRepresentationProxy,
+  vtkPiecewiseFunctionProxy,
   vtkProxyManager,
   vtkSourceProxy,
   vtkView2DProxy,

--- a/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
@@ -194,11 +194,6 @@ function vtkVolumeRepresentationProxy(publicAPI, model) {
 
     const lutProxy = publicAPI.getLookupTableProxy(name);
     const pwfProxy = publicAPI.getPiecewiseFunctionProxy(name);
-    if (pwfProxy.getGaussians().length === 0) {
-      pwfProxy.setGaussians([
-        { position: 0.5, height: 1, width: 0.5, xBias: 0.5, yBias: 0.5 },
-      ]);
-    }
 
     model.property.setRGBTransferFunction(0, lutProxy.getLookupTable());
     model.property.setScalarOpacity(0, pwfProxy.getPiecewiseFunction());

--- a/Sources/Testing/testUtils.js
+++ b/Sources/Testing/testUtils.js
@@ -114,9 +114,37 @@ function removeDOM() {
   REMOVE_DOM_ELEMENTS = true;
 }
 
+function arrayEquals(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function objEquals(a, b) {
+  const k1 = Object.keys(a).sort();
+  const k2 = Object.keys(b).sort();
+  if (!arrayEquals(k1, k2)) {
+    return false;
+  }
+  for (let i = 0; i < k1.length; ++i) {
+    if (a[k1[i]] !== b[k1[i]]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export default {
+  arrayEquals,
   compareImages,
   createGarbageCollector,
   keepDOM,
+  objEquals,
   removeDOM,
 };

--- a/Sources/tests.js
+++ b/Sources/tests.js
@@ -20,6 +20,7 @@ import './Filters/Sources/PlaneSource/test/testPlane';
 import './Filters/Sources/PointSource/test/testPointSource';
 import './Filters/Texture/TextureMapToSphere/test/testTextureMapToSphere';
 import './IO/Misc/PDBReader/test/testMolecule';
+import './Proxy/Core/PiecewiseFunctionProxy/test/testPiecewiseFunctionProxy';
 import './Rendering/Core/AbstractMapper/test/testAbstractMapper';
 import './Rendering/Core/CellPicker/test/testCellPicker';
 import './Rendering/Core/ColorTransferFunction/test/testColorTransferFunction';


### PR DESCRIPTION
Adds Points and Nodes modes to piecewise function proxy. 

Adds `arrayEquals` and `objEquals` to test utils. Adds PiecewiseFunctionProxy test.

Fixes naming error in PiecewiseFunction (Midpoint -> midpoint, Sharpness -> sharpness).