### PR TITLE
fix(RenderWindowInteractor): listen to mouseleave event

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -193,6 +193,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
 
     rootElm[method]('mouseup', publicAPI.handleMouseUp);
+    rootElm[method]('mouseleave', publicAPI.handleMouseUp);
     rootElm[method]('mousemove', publicAPI.handleMouseMove);
     rootElm[method]('touchend', publicAPI.handleTouchEnd, false);
     rootElm[method]('touchcancel', publicAPI.handleTouchEnd, false);


### PR DESCRIPTION
All mouse interactions (left, middle and right button) are stopped once the cursor leaves the renderwindow. This is necessary because the buttonUp events are not received if the cursor is outside the renderwind
ow. In my opinion, this fix greatly improves the usability.