### PR TITLE
feat(Rendering): add support for multiple component vtkVolume

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -582,12 +582,12 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     if (model.VBOBuildString !== toString) {
       // Build the VBOs
       const dims = image.getDimensions();
-      const numComponents = image
+      const numComp = image
         .getPointData()
         .getScalars()
         .getNumberOfComponents();
       if (iType === InterpolationType.NEAREST) {
-        if (numComponents === 4) {
+        if (numComp === 4) {
           model.openGLTexture.setGenerateMipmap(true);
           model.openGLTexture.setMinificationFilter(Filter.NEAREST);
         } else {
@@ -595,7 +595,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         }
         model.openGLTexture.setMagnificationFilter(Filter.NEAREST);
       } else {
-        if (numComponents === 4) {
+        if (numComp === 4) {
           model.openGLTexture.setGenerateMipmap(true);
           model.openGLTexture.setMinificationFilter(
             Filter.LINEAR_MIPMAP_LINEAR
@@ -607,10 +607,6 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       }
       model.openGLTexture.setWrapS(Wrap.CLAMP_TO_EDGE);
       model.openGLTexture.setWrapT(Wrap.CLAMP_TO_EDGE);
-      const numComp = image
-        .getPointData()
-        .getScalars()
-        .getNumberOfComponents();
       const sliceSize = dims[0] * dims[1] * numComp;
 
       const ptsArray = new Float32Array(12);

--- a/webpack.settings.js
+++ b/webpack.settings.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   devServerConfig: {
     public: () => process.env.DEVSERVER_PUBLIC || 'http://localhost:8080',
-    host: () => process.env.DEVSERVER_HOST || 'localhost',
+    host: () => process.env.DEVSERVER_HOST || '0.0.0.0',
     port: () => process.env.DEVSERVER_PORT || 9999,
   },
   options: {


### PR DESCRIPTION
Add support for multicomponent volumes with 2, 3, or 4
components, with or without gradient opacity, and both
dependent and independent components.