### PR TITLE
Allow for non-integer steps in MouseRangeManipulator

### DIFF
--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
@@ -53,7 +53,7 @@ const extent = data.getExtent();
 const kMin = extent[4];
 const kMax = extent[5];
 const kGet = mapper.getSlice;
-const kSet = mapper.setSlice;
+const kSet = (slice) => mapper.setSlice(Math.round(slice));
 
 const rangeManipulator = Manipulators.vtkMouseRangeManipulator.newInstance({
   button: 1,

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
@@ -17,7 +17,7 @@ function vtkMouseRangeManipulator(publicAPI, model) {
   //-------------------------------------------------------------------------
   function scaleDeltaToRange(listener, normalizedDelta) {
     return (
-      normalizedDelta * ((listener.max - listener.min) / listener.step + 1)
+      normalizedDelta * ((listener.max - listener.min) / (listener.step + 1))
     );
   }
 
@@ -27,7 +27,7 @@ function vtkMouseRangeManipulator(publicAPI, model) {
     let value = oldValue + delta + model.incrementalDelta[listener];
 
     const difference = value - listener.min;
-    const stepsToDifference = Math.round(difference / listener.step);
+    const stepsToDifference = difference / listener.step;
     value = listener.min + listener.step * stepsToDifference;
     value = Math.max(value, listener.min);
     value = Math.min(value, listener.max);

--- a/Sources/Proxy/Core/View2DProxy/index.js
+++ b/Sources/Proxy/Core/View2DProxy/index.js
@@ -3,6 +3,8 @@ import vtkMouseRangeManipulator from 'vtk.js/Sources/Interaction/Manipulators/Mo
 import vtkViewProxy from 'vtk.js/Sources/Proxy/Core/ViewProxy';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
+const DEFAULT_STEP_WIDTH = 512;
+
 function formatAnnotationValue(value) {
   if (Array.isArray(value)) {
     return value.map(formatAnnotationValue).join(', ');
@@ -151,13 +153,20 @@ function vtkView2DProxy(publicAPI, model) {
       );
       if (representation.getWindowWidth) {
         const update = () => setWindowWidth(representation.getWindowWidth());
-        const { min, max } = representation.getPropertyDomainByName(
+        const windowWidth = representation.getPropertyDomainByName(
           'windowWidth'
         );
+        const { min, max } = windowWidth;
+
+        let { step } = windowWidth;
+        if (!step || step === 'any') {
+          step = 1 / DEFAULT_STEP_WIDTH;
+        }
+
         model.rangeManipulator.setVerticalListener(
           min,
           max,
-          1,
+          step,
           representation.getWindowWidth,
           setWindowWidth
         );
@@ -169,13 +178,20 @@ function vtkView2DProxy(publicAPI, model) {
       }
       if (representation.getWindowLevel) {
         const update = () => setWindowLevel(representation.getWindowLevel());
-        const { min, max } = representation.getPropertyDomainByName(
+        const windowLevel = representation.getPropertyDomainByName(
           'windowLevel'
         );
+        const { min, max } = windowLevel;
+
+        let { step } = windowLevel;
+        if (!step || step === 'any') {
+          step = 1 / DEFAULT_STEP_WIDTH;
+        }
+
         model.rangeManipulator.setHorizontalListener(
           min,
           max,
-          1,
+          step,
           representation.getWindowLevel,
           setWindowLevel
         );


### PR DESCRIPTION
Modifieds View2DProxy and MouseRangeManipulator to support non-integer steps when performing window width/level operations, i.e. in the range [0,1].

Seems to fix https://github.com/Kitware/paraview-glance/issues/217, and fixes #808 as well.