### PR TITLE
fix(XMLReaders): Remove broken methods from sub-types

### DIFF
--- a/Sources/IO/XML/XMLImageDataReader/index.js
+++ b/Sources/IO/XML/XMLImageDataReader/index.js
@@ -57,10 +57,6 @@ function vtkXMLImageDataReader(publicAPI, model) {
       model.output[outputIndex] = imageData;
     }
   };
-
-  publicAPI.requestData = (inData, outData) => {
-    publicAPI.parseArrayBuffer(model.rawDataBuffer);
-  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/IO/XML/XMLPolyDataReader/index.js
+++ b/Sources/IO/XML/XMLPolyDataReader/index.js
@@ -126,10 +126,6 @@ function vtkXMLPolyDataReader(publicAPI, model) {
       model.output[outputIndex] = polydata;
     }
   };
-
-  publicAPI.requestData = (inData, outData) => {
-    publicAPI.parseArrayBuffer(model.rawDataBuffer);
-  };
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
These methods did the same work as the "superclass", except they invoked a method which doesn't actually exist.