### PR TITLE
WIP: Add Blend Modes to VolumeMapper

### DIFF
--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -1,0 +1,73 @@
+import 'vtk.js/Sources/favicon';
+
+import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
+import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
+  background: [0.1, 0.1, 0.1],
+});
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+
+// ----------------------------------------------------------------------------
+// Example code
+// ----------------------------------------------------------------------------
+// Server is not sending the .gz and whith the compress header
+// Need to fetch the true file name and uncompress it locally
+// ----------------------------------------------------------------------------
+
+const reader = vtkHttpDataSetReader.newInstance({ fetchGzip: true });
+
+const actor = vtkVolume.newInstance();
+const mapper = vtkVolumeMapper.newInstance();
+mapper.setSampleDistance(1.1);
+actor.setMapper(mapper);
+
+// create color and opacity transfer functions
+const ofun = vtkPiecewiseFunction.newInstance();
+ofun.addPoint(0.0, 0.0);
+ofun.addPoint(5000, 0.3);
+ofun.addPoint(30000, 1.0);
+
+actor.getProperty().setScalarOpacity(0, ofun);
+actor.getProperty().setScalarOpacityUnitDistance(0, 3.0);
+actor.getProperty().setInterpolationTypeToLinear();
+actor.getProperty().setShade(true);
+actor.getProperty().setAmbient(0.2);
+actor.getProperty().setDiffuse(0.7);
+actor.getProperty().setSpecular(0.3);
+actor.getProperty().setSpecularPower(8.0);
+
+mapper.setInputConnection(reader.getOutputPort());
+
+reader
+  .setUrl(`${__BASE_PATH__}/data/volume/QIN-HEADNECK-01-0024-PET-WB-0.vti`)
+  .then(() => {
+    reader.loadData().then(() => {
+      renderer.addVolume(actor);
+      const interactor = renderWindow.getInteractor();
+      interactor.setDesiredUpdateRate(15.0);
+      renderer.resetCamera();
+      renderer.getActiveCamera().elevation(-70);
+      renderWindow.render();
+    });
+  });
+
+// -----------------------------------------------------------
+// Make some variables global so that you can inspect and
+// modify objects in your browser's developer console:
+// -----------------------------------------------------------
+
+global.source = reader;
+global.mapper = mapper;
+global.actor = actor;
+global.ofun = ofun;
+global.renderer = renderer;
+global.renderWindow = renderWindow;

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -128,6 +128,18 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         '//VTK::MaximumSamplesValue',
         `${Math.ceil(maxSamples)}`
       ).result;
+
+      const BLEND_MODE = {
+        COMPOSITE: 0,
+        MAXIMUM_INTENSITY_PROJECTION: 1,
+      };
+
+      const blendMode = BLEND_MODE.MAXIMUM_INTENSITY_PROJECTION;
+      FSSource = vtkShaderProgram.substitute(
+        FSSource,
+        '//VTK::BlendMode',
+        `${blendMode}`
+      ).result;
     } else {
       // WebGL1
       // compute the tcoords
@@ -1093,7 +1105,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       vtkMath.uninitializeBounds(model.Bounds);
       return;
     }
-    model.bounnds = publicAPI.getInput().getBounds();
+    model.bounds = publicAPI.getInput().getBounds();
   };
 
   publicAPI.updateBufferObjects = (ren, actor) => {
@@ -1309,7 +1321,7 @@ const DEFAULT_VALUES = {
   opacityTexture: null,
   opacityTextureString: null,
   colorTexture: null,
-  colortextureString: null,
+  colorTextureString: null,
   lightingTexture: null,
   lightingTextureString: null,
   jitterTexture: null,


### PR DESCRIPTION
Hello!

We would like to display volumes with maximum intensity projection and would like to help contribute this back to vtk-js. I know that ImageReslice has a SlabMode which can be used to do this in the CPU, but we would like to do it in the shader inside the VolumeMapper, if possible.

I took a stab at adding it to the VolumeMapper, and I was wondering if you could give me some feedback about whether or not this is the right approach before I went any further. My idea is to add [SetBlendModeToMaximumIntensity](https://vtk.org/doc/nightly/html/classvtkVolumeMapper.html#a8397e8507a80e81bfbf733f130fefde3) which is present in the C++ version.

All I've added now is a blend mode condition, which defaults to Composite, and a pathway in the WebGL2 shader to compute the maximum value along the ray.

Does this look like the right approach? Would you accept a PR to add additional blend modes to the mapper?

As an aside, it would be helpful if you could provide the LIDC2.vti file in .vtk format. Maybe I missed something, but I couldn't find an easy way to read the file. I know that in Utilities you provide a way to go from .vtk to the json .vti format, but I didn't see a way to go back, so for my testing I had to create a new file.

Here's a visualization of how it looks right now. On the left is the Python version, on the right is the VTK.js version.

![VTK-MIP](https://user-images.githubusercontent.com/607793/58408869-15624e00-806f-11e9-985f-58c2fb39195d.gif)

The example can be run with
```
npm run example -- VolumeMapperBlendModes
```

but you will need to download the data linked at the bottom of the post, unzip it, and put it in the Data folder.

### Known issues:
- Visualization looks strange, there is black speckling when compared to the Python version
- Need to implement the same pathway in WebGL 1
- Need to add the set/get macro for the API to VolumeMapper
- Should decide which dataset we want to use for an Example, or if this should just be rolled into the normal VolumeMapper example. Seems unnecessary to include yet another large dataset for just this functionality, but I had no choice for now.

#### Etc:
- Fixed a couple of typos ('bounnds' and 'colortextureString') in the volumeMapper. I don't think they really had any impact though.

Python code I've been using for comparison:
```python
#!/usr/bin/env python
from vtk import *

filename = "QIN-HEADNECK-01-0024-PET-WB-0.vtk"

reader = vtkGenericDataObjectReader()
reader.SetFileName(filename)
reader.Update()
imageData = reader.GetOutput()

# Create transfer mapping scalar value to opacity.
opacityFunction = vtkPiecewiseFunction()
opacityFunction.AddPoint(0, 0.0)
opacityFunction.AddPoint(5000, 0.3)
opacityFunction.AddPoint(30000, 1.0)

volumeProperty = vtkVolumeProperty()
volumeProperty.SetScalarOpacity(opacityFunction)
volumeProperty.ShadeOn()
volumeProperty.SetInterpolationTypeToLinear()
volumeProperty.SetScalarOpacityUnitDistance(3)
volumeProperty.SetAmbient(0.2);
volumeProperty.SetDiffuse(0.7);
volumeProperty.SetSpecular(0.3);
volumeProperty.SetSpecularPower(8.0);

volumeMapper = vtkGPUVolumeRayCastMapper()
volumeMapper.SetBlendModeToMaximumIntensity()
volumeMapper.SetInputData(imageData)
volumeMapper.SetSampleDistance(1.1)

volume = vtkVolume()
volume.SetMapper(volumeMapper)
volume.SetProperty(volumeProperty)

# create a rendering window and renderer
renderer = vtkRenderer()
renderer.SetBackground(0.1,0.1,0.1)

window = vtkRenderWindow()
window.SetSize(1024,1024)
window.AddRenderer(renderer)

interactor = vtkRenderWindowInteractor()
interactor.SetRenderWindow(window)

style = vtkInteractorStyleTrackballCamera();
interactor.SetInteractorStyle(style);

renderer.AddVolume(volume)

renderer.ResetCameraClippingRange()
renderer.ResetCamera()

 # Start
interactor.Initialize()
window.Render()
interactor.Start()
```

**Here's the VTK file:**
*.vtk format:* https://www.dropbox.com/s/pppvgdi9wlcogoz/QIN-HEADNECK-01-0024-PET-WB-0.vtk?dl=0

*zipped .vti format for vtk-js:* https://www.dropbox.com/s/tr6kfambzcj1jcu/QIN-HEADNECK-01-0024-PET-WB-0.vti.zip?dl=0
