### PR TITLE
fix(MatrixBuilder): Use a more tolerant epsilon for zero-comparison

### DIFF
--- a/Sources/Common/Core/MatrixBuilder/index.js
+++ b/Sources/Common/Core/MatrixBuilder/index.js
@@ -5,7 +5,7 @@ const NoOp = (v) => v;
 const IDENTITY = new Float64Array(16);
 mat4.identity(IDENTITY);
 
-const EPSILON = 1e-16;
+const EPSILON = 1e-6;
 
 class Transform {
   constructor(useDegree = false) {


### PR DESCRIPTION
Use a more tolerant epsilon. I was running into issues where epsilon was too narrow, resulting in a zero vector after vector transformation.