### PR TITLE
fix(vtkVolumeFS): Address sampling issues during thin-slice volume rendering

### DIFF
--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -816,7 +816,6 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           fbSize[0] !== Math.floor(size[0] * 0.7) ||
           fbSize[1] !== Math.floor(size[1] * 0.7)
         ) {
-          console.log('resizing');
           model.framebuffer.create(
             Math.floor(size[0] * 0.7),
             Math.floor(size[1] * 0.7)

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -518,7 +518,9 @@ void applyBlend(vec3 posIS, vec3 stepIS, vec3 tdims, float numSteps, vec3 startR
   vec3 tstep = 1.0/tdims;
 
   // integer number of steps to take and residual step size
-  int count = int(numSteps - 0.05); // end slightly inside
+  // TODO: This seems to fix the issue for thick-slab MIP? Off-by-one error?
+  int count = int(numSteps - 1.0); // end slightly inside
+  // int count = int(numSteps - 0.05); // end slightly inside
   float residual = numSteps - float(count);
   vec3 initialPosIS = posIS - startResidualIS;
 

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -660,15 +660,15 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
 
     vec4 sum = vec4(0.);
 
+    averageIPScalarRangeMin.a = tValue.a;
+    averageIPScalarRangeMax.a = tValue.a;
+
+    if (all(greaterThanEqual(tValue, averageIPScalarRangeMin)) &&
+    all(lessThanEqual(tValue, averageIPScalarRangeMax))) {
+      sum += tValue;
+    }
+
     if (raySteps <= 1.0) {
-      averageIPScalarRangeMin.a = tValue.a;
-      averageIPScalarRangeMax.a = tValue.a;
-
-      if (all(greaterThanEqual(tValue, averageIPScalarRangeMin)) &&
-          all(lessThanEqual(tValue, averageIPScalarRangeMax))) {
-        sum += tValue;
-      }
-
       gl_FragData[0] = getColorForValue(sum, posIS, tstep);
       return;
     }

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -549,7 +549,7 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
     // handle very thin volumes
     if (raySteps <= 1.0)
     {
-      tColor.a *= raySteps;
+      tColor.a = 1.0 - pow(1.0 - tColor.a, raySteps);
       gl_FragData[0] = tColor;
       return;
     }


### PR DESCRIPTION
Addresses #1146 

### Changes:

- Checks inside `computeIndexSpaceValues` if the length of the ray is smaller than the sample distance. If so, sets numSteps to 1.0 so we can skip some unnecessary computations
- Adds early exits for each blend mode in case numSteps is 1.0. In this case, we can skip the whole ray traversal loop and just take the first value.
- Stores the initial position along the ray so it can be passed to applyBlend as startResidualIS.

The idea is that the first sample along the ray would be from the initial position in the volume, and then there would be the usual sampling loop up to 1-step away from the end, and finally the residual step to sample the end position. That is why we are computing `initialPosIS = posIS - startResidual`.

I'm leaving this as a draft for now because I am still seeing the jitter speckling pattern on normal composite blend volume rendering (e.g. `npm run example -- VolumeMapper` and thick-slab MIP/MinIP, but not AverageIP) , though it is not as apparent now.

I figure that the speckling is caused by the texture being sampled outside of the texture dimensions, which is why it shows up as black spots.

### Testing
The easiest way to test this is to use `npm run example -- InteractorStyleMPRSlice`. If you want to see how it changes in thicker slabs, edit the +1 and +0.1 values here: https://github.com/Kitware/vtk-js/blob/master/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js#L117

Set them both to something like 20 or 30.

and add mapper.setBlendModeToMaximumIntensity() in the example here: https://github.com/Kitware/vtk-js/blob/master/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js#L41