### PR TITLE
fix(widgets): add exports for PaintWidget

### DIFF
--- a/Sources/Filters/General/index.js
+++ b/Sources/Filters/General/index.js
@@ -5,6 +5,7 @@ import vtkImageMarchingSquares from './ImageMarchingSquares';
 import vtkImageStreamline from './ImageStreamline';
 import vtkMoleculeToRepresentation from './MoleculeToRepresentation';
 import vtkOutlineFilter from './OutlineFilter';
+import vtkPaintFilter from './PaintFilter';
 import vtkWarpScalar from './WarpScalar';
 
 export default {
@@ -15,5 +16,6 @@ export default {
   vtkImageStreamline,
   vtkMoleculeToRepresentation,
   vtkOutlineFilter,
+  vtkPaintFilter,
   vtkWarpScalar,
 };

--- a/Sources/Widgets/Widgets3D/index.js
+++ b/Sources/Widgets/Widgets3D/index.js
@@ -1,7 +1,9 @@
 import vtkImplicitPlaneWidget from './ImplicitPlaneWidget';
+import vtkPaintWidget from './PaintWidget';
 import vtkPolyLineWidget from './PolyLineWidget';
 
 export default {
   vtkImplicitPlaneWidget,
+  vtkPaintWidget,
   vtkPolyLineWidget,
 };


### PR DESCRIPTION
The paint widget code was merged, but isn't included in the dist/vtk.js build without this export.