### PR TITLE
fix(ITKImageReader): Support itk.js 9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6336,6 +6336,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "nan": "2.10.0",
         "node-pre-gyp": "0.6.39"
@@ -10461,7 +10462,8 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.9",


### PR DESCRIPTION
itk.js 9.0.0 contains breaking changes. This changeset keeps
ITKImageReader backwards compatible with pre-9.0.0 itk.js installs.

This just terminates all webworkers after a single use. Do we want this configurable?

@thewtex 