### PR TITLE
fix(XMLReader): Incorrect offset assignment

### DIFF
--- a/Sources/IO/XML/XMLReader/index.js
+++ b/Sources/IO/XML/XMLReader/index.js
@@ -399,7 +399,7 @@ function vtkXMLReader(publicAPI, model) {
         const offset = Number(arrayElems[i].getAttribute('offset'));
         let nextOffset = 0;
         if (i === arrayElems.length - 1) {
-          nextOffset = appendedBuffer.length;
+          nextOffset = appendedBuffer.length || appendedBuffer.byteLength;
         } else {
           nextOffset = Number(arrayElems[i + 1].getAttribute('offset'));
         }


### PR DESCRIPTION
appendedBuffer can either be a String or ArrayBuffer.

Fixes: https://github.com/Kitware/paraview-glance/issues/195