### PR TITLE
fix(Examples): Add interactors to DepthTest and SpheresAndLabels

### DIFF
--- a/Examples/Geometry/DepthTest/index.js
+++ b/Examples/Geometry/DepthTest/index.js
@@ -10,6 +10,7 @@ import vtkPixelSpaceCallbackMapper from 'vtk.js/Sources/Rendering/Core/PixelSpac
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
 import vtk from 'vtk.js/Sources/vtk';
 
 // Need polydata registered in the vtk factory
@@ -302,6 +303,8 @@ const interactor = vtkRenderWindowInteractor.newInstance();
 interactor.setView(openglRenderWindow);
 interactor.initialize();
 interactor.bindEvents(container);
+
+interactor.setInteractorStyle(vtkInteractorStyleTrackballCamera.newInstance());
 
 // Handle window resize
 function resize() {

--- a/Examples/Geometry/SpheresAndLabels/index.js
+++ b/Examples/Geometry/SpheresAndLabels/index.js
@@ -8,6 +8,7 @@ import vtkPixelSpaceCallbackMapper from 'vtk.js/Sources/Rendering/Core/PixelSpac
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
 
 import style from './style.module.css';
 
@@ -89,6 +90,8 @@ const interactor = vtkRenderWindowInteractor.newInstance();
 interactor.setView(openglRenderWindow);
 interactor.initialize();
 interactor.bindEvents(container);
+
+interactor.setInteractorStyle(vtkInteractorStyleTrackballCamera.newInstance());
 
 // Handle window resize
 function resize() {


### PR DESCRIPTION
Adds interactor styles to two examples that didn't have them.

Fixes #981. Pinging #1011 because it references this issue.