### PR TITLE
Crop widget v2

### DIFF
--- a/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/Constants.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/Constants.js
@@ -1,3 +1,0 @@
-const Events = ['PlanesPositionChanged'];
-
-export default { Events };

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
@@ -162,7 +162,7 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
     for (let i = 0; i < model.handles.length; ++i) {
       if (model.handlePositions[i]) {
         const { actor, source } = model.handles[i];
-        source.setRadius(5);
+        source.setRadius(model.handleSizes[i]);
         source.setCenter(model.handlePositions[i]);
 
         if (model.activeHandleIndex === i) {
@@ -211,6 +211,7 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
 const DEFAULT_VALUES = {
   activeHandleIndex: -1,
   handlePositions: Array(TOTAL_NUM_HANDLES).fill(null),
+  handleSizes: Array(TOTAL_NUM_HANDLES).fill(0),
   bboxCorners: Array(8).fill([0, 0, 0]),
   edgeColor: [1.0, 1.0, 1.0],
 };
@@ -226,6 +227,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, ['activeHandleIndex']);
   macro.setGetArray(publicAPI, model, ['edgeColor'], 3);
   macro.setGetArray(publicAPI, model, ['handlePositions'], TOTAL_NUM_HANDLES);
+  macro.setGetArray(publicAPI, model, ['handleSizes'], TOTAL_NUM_HANDLES);
   macro.setGetArray(publicAPI, model, ['bboxCorners'], 8);
 
   // Object methods

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
@@ -6,6 +6,9 @@ import vtkWidgetRepresentation from 'vtk.js/Sources/Interaction/Widgets/WidgetRe
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import Constants from 'vtk.js/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants';
+
+const { TOTAL_NUM_HANDLES } = Constants;
 
 // prettier-ignore
 const LINE_ARRAY = [
@@ -22,11 +25,6 @@ const LINE_ARRAY = [
   2, 2, 6,
   2, 3, 7,
 ];
-
-// first 6 are face handles,
-// next 12 are edge handles,
-// last 8 are corner handles.
-const TOTAL_NUM_HANDLES = 26;
 
 // ----------------------------------------------------------------------------
 // vtkImageCroppingRegionsRepresentation methods

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
@@ -51,7 +51,7 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
   model.picker.initializePickList();
 
   // order: xmin, xmax, ymin, ymax, zmin, zmax
-  model.handles = Array(6)
+  model.handles = Array(18)
     .fill(null)
     .map(() => {
       const source = vtkSphereSource.newInstance();
@@ -66,7 +66,7 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
       return { source, mapper, actor };
     });
 
-  model.handlePositions = Array(6)
+  model.handlePositions = Array(18)
     .fill([])
     .map(() => [0, 0, 0]);
 
@@ -215,7 +215,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   macro.setGet(publicAPI, model, ['activeHandleIndex']);
   macro.setGetArray(publicAPI, model, ['edgeColor'], 3);
-  macro.setGetArray(publicAPI, model, ['handlePositions'], 6);
+  macro.setGetArray(publicAPI, model, ['handlePositions'], 18);
   macro.setGetArray(publicAPI, model, ['bboxCorners'], 8);
 
   // Object methods

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation/index.js
@@ -172,33 +172,15 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
     publicAPI.modified();
   };
 
-  publicAPI.highlight = (handleIndex) => {
-    model.handles.forEach((h, i) => {
-      if (handleIndex === i) {
-        h.actor.getProperty().setColor(0, 1, 0);
-      } else {
-        h.actor.getProperty().setColor(1, 1, 1);
-      }
-    });
-  };
-
-  publicAPI.setHandles = (handles) => {
-    // TODO deep equality check
-    model.handlePositions = handles;
-    publicAPI.updateGeometry();
-  };
-
   publicAPI.setSlice = (slice) => {
     if (slice !== model.slice) {
       model.slice = slice;
-      publicAPI.updateGeometry();
     }
   };
 
   publicAPI.setSliceOrientation = (sliceOrientation) => {
     if (sliceOrientation !== model.sliceOrientation) {
       model.sliceOrientation = sliceOrientation;
-      publicAPI.updateGeometry();
     }
   };
 
@@ -227,9 +209,16 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
   // Force update the geometry
   publicAPI.updateGeometry = () => {
     for (let i = 0; i < model.handles.length; ++i) {
-      const { source } = model.handles[i];
+      const { actor, source } = model.handles[i];
       source.setRadius(5);
       source.setCenter(model.handlePositions[i]);
+
+      if (model.activeHandleIndex === i) {
+        actor.getProperty().setColor(0, 1, 0);
+      } else {
+        actor.getProperty().setColor(1, 1, 1);
+      }
+    }
     }
     publicAPI.modified();
   };
@@ -250,6 +239,9 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
   publicAPI.setProperty = (property) => {
     model.actor.setProperty(property);
   };
+
+  // modifications will result in geometry updates
+  publicAPI.onModified(publicAPI.updateGeometry);
 }
 
 // ----------------------------------------------------------------------------
@@ -257,7 +249,8 @@ function vtkImageCroppingRegionsRepresentation(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  handlePositions: [],
+  activeHandleIndex: -1,
+  handlePositions: Array(6).fill([0, 0, 0]),
   opacity: 0.5,
   edgeColor: [1.0, 1.0, 1.0],
 };
@@ -281,6 +274,8 @@ export function extend(publicAPI, model, initialValues = {}) {
     'edgeColor',
   ]);
 
+  macro.setGet(publicAPI, model, ['activeHandleIndex']);
+  macro.setGetArray(publicAPI, model, ['handlePositions'], 6);
   // Object methods
   vtkImageCroppingRegionsRepresentation(publicAPI, model);
 }

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
@@ -18,6 +18,6 @@ const Orientation = {
   XY: 2,
 };
 
-const CropWidgetEvents = ['CroppingPlanesPositionChanged'];
+const CropWidgetEvents = ['CroppingPlanesChanged'];
 
 export default { WidgetState, CropWidgetEvents, Orientation };

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
@@ -1,23 +1,8 @@
 const WidgetState = {
   IDLE: 0,
-  CROPPING: 10,
-
-  MOVE_LEFT: 1,
-  MOVE_RIGHT: 2,
-  MOVE_BOTTOM: 3,
-  MOVE_TOP: 4,
-  MOVE_LEFT_BOTTOM: 5,
-  MOVE_LEFT_TOP: 6,
-  MOVE_RIGHT_BOTTOM: 7,
-  MOVE_RIGHT_TOP: 8,
-};
-
-const Orientation = {
-  YZ: 0,
-  XZ: 1,
-  XY: 2,
+  CROPPING: 1,
 };
 
 const CropWidgetEvents = ['CroppingPlanesChanged'];
 
-export default { WidgetState, CropWidgetEvents, Orientation };
+export default { WidgetState, CropWidgetEvents };

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
@@ -5,4 +5,9 @@ const WidgetState = {
 
 const CropWidgetEvents = ['CroppingPlanesChanged'];
 
-export default { WidgetState, CropWidgetEvents };
+// first 6 are face handles,
+// next 12 are edge handles,
+// last 8 are corner handles.
+const TOTAL_NUM_HANDLES = 26;
+
+export default { TOTAL_NUM_HANDLES, WidgetState, CropWidgetEvents };

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants.js
@@ -1,5 +1,7 @@
 const WidgetState = {
   IDLE: 0,
+  CROPPING: 10,
+
   MOVE_LEFT: 1,
   MOVE_RIGHT: 2,
   MOVE_BOTTOM: 3,

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
@@ -95,18 +95,8 @@ function setupWidget(volumeMapper, imageMapper) {
   widget.setEnabled(true);
 
   // getWidgetRep() returns a widget AFTER setEnabled(true).
-
   // Demonstrate widget representation APIs
-  widget.getWidgetRep().setOpacity(0.8);
   widget.getWidgetRep().setEdgeColor(0.0, 0.0, 1.0);
-
-  imageMapper.onModified(() => {
-    // update slice and slice orientation
-    const sliceMode = imageMapper.getSlicingMode();
-    const slice = imageMapper.getSlice();
-    widget.setSlice(slice);
-    widget.setSliceOrientation(sliceMode);
-  });
 
   renderWindow.render();
 }

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
@@ -84,8 +84,8 @@ const widget = vtkImageCroppingRegionsWidget.newInstance();
 widget.setInteractor(renderWindow.getInteractor());
 
 // Demonstrate cropping planes event update
-widget.onCroppingPlanesPositionChanged(() => {
-  console.log('planes changed:', widget.getWidgetRep().getPlanePositions());
+widget.onCroppingPlanesChanged((planes) => {
+  console.log('planes changed:', planes);
 });
 
 // called when the volume is loaded

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
@@ -6,6 +6,7 @@ import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
 import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
 import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
 import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
 import vtkImageCroppingRegionsWidget from 'vtk.js/Sources/Interaction/Widgets/ImageCroppingRegionsWidget';
 
 import controlPanel from './controlPanel.html';
@@ -17,13 +18,16 @@ import controlPanel from './controlPanel.html';
 const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance();
 const renderer = fullScreenRenderer.getRenderer();
 const renderWindow = fullScreenRenderer.getRenderWindow();
+/* eslint-disable */
 const interactorStyle2D = vtkInteractorStyleImage.newInstance();
-fullScreenRenderer.addController(controlPanel);
-renderWindow.getInteractor().setInteractorStyle(interactorStyle2D);
-renderer.getActiveCamera().setParallelProjection(true);
-
+const interactorStyle3D = vtkInteractorStyleTrackballCamera.newInstance();
+// switch to using interactorStyle2D if you want 2D controls
+renderWindow.getInteractor().setInteractorStyle(interactorStyle3D);
 // set the current image number to the first image
-interactorStyle2D.setCurrentImageNumber(0);
+// interactorStyle2D.setCurrentImageNumber(0);
+/* eslint-enable */
+fullScreenRenderer.addController(controlPanel);
+// renderer.getActiveCamera().setParallelProjection(true);
 
 // ----------------------------------------------------------------------------
 // Helper methods for setting up control panel
@@ -91,12 +95,13 @@ widget.onCroppingPlanesChanged((planes) => {
 // called when the volume is loaded
 function setupWidget(volumeMapper, imageMapper) {
   widget.setVolumeMapper(volumeMapper);
-  widget.setHandleSize(10); // in pixels
+  widget.setHandleSize(12); // in pixels
   widget.setEnabled(true);
 
-  // getWidgetRep() returns a widget AFTER setEnabled(true).
-  // Demonstrate widget representation APIs
-  widget.getWidgetRep().setEdgeColor(0.0, 0.0, 1.0);
+  // demonstration of setting various types of handles
+  widget.setFaceHandlesEnabled(true);
+  // widget.setEdgeHandlesEnabled(true);
+  widget.setCornerHandlesEnabled(true);
 
   renderWindow.render();
 }
@@ -112,11 +117,9 @@ renderer.addViewProp(actor);
 
 const reader = vtkHttpDataSetReader.newInstance({ fetchGzip: true });
 reader
-  .setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`, { loadData: true })
+  .setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`, { loadData: true })
   .then(() => {
     const data = reader.getOutputData();
-    // NOTE we don't care about image direction here
-    data.setDirection(1, 0, 0, 0, 1, 0, 0, 0, 1);
 
     volumeMapper.setInputData(data);
     imageMapper.setInputData(data);

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -31,8 +31,9 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
 
   model.widgetState = {
     activeHandleIndex: -1,
-    // xmin, xmax, ymin, ymax, zmin, zmax
+    // index space: xmin, xmax, ymin, ymax, zmin, zmax
     planes: Array(6).fill(0),
+    // world space coords
     handles: Array(6)
       .fill([])
       .map(() => [0, 0, 0]),
@@ -143,8 +144,12 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
       const bounds = model.volumeMapper.getBounds();
       model.widgetRep.placeWidget(...bounds);
 
-      model.widgetRep.highlight(model.widgetState.activeHandleIndex);
-      model.widgetRep.setHandles(model.widgetState.handles);
+      const { activeHandleIndex, handles } = model.widgetState;
+      model.widgetRep.set({
+        activeHandleIndex,
+        handlePositions: handles,
+      });
+
       publicAPI.render();
     }
   };

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -1,69 +1,57 @@
 import macro from 'vtk.js/Sources/macro';
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
 import vtkAbstractWidget from 'vtk.js/Sources/Interaction/Widgets/AbstractWidget';
 import vtkImageCroppingRegionsRepresentation from 'vtk.js/Sources/Interaction/Widgets/ImageCroppingRegionsRepresentation';
 import Constants from 'vtk.js/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/Constants';
+import { vec3 } from 'gl-matrix';
 
 const { vtkErrorMacro, VOID, EVENT_ABORT } = macro;
-const { WidgetState, CropWidgetEvents, Orientation } = Constants;
+const { WidgetState, CropWidgetEvents } = Constants;
 
 // ----------------------------------------------------------------------------
 // vtkImageCroppingRegionsWidget methods
 // ----------------------------------------------------------------------------
 
-// Returns cursor name based on widget state
-function getCursorState(state) {
-  switch (state) {
-    case WidgetState.MOVE_LEFT:
-    case WidgetState.MOVE_RIGHT:
-      return 'ew-resize';
-
-    case WidgetState.MOVE_BOTTOM:
-    case WidgetState.MOVE_TOP:
-      return 'ns-resize';
-
-    case WidgetState.MOVE_LEFT_BOTTOM:
-    case WidgetState.MOVE_LEFT_TOP:
-    case WidgetState.MOVE_RIGHT_BOTTOM:
-    case WidgetState.MOVE_RIGHT_TOP:
-      return 'all-scroll';
-
-    case WidgetState.IDLE:
-    default:
-      return 'default';
-  }
-}
-
 function vtkImageCroppingRegionsWidget(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkImageCroppingRegionsWidget');
 
-  // private variables
-  let widgetState = WidgetState.IDLE;
-  let isCropMoving = false;
+  model.widgetState = {
+    activeHandleIndex: -1,
+    // xmin, xmax, ymin, ymax, zmin, zmax
+    planes: Array(6).fill(0),
+    handles: Array(6)
+      .fill([])
+      .map(() => [0, 0, 0]),
+    controlState: WidgetState.IDLE,
+  };
 
   // Overriden method
   publicAPI.createDefaultRepresentation = () => {
     if (!model.widgetRep) {
       model.widgetRep = vtkImageCroppingRegionsRepresentation.newInstance();
-
-      model.widgetRep.onPlanesPositionChanged(
-        publicAPI.invokeCroppingPlanesPositionChanged
-      );
-
       publicAPI.updateRepresentation();
     }
+  };
+
+  publicAPI.updateWidgetState = (state) => {
+    model.widgetState = Object.assign({}, model.widgetState, state);
+    publicAPI.updateRepresentation();
+    publicAPI.modified();
   };
 
   publicAPI.setVolumeMapper = (volumeMapper) => {
     if (volumeMapper !== model.volumeMapper) {
       model.volumeMapper = volumeMapper;
       if (model.enabled) {
+        publicAPI.resetWidgetState();
         publicAPI.updateRepresentation();
       }
     }
   };
 
-  publicAPI.updateRepresentation = () => {
+  publicAPI.resetWidgetState = () => {
     if (!model.volumeMapper) {
       vtkErrorMacro('Volume mapper must be set to update representation');
       return;
@@ -73,44 +61,114 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
       return;
     }
 
-    const bounds = model.volumeMapper.getBounds();
-
-    model.widgetRep.placeWidget(...bounds);
-    publicAPI.updateWidget();
-  };
-
-  // Force a widget update
-  publicAPI.updateWidget = () => {
     const data = model.volumeMapper.getInputData();
-    const origin = data.getOrigin();
-    const spacing = data.getSpacing();
-    const slice =
-      origin[model.sliceOrientation] +
-      spacing[model.sliceOrientation] * model.slice;
+    const planes = data.getExtent();
+    const transform = data.getIndexToWorld();
 
-    model.widgetRep.setSliceOrientation(model.sliceOrientation);
-    // set the widget representation slice + 1 to prevent z fighting
-    model.widgetRep.setSlice(slice + 1);
+    const handles = model.widgetState.handles.map((h, i) => {
+      const center = [0, 0, 0].map((c, j) => {
+        if (j === Math.floor(i / 2)) {
+          return planes[i];
+        }
+        return (planes[j * 2] + planes[j * 2 + 1]) / 2;
+      });
 
-    publicAPI.modified();
+      // transform points
+      const vin = vec3.fromValues(...center);
+      const vout = vec3.create();
+      vec3.transformMat4(vout, vin, transform);
+
+      return [vout[0], vout[1], vout[2]];
+    });
+
+    publicAPI.updateWidgetState({
+      handles,
+      planes,
+    });
   };
 
-  publicAPI.setSlice = (slice) => {
-    if (slice !== model.slice) {
-      model.slice = slice;
-      if (model.enabled) {
-        publicAPI.updateWidget();
-      }
+  publicAPI.setEnabled = macro.chain(publicAPI.setEnabled, (enable) => {
+    if (enable) {
+      publicAPI.resetWidgetState();
+    }
+  });
+
+  publicAPI.updateRepresentation = () => {
+    if (model.widgetRep) {
+      const bounds = model.volumeMapper.getBounds();
+      model.widgetRep.placeWidget(...bounds);
+
+      model.widgetRep.highlight(model.widgetState.activeHandleIndex);
+      model.widgetRep.setHandles(model.widgetState.handles);
+      publicAPI.render();
     }
   };
 
-  publicAPI.setSliceOrientation = (sliceOrientation) => {
-    if (sliceOrientation !== model.sliceOrientation) {
-      model.sliceOrientation = sliceOrientation;
-      if (model.enabled) {
-        publicAPI.updateWidget();
+  publicAPI.setSlice = (slice) => {};
+
+  publicAPI.setSliceOrientation = (sliceOrientation) => {};
+
+  // Given display coordinates and a plane, returns the
+  // point on the plane that corresponds to display coordinates.
+  publicAPI.displayToPlane = (displayCoords, planePoint, planeNormal) => {
+    const view = publicAPI.getInteractor().getView();
+    const renderer = publicAPI.getInteractor().getCurrentRenderer();
+    const camera = renderer.getActiveCamera();
+
+    const cameraFocalPoint = camera.getFocalPoint();
+    const cameraPos = camera.getPosition();
+
+    // Adapted from vtkPicker
+    const focalPointDispCoords = view.worldToDisplay(
+      ...cameraFocalPoint,
+      renderer
+    );
+    const worldCoords = view.displayToWorld(
+      displayCoords[0],
+      displayCoords[1],
+      focalPointDispCoords[2], // Use focal point for z coord
+      renderer
+    );
+
+    // compute ray from camera to selection
+    const ray = [0, 0, 0];
+    for (let i = 0; i < 3; ++i) {
+      ray[i] = worldCoords[i] - cameraPos[i];
+    }
+
+    const dop = camera.getDirectionOfProjection();
+    vtkMath.normalize(dop);
+    const rayLength = vtkMath.dot(dop, ray);
+
+    const clipRange = camera.getClippingRange();
+
+    const p1World = [0, 0, 0];
+    const p2World = [0, 0, 0];
+
+    // get line segment coords from ray based on clip range
+    if (camera.getParallelProjection()) {
+      const tF = clipRange[0] - rayLength;
+      const tB = clipRange[1] - rayLength;
+      for (let i = 0; i < 3; i++) {
+        p1World[i] = planePoint[i] + tF * dop[i];
+        p2World[i] = planePoint[i] + tB * dop[i];
+      }
+    } else {
+      const tF = clipRange[0] / rayLength;
+      const tB = clipRange[1] / rayLength;
+      for (let i = 0; i < 3; i++) {
+        p1World[i] = cameraPos[i] + tF * ray[i];
+        p2World[i] = cameraPos[i] + tB * ray[i];
       }
     }
+
+    const r = vtkPlane.intersectWithLine(
+      p1World,
+      p2World,
+      planePoint,
+      planeNormal
+    );
+    return r.intersection ? r.x : null;
   };
 
   publicAPI.handleLeftButtonPress = (callData) =>
@@ -131,350 +189,64 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
   publicAPI.handleRightButtonRelease = (callData) =>
     publicAPI.endMoveAction(callData);
 
-  publicAPI.handleMouseMove = (callData) => {
-    if (isCropMoving) {
-      return publicAPI.moveAction(callData);
-    }
-    return publicAPI.hoverAction(callData);
-  };
+  publicAPI.handleMouseMove = (callData) => publicAPI.moveAction(callData);
 
   publicAPI.pressAction = (callData) => {
-    if (widgetState === WidgetState.IDLE) {
-      return VOID;
-    }
-    isCropMoving = true;
-    // prevent low-priority observers from receiving the event
-    return EVENT_ABORT;
-  };
-
-  publicAPI.hoverAction = (callData) => {
-    if (!model.widgetRep) {
-      return VOID;
-    }
-
-    // Do not change widget state if moving the crop region.
-    if (isCropMoving) {
-      return VOID;
-    }
-
-    const mousePos = [callData.position.x, callData.position.y];
-    const planes = model.widgetRep.getPlanePositions();
-    // Assume we should use the first view
-    const view = model.interactor.getView();
-    const camUp = callData.pokedRenderer.getActiveCamera().getViewUp();
-
-    let ax1;
-    let ax2;
-    let camUp2D;
-
-    switch (model.sliceOrientation) {
-      case Orientation.YZ:
-        ax1 = [planes[2], planes[3]]; // Y crop bounds
-        ax2 = [planes[4], planes[5]]; // Z crop bounds
-        camUp2D = [camUp[1], camUp[2]];
-        break;
-      case Orientation.XZ: // ZX
-        ax1 = [planes[0], planes[1]]; // X crop bounds
-        ax2 = [planes[4], planes[5]]; // Z crop bounds
-        // reverse camUp to be -Z, then X
-        camUp2D = [-camUp[2], camUp[0]];
-        break;
-      case Orientation.XY:
-        ax1 = [planes[0], planes[1]]; // X crop bounds
-        ax2 = [planes[2], planes[3]]; // Y crop bounds
-        camUp2D = [camUp[0], camUp[1]];
-        break;
-      default:
-        vtkErrorMacro('Invalid slice orientation');
-        return VOID;
-    }
-
-    let leftBottom; // [left, bottom]
-    let rightTop; // [right, top]
-
-    // handle camera view up
-    const camUp2DHash = camUp2D[0] + 10 * camUp2D[1];
-    switch (camUp2DHash) {
-      case 1: // [1, 0]
-        leftBottom = [ax1[0], ax2[1]];
-        rightTop = [ax1[1], ax2[0]];
-        break;
-      case -1: // [-1, 0]
-        leftBottom = [ax1[1], ax2[0]];
-        rightTop = [ax1[0], ax2[1]];
-        break;
-      case 10: // [0, 1]
-        leftBottom = [ax1[0], ax2[0]];
-        rightTop = [ax1[1], ax2[1]];
-        break;
-      case -10: // [0, -1]
-        leftBottom = [ax1[1], ax2[1]];
-        rightTop = [ax1[0], ax2[0]];
-        break;
-      default:
-        vtkErrorMacro('Invalid camera view-up');
-        return VOID;
-    }
-
-    let left;
-    let bottom;
-    let right;
-    let top;
-
-    switch (model.sliceOrientation) {
-      case Orientation.YZ:
-        [left, bottom] = view.worldToDisplay(
-          model.slice,
-          leftBottom[0],
-          leftBottom[1],
-          callData.pokedRenderer
-        );
-        [right, top] = view.worldToDisplay(
-          model.slice,
-          rightTop[0],
-          rightTop[1],
-          callData.pokedRenderer
-        );
-        break;
-      case Orientation.XZ: // ZX
-        [left, bottom] = view.worldToDisplay(
-          leftBottom[0],
-          model.slice,
-          leftBottom[1],
-          callData.pokedRenderer
-        );
-        [right, top] = view.worldToDisplay(
-          rightTop[0],
-          model.slice,
-          rightTop[1],
-          callData.pokedRenderer
-        );
-        break;
-      case Orientation.XY:
-        [left, bottom] = view.worldToDisplay(
-          leftBottom[0],
-          leftBottom[1],
-          model.slice,
-          callData.pokedRenderer
-        );
-        [right, top] = view.worldToDisplay(
-          rightTop[0],
-          rightTop[1],
-          model.slice,
-          callData.pokedRenderer
-        );
-        break;
-      default:
-      // noop
-    }
-
-    const leftDist = Math.abs(left - mousePos[0]);
-    const rightDist = Math.abs(right - mousePos[0]);
-    const bottomDist = Math.abs(bottom - mousePos[1]);
-    const topDist = Math.abs(top - mousePos[1]);
-
-    if (leftDist < model.handleSize) {
-      if (bottomDist < model.handleSize) {
-        widgetState = WidgetState.MOVE_LEFT_BOTTOM;
-      } else if (topDist < model.handleSize) {
-        widgetState = WidgetState.MOVE_LEFT_TOP;
-      } else {
-        widgetState = WidgetState.MOVE_LEFT;
+    if (model.widgetState.controlState === WidgetState.IDLE) {
+      const handleIndex = model.widgetRep.getEventIntersection(callData);
+      if (handleIndex > -1) {
+        model.activeHandleIndex = handleIndex;
+        publicAPI.updateWidgetState({
+          activeHandleIndex: handleIndex,
+          controlState: WidgetState.CROPPING,
+        });
+        return EVENT_ABORT;
       }
-    } else if (rightDist < model.handleSize) {
-      if (bottomDist < model.handleSize) {
-        widgetState = WidgetState.MOVE_RIGHT_BOTTOM;
-      } else if (topDist < model.handleSize) {
-        widgetState = WidgetState.MOVE_RIGHT_TOP;
-      } else {
-        widgetState = WidgetState.MOVE_RIGHT;
-      }
-    } else if (bottomDist < model.handleSize) {
-      widgetState = WidgetState.MOVE_BOTTOM;
-    } else if (topDist < model.handleSize) {
-      widgetState = WidgetState.MOVE_TOP;
-    } else {
-      widgetState = WidgetState.IDLE;
     }
-
-    model.interactor.getView().setCursor(getCursorState(widgetState));
     return VOID;
   };
 
   publicAPI.moveAction = (callData) => {
-    if (widgetState === WidgetState.IDLE) {
+    const { controlState, handles, activeHandleIndex } = model.widgetState;
+    if (controlState === WidgetState.IDLE || activeHandleIndex === -1) {
       return VOID;
     }
 
     const mouse = [callData.position.x, callData.position.y];
-    const view = model.interactor.getView();
-    const planes = model.widgetRep.getPlanePositions();
-    const bounds = model.widgetRep.getInitialBounds();
-    const camUp = callData.pokedRenderer.getActiveCamera().getViewUp();
+    const handlePos = handles[activeHandleIndex];
+    const renderer = publicAPI.getInteractor().getCurrentRenderer();
+    const camera = renderer.getActiveCamera();
+    const dop = camera.getDirectionOfProjection();
 
-    let newPos = view.displayToWorld(...mouse, 0, callData.pokedRenderer);
+    const point = publicAPI.displayToPlane(mouse, handlePos, dop);
+    if (point) {
+      // Constrain point to axis
+      const orientation = model.volumeMapper.getInputData().getDirection();
+      const offset = Math.floor(activeHandleIndex / 2) * 3;
+      const axis = orientation.slice(offset, offset + 3);
 
-    let ax1;
-    let ax2;
-    let bounds1;
-    let bounds2;
-    let camUp2D;
+      const newPos = [0, 0, 0];
+      const relMoveVect = [0, 0, 0];
+      const projection = [0, 0, 0];
+      vtkMath.subtract(point, handlePos, relMoveVect);
+      vtkMath.projectVector(relMoveVect, axis, projection);
+      vtkMath.add(handlePos, projection, newPos);
 
-    switch (model.sliceOrientation) {
-      case Orientation.YZ:
-        ax1 = [planes[2], planes[3]]; // Y crop pos
-        ax2 = [planes[4], planes[5]]; // Z crop pos
-        bounds1 = [bounds[2], bounds[3]];
-        bounds2 = [bounds[4], bounds[5]];
-        camUp2D = [camUp[1], camUp[2]];
-        newPos = [newPos[1], newPos[2]];
-        break;
-      case Orientation.XZ: // ZX
-        ax1 = [planes[4], planes[5]]; // Z crop pos
-        ax2 = [planes[0], planes[1]]; // X crop pos
-        bounds1 = [bounds[4], bounds[5]];
-        bounds2 = [bounds[0], bounds[1]];
-        // reverse camUp and newPos to be Z (not -Z as before), then X
-        camUp2D = [camUp[2], camUp[0]];
-        newPos = [newPos[2], newPos[0]];
-        break;
-      case Orientation.XY:
-        ax1 = [planes[0], planes[1]]; // X crop pos
-        ax2 = [planes[2], planes[3]]; // Y crop pos
-        bounds1 = [bounds[0], bounds[1]];
-        bounds2 = [bounds[2], bounds[3]];
-        camUp2D = [camUp[0], camUp[1]];
-        newPos = [newPos[0], newPos[1]];
-        break;
-      default:
-        vtkErrorMacro('Invalid slice orientation');
-        return VOID;
+      const newHandles = handles.slice();
+      newHandles[activeHandleIndex] = newPos;
+
+      publicAPI.updateWidgetState({
+        handles: newHandles,
+      });
     }
-
-    let left;
-    let bottom;
-    let right;
-    let top;
-
-    // handle camera view up
-    const camUp2DHash = camUp2D[0] + 10 * camUp2D[1];
-    switch (camUp2DHash) {
-      case 1: // [1, 0]
-        [left, bottom, right, top] = [ax2[1], ax1[0], ax2[0], ax1[1]];
-        // swap axes
-        newPos = [newPos[1], newPos[0]];
-        [bounds1, bounds2] = [bounds2, bounds1];
-        break;
-      case -1: // [-1, 0]
-        [left, bottom, right, top] = [ax2[0], ax1[1], ax2[1], ax1[0]];
-        // swap axes
-        newPos = [newPos[1], newPos[0]];
-        [bounds1, bounds2] = [bounds2, bounds1];
-        break;
-      case 10: // [0, 1]
-        [left, bottom, right, top] = [ax1[0], ax2[0], ax1[1], ax2[1]];
-        break;
-      case -10: // [0, -1]
-        [left, bottom, right, top] = [ax1[1], ax2[1], ax1[0], ax2[0]];
-        break;
-      default:
-        vtkErrorMacro('Invalid camera view-up');
-        return VOID;
-    }
-
-    // Is there a better way than using a fudge factor?
-    const fudge = 1e-12;
-    if (
-      widgetState === WidgetState.MOVE_LEFT ||
-      widgetState === WidgetState.MOVE_LEFT_TOP ||
-      widgetState === WidgetState.MOVE_LEFT_BOTTOM
-    ) {
-      if (left > right) {
-        left = Math.max(right + fudge, Math.min(bounds1[1], newPos[0]));
-      } else {
-        left = Math.max(bounds1[0], Math.min(right, newPos[0]));
-      }
-    }
-    if (
-      widgetState === WidgetState.MOVE_RIGHT ||
-      widgetState === WidgetState.MOVE_RIGHT_TOP ||
-      widgetState === WidgetState.MOVE_RIGHT_BOTTOM
-    ) {
-      if (left > right) {
-        right = Math.max(bounds1[0], Math.min(left - fudge, newPos[0]));
-      } else {
-        right = Math.max(left, Math.min(bounds1[1], newPos[0]));
-      }
-    }
-    if (
-      widgetState === WidgetState.MOVE_BOTTOM ||
-      widgetState === WidgetState.MOVE_LEFT_BOTTOM ||
-      widgetState === WidgetState.MOVE_RIGHT_BOTTOM
-    ) {
-      if (bottom > top) {
-        bottom = Math.max(top + fudge, Math.min(bounds2[1], newPos[1]));
-      } else {
-        bottom = Math.max(bounds2[0], Math.min(top, newPos[1]));
-      }
-    }
-    if (
-      widgetState === WidgetState.MOVE_TOP ||
-      widgetState === WidgetState.MOVE_LEFT_TOP ||
-      widgetState === WidgetState.MOVE_RIGHT_TOP
-    ) {
-      if (bottom > top) {
-        top = Math.max(bounds2[0], Math.min(bottom - fudge, newPos[1]));
-      } else {
-        top = Math.max(bottom, Math.min(bounds2[1], newPos[1]));
-      }
-    }
-
-    // revert cam view up transform
-    switch (camUp2DHash) {
-      case 1: // [1, 0]
-        [ax2[1], ax1[0], ax2[0], ax1[1]] = [left, bottom, right, top];
-        break;
-      case -1: // [-1, 0]
-        [ax2[0], ax1[1], ax2[1], ax1[0]] = [left, bottom, right, top];
-        break;
-      case 10: // [0, 1]
-        [ax1[0], ax2[0], ax1[1], ax2[1]] = [left, bottom, right, top];
-        break;
-      case -10: // [0, -1]
-        [ax1[1], ax2[1], ax1[0], ax2[0]] = [left, bottom, right, top];
-        break;
-      default:
-        vtkErrorMacro('Invalid camera view-up');
-        return VOID;
-    }
-
-    // assign new plane values
-    switch (model.sliceOrientation) {
-      case Orientation.YZ:
-        [planes[2], planes[3]] = ax1;
-        [planes[4], planes[5]] = ax2;
-        break;
-      case Orientation.XZ: // ZX
-        [planes[0], planes[1]] = ax2;
-        [planes[4], planes[5]] = ax1;
-        break;
-      case Orientation.XY:
-        [planes[0], planes[1]] = ax1;
-        [planes[2], planes[3]] = ax2;
-        break;
-      default:
-        vtkErrorMacro('Invalid slice orientation');
-        return VOID;
-    }
-
-    model.widgetRep.setPlanePositions(...planes);
-    model.interactor.render();
-
     return EVENT_ABORT;
   };
 
   publicAPI.endMoveAction = () => {
-    isCropMoving = false;
+    publicAPI.updateWidgetState({
+      activeHandleIndex: -1,
+      controlState: WidgetState.IDLE,
+    });
   };
 }
 

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -209,8 +209,8 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
       const tF = clipRange[0] - rayLength;
       const tB = clipRange[1] - rayLength;
       for (let i = 0; i < 3; i++) {
-        p1World[i] = planePoint[i] + tF * dop[i];
-        p2World[i] = planePoint[i] + tB * dop[i];
+        p1World[i] = worldCoords[i] + tF * dop[i];
+        p2World[i] = worldCoords[i] + tB * dop[i];
       }
     } else {
       const tF = clipRange[0] / rayLength;

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -246,6 +246,8 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
     }
   };
 
+  publicAPI.getCroppingPlanes = () => model.widgetState.planes.slice();
+
   publicAPI.updateRepresentation = () => {
     if (model.widgetRep) {
       const bounds = model.volumeMapper.getBounds();

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -7,12 +7,7 @@ import Constants from 'vtk.js/Sources/Interaction/Widgets/ImageCroppingRegionsWi
 import { vec3 } from 'gl-matrix';
 
 const { vtkErrorMacro, VOID, EVENT_ABORT } = macro;
-const { WidgetState, CropWidgetEvents } = Constants;
-
-// first 6 are face handles,
-// next 12 are edge handles,
-// last 8 are corner handles.
-const TOTAL_NUM_HANDLES = 26;
+const { TOTAL_NUM_HANDLES, WidgetState, CropWidgetEvents } = Constants;
 
 // Determines the ordering of edge handles for some fixed axis
 const EDGE_ORDER = [[0, 0], [0, 1], [1, 0], [1, 1]];

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -95,6 +95,30 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
       });
   };
 
+  publicAPI.planesToBBoxCorners = (planes) => {
+    if (!model.volumeMapper || !model.volumeMapper.getInputData()) {
+      return null;
+    }
+
+    const indexToWorld = model.volumeMapper.getInputData().getIndexToWorld();
+    return [
+      [planes[0], planes[2], planes[4]],
+      [planes[0], planes[2], planes[5]],
+      [planes[0], planes[3], planes[4]],
+      [planes[0], planes[3], planes[5]],
+      [planes[1], planes[2], planes[4]],
+      [planes[1], planes[2], planes[5]],
+      [planes[1], planes[3], planes[4]],
+      [planes[1], planes[3], planes[5]],
+    ].map((coord) => {
+      const vin = vec3.fromValues(...coord);
+      const vout = vec3.create();
+      vec3.transformMat4(vout, vin, indexToWorld);
+
+      return [vout[0], vout[1], vout[2]];
+    });
+  };
+
   publicAPI.handlesToPlanes = (handles) => {
     if (!model.volumeMapper || !model.volumeMapper.getInputData()) {
       return null;
@@ -144,10 +168,13 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
       const bounds = model.volumeMapper.getBounds();
       model.widgetRep.placeWidget(...bounds);
 
-      const { activeHandleIndex, handles } = model.widgetState;
+      const { activeHandleIndex, handles, planes } = model.widgetState;
+      const bboxCorners = publicAPI.planesToBBoxCorners(planes);
+
       model.widgetRep.set({
         activeHandleIndex,
         handlePositions: handles,
+        bboxCorners,
       });
 
       publicAPI.render();

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -163,10 +163,6 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
     }
   };
 
-  publicAPI.setSlice = (slice) => {};
-
-  publicAPI.setSliceOrientation = (sliceOrientation) => {};
-
   // Given display coordinates and a plane, returns the
   // point on the plane that corresponds to display coordinates.
   publicAPI.displayToPlane = (displayCoords, planePoint, planeNormal) => {
@@ -327,8 +323,6 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   // volumeMapper: null,
-  slice: 0,
-  sliceOrientation: 2, // XY
   handleSize: 3,
 };
 
@@ -346,7 +340,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   );
 
   macro.setGet(publicAPI, model, ['handleSize']);
-  macro.get(publicAPI, model, ['volumeMapper', 'slice', 'sliceOrientation']);
+  macro.get(publicAPI, model, ['volumeMapper']);
 
   // Object methods
   vtkImageCroppingRegionsWidget(publicAPI, model);


### PR DESCRIPTION
This iteration of the crop widget provides a means of manipulating a box in 3D space. Cropping planes are exported out via an event or via `widget.getCroppingPlanes()`. This is a first pass.

There are three sets of control handles: face handles, edge handles, and corner handles.

A small demo is shown below with face and corner handles.

![cropv2](https://user-images.githubusercontent.com/1812167/40797821-7280495c-64d7-11e8-81ce-79172e516bc1.gif)

@jourdain @martinken @wschroed @aylward