### PR TITLE
fix(ViewStream): Trigger remote image render and interaction fix

### DIFF
--- a/Sources/IO/Core/ImageStream/ViewStream.js
+++ b/Sources/IO/Core/ImageStream/ViewStream.js
@@ -156,6 +156,8 @@ function vtkViewStream(publicAPI, model) {
       promises.push(publicAPI.stopAnimation());
       model.isAnimating = false;
       promises.push(publicAPI.pushCamera());
+    } else {
+      promises.push(publicAPI.render());
     }
 
     return Promise.all(promises);

--- a/Sources/Interaction/Style/InteractorStyleRemoteMouse/index.js
+++ b/Sources/Interaction/Style/InteractorStyleRemoteMouse/index.js
@@ -97,16 +97,16 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
 
   //-------------------------------------------------------------------------
   publicAPI.onButtonDown = (button, callData) => {
-    publicAPI.invokeRemoteMouseEvent(createRemoteEvent(callData));
     model.interactor.requestAnimation(publicAPI.onButtonDown);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
+    publicAPI.invokeRemoteMouseEvent(createRemoteEvent(callData));
   };
 
   //-------------------------------------------------------------------------
   publicAPI.onButtonUp = (button, callData) => {
     publicAPI.invokeRemoteMouseEvent(createRemoteEvent(callData));
-    model.interactor.cancelAnimation(publicAPI.onButtonDown);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
+    model.interactor.cancelAnimation(publicAPI.onButtonDown);
   };
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Make sure the remote image re-renders when the mouse is released
when there's no camera.

Re-order events on mouse interaction so high-DPI displays get
the right starting offset, because the image size changes.