### PR TITLE
fix(OpenGL/RenderWindow): Stop adding bgImage to DOM

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -135,7 +135,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
       // If the renderer is set to use a background
       // image, attach it to the DOM.
-      if (model.useBackgroundImage === true) {
+      if (model.useBackgroundImage) {
         model.el.appendChild(model.bgImage);
       }
 
@@ -518,15 +518,9 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
     // Add or remove the background image from the
     // DOM as specified.
-    if (
-      model.useBackgroundImage === true &&
-      model.el.contains(model.bgImage) === false
-    ) {
+    if (model.useBackgroundImage && !model.el.contains(model.bgImage)) {
       model.el.appendChild(model.bgImage);
-    } else if (
-      model.useBackgroundImage === false &&
-      model.el.contains(model.bgImage) === true
-    ) {
+    } else if (!model.useBackgroundImage && model.el.contains(model.bgImage)) {
       model.el.removeChild(model.bgImage);
     }
   };
@@ -1141,6 +1135,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'textureUnitManager',
     'webgl2',
     'vrDisplay',
+    'useBackgroundImage',
   ]);
 
   macro.setGet(publicAPI, model, [

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -120,9 +120,9 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       // Remove canvas from previous container
       model.el.removeChild(model.canvas);
 
-      // If the renderer has previously used
+      // If the renderer has previously added
       // a background image, remove it from the DOM.
-      if (model.bgImage.src) {
+      if (model.el.contains(model.bgImage)) {
         model.el.removeChild(model.bgImage);
       }
     }
@@ -133,9 +133,9 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
         model.el.appendChild(model.canvas);
       }
 
-      // If the renderer has set a background image,
-      // attach it to the DOM.
-      if (model.el && model.bgImage.src) {
+      // If the renderer is set to use a background
+      // image, attach it to the DOM.
+      if (model.useBackgroundImage === true) {
         model.el.appendChild(model.bgImage);
       }
 
@@ -511,6 +511,24 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.setBackgroundImage = (img) => {
     model.bgImage.src = img.src;
+  };
+
+  publicAPI.setUseBackgroundImage = (value) => {
+    model.useBackgroundImage = value;
+
+    // Add or remove the background image from the
+    // DOM as specified.
+    if (
+      model.useBackgroundImage === true &&
+      model.el.contains(model.bgImage) === false
+    ) {
+      model.el.appendChild(model.bgImage);
+    } else if (
+      model.useBackgroundImage === false &&
+      model.el.contains(model.bgImage) === true
+    ) {
+      model.el.removeChild(model.bgImage);
+    }
   };
 
   function getCanvasDataURL(format = model.imageFormat) {
@@ -1031,6 +1049,9 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       const mainRenderer = model.renderable.getRenderers()[0];
       mainRenderer.getBackgroundByReference()[3] = 0;
 
+      // Enable display of the background image
+      publicAPI.setUseBackgroundImage(true);
+
       // Bind to remote stream
       model.subscription = model.viewStream.onImageReady((e) =>
         publicAPI.setBackgroundImage(e.image)
@@ -1074,6 +1095,7 @@ const DEFAULT_VALUES = {
   vrDisplay: null,
   imageFormat: 'image/png',
   useOffScreen: false,
+  useBackgroundImage: false,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -113,12 +113,17 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.setContainer = (el) => {
     if (model.el && model.el !== el) {
-      // Remove canvas from previous container
-      if (model.canvas.parentNode === model.el) {
-        model.el.removeChild(model.canvas);
-        model.el.removeChild(model.bgImage);
-      } else {
+      if (model.canvas.parentNode !== model.el) {
         vtkErrorMacro('Error: canvas parent node does not match container');
+      }
+
+      // Remove canvas from previous container
+      model.el.removeChild(model.canvas);
+
+      // If the renderer has previously used
+      // a background image, remove it from the DOM.
+      if (model.bgImage.src) {
+        model.el.removeChild(model.bgImage);
       }
     }
 
@@ -126,6 +131,11 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       model.el = el;
       if (model.el) {
         model.el.appendChild(model.canvas);
+      }
+
+      // If the renderer has set a background image,
+      // attach it to the DOM.
+      if (model.el && model.bgImage.src) {
         model.el.appendChild(model.bgImage);
       }
 


### PR DESCRIPTION
Stop adding bgImage to DOM unless setBackgroundImage has been called.

Background images are necessary for remote rendering, but the `<img>` tag is currently being added to
the DOM unnecessarily, even if the user is not using remote rendering. This change prevents this
from occurring.

fix #1007 

This fix seems to be working for me.