### PR TITLE
fix(ITKHelper): Support multi-component pixel types

### DIFF
--- a/Sources/Interaction/Widgets/ResliceCursor/example/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/example/index.js
@@ -29,7 +29,7 @@ let i = 0;
 for (let z = 0; z < dims[2]; z++) {
   for (let y = 0; y < dims[1]; y++) {
     for (let x = 0; x < dims[0]; x++) {
-      newArray[i++] = 256 * (i % (dims[0] * dims[1])) / (dims[0] * dims[1]);
+      newArray[i++] = (256 * (i % (dims[0] * dims[1]))) / (dims[0] * dims[1]);
     }
   }
 }


### PR DESCRIPTION
Support reading multi-component images from itk.js.

All pixel data is added to the vtkImageData's PointData "Scalars" to
facilitate multi-component volume rendering.

If the itk.js PixelType is Vector or CovariantVectors and the dimension
is 3 and there are 3 vector components, the DataArray is also set as the
vtkImageData's PointData "Vectors". VTK does not distinguish vectors and
covariant vectors. ITK images can be N-dimensional and the number of
vector components do not always match the image dimension.

If the itk.js PixelType is SymmetricSecondRankTensor or
DiffusionTensor3D and the dimension is 3 and there are 6 tensor
components, the DataArray is also set as the vtkImageData's PointData
"Tensors".