### PR TITLE
fix(ProxyManager): Unbind DOM event listener before deleting proxy

### DIFF
--- a/Sources/Proxy/Core/ProxyManager/core.js
+++ b/Sources/Proxy/Core/ProxyManager/core.js
@@ -213,6 +213,7 @@ export default function addRegistrationAPI(publicAPI, model) {
       proxy.getRepresentations().forEach((repProxy) => {
         publicAPI.deleteProxy(repProxy);
       });
+      proxy.getInteractor().unbindEvents();
       unRegisterProxy(proxy);
       if (publicAPI.getActiveView() === proxy) {
         publicAPI.setActiveView(publicAPI.getViews()[0]);


### PR DESCRIPTION
The views bind listeners to global object document.body. When deleting views with ProxyManager, the listeners should be removed to prevent a memory leak.