### PR TITLE
Update OpenGl RenderWindow index.js

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -346,7 +346,9 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
           model.vrFrameData = new VRFrameData();
           model.renderable.getInteractor().switchToVRAnimation();
 
-          publicAPI.vrRender();
+          model.vrSceneFrame = model.vrDisplay.requestAnimationFrame(
+            publicAPI.vrRender
+          );
         })
         .catch(() => {
           console.error('failed to requestPresent');


### PR DESCRIPTION
Fixing VR in chrome issue "submitFrame must be called within a VRDisplay.requestAnimationFrame"

Note: tested on Chrome 72 (64-bit) & Firefox 65.0 (64-bit)