### PR TITLE
feat(vtkPlane): Add intersectWithPlane function

### DIFF
--- a/Sources/Common/DataModel/Plane/api.md
+++ b/Sources/Common/DataModel/Plane/api.md
@@ -82,7 +82,7 @@ to Number.MAX_VALUE.
 Given a planes defined by the normals n0 & n1 and origin points p0 & p1, compute the line representing the plane intersection.
 Return an object:
 ```js
-let obj = {intersection: ..., t: ..., l0: ..., l1: ...};
+let obj = {intersection: ..., error: ..., l0: ..., l1: ...};
 ```
 where:
 - **intersection** (*boolean*): indicates if the two planes intersect.

--- a/Sources/Common/DataModel/Plane/api.md
+++ b/Sources/Common/DataModel/Plane/api.md
@@ -13,68 +13,80 @@ Default is [0.0, 0.0, 0.0].
 
 ## Methods
 
-evaluateFunction(x)
-: Evaluate plane equation for point x  
+### evaluateFunction(x)
+Evaluate plane equation for point x.
+Accepts both an array point representation and individual xyz arguments.
 ```js
 plane.evaluateFunction([0.0, 0.0, 0.0]);
 plane.evaluateFunction(0.0, 0.0, 0.0);
 ```
 
-
-evaluateGradient(xyz)
-: Given the point xyz (three floating values) evaluate the equation for the 
-plane gradient. Note that the normal and origin must have already been 
-specified. The method returns an array of three floats.
+### evaluateGradient(xyz)
+Given the point xyz (three floating values) evaluate the equation for the plane gradient. Note that the normal and origin must have already been specified. The method returns an array of three floats.
 
 
-push(distance)
-: Translate the plane in the direction of the normal by the distance
+### push(distance)
+Translate the plane in the direction of the normal by the distance
 specified. Negative values move the plane in the opposite direction.
 
 
-(static) projectPoint(x, origin, normal, xproj)  
-projectPoint(x, xproj)
-: Project a point x onto plane defined by origin and normal. The
-projected point is returned in xproj. NOTE : normal assumed to
+### *(static)* projectPoint(x, origin, normal, xproj)
+### projectPoint(x, xproj)
+Project a point x onto plane defined by origin and normal. The
+projected point is returned in xproj. **NOTE:** normal assumed to
 have magnitude 1.
 
 
-(static) projectVector(v, normal, vproj)  
-projectVector(v, vproj)
-: Project a vector v onto plane defined by origin and normal. The
+### *(static)* projectVector(v, normal, vproj)
+### projectVector(v, vproj)
+Project a vector v onto plane defined by origin and normal. The
 projected vector is returned in vproj.
 
 
-(static) generalizedProjectPoint(x, origin, normal, xproj)  
-generalizedProjectPoint(x, xproj)
-: Project a point x onto plane defined by origin and normal. The
-projected point is returned in xproj. NOTE : normal does NOT have to
+### *(static)* generalizedProjectPoint(x, origin, normal, xproj)
+### generalizedProjectPoint(x, xproj)
+Project a point x onto plane defined by origin and normal. The
+projected point is returned in xproj. **NOTE:** normal does NOT have to
 have magnitude 1.
 
 
-(static) evaluate(normal, origin, x)
-: Quick evaluation of plane equation n(x-origin) = 0.
+### *(static)* evaluate(normal, origin, x)
+Quick evaluation of plane equation n(x-origin) = 0.
 
 
-(static) distanceToPlane(x, origin, normal)  
-distanceToPlane(x)
-: Return the distance of a point x to a plane defined by n (x-p0) = 0.
+### *(static)* distanceToPlane(x, origin, normal)
+### distanceToPlane(x)
+Return the distance of a point x to a plane defined by n (x-p0) = 0.
 The normal n must be magnitude = 1.
 
 
-(static) intersectWithLine(p1, p2, origin, normal)  
-intersectWithLine(p1, p2)
-: Given a line defined by the two points p1,p2; and a plane defined by the
+### *(static)* intersectWithLine(p1, p2, origin, normal)
+### intersectWithLine(p1, p2)
+Given a line defined by the two points p1,p2; and a plane defined by the
 normal n and point p0, compute an intersection.
 Return an object:
 ```js
 let obj = {intersection: ..., t: ..., x: ...};
 ```
 where:
-- **intersection** (*boolean*): indicates if there the plane and line intersect.
+- **intersection** (*boolean*): indicates if the plane and line intersect.
  Intersection is true if (0 <= t <= 1), and false otherwise.
 - **t** (*Number*): parametric coordinate along the line.
 - **x** (*Array*): coordinates of intersection.
 
 If the plane and line are parallel, intersection is false and t is set
 to Number.MAX_VALUE.
+
+### *(static)* intersectWithPlane(plane1Origin, plane1Normal, plane2Origin, plane2Normal)
+### intersectWithPlane(planeOrigin, planeNormal)
+Given a planes defined by the normals n0 & n1 and origin points p0 & p1, compute the line representing the plane intersection.
+Return an object:
+```js
+let obj = {intersection: ..., t: ..., l0: ..., l1: ...};
+```
+where:
+- **intersection** (*boolean*): indicates if the two planes intersect.
+ Intersection is true if (0 <= t <= 1), and false otherwise.
+- **l0** (*Array*): coordinates of point 0 of the intersection line.
+- **l1** (*Array*): coordinates of point 1 of the intersection line.
+- **error** (*String|null*): Conditional, if the planes do not intersect, is it because they are coplanar ('coincide') or parallel ('disjoint').

--- a/Sources/Common/DataModel/Plane/api.md
+++ b/Sources/Common/DataModel/Plane/api.md
@@ -89,4 +89,7 @@ where:
  Intersection is true if (0 <= t <= 1), and false otherwise.
 - **l0** (*Array*): coordinates of point 0 of the intersection line.
 - **l1** (*Array*): coordinates of point 1 of the intersection line.
-- **error** (*String|null*): Conditional, if the planes do not intersect, is it because they are coplanar ('coincide') or parallel ('disjoint').
+- **error** (*String|null*): Conditional, if the planes do not intersect, is it because they are coplanar (`COINCIDE`) or parallel (`DISJOINT`).
+
+### (*const*) COINCIDE, DISJOINT
+Constants for the `intersectWithPlane` function.

--- a/Sources/Common/DataModel/Plane/index.js
+++ b/Sources/Common/DataModel/Plane/index.js
@@ -2,6 +2,8 @@ import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import macro from 'vtk.js/Sources/macro';
 
 const PLANE_TOLERANCE = 1.0e-6;
+const COINCIDE = 'coincide';
+const DISJOINT = 'disjoint';
 
 // ----------------------------------------------------------------------------
 // Global methods
@@ -134,9 +136,9 @@ function intersectWithPlane(
     const v = [];
     vtkMath.subtract(plane1Origin, plane2Origin, v);
     if (vtkMath.dot(plane1Normal, v) === 0) {
-      outObj.error = 'coincide';
+      outObj.error = COINCIDE;
     } else {
-      outObj.error = 'disjoint';
+      outObj.error = DISJOINT;
     }
     return outObj;
   }
@@ -196,6 +198,8 @@ export const STATIC = {
   generalizedProjectPoint,
   intersectWithLine,
   intersectWithPlane,
+  DISJOINT,
+  COINCIDE,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/Plane/test/testPlane.js
+++ b/Sources/Common/DataModel/Plane/test/testPlane.js
@@ -146,7 +146,7 @@ test('Test vtkPlane intersectWithPlane', (t) => {
   let normal = [0.0, 0.0, 1.0];
   let res = plane.intersectWithPlane(origin, normal);
   t.equal(res.intersection, false);
-  t.equal(res.error, 'disjoint');
+  t.equal(res.error, vtkPlane.DISJOINT);
   t.equal(res.l0.length, 0);
   t.equal(res.l1.length, 0);
 
@@ -155,7 +155,7 @@ test('Test vtkPlane intersectWithPlane', (t) => {
   normal = [0.0, 0.0, 1.0];
   res = plane.intersectWithPlane(origin, normal);
   t.equal(res.intersection, false);
-  t.equal(res.error, 'coincide');
+  t.equal(res.error, vtkPlane.COINCIDE);
 
   // test where plane does intersect plane
   origin = [2.0, 0.0, 0.0];

--- a/Sources/Common/DataModel/Plane/test/testPlane.js
+++ b/Sources/Common/DataModel/Plane/test/testPlane.js
@@ -136,6 +136,45 @@ test('Test vtkPlane intersectWithLine', (t) => {
   t.end();
 });
 
+test('Test vtkPlane intersectWithPlane', (t) => {
+  const plane = vtkPlane.newInstance();
+  plane.setOrigin(0.0, 0.0, 0.0);
+  plane.setNormal(0.0, 0.0, 1.0);
+
+  // test where a plane is parallel to plane
+  let origin = [2.0, 2.0, 2.0];
+  let normal = [0.0, 0.0, 1.0];
+  let res = plane.intersectWithPlane(origin, normal);
+  t.equal(res.intersection, false);
+  t.equal(res.error, 'disjoint');
+  t.equal(res.l0.length, 0);
+  t.equal(res.l1.length, 0);
+
+  // test where a plane is coplaner with plane
+  origin = [1.0, 0.0, 0.0];
+  normal = [0.0, 0.0, 1.0];
+  res = plane.intersectWithPlane(origin, normal);
+  t.equal(res.intersection, false);
+  t.equal(res.error, 'coincide');
+
+  // test where plane does intersect plane
+  origin = [2.0, 0.0, 0.0];
+  normal = [1.0, 0.0, 0.0];
+  res = plane.intersectWithPlane(origin, normal);
+  t.equal(res.intersection, true);
+  t.equal(res.l0.length, 3);
+  t.equal(res.l1.length, 3);
+  const l0 = [2, 0, -0];
+  const l1 = [2, -1, 0];
+  for (let i = 0; i < 3; i++) {
+    t.equal(res.l0[i], l0[i]);
+  }
+  for (let i = 0; i < 3; i++) {
+    t.equal(res.l1[i], l1[i]);
+  }
+  t.end();
+});
+
 test('Test vtkPlane evaluateFunction', (t) => {
   const plane = vtkPlane.newInstance();
   plane.setOrigin(0.0, 0.0, 0.0);


### PR DESCRIPTION
Similar to, but not the same as the c++ vtk plane logic, where the c++ version expects a
bound/finite plane and an infinite plane. While the function title might assume being passed another vtkPlane object, I did not build in such function overloading, so the function call expects the normal and origin as separate vectors.

Also updates the documentation for visual clarity and grammar.

With both Plane intersection and Line intersection, I can then build a "3 plane intersection" function.