### PR TITLE
fix(DependencyWebpackRules): vtk.js source identification on Windows

### DIFF
--- a/Utilities/config/dependency.js
+++ b/Utilities/config/dependency.js
@@ -6,12 +6,12 @@ module.exports = {
       rules: [
         {
           test: /\.glsl$/i,
-          include: /vtk\.js\/Sources/,
+          include: /vtk\.js[\/\\]Sources/,
           loader: 'shader-loader',
         },
         {
           test: /\.js$/,
-          include: /vtk\.js\/Sources/,
+          include: /vtk\.js[\/\\]Sources/,
           use: [
             {
               loader: 'babel-loader',
@@ -23,7 +23,7 @@ module.exports = {
         },
         {
           test: /\.worker\.js$/,
-          include: /vtk\.js\/Sources/,
+          include: /vtk\.js[\/\\]Sources/,
           use: [
             {
               loader: 'worker-loader',


### PR DESCRIPTION
This addresses a regression from
5f2439e03981bc00ef5f3c14950782c646119951
where sources are ignored for required Webpack loaders on Windows.