### PR TITLE
perf(Picking): improve picking performance

### DIFF
--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -97,9 +97,10 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
     publicAPI.beginSelection();
     for (
       model.currentPass = PassTypes.MIN_KNOWN_PASS;
-      model.currentPass <= PassTypes.MAX_KNOWN_PASS;
+      model.currentPass <= PassTypes.COMPOSITE_INDEX_PASS;
       model.currentPass++
     ) {
+      console.log(`in pass ${model.currentPass}`);
       if (publicAPI.passRequired(model.currentPass)) {
         publicAPI.preCapturePass(model.currentPass);
         model.openGLRenderWindow.traverseAllPasses();

--- a/Sources/Rendering/OpenGL/HardwareSelector/test/testHardwareSelectorSpeed.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/test/testHardwareSelectorSpeed.js
@@ -82,8 +82,9 @@ test.onlyIfWebGL('Test HardwareSelector', (tapeContext) => {
   console.log(taTime, tbTime, tcTime);
 
   tapeContext.ok(
-    tcTime < tbTime * 200,
-    `Hardware selector is less than twice as slow as a normal render (${taTime}, ${tbTime}, ${tcTime})`
+    // should take about 3 normal renders but we give it some wiggle room
+    tcTime < tbTime * 6,
+    `Hardware selector takes less than six normal renders (${taTime}, ${tbTime}, ${tcTime})`
   );
 
   gc.releaseResources();

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -152,57 +152,6 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::Normal::Impl', '')
       .result;
 
-    const selector = ren.getSelector();
-    const picking = false; // (ren.getRenderWindow().getIsPicking() || selector != null);
-    fragString = '';
-    if (picking) {
-      if (
-        !selector /* ||
-          (this->LastSelectionState >= vtkHardwareSelector::ID_LOW24) */
-      ) {
-        VSSource = vtkShaderProgram.substitute(
-          VSSource,
-          '//VTK::Picking::Dec',
-          ['attribute vec4 selectionId;\n', 'varying vec4 selectionIdVSOutput;']
-        ).result;
-        VSSource = vtkShaderProgram.substitute(
-          VSSource,
-          '//VTK::Picking::Impl',
-          'selectionIdVSOutput = selectionId;'
-        ).result;
-        FSSource = vtkShaderProgram.substitute(
-          FSSource,
-          '//VTK::Picking::Dec',
-          'varying vec4 selectionIdVSOutput;'
-        ).result;
-
-        if (model.context.getExtension('EXT_frag_depth')) {
-          fragString =
-            '    gl_FragData[0] = vec4(selectionIdVSOutput.rgb, 1.0);\n';
-        }
-        FSSource = vtkShaderProgram.substitute(
-          FSSource,
-          '//VTK::Picking::Impl',
-          fragString
-        ).result;
-      } else {
-        FSSource = vtkShaderProgram.substitute(
-          FSSource,
-          '//VTK::Picking::Dec',
-          'uniform vec3 mapperIndex;'
-        ).result;
-
-        if (model.context.getExtension('EXT_frag_depth')) {
-          fragString = '  gl_FragData[0] = vec4(mapperIndex,1.0);\n';
-        }
-        FSSource = vtkShaderProgram.substitute(
-          FSSource,
-          '//VTK::Picking::Impl',
-          fragString
-        ).result;
-      }
-    }
-
     if (model.haveSeenDepthRequest) {
       // special depth impl
       FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::ZBuffer::Impl', [
@@ -228,9 +177,6 @@ function vtkOpenGLStickMapper(publicAPI, model) {
         cellBO.getShaderSourceTime().getMTime() >
           cellBO.getAttributeUpdateTime().getMTime())
     ) {
-      const selector = ren.getSelector();
-      const picking = false; // (ren.getRenderWindow().getIsPicking() || selector !== null);
-
       if (cellBO.getProgram().isAttributeUsed('orientMC')) {
         if (
           !cellBO.getVAO().addAttributeArray(
@@ -280,31 +226,6 @@ function vtkOpenGLStickMapper(publicAPI, model) {
         ) {
           vtkErrorMacro("Error setting 'radiusMC' in shader VAO.");
         }
-      }
-      if (
-        picking &&
-        !selector /* ||
-           (model.LastSelectionState >= vtkHardwareSelector::ID_LOW24) */ &&
-        cellBO.getProgram().isAttributeUsed('selectionId')
-      ) {
-        if (
-          !cellBO
-            .getVAO()
-            .addAttributeArray(
-              cellBO.getProgram(),
-              cellBO.getCABO(),
-              'selectionId',
-              cellBO.getCABO().getColorOffset(),
-              cellBO.getCABO().getColorBOStride(),
-              model.context.UNSIGNED_CHAR,
-              4,
-              true
-            )
-        ) {
-          vtkErrorMacro("Error setting 'selectionId' in shader VAO.");
-        }
-      } else {
-        cellBO.getVAO().removeAttributeArray('selectionId');
       }
     }
 


### PR DESCRIPTION
Since we only support Actor and composite picking we can
make it run quite a bit faster by not rebuilding shaders
and skipping the LOW_ID pass. Current takes about 2.5 times
the cost of a sequental render for 500 actors.