### PR TITLE
fix(CylinderSource): Translate points to center before rotate

### DIFF
--- a/Sources/Filters/Sources/CylinderSource/index.js
+++ b/Sources/Filters/Sources/CylinderSource/index.js
@@ -155,6 +155,7 @@ function vtkCylinderSource(publicAPI, model) {
       .buildFromRadian()
       .translate(...model.center)
       .rotateFromDirections([0, 1, 0], model.direction)
+      .translate(...model.center.map((c) => c * -1))
       .apply(points);
 
     dataset = vtkPolyData.newInstance();


### PR DESCRIPTION
Fixes issue where points were not being centered around origin before applying rotation.