### PR TITLE
docs(MatrixBuilder): Create documentation for and refactor MatrixBuilder class

### DIFF
--- a/Sources/Common/Core/MatrixBuilder/api.md
+++ b/Sources/Common/Core/MatrixBuilder/api.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-vtkMatrixBuilder class provides a system to create a mat4 transformation matrix. All functions return the MatrixBuilder Object instance, allowing transformations to be chained.
+The `vtkMatrixBuilder` class provides a system to create a mat4 transformation matrix. All functions return the MatrixBuilder Object instance, allowing transformations to be chained.
 
 Example:
 ```
@@ -42,12 +42,12 @@ Resets the MatrixBuilder to the Identity matrix.
 ### `apply(typedArray, offset = 0, nbIterations = -1)`
 Multiplies the array by the MatrixBuilder's internal matrix. Updates the array in place.
 Assumes the `typedArray` is an array with sets of 3.
-If specified, `offset` starts at a given position in the array and nbIterations will determine the number of iterations (sets of 3) to loop through.
-Returns the MatrixBuilder instance, allowing chaining to continue.
+If specified, `offset` starts at a given position in the array and `nbIterations` will determine the number of iterations (sets of 3) to loop through.
+Returns the instance for chaining.
 
 ### `getMatrix()`
 Returns the internal `mat4` matrix.
 
 ### `setMatrix(mat4)`
-Copies the given `mat4` into the builder. Useful if you already have a transformation matrix and want to transform it further.
+Copies the given `mat4` into the builder. Useful if you already have a transformation matrix and want to transform it further. Returns the instance for chaining.
 

--- a/Sources/Common/Core/MatrixBuilder/api.md
+++ b/Sources/Common/Core/MatrixBuilder/api.md
@@ -37,17 +37,18 @@ Scales the matrix by sx, sy, sz.
 ### `identity()`
 Resets the MatrixBuilder to the Identity matrix.
 
+### `setMatrix(mat4)`
+Copies the given `mat4` into the builder. Useful if you already have a transformation matrix and want to transform it further. Returns the instance for chaining.
+
 ## Using the MatrixBuilder result
 
 ### `apply(typedArray, offset = 0, nbIterations = -1)`
-Multiplies the array by the MatrixBuilder's internal matrix. Updates the array in place.
-Assumes the `typedArray` is an array with sets of 3.
-If specified, `offset` starts at a given position in the array and `nbIterations` will determine the number of iterations (sets of 3) to loop through.
+Multiplies the array by the MatrixBuilder's internal matrix, in sets of 3. Updates the array in place.
+If specified, `offset` starts at a given position in the array, and `nbIterations` will determine the number of iterations (sets of 3) to loop through. Assumes the `typedArray` is an array of multiples of 3, unless specifically handling with offset and iterations.
 Returns the instance for chaining.
 
 ### `getMatrix()`
 Returns the internal `mat4` matrix.
 
-### `setMatrix(mat4)`
-Copies the given `mat4` into the builder. Useful if you already have a transformation matrix and want to transform it further. Returns the instance for chaining.
+
 

--- a/Sources/Common/Core/MatrixBuilder/api.md
+++ b/Sources/Common/Core/MatrixBuilder/api.md
@@ -13,41 +13,41 @@ The vtkMatrixBuilder class has two functions, `vtkMatrixBuilder.buildFromDegree(
 
 ## Transformation Functions
 
-`rotateFromDirections(originDirection, targetDirection)`
+### `rotateFromDirections(originDirection, targetDirection)`
 Multiplies the current matrix with a transformation matrix created by normalizing both direction vectors and rotating around the axis of the crossProduct by the angle from the dotProduct of the two directions.
 
-`rotate(angle, axis)`
-Normalizes the axis of rotation then rotates the current matrix `angle` degrees/radians around the provided axis
+### `rotate(angle, axis)`
+Normalizes the axis of rotation then rotates the current matrix `angle` degrees/radians around the provided axis.
 
-`rotateX(angle)`
+### `rotateX(angle)`
 Rotates `angle` degrees/radians around the X axis.
 
-`rotateY(angle)`
+### `rotateY(angle)`
 Rotates `angle` degrees/radians around the Y axis.
 
-`rotateZ(angle)`
+### `rotateZ(angle)`
 Rotates `angle` degrees/radians around the Z axis.
 
-`translate(x, y, z)`
+### `translate(x, y, z)`
 Translates the matrix by x, y, z.
 
-`scale(sx, sy, sz)`
+### `scale(sx, sy, sz)`
 Scales the matrix by sx, sy, sz.
 
-`identity()`
+### `identity()`
 Resets the MatrixBuilder to the Identity matrix.
 
 ## Using the MatrixBuilder result
 
-`apply(typedArray, offset = 0, nbIterations = -1)`
+### `apply(typedArray, offset = 0, nbIterations = -1)`
 Multiplies the array by the MatrixBuilder's internal matrix. Updates the array in place.
 Assumes the `typedArray` is an array with sets of 3.
 If specified, `offset` starts at a given position in the array and nbIterations will determine the number of iterations (sets of 3) to loop through.
 Returns the MatrixBuilder instance, allowing chaining to continue.
 
-`getMatrix()`
+### `getMatrix()`
 Returns the internal `mat4` matrix.
 
-`setMatrix(mat4)`
+### `setMatrix(mat4)`
 Copies the given `mat4` into the builder. Useful if you already have a transformation matrix and want to transform it further.
 

--- a/Sources/Common/Core/MatrixBuilder/api.md
+++ b/Sources/Common/Core/MatrixBuilder/api.md
@@ -1,0 +1,49 @@
+## Introduction
+
+vtkMatrixBuilder class provides a system to create a mat4 transformation matrix. All functions return the MatrixBuilder Object instance, allowing transformations to be chained.
+
+Example: `vtkMatrixBuilder.buildfromDegree().translate(1,0,2).rotateZ(45).apply()`
+
+## Creating an instance
+The vtkMatrixBuilder class has two functions, `vtkMatrixBuilder.buildFromDegree()` and `vtkMatrixbuilder.buildFromRadian()`, predefining the angle format used for transformations and returning a MatrixBuilder instance. The matrix is initialized with the Identity Matrix.
+
+## Transformation Functions
+
+`rotateFromDirections(originDirection, targetDirection)`
+Multiplies the current matrix with a transformation matrix created by normalizing both direction vectors and rotating around the axis of the crossProduct by the angle from the dotProduct of the two directions.
+
+`rotate(angle, axis)`
+Normalizes the axis of rotation then rotates the current matrix `angle` degrees/radians around the provided axis
+
+`rotateX(angle)`
+Rotates `angle` degrees/radians around the X axis.
+
+`rotateY(angle)`
+Rotates `angle` degrees/radians around the Y axis.
+
+`rotateZ(angle)`
+Rotates `angle` degrees/radians around the Z axis.
+
+`translate(x, y, z)`
+Translates the matrix by x, y, z.
+
+`scale(sx, sy, sz)`
+Scales the matrix by sx, sy, sz.
+
+`identity()`
+Resets the MatrixBuilder to the Identity matrix.
+
+## Using the MatrixBuilder result
+
+`apply(typedArray, offset = 0, nbIterations = -1)`
+Multiplies the array by the MatrixBuilder's internal matrix. Updates the array in place.
+Assumes the `typedArray` is an array with sets of 3.
+If specified, `offset` starts at a given position in the array and nbIterations will determine the number of iterations (sets of 3) to loop through.
+Returns the MatrixBuilder instance, allowing chaining to continue.
+
+`getMatrix()`
+Returns the internal `mat4` matrix.
+
+`setMatrix(mat4)`
+Copies the given `mat4` into the builder. Useful if you already have a transformation matrix and want to transform it further.
+

--- a/Sources/Common/Core/MatrixBuilder/api.md
+++ b/Sources/Common/Core/MatrixBuilder/api.md
@@ -2,7 +2,11 @@
 
 vtkMatrixBuilder class provides a system to create a mat4 transformation matrix. All functions return the MatrixBuilder Object instance, allowing transformations to be chained.
 
-Example: `vtkMatrixBuilder.buildfromDegree().translate(1,0,2).rotateZ(45).apply()`
+Example:
+```
+let point = [2,5,12];
+vtkMatrixBuilder.buildfromDegree().translate(1,0,2).rotateZ(45).apply(point);
+```
 
 ## Creating an instance
 The vtkMatrixBuilder class has two functions, `vtkMatrixBuilder.buildFromDegree()` and `vtkMatrixbuilder.buildFromRadian()`, predefining the angle format used for transformations and returning a MatrixBuilder instance. The matrix is initialized with the Identity Matrix.

--- a/Sources/Common/Core/MatrixBuilder/index.js
+++ b/Sources/Common/Core/MatrixBuilder/index.js
@@ -1,4 +1,5 @@
 import { vec3, mat4, glMatrix } from 'gl-matrix';
+import { areMatricesEqual } from 'vtk.js/Sources/Common/Core/Math';
 
 const NoOp = (v) => v;
 
@@ -79,25 +80,15 @@ class Transform {
     return this;
   }
 
+  identity() {
+    mat4.identity(this.matrix);
+    return this;
+  }
+
+  //-----------
+
   apply(typedArray, offset = 0, nbIterations = -1) {
-    if (
-      IDENTITY[0] === this.matrix[0] &&
-      IDENTITY[1] === this.matrix[1] &&
-      IDENTITY[2] === this.matrix[2] &&
-      IDENTITY[3] === this.matrix[3] &&
-      IDENTITY[4] === this.matrix[4] &&
-      IDENTITY[5] === this.matrix[5] &&
-      IDENTITY[6] === this.matrix[6] &&
-      IDENTITY[7] === this.matrix[7] &&
-      IDENTITY[8] === this.matrix[8] &&
-      IDENTITY[9] === this.matrix[9] &&
-      IDENTITY[10] === this.matrix[10] &&
-      IDENTITY[11] === this.matrix[11] &&
-      IDENTITY[12] === this.matrix[12] &&
-      IDENTITY[13] === this.matrix[13] &&
-      IDENTITY[14] === this.matrix[14] &&
-      IDENTITY[15] === this.matrix[15]
-    ) {
+    if (areMatricesEqual(IDENTITY, this.matrix)) {
       // Make sure we can chain apply...
       return this;
     }
@@ -120,35 +111,10 @@ class Transform {
     return this.matrix;
   }
 
-  getVTKMatrix() {
-    mat4.transpose(this.matrix, this.matrix);
-    return this.matrix;
-  }
-
   setMatrix(mat4x4) {
     if (!!mat4x4 && mat4x4.length === 16) {
-      this.matrix[0] = mat4x4[0];
-      this.matrix[1] = mat4x4[1];
-      this.matrix[2] = mat4x4[2];
-      this.matrix[3] = mat4x4[3];
-      this.matrix[4] = mat4x4[4];
-      this.matrix[5] = mat4x4[5];
-      this.matrix[6] = mat4x4[6];
-      this.matrix[7] = mat4x4[7];
-      this.matrix[8] = mat4x4[8];
-      this.matrix[9] = mat4x4[9];
-      this.matrix[10] = mat4x4[10];
-      this.matrix[11] = mat4x4[11];
-      this.matrix[12] = mat4x4[12];
-      this.matrix[13] = mat4x4[13];
-      this.matrix[14] = mat4x4[14];
-      this.matrix[15] = mat4x4[15];
+      mat4.copy(this.matrix, mat4x4);
     }
-    return this;
-  }
-
-  identity() {
-    mat4.identity(this.matrix);
     return this;
   }
 }


### PR DESCRIPTION

BREAKING CHANGE: Remove getVTKMatrix function as it had a side-effect, was poorly named, and was not referenced anywhere else. If the user wants to transpose the matrix, they can do it after calling `getMatrix()`