### PR TITLE
fix(vtkPlane): Fix overloaded intersection in `intersectWithLine()` r…

### DIFF
--- a/Sources/Common/DataModel/Plane/api.md
+++ b/Sources/Common/DataModel/Plane/api.md
@@ -5,91 +5,110 @@ projecting points onto a plane, evaluating the plane equation, and
 returning plane normal.
 
 ### normal (set/get)
+
 Plane normal. Plane is defined by point and normal. Default is [0.0, 0.0, 1.0].
 
 ### origin (set/get)
+
 Point through which plane passes. Plane is defined by point and normal.
 Default is [0.0, 0.0, 0.0].
 
 ## Methods
 
 ### evaluateFunction(x)
+
 Evaluate plane equation for point x.
 Accepts both an array point representation and individual xyz arguments.
+
 ```js
 plane.evaluateFunction([0.0, 0.0, 0.0]);
 plane.evaluateFunction(0.0, 0.0, 0.0);
 ```
 
 ### evaluateGradient(xyz)
+
 Given the point xyz (three floating values) evaluate the equation for the plane gradient. Note that the normal and origin must have already been specified. The method returns an array of three floats.
 
-
 ### push(distance)
+
 Translate the plane in the direction of the normal by the distance
 specified. Negative values move the plane in the opposite direction.
 
+### _(static)_ projectPoint(x, origin, normal, xproj)
 
-### *(static)* projectPoint(x, origin, normal, xproj)
 ### projectPoint(x, xproj)
+
 Project a point x onto plane defined by origin and normal. The
 projected point is returned in xproj. **NOTE:** normal assumed to
 have magnitude 1.
 
+### _(static)_ projectVector(v, normal, vproj)
 
-### *(static)* projectVector(v, normal, vproj)
 ### projectVector(v, vproj)
+
 Project a vector v onto plane defined by origin and normal. The
 projected vector is returned in vproj.
 
+### _(static)_ generalizedProjectPoint(x, origin, normal, xproj)
 
-### *(static)* generalizedProjectPoint(x, origin, normal, xproj)
 ### generalizedProjectPoint(x, xproj)
+
 Project a point x onto plane defined by origin and normal. The
 projected point is returned in xproj. **NOTE:** normal does NOT have to
 have magnitude 1.
 
+### _(static)_ evaluate(normal, origin, x)
 
-### *(static)* evaluate(normal, origin, x)
 Quick evaluation of plane equation n(x-origin) = 0.
 
+### _(static)_ distanceToPlane(x, origin, normal)
 
-### *(static)* distanceToPlane(x, origin, normal)
 ### distanceToPlane(x)
+
 Return the distance of a point x to a plane defined by n (x-p0) = 0.
 The normal n must be magnitude = 1.
 
+### _(static)_ intersectWithLine(p1, p2, origin, normal)
 
-### *(static)* intersectWithLine(p1, p2, origin, normal)
 ### intersectWithLine(p1, p2)
+
 Given a line defined by the two points p1,p2; and a plane defined by the
 normal n and point p0, compute an intersection.
 Return an object:
+
 ```js
-let obj = {intersection: ..., t: ..., x: ...};
+let obj = {intersection: ..., betweenPoints: ..., t: ..., x: ...};
 ```
+
 where:
-- **intersection** (*boolean*): indicates if the plane and line intersect.
- Intersection is true if (0 <= t <= 1), and false otherwise.
-- **t** (*Number*): parametric coordinate along the line.
-- **x** (*Array*): coordinates of intersection.
+
+- **intersection** (_boolean_): indicates if the plane and line intersect.
+- **betweenPoints** (_boolean_): indicates if the intersection is between the provided points. True if (0 <= t <= 1), and false otherwise.
+- **t** (_Number_): parametric coordinate along the line.
+- **x** (_Array_): coordinates of intersection.
 
 If the plane and line are parallel, intersection is false and t is set
 to Number.MAX_VALUE.
 
-### *(static)* intersectWithPlane(plane1Origin, plane1Normal, plane2Origin, plane2Normal)
+### _(static)_ intersectWithPlane(plane1Origin, plane1Normal, plane2Origin, plane2Normal)
+
 ### intersectWithPlane(planeOrigin, planeNormal)
+
 Given a planes defined by the normals n0 & n1 and origin points p0 & p1, compute the line representing the plane intersection.
 Return an object:
+
 ```js
 let obj = {intersection: ..., error: ..., l0: ..., l1: ...};
 ```
-where:
-- **intersection** (*boolean*): indicates if the two planes intersect.
- Intersection is true if (0 <= t <= 1), and false otherwise.
-- **l0** (*Array*): coordinates of point 0 of the intersection line.
-- **l1** (*Array*): coordinates of point 1 of the intersection line.
-- **error** (*String|null*): Conditional, if the planes do not intersect, is it because they are coplanar (`COINCIDE`) or parallel (`DISJOINT`).
 
-### (*const*) COINCIDE, DISJOINT
+where:
+
+- **intersection** (_boolean_): indicates if the two planes intersect.
+  Intersection is true if (0 <= t <= 1), and false otherwise.
+- **l0** (_Array_): coordinates of point 0 of the intersection line.
+- **l1** (_Array_): coordinates of point 1 of the intersection line.
+- **error** (_String|null_): Conditional, if the planes do not intersect, is it because they are coplanar (`COINCIDE`) or parallel (`DISJOINT`).
+
+### (_const_) COINCIDE, DISJOINT
+
 Constants for the `intersectWithPlane` function.

--- a/Sources/Common/DataModel/Plane/index.js
+++ b/Sources/Common/DataModel/Plane/index.js
@@ -69,7 +69,12 @@ function generalizedProjectPoint(x, origin, normal, xproj) {
 }
 
 function intersectWithLine(p1, p2, origin, normal) {
-  const outObj = { intersection: false, t: Number.MAX_VALUE, x: [] };
+  const outObj = {
+    intersection: false,
+    betweenPoints: false,
+    t: Number.MAX_VALUE,
+    x: [],
+  };
 
   const p21 = [];
   const p1Origin = [];
@@ -102,14 +107,16 @@ function intersectWithLine(p1, p2, origin, normal) {
     return outObj;
   }
 
-  // Valid intersection
+  // Where on the line between p1 and p2 is the intersection
+  // If between 0 and 1, it is between the two points. If < 0 it's before p1, if > 1 it's after p2
   outObj.t = num / den;
 
   outObj.x[0] = p1[0] + outObj.t * p21[0];
   outObj.x[1] = p1[1] + outObj.t * p21[1];
   outObj.x[2] = p1[2] + outObj.t * p21[2];
 
-  outObj.intersection = outObj.t >= 0.0 && outObj.t <= 1.0;
+  outObj.intersection = true;
+  outObj.betweenPoints = outObj.t >= 0.0 && outObj.t <= 1.0;
   return outObj;
 }
 

--- a/Sources/Common/DataModel/Plane/test/testPlane.js
+++ b/Sources/Common/DataModel/Plane/test/testPlane.js
@@ -114,6 +114,7 @@ test('Test vtkPlane intersectWithLine', (t) => {
   p2 = [-1.0, 0.0, -1.0];
   res = plane.intersectWithLine(p1, p2);
   t.equal(res.intersection, true);
+  t.equal(res.betweenPoints, true);
   t.equal(res.t, 0.5);
   t.equal(res.x.length, 3);
   let correct = [-1.0, 0.0, 0.0];
@@ -121,11 +122,12 @@ test('Test vtkPlane intersectWithLine', (t) => {
     t.equal(res.x[i], correct[i]);
   }
 
-  // test where line does not intersect plane
+  // test where line intersects the plane outside of the provided points
   p1 = [-2.0, 0.0, -2.0];
   p2 = [2.0, 0.0, -1.0];
   res = plane.intersectWithLine(p1, p2);
-  t.equal(res.intersection, false);
+  t.equal(res.intersection, true);
+  t.equal(res.betweenPoints, false);
   t.equal(res.t, 2);
   t.equal(res.x.length, 3);
   correct = [6.0, 0.0, 0.0];


### PR DESCRIPTION
…esult.

See github issue #1189: result.intersect value is used both to say "Line and Plane are parallel
(false)" and "Plane intersects line between the line's provided points (true / false)". So the
latter intent is extracted into a new variable `result.betweenPoints`

BREAKING CHANGE: return result is changed if the line intersects the plane but outside of the
provided points. Previously would return intersect:false, but now intersect:true and
betweenPoints:false

fix #1189