### PR TITLE
fix(OpenGLVolume): Properly initialize keyMatrixTime with mtime=0

### DIFF
--- a/Sources/Rendering/OpenGL/Volume/index.js
+++ b/Sources/Rendering/OpenGL/Volume/index.js
@@ -106,7 +106,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkViewNode.extend(publicAPI, model, initialValues);
 
   model.keyMatrixTime = {};
-  macro.obj(model.keyMatrixTime);
+  macro.obj(model.keyMatrixTime, { mtime: 0 });
   model.normalMatrix = mat3.create();
   model.MCWCMatrix = mat4.create();
 


### PR DESCRIPTION
Initialize model.keyMatrixTime with mtime=0 so that actor matrices are calculated on first pass