### PR TITLE
feat(ImageStream): Add ViewStream inheritance support

### DIFF
--- a/Sources/IO/Core/ImageStream/index.js
+++ b/Sources/IO/Core/ImageStream/index.js
@@ -74,14 +74,24 @@ function vtkImageStream(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
-  function unregisterViewStream(view) {
+  publicAPI.registerViewStream = (view) => {
+    model.viewStreams.push(view);
+  };
+
+  // --------------------------------------------------------------------------
+
+  publicAPI.unregisterViewStream = (view) => {
     model.viewStreams = model.viewStreams.filter((v) => v !== view);
-  }
+  };
 
   // --------------------------------------------------------------------------
 
   publicAPI.createViewStream = (viewId = '-1', size = [400, 400]) => {
-    const { setServerAnimationFPS, getServerAnimationFPS } = publicAPI;
+    const {
+      setServerAnimationFPS,
+      getServerAnimationFPS,
+      unregisterViewStream,
+    } = publicAPI;
     const viewStream = ViewStream.newInstance({
       protocol: model.protocol,
       unregisterViewStream,
@@ -92,7 +102,7 @@ function vtkImageStream(publicAPI, model) {
     });
     viewStream.setViewId(viewId);
     viewStream.setSize(size[0], size[1]);
-    model.viewStreams.push(viewStream);
+    publicAPI.registerViewStream(viewStream);
 
     return viewStream;
   };
@@ -112,6 +122,7 @@ function vtkImageStream(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  // protocol: null,
   viewStreams: [],
   serverAnimationFPS: -1,
 };
@@ -123,7 +134,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   macro.obj(publicAPI, model);
-  macro.get(publicAPI, model, ['serverAnimationFPS']);
+  macro.get(publicAPI, model, ['serverAnimationFPS', 'protocol']);
 
   // Object specific methods
   vtkImageStream(publicAPI, model);


### PR DESCRIPTION
Make it possible to create your own ViewStream and register it
in the ImageStream:
```
function createMyViewStream(imageStream, viewId = '-1', size = [400, 400]){
  const { setServerAnimationFPS,
          getServerAnimationFPS,
          unregisterViewStream } = imageStream;
  const viewStream = MyViewStream.newInstance({
    protocol: imageStream.getProtocol(),
    unregisterViewStream,
    sharedAPI: {
      setServerAnimationFPS,
      getServerAnimationFPS,
    },
  });
  viewStream.setViewId(viewId);
  viewStream.setSize(size[0], size[1]);

  return viewStream;
};

const viewStream = createMyViewStream(imageStream, viewId);
view.imageStream.registerViewStream(viewStream);
```
