### PR TITLE
fix(ViewProxy): Don't request animation when change in view orientati…

### DIFF
--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -423,6 +423,16 @@ function vtkViewProxy(publicAPI, model) {
       }
     }
 
+    if (animationStack.length === 1) {
+      // update camera directly
+      model.camera.set(animationStack.pop());
+      model.renderer.resetCameraClippingRange();
+      if (model.interactor.getLightFollowCamera()) {
+        model.renderer.updateLightsGeometryToFollowCamera();
+      }
+      return Promise.resolve();
+    }
+
     return new Promise((resolve, reject) => {
       const now = performance.now().toString();
       const animationRequester = `ViewProxy.updateOrientation.${now}`;


### PR DESCRIPTION
…on requires only 1 step

When updating view orientation, changes will be applied directly to the camera when the animation
stack only contains the destination camera position and viewUp rather than requesting an animation

fix #894