### PR TITLE
fix(LineWidget): Do not unnecessary refresh view on mouse move

### DIFF
--- a/Sources/Interaction/Widgets/LineWidget/index.js
+++ b/Sources/Interaction/Widgets/LineWidget/index.js
@@ -156,23 +156,24 @@ function vtkLineWidget(publicAPI, model) {
 
   publicAPI.moveAction = (callData) => {
     const position = [callData.position.x, callData.position.y];
+    let modified = false;
 
     if (model.widgetState === WidgetState.MANIPULATE) {
       // In MANIPULATE, we are hovering above the widget
       // Check if above a sphere and enable/disable if needed
       const state = model.widgetRep.computeInteractionState(position);
       setCursor(state);
-      if (state !== State.OUTSIDE) {
-        if (state === State.ONP1) {
-          model.point1Widget.setEnabled(1);
-          model.point2Widget.setEnabled(0);
-        } else if (state === State.ONP2) {
-          model.point1Widget.setEnabled(0);
-          model.point2Widget.setEnabled(1);
-        }
-      } else {
-        model.point1Widget.setEnabled(0);
-        model.point2Widget.setEnabled(0);
+
+      const enablePoint1Widget = state === State.ONP1;
+      const enablePoint2Widget = state === State.ONP2;
+
+      if (enablePoint1Widget !== model.point1Widget.getEnabled()) {
+        model.point1Widget.setEnabled(enablePoint1Widget);
+        modified = true;
+      }
+      if (enablePoint2Widget !== model.point2Widget.getEnabled()) {
+        model.point2Widget.setEnabled(enablePoint2Widget);
+        modified = true;
       }
     } else if (model.widgetState === WidgetState.START) {
       // In START, we are placing the sphere widgets.
@@ -186,6 +187,7 @@ function vtkLineWidget(publicAPI, model) {
       } else {
         model.widgetRep.setPoint2WorldPosition(pos3D);
       }
+      modified = true;
     } else if (model.widgetState === WidgetState.ACTIVE) {
       // In ACTIVE, we are moving a sphere widget.
       // Update the line extremities to follow the spheres.
@@ -195,10 +197,13 @@ function vtkLineWidget(publicAPI, model) {
       model.widgetRep.setPoint2WorldPosition(
         model.point2Widget.getWidgetRep().getWorldPosition()
       );
+      modified = true;
     }
 
-    publicAPI.invokeInteractionEvent();
-    publicAPI.render();
+    if (modified) {
+      publicAPI.invokeInteractionEvent();
+      publicAPI.render();
+    }
   };
 
   publicAPI.endSelectAction = (callData) => {

--- a/Sources/Rendering/Core/InteractorObserver/index.js
+++ b/Sources/Rendering/Core/InteractorObserver/index.js
@@ -149,7 +149,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.event(publicAPI, model, 'EndInteractionEvent');
 
   // Create get-only macros
-  macro.get(publicAPI, model, ['interactor']);
+  macro.get(publicAPI, model, ['interactor', 'enabled']);
 
   // Create get-set macros
   macro.setGet(publicAPI, model, ['priority']);


### PR DESCRIPTION
In Manipulate mode, when hovering the render window, the LineWidget could trigger an unnecessary
InteractionEvent and refresh