### PR TITLE
Paint filter: better undo redo

### DIFF
--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -221,12 +221,7 @@ reader
     // don't set to 0, since that's our empty label color from our pwf
     painter.setLabel(1);
     // set custom threshold
-    painter.setVoxelFunc((bgValue, label, idx) => {
-      if (bgValue > 145) {
-        return label;
-      }
-      return null;
-    });
+    painter.setVoxelFunc((bgValue, idx) => bgValue > 145);
 
     // default slice orientation/mode and camera view
     const sliceMode = vtkImageMapper.SlicingMode.K;


### PR DESCRIPTION
Uses a more memory-intensive approach to undo/redo that is simpler and more flexible in history length.

Older approach had issues with incorrect undo behavior when restoring label values.