### PR TITLE
refactor(Core/Camera): Refactor Camera Docs, implement applyTransform()

### DIFF
--- a/Sources/Rendering/Core/Camera/api.md
+++ b/Sources/Rendering/Core/Camera/api.md
@@ -12,109 +12,109 @@ camera perspective.
 Construct camera instance with its focal point at the origin, and position=(0,0,1). The
 view up is along the y-axis, view angle is 30 degrees, and the clipping range is (.1,1000).
 
-### position
+### `setPosition(x, y, z)`, `getPosition()`
 
 Set/Get the position of the camera in world coordinates. The default position is (0,0,1).
 
-### focalPoint
+### `setFocalPoint(x, y, z)`, `getFocalPoint()`
 
 Set/Get the focal of the camera in world coordinates. The default focal point is the origin.
 
-### viewUp
+### `setViewUp(x, y, z)`, `getViewUp()`
 
 Set/Get the view up direction for the camera. The default is (0,1,0).
 
-### orthogonalizeViewUp()
+### `orthogonalizeViewUp()`
 
 Recompute the ViewUp vector to force it to be perpendicular to camera->focalpoint vector.
 Unless you are going to use Yaw or Azimuth on the camera, there is no need to do this.
 
-### setDistance(dist)
+### `setDistance(dist)`
 
-Move the focal point so that it is the specified distance from the camera position. This
-distance must be positive.
+Move the focal point so that it is the specified distance from the camera position, along the view plane normal.
+This distance must be positive.
 
-### getDistance()
+### `getDistance()`
 
 Return the distance from the camera position to the focal point. This distance is positive.
 
-### getDirectionOfProjection()
+### `setDirectionOfProjection(x, y, z)`
+
+Recalculates the focalPoint position to be the same distance from the camera as before, but along the new projection vector.
+
+### `getDirectionOfProjection()`
 
 Get the vector in the direction from the camera position to the focal point. This is usually
 the opposite of the ViewPlaneNormal, the vector perpendicular to the screen, unless the view
 is oblique.
 
-### dolly(value)
+### `dolly(value)`
 
 Divide the camera's distance from the focal point by the given dolly value. Use a value
 greater than one to dolly-in toward the focal point, and use a value less than one to dolly-out
 away from the focal point.
 
-### roll
+### `roll(degrees)`
 
-Get/Set the roll angle of the camera about the direction of projection.
+Rotate the camera about the direction of projection. This will spin the camera about its view axis.
 
-### roll(angle)
-
-Rotate the camera about the direction of projection. This will spin the camera about its axis.
-
-### azimuth(angle)
+### `azimuth(degrees)`
 
 Rotate the camera about the view up vector centered at the focal point. Note that the view up
 vector is whatever was set via SetViewUp, and is not necessarily perpendicular to the direction
 of projection. The result is a horizontal rotation of the camera.
 
-### yaw(angle)
+### `yaw(degrees)`
 
 Rotate the focal point about the view up vector, using the camera's position as the center of
 rotation. Note that the view up vector is whatever was set via SetViewUp, and is not necessarily
 perpendicular to the direction of projection. The result is a horizontal rotation of the scene.
 
-### elevation(angle)
+### `elevation(degrees)`
 
 Rotate the camera about the cross product of the negative of the direction of projection and the
 view up vector, using the focal point as the center of rotation. The result is a vertical rotation
 of the scene.
 
-### pitch(angle)
+### `pitch(degrees)`
 
 Rotate the focal point about the cross product of the view up vector and the direction of projection,
 using the camera's position as the center of rotation. The result is a vertical rotation of the camera.
 
-### parallelProjection
+### `zoom(factor)`
+
+In perspective mode, decrease the view angle by the specified factor. In parallel mode, decrease
+the parallel scale by the specified factor. A value greater than 1 is a zoom-in, a value less than
+1 is a zoom-out.
+
+### `setParallelProjection(boolean)`, `getParallelProjection()`
 
 Set/Get the value of the ParallelProjection instance variable. This determines if the camera should do
 a perspective or parallel projection.
 
-### useHorizontalViewAngle
+### `setUseHorizontalViewAngle(degrees)`, `getUseHorizontalViewAngle()`
 
 Set/Get the value of the UseHorizontalViewAngle instance variable. If set, the camera's view angle
 represents a horizontal view angle, rather than the default vertical view angle. This is useful if
 the application uses a display device which whose specs indicate a particular horizontal view angle,
 or if the application varies the window height but wants to keep the perspective transform unchanges.
 
-### viewAngle
+### `setViewAngle(degrees)`, `getViewAngle()`
 
 Set/Get the camera view angle, which is the angular height of the camera view measured in degrees.
 The default angle is 30 degrees. This method has no effect in parallel projection mode. The formula
-for setting the angle up for perfect perspective viewing is: angle = 2*atan((h/2)/d) where h is the
-height of the RenderWindow (measured by holding a ruler up to your screen) and d is the distance
+for setting the angle up for perfect perspective viewing is: `angle = 2*atan((h/2)/d)` where `h` is the
+height of the RenderWindow (measured by holding a ruler up to your screen) and `d` is the distance
 from your eyes to the screen.
 
-### parallelScale
+### `setParallelScale(scale)`, `getParallelScale()`
 
 Set/Get the scaling used for a parallel projection, i.e. the height of the viewport in
 world-coordinate distances. The default is 1. Note that the "scale" parameter works as an "inverse
 scale" --- larger numbers produce smaller images. This method has no effect in perspective projection
 mode.
 
- ### zoom(factor)
-
-In perspective mode, decrease the view angle by the specified factor. In parallel mode, decrease
-the parallel scale by the specified factor. A value greater than 1 is a zoom-in, a value less than
-1 is a zoom-out.
-
-### clippingRange
+### `setClippingRange(near, far)`, `getClippingRange()`
 
 Set/Get the location of the near and far clipping planes along the direction of projection. Both
 of these values must be positive. How the clipping planes are set can have a large impact on how
@@ -123,152 +123,159 @@ Setting it to 0.01 when it really could be 1.0 can have a big impact on your Z-b
 farther away. The default clipping range is (0.1,1000). Clipping distance is measured in world
 coordinates.
 
-### thickness
-
-Set/Get the distance between clipping planes. This method adjusts the far clipping plane to be
-set a distance 'thickness' beyond the near clipping plane.
-
-### windowCenter
+### `setWindowCenter(x,y)`, `getWindowCenter()`
 
 Set/Get the center of the window in viewport coordinates. The viewport coordinate range is
-([-1,+1],[-1,+1]). This method is for if you have one window which consists of several viewports,
+`([-1,+1],[-1,+1])`. This method is for if you have one window which consists of several viewports,
 or if you have several screens which you want to act together as one large screen.
 
-### setObliqueAngles(alpha, beta)
+### `getViewPlaneNormal()`
 
-Set the oblique viewing angles. The first angle, alpha, is the angle (measured from the horizontal)
+Get the viewPlaneNormal `[x,y,z]` array. This vector will point opposite to the direction of projection, unless
+you have created a sheared output view using SetViewShear/SetObliqueAngles (not implemented).
+
+Note: to set the viewPlaneNormal, use `setDirectionOfProjection()`
+
+### `SetUseOffAxisProjection(boolean)`, `getUseOffAxisProjection()`
+
+Set/Get use offaxis frustum. OffAxis frustum is used for off-axis frustum calculations in `getProjectionMatrix()`,
+specificly for stereo rendering. For reference see "High Resolution Virtual Reality", in Proc.
+SIGGRAPH '92, Computer Graphics, pages 195-202, 1992.
+
+Note: offAxis projection is **_NOT IMPLEMENTED_**.
+
+### `setScreenBottomLeft(x, y, z)`, `getScreenBottomLeft()`
+
+Set/Get top left corner point of the screen. This will be used only for offaxis frustum
+calculation. Default is (-0.5, -0.5, -0.5). Can set individual x,y,z, or provide an array `[x,y,z]`. Returns an array.
+
+### `setScreenBottomRight(x, y, z)`, `getScreenBottomRight()`
+
+Set/Get bottom left corner point of the screen. This will be used only for offaxis frustum
+calculation. Default is (0.5, -0.5, -0.5). Can set individual x,y,z, or provide an array `[x,y,z]`. Returns an array.
+
+### `setScreenTopRight(x, y, z)`, `getScreenTopRight()`
+
+Set/Get top right corner point of the screen. This will be used only for offaxis frustum
+calculation. Default is (0.5, 0.5, -0.5). Can set individual x,y,z, or provide an array `[x,y,z]`. Returns an array.
+
+### `setViewMatrix(mat4)`
+Manually set the view matrix. Overrides camera position, focal point, and view up, until set to `null`.
+
+### `getViewMatrix()`
+
+Return the matrix of the view transform. The ViewTransform depends on only three ivars:  the
+Position, the FocalPoint, and the ViewUp vector. All the other methods are there simply for
+the sake of the users' convenience.
+
+### `setProjectionMatrix(mat4)`
+
+Manually set the projection transform matrix. Overrides camera position, focal point, and view up, until set to `null`.
+
+### `getProjectionMatrix(aspect, nearz, farz)`
+
+Return the projection transform matrix, which converts from camera coordinates to viewport
+coordinates. The 'aspect' is the width/height for the viewport, and the nearz and farz are
+the Z-buffer values that map to the near and far clipping planes. The viewport coordinates of
+a point located inside the frustum are in the range `([-1,+1],[-1,+1],[nearz,farz])`.
+
+### `getCompositeProjectionMatrix(aspect, nearz, farz)`
+
+Return the concatenation of the ViewTransform and the ProjectionTransform. This transform
+will convert world coordinates to viewport coordinates. The 'aspect' is the width/height
+for the viewport, and the nearz and farz are the Z-buffer values that map to the near and
+far clipping planes. The viewport coordinates of a point located inside the frustum are
+in the range `([-1,+1],[-1,+1],[nearz,farz])`.
+
+### `setFreezeFocalPoint(boolean)`, `getFreezeFocalPoint()`
+
+Set/Get the value of the FreezeDolly instance variable. This determines if the camera should move the focal
+point with the camera position. Only used by the `MouseCameraTrackballZoomManipulator`, or can be referenced in
+any manipulator you choose to build.
+
+### `setOrientationWXYZ(degrees, x,y,z)`
+
+Move the focalPoint and viewUp by rotating the camera `degrees` about the `[x,y,z]` vector using Quaternion math, maintaining the focalPoint distance.
+
+### `applyTransform(transformMat4)`
+
+Apply a transform to the camera. The camera position, focal-point, and view-up are all re-calculated
+using the 4x4 transform matrix.
+
+
+## Unimplemented methods
+
+### `getRoll()`, `setRoll(roll)`
+
+**_NOT IMPLEMENTED._** Get/Set the roll angle of the camera about the direction of projection.
+
+### `setThickness(thickness)`, `getThickness()`
+
+**_NOT IMPLEMENTED._** Set/Get the distance between clipping planes. This method adjusts the far clipping plane to be
+set a distance 'thickness' beyond the near clipping plane.
+
+### `setObliqueAngles(alpha, beta)`
+
+**_NOT IMPLEMENTED._** Set the oblique viewing angles. The first angle, alpha, is the angle (measured from the horizontal)
 that rays along the direction of projection will follow once projected onto the 2D screen. The
 second angle, beta, is the angle between the view plane and the direction of projection. This
 creates a shear transform x' = x + dz*cos(alpha)/tan(beta), y' = dz*sin(alpha)/tan(beta) where
 dz is the distance of the point from the focal plane. The angles are (45,90) by default. Oblique
 projections commonly use (30,63.435).
 
-### applyTransform(transform)
+### `getProjectionMatrix(renderer)`
 
-Apply a transform to the camera. The camera position, focal-point, and view-up are re-calculated
-using the transform's matrix to multiply the old points by the new transform.
-
-### viewPlaneNormal
-
-Get the ViewPlaneNormal. This vector will point opposite to the direction of projection, unless
-you have created a sheared output view using SetViewShear/SetObliqueAngles.
-
-### focalDisk
-
-Set the size of the cameras lens in world coordinates. This is only used when the renderer is
-doing focal depth rendering. When that is being done the size of the focal disk will effect
-how significant the depth effects will be.
-
-### useOffAxisProjection
-
-Set/Get use offaxis frustum. OffAxis frustum is used for off-axis frustum calculations
-specificly for stereo rendering. For reference see "High Resolution Virtual Reality", in Proc.
-SIGGRAPH '92, Computer Graphics, pages 195-202, 1992.
-
-### screenBottomLeft
-
-Set/Get top left corner point of the screen. This will be used only for offaxis frustum
-calculation. Default is (-0.5, -0.5, -0.5).
-
-### screenBottomRight
-
-Set/Get bottom left corner point of the screen. This will be used only for offaxis frustum
-calculation. Default is (0.5, -0.5, -0.5).
-
-### screenTopRight
-
-Set/Get top right corner point of the screen. This will be used only for offaxis frustum
-calculation. Default is (0.5, 0.5, -0.5).
-
-### getViewMatrix()
-
-Return the matrix of the view transform. The ViewTransform depends on only three ivars:  the
-Position, the FocalPoint, and the ViewUp vector. All the other methods are there simply for
-the sake of the users' convenience.
-
-### getProjectionMatrix(aspect, nearz, farz)
-
-Return the projection transform matrix, which converts from camera coordinates to viewport
-coordinates. The 'aspect' is the width/height for the viewport, and the nearz and farz are
-the Z-buffer values that map to the near and far clipping planes. The viewport coordinates of
-a point located inside the frustum are in the range ([-1,+1],[-1,+1],[nearz,farz]).
-
-### getCompositeProjectionMatrix(aspect, nearz, farz)
-
-Return the concatenation of the ViewTransform and the ProjectionTransform. This transform
-will convert world coordinates to viewport coordinates. The 'aspect' is the width/height
-for the viewport, and the nearz and farz are the Z-buffer values that map to the near and
-far clipping planes. The viewport coordinates of a point located inside the frustum are
-in the range ([-1,+1],[-1,+1],[nearz,farz]).
-
-### getProjectionMatrix(renderer)
-
-Given a vtkRenderer, return the projection transform matrix, which converts from camera
+**_NOT IMPLEMENTED._** Given a vtkRenderer, return the projection transform matrix, which converts from camera
 coordinates to viewport coordinates. This method computes the aspect, nearz and farz,
 then calls the more specific signature of GetCompositeProjectionTransformMatrix.
 
-### render(renderer)
+### `getFrustumPlanes(aspect, planes)`
 
-This method causes the camera to set up whatever is required for viewing the scene. This
-is actually handled by an subclass of vtkCamera, which is created through New()
-
-### getViewingRaysMTime()
-
-Return the MTime that concerns recomputing the view rays of the camera.
-
-### viewingRaysModified()
-
-Mark that something has changed which requires the view rays to be recomputed.
-
-### getFrustumPlanes(aspect, planes)
-
-Get the plane equations that bound the view frustum. The plane normals point inward.
+**_NOT IMPLEMENTED._** Get the plane equations that bound the view frustum. The plane normals point inward.
 The planes array contains six plane equations of the form (Ax+By+Cz+D=0), the first
 four values are (A,B,C,D) which repeats for each of the planes. The planes are given
 in the following order: -x,+x,-y,+y,-z,+z. Warning: it means left,right,bottom,top,far,near
 (NOT near,far) The aspect of the viewport is needed to correctly compute the planes
 
-### getOrientation()
+### `getOrientation()`
 
-Get the orientation of the camera (x, y, z orientation angles from the transformation matrix).
+**_NOT IMPLEMENTED._** Get the orientation of the camera (x, y, z orientation angles from the transformation matrix).
 
-### getOrientationWXYZ()
+### `getOrientationWXYZ()`
 
-Get the wxyz angle+axis representing the current orientation. The angle is in degrees and
+**_NOT IMPLEMENTED._** Get the wxyz angle+axis representing the current orientation. The angle is in degrees and
 the axis is a unit vector.
 
-### getCameraLightTransformMatrix()
+### `getCameraLightTransformMatrix()`
 
-Returns a transformation matrix for a coordinate frame attached to the camera, where the
+**_NOT IMPLEMENTED._** Returns a transformation matrix for a coordinate frame attached to the camera, where the
 camera is located at (0, 0, 1) looking at the focal point at (0, 0, 0), with up being (0, 1, 0).
 
-### updateViewport()
+### `deepCopy(sourceCamera)`
 
-Update the viewport.
-
-### leftEye
-
-Set/Get the Left Eye setting.
-
-### shallowCopy(sourceCamera)
-
-Copy the properties of `source' into `this'. Copy pointers of matrices. Do not pass
+**_NOT IMPLEMENTED._** Copy the properties of `source` into `this`. Copy the contents of the matrices. Do not pass
 null source camera or this camera.
 
-### deepCopy(sourceCamera)
 
-Copy the properties of `source' into `this'. Copy the contents of the matrices. Do not pass
+## Inherited from macro.obj
+
+### `modified(mtime?)`
+
+Set the camera as modified, update the internal modified time, and notify all callbacks.
+If a modifiedTime `mtime` value is provided but older than the internal time, or the camera is marked as deleted, does nothing.
+
+### `getMtime()`
+returns the last modified time.
+
+### `onModified(callback)`
+registers the callback, and returns a function to unregister and stop listening.
+
+### `shallowCopy(sourceCamera)`
+
+Copy the properties of `sourceCamera` into `this`. Copy pointers of matrices. Do not pass
 null source camera or this camera.
 
-### freezeFocalPoint
+### render(renderer)
 
-Set/Get the value of the FreezeDolly instance variable. This determines if the camera should
-move the focal point with the camera position.
-
-### useScissor
-
-Enable/Disable the scissor.
-
-### scissorRect
-
-Set/Get the vtkRect value of the scissor.
+This method causes the camera to set up whatever is required for viewing the scene. This
+is actually handled by an subclass of vtkCamera, which is created through New()

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -145,7 +145,6 @@ function vtkCamera(publicAPI, model) {
     computeViewPlaneNormal();
   };
 
-
   //----------------------------------------------------------------------------
   // Move the position of the camera along the view plane normal. Moving
   // towards the focal point (e.g., > 1) is a dolly-in, moving away

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -39,6 +39,14 @@ function vtkCamera(publicAPI, model) {
   const newPosition = vec3.create();
   const newFocalPoint = vec3.create();
 
+  // Internal Functions that don't need to be public
+  function computeViewPlaneNormal() {
+    // VPN is -DOP
+    model.viewPlaneNormal[0] = -model.directionOfProjection[0];
+    model.viewPlaneNormal[1] = -model.directionOfProjection[1];
+    model.viewPlaneNormal[2] = -model.directionOfProjection[2];
+  }
+
   publicAPI.orthogonalizeViewUp = () => {
     const vt = publicAPI.getViewMatrix();
     model.viewUp[0] = vt[4];
@@ -134,16 +142,9 @@ function vtkCamera(publicAPI, model) {
     model.directionOfProjection[1] = dy / model.distance;
     model.directionOfProjection[2] = dz / model.distance;
 
-    publicAPI.computeViewPlaneNormal();
+    computeViewPlaneNormal();
   };
 
-  //----------------------------------------------------------------------------
-  publicAPI.computeViewPlaneNormal = () => {
-    // VPN is -DOP
-    model.viewPlaneNormal[0] = -model.directionOfProjection[0];
-    model.viewPlaneNormal[1] = -model.directionOfProjection[1];
-    model.viewPlaneNormal[2] = -model.directionOfProjection[2];
-  };
 
   //----------------------------------------------------------------------------
   // Move the position of the camera along the view plane normal. Moving
@@ -163,10 +164,6 @@ function vtkCamera(publicAPI, model) {
       model.focalPoint[2] - d * model.directionOfProjection[2]
     );
   };
-
-  publicAPI.setRoll = (roll) => {};
-
-  publicAPI.getRoll = () => {};
 
   publicAPI.roll = (angle) => {
     const eye = model.position;
@@ -266,6 +263,7 @@ function vtkCamera(publicAPI, model) {
   publicAPI.elevation = (angle) => {
     const fp = model.focalPoint;
 
+    // get the eye / camera position from the viewMatrix
     const vt = publicAPI.getViewMatrix();
     const axis = [-vt[0], -vt[1], -vt[2]];
 
@@ -320,21 +318,13 @@ function vtkCamera(publicAPI, model) {
       vec3.fromValues(-position[0], -position[1], -position[2])
     );
 
-    // apply the transform to the position
+    // apply the transform to the focal point
     vec3.transformMat4(
       newFocalPoint,
-      vec3.fromValues(
-        model.focalPoint[0],
-        model.focalPoint[1],
-        model.focalPoint[2]
-      ),
+      vec3.fromValues(...model.focalPoint),
       trans
     );
-    publicAPI.setFocalPoint(
-      newFocalPoint[0],
-      newFocalPoint[1],
-      newFocalPoint[2]
-    );
+    publicAPI.setFocalPoint(...newFocalPoint);
   };
 
   publicAPI.zoom = (factor) => {
@@ -349,9 +339,41 @@ function vtkCamera(publicAPI, model) {
     publicAPI.modified();
   };
 
-  publicAPI.setThickness = (thickness) => {};
+  publicAPI.applyTransform = (transformMat4) => {
+    const vuOld = [...model.viewUp, 1.0];
+    const posNew = [];
+    const fpNew = [];
+    const vuNew = [];
 
+    vuOld[0] += model.position[0];
+    vuOld[1] += model.position[1];
+    vuOld[2] += model.position[2];
+
+    vec4.transformMat4(posNew, [...model.position, 1.0], transformMat4);
+    vec4.transformMat4(fpNew, [...model.focalPoint, 1.0], transformMat4);
+    vec4.transformMat4(vuNew, vuOld, transformMat4);
+
+    vuNew[0] -= posNew[0];
+    vuNew[1] -= posNew[1];
+    vuNew[2] -= posNew[2];
+
+    publicAPI.setPosition(...posNew.slice(0, 3));
+    publicAPI.setFocalPoint(...fpNew.slice(0, 3));
+    publicAPI.setViewUp(...vuNew.slice(0, 3));
+  };
+
+  // Unimplemented functions
+  publicAPI.setRoll = (angle) => {}; // dependency on GetOrientation() and a model.ViewTransform object, see https://github.com/Kitware/VTK/blob/master/Common/Transforms/vtkTransform.cxx and https://vtk.org/doc/nightly/html/classvtkTransform.html
+  publicAPI.getRoll = () => {};
+  publicAPI.setThickness = (thickness) => {};
   publicAPI.setObliqueAngles = (alpha, beta) => {};
+  publicAPI.getOrientation = () => {};
+  publicAPI.getOrientationWXYZ = () => {};
+  publicAPI.getFrustumPlanes = (aspect) => {
+    // Return array of 24 params (4 params for each of 6 plane equations)
+  };
+  publicAPI.getCameraLightTransformMatrix = () => {};
+  publicAPI.deepCopy = (sourceCamera) => {};
 
   publicAPI.physicalOrientationToWorldDirection = (ori) => {
     // push the x axis through the orientation quat
@@ -463,16 +485,13 @@ function vtkCamera(publicAPI, model) {
     }
 
     const result = mat4.create();
-    const eye = model.position;
-    const at = model.focalPoint;
-    const up = model.viewUp;
 
     mat4.lookAt(
       tmpMatrix,
-      vec3.fromValues(eye[0], eye[1], eye[2]), // eye
-      vec3.fromValues(at[0], at[1], at[2]), // at
-      vec3.fromValues(up[0], up[1], up[2])
-    ); // up
+      vec3.fromValues(...model.position), // eye
+      vec3.fromValues(...model.focalPoint), // at
+      vec3.fromValues(...model.viewUp) // up
+    );
 
     mat4.transpose(tmpMatrix, tmpMatrix);
 
@@ -488,12 +507,8 @@ function vtkCamera(publicAPI, model) {
     const result = mat4.create();
 
     if (model.projectionMatrix) {
-      vec3.set(
-        tmpvec1,
-        1 / model.physicalScale,
-        1 / model.physicalScale,
-        1 / model.physicalScale
-      );
+      const scale = 1 / model.physicalScale;
+      vec3.set(tmpvec1, scale, scale, scale);
 
       mat4.copy(result, model.projectionMatrix);
       mat4.scale(result, result, tmpvec1);
@@ -569,14 +584,6 @@ function vtkCamera(publicAPI, model) {
     return result;
   };
 
-  publicAPI.getFrustumPlanes = (aspect) => {
-    // Return array of 24 params (4 params for each of 6 plane equations)
-  };
-
-  publicAPI.getOrientation = () => {};
-
-  publicAPI.getOrientationWXYZ = () => {};
-
   publicAPI.setDirectionOfProjection = (x, y, z) => {
     if (
       model.directionOfProjection[0] === x &&
@@ -596,7 +603,7 @@ function vtkCamera(publicAPI, model) {
     model.focalPoint[0] = model.position[0] + vec[0] * model.distance;
     model.focalPoint[1] = model.position[1] + vec[1] * model.distance;
     model.focalPoint[2] = model.position[2] + vec[2] * model.distance;
-    publicAPI.computeViewPlaneNormal();
+    computeViewPlaneNormal();
   };
 
   // used to handle convert js device orientation angles
@@ -678,8 +685,8 @@ function vtkCamera(publicAPI, model) {
     const newvup = vec3.create();
     vec3.transformMat4(newvup, vup, quatMat);
 
-    publicAPI.setDirectionOfProjection(newdop[0], newdop[1], newdop[2]);
-    publicAPI.setViewUp(newvup[0], newvup[1], newvup[2]);
+    publicAPI.setDirectionOfProjection(...newdop);
+    publicAPI.setViewUp(...newvup);
     publicAPI.modified();
   };
 
@@ -736,7 +743,6 @@ export const DEFAULT_VALUES = {
   screenBottomRight: [0.5, -0.5, -0.5],
   screenTopRight: [0.5, 0.5, -0.5],
   freezeFocalPoint: false,
-  useScissor: false,
   projectionMatrix: null,
   viewMatrix: null,
 
@@ -764,7 +770,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'parallelScale',
     'useOffAxisProjection',
     'freezeFocalPoint',
-    'useScissor',
     'physicalScale',
   ]);
 


### PR DESCRIPTION
Refactor Camera code for clarity, moving unimplemented functions together, implemented `applyTransform()` function.

Fix docs to remove bad references, update function defs to be more clear.

Removed "Scissor" references that were not implemented nor referenced anywhere, even in VTK C++ code.

Related to https://github.com/Kitware/vtk-js/issues/1135