### PR TITLE
fix: return [] rather than null

### DIFF
--- a/Sources/Rendering/Core/Prop/index.js
+++ b/Sources/Rendering/Core/Prop/index.js
@@ -24,9 +24,9 @@ function vtkProp(publicAPI, model) {
   };
 
   publicAPI.getNestedProps = () => null;
-  publicAPI.getActors = () => null;
-  publicAPI.getActors2D = () => null;
-  publicAPI.getVolumes = () => null;
+  publicAPI.getActors = () => [];
+  publicAPI.getActors2D = () => [];
+  publicAPI.getVolumes = () => [];
 
   publicAPI.pick = notImplemented('pick');
   publicAPI.hasKey = notImplemented('hasKey');

--- a/Sources/Rendering/Core/Viewport/index.js
+++ b/Sources/Rendering/Core/Viewport/index.js
@@ -39,7 +39,7 @@ function vtkViewport(publicAPI, model) {
   function gatherProps(prop, allProps = []) {
     allProps.push(prop);
     const children = prop.getNestedProps();
-    if (children) {
+    if (children && children.length) {
       for (let i = 0; i < children.length; i++) {
         gatherProps(children[i], allProps);
       }


### PR DESCRIPTION
Calling code is expecting to be able to concat the results of these functions. For example see the implementation of vtkRenderer::getActors() implementation. The current implementation
ends up with nulls in the array and iteration issues.