### PR TITLE
fix(ImageStream): typo in disconnect

### DIFF
--- a/Sources/IO/Core/ImageStream/index.js
+++ b/Sources/IO/Core/ImageStream/index.js
@@ -64,12 +64,11 @@ function vtkImageStream(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.disconnect = () => {
-    if (model.protocol && model.connected) {
-      model.protocol.unsubscribeToImageStream(
-        model.imageStreamTopicSubscription
-      );
-      model.imageStreamTopicSubscription = null;
+    if (model.protocol && model.connected && model.renderTopicSubscription) {
+      model.protocol.unsubscribeToImageStream(model.renderTopicSubscription);
+      model.renderTopicSubscription = null;
     }
+    model.connected = false;
   };
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
The subscription variable name was incorrect, and
the connected flag needed to be turned off.