### PR TITLE
fix(Rendering): fix bugs in volume Rendering

### DIFF
--- a/Sources/Filters/General/ImageCropFilter/example/controlPanel.html
+++ b/Sources/Filters/General/ImageCropFilter/example/controlPanel.html
@@ -9,7 +9,7 @@
     </td>
   </tr>
   <tr>
-    <td>I</td>
+    <td>J</td>
     <td>
       <input class='Jmin' type="range" min="0" max="2.0" step="1" value="1" />
     </td>

--- a/Sources/Filters/General/ImageCropFilter/index.js
+++ b/Sources/Filters/General/ImageCropFilter/index.js
@@ -95,7 +95,7 @@ function vtkImageCropFilter(publicAPI, model) {
     const dims = input.getDimensions();
     const jStride = numberOfComponents * dims[0];
     const kStride = numberOfComponents * dims[0] * dims[1];
-    const beginOffset = cropped[0] * numberOfComponents;
+    const beginOffset = (cropped[0] - extent[0]) * numberOfComponents;
     const stripSize = (cropped[1] - cropped[0] + 1) * numberOfComponents; // +1 because subarray end is exclusive
 
     // crop image
@@ -103,14 +103,14 @@ function vtkImageCropFilter(publicAPI, model) {
     let index = 0;
     for (let k = cropped[4]; k <= cropped[5]; ++k) {
       for (let j = cropped[2]; j <= cropped[3]; ++j) {
-        const begin = beginOffset + j * jStride + k * kStride;
+        const begin =
+          beginOffset + (j - extent[2]) * jStride + (k - extent[4]) * kStride;
         const end = begin + stripSize;
         const slice = scalarsData.subarray(begin, end);
         croppedArray.set(slice, index);
         index += slice.length;
       }
     }
-
     const outImage = vtkImageData.newInstance({
       extent: cropped,
       origin: input.getOrigin(),

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -171,6 +171,13 @@ function vtkOpenGLTexture(publicAPI, model) {
           model.context.TEXTURE_WRAP_T,
           publicAPI.getOpenGLWrapMode(model.wrapT)
         );
+        if (model.openGLRenderWindow.getWebgl2()) {
+          model.context.texParameteri(
+            model.target,
+            model.context.TEXTURE_WRAP_R,
+            publicAPI.getOpenGLWrapMode(model.wrapR)
+          );
+        }
 
         model.context.bindTexture(model.target, null);
       }

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -443,9 +443,9 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const vsize = vec3.create();
     vec3.set(
       vsize,
-      (ext[1] - ext[0]) * spc[0],
-      (ext[3] - ext[2]) * spc[1],
-      (ext[5] - ext[4]) * spc[2]
+      (ext[1] - ext[0] + 1) * spc[0],
+      (ext[3] - ext[2] + 1) * spc[1],
+      (ext[5] - ext[4] + 1) * spc[2]
     );
     program.setUniform3f('vSpacing', spc[0], spc[1], spc[2]);
 
@@ -1054,6 +1054,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         }
       }
 
+      model.opacityTexture.releaseGraphicsResources(model.openGLRenderWindow);
       model.opacityTexture.setMinificationFilter(Filter.LINEAR);
       model.opacityTexture.setMagnificationFilter(Filter.LINEAR);
 
@@ -1107,6 +1108,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         }
       }
 
+      model.colorTexture.releaseGraphicsResources(model.openGLRenderWindow);
       model.colorTexture.setMinificationFilter(Filter.LINEAR);
       model.colorTexture.setMagnificationFilter(Filter.LINEAR);
 
@@ -1125,6 +1127,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     if (model.scalarTextureString !== toString) {
       // Build the textures
       const dims = image.getDimensions();
+      model.scalarTexture.releaseGraphicsResources(model.openGLRenderWindow);
       model.scalarTexture.resetFormatAndType();
       model.scalarTexture.create3DFilterableFromRaw(
         dims[0],


### PR DESCRIPTION
Fix an issue where a texture is reused multiple times
with cropped data.

Fix an issue with the crop filter where the inputs
extent is not considered when computing offsets.

Fix a rendering issue where the mapping of the volume
to pixels was not quite correct resulting in deformations
when rendering cropped images.