### PR TITLE
fix(MoleculeToRepresentation): Fix bond colors when hiding atoms interactively

### DIFF
--- a/Sources/Filters/General/MoleculeToRepresentation/index.js
+++ b/Sources/Filters/General/MoleculeToRepresentation/index.js
@@ -77,6 +77,7 @@ function vtkMoleculeToRepresentation(publicAPI, model) {
     bondPositionData.length = 0;
     bondScaleData.length = 0;
     bondOrientationData.length = 0;
+    bondColorData.length = 0;
 
     if (moleculedata.getAtoms()) {
       if (moleculedata.getAtoms().coords !== undefined) {


### PR DESCRIPTION
Took some debugging to understand why the example would work fine, but the bond colors would be wrong when running interactively in Paraview Glance. In the end it was a one line fix.

![screenshot-2018-6-12 paraview glance](https://user-images.githubusercontent.com/15913822/41319150-df6412fc-6e68-11e8-8272-f22691911a07.png)

![screenshot-2018-6-12 paraview glance 1](https://user-images.githubusercontent.com/15913822/41319157-e438005e-6e68-11e8-922b-cf3468b85c7b.png)
