### PR TITLE
fix(InteractorStyleMPRSlice): Keep clipping range consistent

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
@@ -114,7 +114,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
     const renderer = model.interactor.getCurrentRenderer();
     const camera = renderer.getActiveCamera();
     const dist = camera.getDistance();
-    camera.setClippingRange(dist, dist + 1);
+    camera.setClippingRange(dist, dist + 0.1);
   });
 
   const superSetVolumeMapper = publicAPI.setVolumeMapper;


### PR DESCRIPTION
fix(InteractorStyleMPRSlice): Keep clipping range consistent between mouse movement and initial setup

This is a tiny change that I have already discussed once with @floryst. Essentially we use 0.1 in one place:

https://github.com/Kitware/vtk-js/blob/c9fa0ceb23390af7b9059056b18024ffa96fa9c5/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js#L295-L300

and 1 in the other for the width of the clipping range. It seems more sensible to make them both 0.1.

I'm only sending this PR because I ran into different behaviour in the mapper during mouse movement / initial setup.

Right now changing this won't really have much impact, but in an upcoming PR we have a special path for cases where the ray path distance is less than sampling distance, and in that case this value being smaller will improve the performance.