### PR TITLE
fix(PaintFilter): Record history when using voxelFunc

### DIFF
--- a/Sources/Filters/General/PaintFilter/index.js
+++ b/Sources/Filters/General/PaintFilter/index.js
@@ -67,6 +67,10 @@ function vtkPaintFilter(publicAPI, model) {
               if (out !== null) {
                 data[i] = out;
               }
+
+              history.buffer[i] |= 1 << history.cindex;
+            } else {
+              history.buffer[i] &= ~(1 << history.cindex);
             }
           }
         } else {


### PR DESCRIPTION
Correctly record history when using voxelFunc to threshold voxels.

Fixes #1028 

@agirault 