### PR TITLE
Add opacity function to ImageProperty

### DIFF
--- a/Sources/Rendering/Core/ImageMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageMapper/example/index.js
@@ -6,6 +6,8 @@ import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource
 import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
 import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
 import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
+import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
+import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
 
 const { SlicingMode } = Constants;
 
@@ -32,9 +34,24 @@ mapper.setSliceAtFocalPoint(true);
 mapper.setSlicingMode(SlicingMode.Z);
 // mapper.setZSlice(5);
 
+const rgb = vtkColorTransferFunction.newInstance();
+global.rgb = rgb;
+rgb.addRGBPoint(0, 0, 0, 0);
+rgb.addRGBPoint(255, 1, 1, 1);
+
+const ofun = vtkPiecewiseFunction.newInstance();
+global.ofun = ofun;
+ofun.addPoint(0, 1);
+ofun.addPoint(150, 1);
+ofun.addPoint(180, 0);
+ofun.addPoint(255, 0);
+
 const actor = vtkImageSlice.newInstance();
 actor.getProperty().setColorWindow(255);
 actor.getProperty().setColorLevel(127);
+// Uncomment this if you want to use a fixed colorwindow/level
+// actor.getProperty().setRGBTransferFunction(rgb);
+actor.getProperty().setScalarOpacity(ofun);
 actor.setMapper(mapper);
 renderer.addActor(actor);
 

--- a/Sources/Rendering/Core/ImageProperty/api.md
+++ b/Sources/Rendering/Core/ImageProperty/api.md
@@ -54,3 +54,9 @@ Control the opacity of this image.
 
 Specify vtkColorTransferFunction to map scalars to colors. If set, then
 colorWindow and colorLevel are not used.
+
+### scalarOpacity
+
+Specify a vtkPiecewiseFunction to map image intensities to opacities. This
+will only work on single-component images. The overall image opacity can
+still be affected by the `opacity` property.

--- a/Sources/Rendering/Core/ImageProperty/index.js
+++ b/Sources/Rendering/Core/ImageProperty/index.js
@@ -34,6 +34,7 @@ const DEFAULT_VALUES = {
   diffuse: 0.0,
   opacity: 1.0,
   rGBTransferFunction: null,
+  scalarOpacity: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -52,6 +53,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'diffuse',
     'opacity',
     'rGBTransferFunction',
+    'scalarOpacity',
   ]);
 
   publicAPI.getMTime = () => {

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -43,6 +43,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model.tris.setOpenGLRenderWindow(model.openGLRenderWindow);
       model.openGLTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
       model.colorTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.opacityTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
       const ren = model.openGLRenderer.getRenderable();
       model.openGLCamera = model.openGLRenderer.getViewNodeFor(
         ren.getActiveCamera()
@@ -122,10 +123,15 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
     FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::TCoord::Dec', [
       'varying vec2 tcoordVCVSOutput;',
+      // color shift and scale
       'uniform float shift;',
       'uniform float scale;',
+      // opacity shift and scale
+      'uniform float oshift;',
+      'uniform float oscale;',
       'uniform sampler2D texture1;',
       'uniform sampler2D colorTexture1;',
+      'uniform sampler2D opacityTexture1;',
       'uniform float opacity;',
     ]).result;
     switch (tNumComp) {
@@ -134,8 +140,10 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           FSSource,
           '//VTK::TCoord::Impl',
           [
-            'float intensity = texture2D(texture1, tcoordVCVSOutput).r*scale + shift;',
-            'gl_FragData[0] = vec4(texture2D(colorTexture1, vec2(intensity, 0.5)).rgb, opacity);',
+            'float intensity = texture2D(texture1, tcoordVCVSOutput).r;',
+            'vec3 tcolor = texture2D(colorTexture1, vec2(intensity * scale + shift, 0.5)).rgb;',
+            'float scalarOpacity = texture2D(opacityTexture1, vec2(intensity * oscale + oshift, 0.5)).r;',
+            'gl_FragData[0] = vec4(tcolor, scalarOpacity * opacity);',
           ]
         ).result;
         break;
@@ -309,6 +317,18 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     const scale = oglShiftScale.scale / cw;
     const shift = (oglShiftScale.shift - cl) / cw + 0.5;
 
+    // opacity shift/scale
+    const ofun = actor.getProperty().getScalarOpacity();
+    let oscale = 1.0;
+    let oshift = 0.0;
+    if (ofun) {
+      const oRange = ofun.getRange();
+      const length = oRange[1] - oRange[0];
+      const mid = 0.5 * (oRange[0] + oRange[1]);
+      oscale = oglShiftScale.scale / length;
+      oshift = (oglShiftScale.shift - mid) / length + 0.5;
+    }
+
     if (model.haveSeenDepthRequest) {
       cellBO
         .getProgram()
@@ -318,8 +338,13 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     cellBO.getProgram().setUniformf('shift', shift);
     cellBO.getProgram().setUniformf('scale', scale);
 
+    cellBO.getProgram().setUniformf('oshift', oshift);
+    cellBO.getProgram().setUniformf('oscale', oscale);
+
     const texColorUnit = model.colorTexture.getTextureUnit();
+    const texOpacityUnit = model.opacityTexture.getTextureUnit();
     cellBO.getProgram().setUniformi('colorTexture1', texColorUnit);
+    cellBO.getProgram().setUniformi('opacityTexture1', texOpacityUnit);
   };
 
   publicAPI.setCameraShaderParameters = (cellBO, ren, actor) => {
@@ -359,6 +384,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     // activate the texture
     model.openGLTexture.activate();
     model.colorTexture.activate();
+    model.opacityTexture.activate();
 
     // draw polygons
     if (model.tris.getCABO().getElementCount()) {
@@ -370,6 +396,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
     model.openGLTexture.deactivate();
     model.colorTexture.deactivate();
+    model.opacityTexture.deactivate();
   };
 
   publicAPI.renderPieceFinish = (ren, actor) => {};
@@ -436,9 +463,13 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     if (iType === InterpolationType.NEAREST) {
       model.colorTexture.setMinificationFilter(Filter.NEAREST);
       model.colorTexture.setMagnificationFilter(Filter.NEAREST);
+      model.opacityTexture.setMinificationFilter(Filter.NEAREST);
+      model.opacityTexture.setMagnificationFilter(Filter.NEAREST);
     } else {
       model.colorTexture.setMinificationFilter(Filter.LINEAR);
       model.colorTexture.setMagnificationFilter(Filter.LINEAR);
+      model.opacityTexture.setMinificationFilter(Filter.LINEAR);
+      model.opacityTexture.setMagnificationFilter(Filter.LINEAR);
     }
 
     const cWidth = 1024;
@@ -477,6 +508,43 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           3,
           VtkDataTypes.UNSIGNED_CHAR,
           cTable
+        );
+      }
+    }
+
+    const oWidth = 1024;
+    const oTable = new Uint8Array(oWidth);
+    const ofun = actor.getProperty().getScalarOpacity();
+    if (ofun) {
+      const ofunToString = `${ofun.getMTime()}`;
+      if (model.opacityTextureString !== ofunToString) {
+        const oRange = ofun.getRange();
+        const ofTable = new Float32Array(oWidth);
+        ofun.getTable(oRange[0], oRange[1], oWidth, ofTable, 1);
+        for (let i = 0; i < oWidth; ++i) {
+          oTable[i] = 255.0 * ofTable[i];
+        }
+        model.opacityTextureString = ofunToString;
+        model.opacityTexture.create2DFromRaw(
+          oWidth,
+          1,
+          1,
+          VtkDataTypes.UNSIGNED_CHAR,
+          oTable
+        );
+      }
+    } else {
+      const ofunToString = '0';
+      if (model.opacityTextureString !== ofunToString) {
+        // default is opaque
+        oTable.fill(255.0);
+        model.opacityTextureString = ofunToString;
+        model.opacityTexture.create2DFromRaw(
+          oWidth,
+          1,
+          1,
+          VtkDataTypes.UNSIGNED_CHAR,
+          oTable
         );
       }
     }
@@ -689,6 +757,7 @@ const DEFAULT_VALUES = {
   tris: null,
   imagemat: null,
   colorTexture: null,
+  opacityTexture: null,
   lastHaveSeenDepthRequest: false,
   haveSeenDepthRequest: false,
   lastTextureComponents: 0,
@@ -705,6 +774,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.tris = vtkHelper.newInstance();
   model.openGLTexture = vtkOpenGLTexture.newInstance();
   model.colorTexture = vtkOpenGLTexture.newInstance();
+  model.opacityTexture = vtkOpenGLTexture.newInstance();
 
   model.imagemat = mat4.create();
 


### PR DESCRIPTION
This adds a scalarOpacity function to ImageProperty, and adds support for it in ImageMapper.

Helps address #714 

Does having a scalarOpacity function for images make enough sense as a whole? To me, this seems like a reasonable approach for layering transparent images on top of one another. Also, as I've not done WebGL much before, a code review would be great @jourdain @martinken 