### PR TITLE
fix(ProxyManager): Set state rendering timeout to 0

### DIFF
--- a/Sources/Proxy/Core/ProxyManager/state.js
+++ b/Sources/Proxy/Core/ProxyManager/state.js
@@ -62,7 +62,7 @@ export default function addStateAPI(publicAPI, model) {
         proxyMapping[view].getRenderWindow().render();
         proxyMapping[view].getCamera().set(cameras[view]);
         proxyMapping[view].renderLater();
-      }, 1000);
+      }, 0);
     });
     return state.userData;
   };


### PR DESCRIPTION
There shouldn't be any reason to set this to 1000 that I can tell, so set this timeout to 0 so renderers don't "jump" after 1 second.