### PR TITLE
fix(Rendering): improve the termination of vol ren rays

### DIFF
--- a/Sources/Rendering/Misc/GenericRenderWindow/index.js
+++ b/Sources/Rendering/Misc/GenericRenderWindow/index.js
@@ -21,13 +21,13 @@ function vtkGenericRenderWindow(publicAPI, model) {
   model.renderer = vtkRenderer.newInstance();
   model.renderWindow.addRenderer(model.renderer);
 
-  // OpenGlRenderWindow
-  model.openGlRenderWindow = vtkOpenGLRenderWindow.newInstance();
-  model.renderWindow.addView(model.openGlRenderWindow);
+  // OpenGLRenderWindow
+  model.openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
+  model.renderWindow.addView(model.openGLRenderWindow);
 
   // Interactor
   model.interactor = vtkRenderWindowInteractor.newInstance();
-  model.interactor.setView(model.openGlRenderWindow);
+  model.interactor.setView(model.openGLRenderWindow);
   model.interactor.initialize();
 
   // Expose background
@@ -41,7 +41,7 @@ function vtkGenericRenderWindow(publicAPI, model) {
     if (model.container) {
       const dims = model.container.getBoundingClientRect();
       const devicePixelRatio = window.devicePixelRatio || 1;
-      model.openGlRenderWindow.setSize(
+      model.openGLRenderWindow.setSize(
         Math.floor(dims.width * devicePixelRatio),
         Math.floor(dims.height * devicePixelRatio)
       );
@@ -53,7 +53,7 @@ function vtkGenericRenderWindow(publicAPI, model) {
   // Handle DOM container relocation
   publicAPI.setContainer = (el) => {
     if (model.container) {
-      model.openGlRenderWindow.setContainer(model.container);
+      model.openGLRenderWindow.setContainer(model.container);
       model.interactor.unbindEvents(model.container);
     }
 
@@ -62,7 +62,7 @@ function vtkGenericRenderWindow(publicAPI, model) {
 
     // Bind to new container
     if (model.container) {
-      model.openGlRenderWindow.setContainer(model.container);
+      model.openGLRenderWindow.setContainer(model.container);
       model.interactor.bindEvents(model.container);
     }
   };
@@ -94,7 +94,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.get(publicAPI, model, [
     'renderWindow',
     'renderer',
-    'openGlRenderWindow',
+    'openGLRenderWindow',
     'interactor',
     'container',
   ]);

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -194,15 +194,19 @@ void main()
       dot(endVC, vPlaneNormal0),
       dot(endVC, vPlaneNormal2),
       dot(endVC, vPlaneNormal4));
-    vec3 vdelta = endvpos - vpos;
-    float numSteps = length(vdelta) / sampleDistance;
-    vdelta = vdelta / numSteps;
 
     // start slightly inside and apply some jitter
     float jitter = texture2D(jtexture, gl_FragCoord.xy/32.0).r;
-    vpos = vpos + vdelta*(0.01 + 0.98*jitter);
+    vec3 vdelta = endvpos - vpos;
+    vpos = vpos + normalize(vdelta)*(0.01 + 0.98*jitter)*sampleDistance;
+
+    // update vdelta post jitter
+    vdelta = endvpos - vpos;
+    float numSteps = length(vdelta) / sampleDistance;
+    vdelta = vdelta / float(numSteps);
+
     vec4 color = vec4(0.0, 0.0, 0.0, 0.0);
-    int count = int(numSteps - 0.2); // end slightly inside
+    int count = int(numSteps - 0.05); // end slightly inside
 
     vec3 ijk = vpos * vVCToIJK;
     vdelta = vdelta * vVCToIJK;


### PR DESCRIPTION
Better handling of the end condition of rays where the
opacity peaks right where the ray ends. Solve by taking
a last residual step on webgl2. Improve for both webgl1
and webgl2 with better starting loaction and step calculation.

Fix naming of openGLRenderWindow in GenericRenderWindow