### PR TITLE
fix(WidgetManager): Support turning off picking before setRenderer()

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -167,7 +167,10 @@ function vtkWidgetManager(publicAPI, model) {
     );
 
     publicAPI.modified();
-    publicAPI.enablePicking();
+
+    if (model.pickingEnabled) {
+      publicAPI.enablePicking();
+    }
   };
 
   publicAPI.addWidget = (widget, viewType, initialValues) => {


### PR DESCRIPTION
Similar to when we update our subscriptions with the interactor "onEndAnimation" event (a little
higher up in setRenderer()), we should first check if picking is enabled before calling the method
to enable it.