### PR TITLE
fix(VolumeMapper): Add Jittering options

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
@@ -29,6 +29,11 @@ const actor = vtkVolume.newInstance();
 const mapper = vtkVolumeMapper.newInstance();
 actor.setMapper(mapper);
 
+// When we perform multiplanar reconstruction in this manner,
+// it is necessary to turn off jittering during raycasting to
+// avoid noise artifacts.
+mapper.setJittering(false);
+
 const reader = vtkHttpDataSetReader.newInstance({
   fetchGzip: true,
 });

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -37,6 +37,7 @@ const DEFAULT_VALUES = {
   imageSampleDistance: 1.0,
   maximumSamplesPerRay: 1000,
   autoAdjustSampleDistances: true,
+  jittering: true,
 };
 
 // ----------------------------------------------------------------------------
@@ -53,6 +54,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'imageSampleDistance',
     'maximumSamplesPerRay',
     'autoAdjustSampleDistances',
+    'jittering',
   ]);
 
   macro.event(publicAPI, model, 'lightingActivated');

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -177,6 +177,21 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       ]).result;
     }
 
+    // if we need jitter
+    const jitter = model.renderable.getJittering();
+    if (jitter) {
+      FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::Jitter::Dec', [
+        'uniform sampler2D jtexture;',
+      ]).result;
+
+      FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::Jitter::Impl', [
+        '// start slightly inside and apply some jitter',
+        'float jitter = texture2D(jtexture, gl_FragCoord.xy/32.0).r;',
+        'delta = endPos - pos;',
+        'pos = pos + normalize(delta)*(0.01 + 0.98*jitter)*sampleDistance;',
+      ]).result;
+    }
+
     shaders.Fragment = FSSource;
 
     publicAPI.replaceShaderLight(shaders, ren, actor);

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -101,7 +101,7 @@ uniform float cshift0;
 uniform float cscale0;
 
 // jitter texture
-uniform sampler2D jtexture;
+//VTK::Jitter::Dec
 
 // some 3D texture values
 uniform float sampleDistance;
@@ -577,10 +577,9 @@ void computeIndexSpaceValues(out vec3 pos, out vec3 step, out float numSteps, ve
     dot(endPos, vPlaneNormal2),
     dot(endPos, vPlaneNormal4));
 
-  // start slightly inside and apply some jitter
-  float jitter = texture2D(jtexture, gl_FragCoord.xy/32.0).r;
-  vec3 delta = endPos - pos;
-  pos = pos + normalize(delta)*(0.01 + 0.98*jitter)*sampleDistance;
+  vec3 delta = vec3(0,0,0);
+
+  //VTK::Jitter::Impl
 
   // update vdelta post jitter
   delta = endPos - pos;


### PR DESCRIPTION
When working on https://github.com/Kitware/vtk-js/pull/1093 we noticed that turning off jittering helped avoid the stochastic noise we were seeing when using the volume mapper with the MPR-Slice Interactor Style (https://kitware.github.io/vtk-js/examples/InteractorStyleMPRSlice.html). This PR adds the 'jittering' option, which defaults to true, in order to allow this to be disabled when desired.

@martinken, feel free to trash this PR if you find another answer for the speckling. Note that this does not fix the MIP/MinIP/AverageIP case, it only fixes it for composite rendering.

This can be tested with `npm run example -- InteractorStyleMPRSlice`