### PR TITLE
feat(PolyDataMapper): Upload point data to VBO

### DIFF
--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -595,6 +595,8 @@ const DEFAULT_VALUES = {
   resolveCoincidentTopology: false,
 
   viewSpecificProperties: null,
+
+  customShaderAttributes: [],
 };
 
 // ----------------------------------------------------------------------------
@@ -624,6 +626,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'static',
     'useLookupTableScalarRange',
     'viewSpecificProperties',
+    'customShaderAttributes', // point data array names that will be transfered to the VBO
   ]);
   macro.setGetArray(publicAPI, model, ['scalarRange'], 2);
 

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1236,6 +1236,28 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       } else {
         cellBO.getVAO().removeAttributeArray('normalMC');
       }
+
+      model.renderable.getCustomShaderAttributes().forEach((attrName, idx) => {
+        if (cellBO.getProgram().isAttributeUsed(`${attrName}MC`)) {
+          if (
+            !cellBO
+              .getVAO()
+              .addAttributeArray(
+                cellBO.getProgram(),
+                cellBO.getCABO(),
+                `${attrName}MC`,
+                cellBO.getCABO().getCustomData()[idx].offset,
+                cellBO.getCABO().getStride(),
+                model.context.FLOAT,
+                cellBO.getCABO().getCustomData()[idx].components,
+                false
+              )
+          ) {
+            vtkErrorMacro(`Error setting ${attrName}MC in shader VAO.`);
+          }
+        }
+      });
+
       if (
         cellBO.getProgram().isAttributeUsed('tcoordMC') &&
         cellBO.getCABO().getTCoordOffset()
@@ -1825,6 +1847,9 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
         cellOffset: 0,
         haveCellScalars: model.haveCellScalars,
         haveCellNormals: model.haveCellNormals,
+        customAttributes: model.renderable
+          .getCustomShaderAttributes()
+          .map((arrayName) => poly.getPointData().getArrayByName(arrayName)),
       };
       options.cellOffset += model.primitives[primTypes.Points]
         .getCABO()


### PR DESCRIPTION
This PR allows the user to upload point data attributes to the VBO in order to access them from a custom shader.  
The name of the attribute in the shader is the name of the array with the suffix `MC` standing for `Model Coordinates`.