### PR TITLE
fix(Rendering): support FragDepth on webgl2

### DIFF
--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -964,6 +964,30 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
           ).result;
         }
       }
+      if (model.openGLRenderWindow.getWebgl2()) {
+        if (cp.factor !== 0.0) {
+          FSSource = vtkShaderProgram.substitute(
+            FSSource,
+            '//VTK::UniformFlow::Impl',
+            [
+              'float cscale = length(vec2(dFdx(gl_FragCoord.z),dFdy(gl_FragCoord.z)));',
+              '//VTK::UniformFlow::Impl',
+            ],
+            false
+          ).result;
+          FSSource = vtkShaderProgram.substitute(
+            FSSource,
+            '//VTK::Depth::Impl',
+            'gl_FragDepth = gl_FragCoord.z + cfactor*cscale + 0.000016*coffset;'
+          ).result;
+        } else {
+          FSSource = vtkShaderProgram.substitute(
+            FSSource,
+            '//VTK::Depth::Impl',
+            'gl_FragDepth = gl_FragCoord.z + 0.000016*coffset;'
+          ).result;
+        }
+      }
       shaders.Fragment = FSSource;
     }
   };

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -71,6 +71,9 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
     if (model.context.getExtension('EXT_frag_depth')) {
       fragString = 'gl_FragDepthEXT = (pos.z / pos.w + 1.0) / 2.0;\n';
     }
+    if (model.openGLRenderWindow.getWebgl2()) {
+      fragString = 'gl_FragDepth = (pos.z / pos.w + 1.0) / 2.0;\n';
+    }
     FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::Depth::Impl', [
       // compute the eye position and unit direction
       '  vec3 EyePos;\n',

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -72,6 +72,9 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     if (model.context.getExtension('EXT_frag_depth')) {
       fragString = '  gl_FragDepthEXT = (pos.z / pos.w + 1.0) / 2.0;\n';
     }
+    if (model.openGLRenderWindow.getWebgl2()) {
+      fragString = 'gl_FragDepth = (pos.z / pos.w + 1.0) / 2.0;\n';
+    }
     // see https://www.cl.cam.ac.uk/teaching/1999/AGraphHCI/SMAG/node2.html
     FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::Depth::Impl', [
       // compute the eye position and unit direction


### PR DESCRIPTION
The stick, sphere, and coincincident point support was
not fully working on webgl2 resulting in incorrectly rendered
spheres/sticks/polydata. This topic fixes that.