### PR TITLE
fix(Rendering): add distortion pass, fix sizing, skybox

### DIFF
--- a/Examples/Applications/SkyboxViewer/index.md
+++ b/Examples/Applications/SkyboxViewer/index.md
@@ -18,6 +18,10 @@ The Skybox Viewer can be used as a link that encode both the Viewer path, the da
 | viewAngle | Adjust view angle of the camera             | 60                |
 | debug     | Show grid for eye separation                | false             |
 | timer     | automatically increment position in seconds | 0                 |
+| k1        | first radial distortion constant            | 0.2               |
+| k2        | second radial distortion constant           | 0.0               |
+| centerY   | Y center of the window (-1, 1)              | 0.0               |
+
 
 ### Examples
 

--- a/Sources/Rendering/OpenGL/ForwardPass/index.js
+++ b/Sources/Rendering/OpenGL/ForwardPass/index.js
@@ -42,7 +42,7 @@ function vtkForwardPass(publicAPI, model) {
         (model.opaqueActorCount > 0 && model.volumeCount > 0) ||
         model.depthRequested
       ) {
-        const size = viewNode.getSize();
+        const size = viewNode.getFramebufferSize();
         // make sure the framebuffer is setup
         if (model.framebuffer === null) {
           model.framebuffer = vtkOpenGLFramebuffer.newInstance();

--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -26,6 +26,7 @@ function vtkFramebuffer(publicAPI, model) {
     model.previousDrawBinding = gl.getParameter(
       model.context.FRAMEBUFFER_BINDING
     );
+    model.previousActiveFramebuffer = model.openGLRenderWindow.getActiveFramebuffer();
   };
 
   publicAPI.saveCurrentBuffers = (modeIn) => {
@@ -42,6 +43,9 @@ function vtkFramebuffer(publicAPI, model) {
   publicAPI.restorePreviousBindings = (modeIn) => {
     const gl = model.context;
     gl.bindFramebuffer(gl.FRAMEBUFFER, model.previousDrawBinding);
+    model.openGLRenderWindow.setActiveFramebuffer(
+      model.previousActiveFramebuffer
+    );
   };
 
   publicAPI.restorePreviousBuffers = (modeIn) => {
@@ -56,6 +60,7 @@ function vtkFramebuffer(publicAPI, model) {
     if (model.colorTexture) {
       model.colorTexture.bind();
     }
+    model.openGLRenderWindow.setActiveFramebuffer(publicAPI);
   };
 
   publicAPI.create = (width, height) => {
@@ -164,6 +169,7 @@ const DEFAULT_VALUES = {
   previousReadBinding: 0,
   previousDrawBuffer: 0,
   previousReadBuffer: 0,
+  previousActiveFramebuffer: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -124,9 +124,16 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     }
   };
 
+  publicAPI.getFramebufferSize = () => {
+    if (model.activeFramebuffer) {
+      return model.activeFramebuffer.getSize();
+    }
+    return model.size;
+  };
+
   publicAPI.isInViewport = (x, y, viewport) => {
     const vCoords = viewport.getViewportByReference();
-    const size = model.size;
+    const size = publicAPI.getFramebufferSize();
     if (
       vCoords[0] * size[0] <= x &&
       vCoords[2] * size[0] >= x &&
@@ -140,7 +147,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.getViewportSize = (viewport) => {
     const vCoords = viewport.getViewportByReference();
-    const size = model.size;
+    const size = publicAPI.getFramebufferSize();
     return [
       (vCoords[2] - vCoords[0]) * size[0],
       (vCoords[3] - vCoords[1]) * size[1],
@@ -152,17 +159,15 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     return [size[0] * 0.5, size[1] * 0.5];
   };
 
-  publicAPI.displayToNormalizedDisplay = (x, y, z) => [
-    x / model.size[0],
-    y / model.size[1],
-    z,
-  ];
+  publicAPI.displayToNormalizedDisplay = (x, y, z) => {
+    const size = publicAPI.getFramebufferSize();
+    return [x / size[0], y / size[1], z];
+  };
 
-  publicAPI.normalizedDisplayToDisplay = (x, y, z) => [
-    x * model.size[0],
-    y * model.size[1],
-    z,
-  ];
+  publicAPI.normalizedDisplayToDisplay = (x, y, z) => {
+    const size = publicAPI.getFramebufferSize();
+    return [x * size[0], y * size[1], z];
+  };
 
   publicAPI.worldToView = (x, y, z, renderer) => {
     const dims = publicAPI.getViewportSize(renderer);
@@ -201,13 +206,15 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     return [x, y, z];
   };
 
-  publicAPI.normalizedViewportToViewport = (x, y, z) => [
-    x * (model.size[0] - 1.0),
-    y * (model.size[1] - 1.0),
-    z,
-  ];
+  publicAPI.normalizedViewportToViewport = (x, y, z) => {
+    const size = publicAPI.getFramebufferSize();
+    return [x * (size[0] - 1.0), y * (size[1] - 1.0), z];
+  };
 
-  publicAPI.displayToLocalDisplay = (x, y, z) => [x, model.size[1] - y - 1, z];
+  publicAPI.displayToLocalDisplay = (x, y, z) => {
+    const size = publicAPI.getFramebufferSize();
+    return [x, size[1] - y - 1, z];
+  };
 
   publicAPI.viewportToNormalizedDisplay = (x, y, z, renderer) => {
     let vCoords = renderer.getViewportByReference();
@@ -939,6 +946,7 @@ const DEFAULT_VALUES = {
   vrResolution: [2160, 1200],
   queryVRSize: false,
   hideInVR: true,
+  activeFramebuffer: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -977,6 +985,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'cursor',
     'hideInVR',
     'queryVRSize',
+    'activeFramebuffer',
   ]);
 
   macro.setGetArray(publicAPI, model, ['size', 'vrResolution'], 2);

--- a/Sources/Rendering/OpenGL/Skybox/index.js
+++ b/Sources/Rendering/OpenGL/Skybox/index.js
@@ -133,24 +133,24 @@ function vtkOpenGLSkybox(publicAPI, model) {
         model.openGLRenderWindow.getShaderCache().readyShaderProgramArray(
           `//VTK::System::Dec
            attribute vec3 vertexMC;
-           varying vec3 TexCoords;
            uniform mat4 IMCDCMatrix;
-           uniform vec3 camPos;
+           varying vec3 TexCoords;
            void main () {
             gl_Position = vec4(vertexMC.xyz, 1.0);
             vec4 wpos = IMCDCMatrix * gl_Position;
-            TexCoords = normalize(wpos.xyz/wpos.w - camPos);
+            TexCoords = wpos.xyz/wpos.w;
            }`,
           `//VTK::System::Dec
            //VTK::Output::Dec
            varying vec3 TexCoords;
            uniform samplerCube sbtexture;
+           uniform vec3 camPos;
            void main () {
              // skybox looks from inside out
              // which means we have to adjust
              // our tcoords. Otherwise text would
              // be flipped
-             vec3 tc = TexCoords;
+             vec3 tc = normalize(TexCoords - camPos);
              if (abs(tc.z) < max(abs(tc.x),abs(tc.y)))
              {
                tc = vec3(1.0, 1.0, -1.0) * tc;

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -774,7 +774,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       const sz = model.framebuffer.getSize();
       return [model.fvp[0] * sz[0], model.fvp[1] * sz[1]];
     }
-    return model.openGLRenderWindow.getSize();
+    return model.openGLRenderWindow.getFramebufferSize();
   };
 
   publicAPI.renderPieceStart = (ren, actor) => {
@@ -836,7 +836,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     // console.log(`awin aft  ${model.avgWindowArea} ${model.avgFrameTime}`);
     const xyf = model.lastXYF;
 
-    const size = model.openGLRenderWindow.getSize();
+    const size = model.openGLRenderWindow.getFramebufferSize();
     // const newSize = [
     //   Math.floor((size[0] / xyf) + 0.5),
     //   Math.floor((size[1] / xyf) + 0.5)];
@@ -1030,7 +1030,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           .readyShaderProgram(model.copyShader);
       }
 
-      const size = model.openGLRenderWindow.getSize();
+      const size = model.openGLRenderWindow.getFramebufferSize();
       model.context.viewport(0, 0, size[0], size[1]);
 
       // activate texture


### PR DESCRIPTION
Add a second order radial distorion pass to vtk.js

To support this, change the size queries on render
window to use the size of the active framebuffer
which may be the hardware buffer or a framebuffer
object.

Fix an issue in the skybox where the interpolaiton of
coordinates was incorrect. Most noticable for larger
view angles.