### PR TITLE
Scope build rules to source tree

### DIFF
--- a/Utilities/config/dependency.js
+++ b/Utilities/config/dependency.js
@@ -6,12 +6,12 @@ module.exports = {
       rules: [
         {
           test: /\.glsl$/i,
-          include: /vtk\.js/,
+          include: /vtk\.js\/Sources/,
           loader: 'shader-loader',
         },
         {
           test: /\.js$/,
-          include: /vtk\.js/,
+          include: /vtk\.js\/Sources/,
           use: [
             {
               loader: 'babel-loader',
@@ -23,7 +23,7 @@ module.exports = {
         },
         {
           test: /\.worker\.js$/,
-          include: /vtk\.js/,
+          include: /vtk\.js\/Sources/,
           use: [
             {
               loader: 'worker-loader',


### PR DESCRIPTION
Fixes #993 

I tested this on the geode repo and this alleviated the need for the babel.config workaround (namely `ignore: [/\/core-js/]`).