### PR TITLE
fix(ProxyManager): Use setContainer() to gain ability to check if unbind is needed

### DIFF
--- a/Sources/Proxy/Core/ProxyManager/core.js
+++ b/Sources/Proxy/Core/ProxyManager/core.js
@@ -213,7 +213,7 @@ export default function addRegistrationAPI(publicAPI, model) {
       proxy.getRepresentations().forEach((repProxy) => {
         publicAPI.deleteProxy(repProxy);
       });
-      proxy.getInteractor().unbindEvents();
+      proxy.setContainer(null);
       unRegisterProxy(proxy);
       if (publicAPI.getActiveView() === proxy) {
         publicAPI.setActiveView(publicAPI.getViews()[0]);


### PR DESCRIPTION
Check if view proxy has container before try to unbind when deleting view proxy.
This is a bug fix for https://github.com/Kitware/vtk-js/pull/994
