### PR TITLE
Misc SVG widget changes

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -326,6 +326,10 @@ function vtkWidgetManager(publicAPI, model) {
 
       removeFromSvgLayer(viewWidget);
 
+      if (model.widgetInFocus === viewWidget) {
+        publicAPI.releaseFocus();
+      }
+
       // free internal model + unregister it from its parent
       viewWidget.delete();
     }

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -99,7 +99,8 @@ function vtkWidgetManager(publicAPI, model) {
 
   function enableSvgLayer() {
     const container = model.openGLRenderWindow.getReferenceByName('el');
-    container.appendChild(model.svgWrapper);
+    const canvas = model.openGLRenderWindow.getCanvas();
+    container.insertBefore(model.svgWrapper, canvas.nextSibling);
   }
 
   function disableSvgLayer() {

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -153,12 +153,14 @@ function vtkWidgetManager(publicAPI, model) {
             .map((r) => r.render());
           Promise.all(pendingContent).then((nodes) => {
             const g = widgetToSvgMap.get(widget);
-            const newG = createSvgElement('g');
-            for (let ni = 0; ni < nodes.length; ni++) {
-              newG.appendChild(nodes[ni]);
-            }
-            if (g.innerHTML !== newG.innerHTML) {
-              g.innerHTML = newG.innerHTML;
+            if (g) {
+              const newG = createSvgElement('g');
+              for (let ni = 0; ni < nodes.length; ni++) {
+                newG.appendChild(nodes[ni]);
+              }
+              if (g.innerHTML !== newG.innerHTML) {
+                g.innerHTML = newG.innerHTML;
+              }
             }
           });
         }

--- a/Sources/Widgets/SVG/SVGRepresentation/index.js
+++ b/Sources/Widgets/SVG/SVGRepresentation/index.js
@@ -39,7 +39,7 @@ function vtkSVGRepresentation(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkSVGRepresentation');
 
-  const deferred = [];
+  let deferred = null;
 
   model.psActor = vtkActor.newInstance({ pickable: false });
   model.psMapper = vtkPixelSpaceCallbackMapper.newInstance();
@@ -49,8 +49,11 @@ function vtkSVGRepresentation(publicAPI, model) {
   model.psActor.setMapper(model.psMapper);
 
   model.psMapper.setCallback((...args) => {
-    while (deferred.length) {
-      deferred.pop().resolve({
+    if (deferred) {
+      const d = deferred;
+      deferred = null;
+
+      d.resolve({
         coords: args[0],
         camera: args[1],
         aspect: args[2],
@@ -74,9 +77,8 @@ function vtkSVGRepresentation(publicAPI, model) {
     model.points.getPoints().setData(pts);
     model.points.modified();
 
-    const d = defer();
-    deferred.push(d);
-    return d.promise;
+    deferred = defer();
+    return deferred.promise;
   };
 
   // --------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/DistanceWidget/index.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/index.js
@@ -54,9 +54,8 @@ function vtkDistanceWidget(publicAPI, model) {
     if (handles.length !== 2) {
       return 0;
     }
-    return distance2BetweenPoints(
-      handles[0].getOrigin(),
-      handles[1].getOrigin()
+    return Math.sqrt(
+      distance2BetweenPoints(handles[0].getOrigin(), handles[1].getOrigin())
     );
   };
 


### PR DESCRIPTION
- change where SVG layer is inserted (immediately after canvas)
- don't buffer points when calling worldPointsToPixelSpace. This was from an old idea that was scrapped, but the code wasn't changed to reflect that we don't need to buffer anymore.