### PR TITLE
WIP: feat(vtkDracoReader): Add Draco reader

### DIFF
--- a/Sources/IO/Geometry/DracoReader/example/index.js
+++ b/Sources/IO/Geometry/DracoReader/example/index.js
@@ -1,0 +1,60 @@
+import 'vtk.js/Sources/favicon';
+
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkDracoReader from 'vtk.js/Sources/IO/Geometry/DracoReader';
+
+// ----------------------------------------------------------------------------
+// Example code
+// ----------------------------------------------------------------------------
+
+const reader = vtkDracoReader.newInstance();
+const mapper = vtkMapper.newInstance({ scalarVisibility: false });
+const actor = vtkActor.newInstance();
+
+actor.setMapper(mapper);
+mapper.setInputConnection(reader.getOutputPort());
+
+// ----------------------------------------------------------------------------
+
+function update() {
+  const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance();
+  const renderer = fullScreenRenderer.getRenderer();
+  const renderWindow = fullScreenRenderer.getRenderWindow();
+
+  const resetCamera = renderer.resetCamera;
+  const render = renderWindow.render;
+
+  renderer.addActor(actor);
+  resetCamera();
+  render();
+}
+
+// ----------------------------------------------------------------------------
+// Use a file reader to load a local file
+// ----------------------------------------------------------------------------
+
+const myContainer = document.querySelector('body');
+const fileContainer = document.createElement('div');
+fileContainer.innerHTML = '<input type="file" class="file"/>';
+myContainer.appendChild(fileContainer);
+
+const fileInput = fileContainer.querySelector('input');
+
+function handleFile(event) {
+  event.preventDefault();
+  const dataTransfer = event.dataTransfer;
+  const files = event.target.files || dataTransfer.files;
+  if (files.length === 1) {
+    myContainer.removeChild(fileContainer);
+    const fileReader = new FileReader();
+    fileReader.onload = function onLoad(e) {
+      reader.parseAsArrayBuffer(fileReader.result);
+      update();
+    };
+    fileReader.readAsArrayBuffer(files[0]);
+  }
+}
+
+fileInput.addEventListener('change', handleFile);

--- a/Sources/IO/Geometry/DracoReader/index.js
+++ b/Sources/IO/Geometry/DracoReader/index.js
@@ -1,0 +1,289 @@
+import DataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper';
+import macro from 'vtk.js/Sources/macro';
+import vtkCellArray from 'vtk.js/Sources/Common/Core/CellArray';
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+
+import CreateDracoModule from 'draco3d/draco_decoder_nodejs';
+
+const { vtkErrorMacro } = macro;
+
+// ----------------------------------------------------------------------------
+// vtkDracoReader methods
+// ----------------------------------------------------------------------------
+
+function decodeBuffer(buffer, decoderModule) {
+  const byteArray = new Int8Array(buffer);
+  const decoder = new decoderModule.Decoder();
+  const decoderBuffer = new decoderModule.DecoderBuffer();
+  decoderBuffer.Init(byteArray, byteArray.length);
+
+  const geometryType = decoder.GetEncodedGeometryType(decoderBuffer);
+
+  let dracoGeometry;
+  if (geometryType === decoderModule.TRIANGULAR_MESH) {
+    dracoGeometry = new decoderModule.Mesh();
+    const status = decoder.DecodeBufferToMesh(decoderBuffer, dracoGeometry);
+    if (!status.ok()) {
+      vtkErrorMacro(`Could not decode Draco file: ${status.error_msg()}`);
+    }
+  } else {
+    vtkErrorMacro('Wrong geometry type, expected mesh, got point cloud.');
+  }
+
+  decoderModule.destroy(decoderBuffer);
+  decoderModule.destroy(decoder);
+  return dracoGeometry;
+}
+
+function getDracoAttributeAsFloat32Array(
+  dracoGeometry,
+  attributeId,
+  decoderModule
+) {
+  const decoder = new decoderModule.Decoder();
+  const attribute = decoder.GetAttribute(dracoGeometry, attributeId);
+  const numberOfComponents = attribute.num_components();
+  const numberOfPoints = dracoGeometry.num_points();
+  const numberOfValues = numberOfPoints * numberOfComponents;
+
+  const attributeData = new decoderModule.DracoFloat32Array();
+  decoder.GetAttributeFloatForAllPoints(
+    dracoGeometry,
+    attribute,
+    attributeData
+  );
+
+  const attributeArray = new Float32Array(numberOfValues);
+  for (let i = 0; i < numberOfValues; i++) {
+    attributeArray[i] = attributeData.GetValue(i);
+  }
+
+  return attributeArray;
+}
+
+function getPolyDataFromDracoGeometry(dracoGeometry, decoderModule) {
+  const decoder = new decoderModule.Decoder();
+
+  // Get position attribute ID
+  const positionAttributeId = decoder.GetAttributeId(
+    dracoGeometry,
+    decoderModule.POSITION
+  );
+
+  if (positionAttributeId === -1) {
+    console.error('No position attribute found in the decoded model.');
+    decoderModule.destroy(decoder);
+    decoderModule.destroy(dracoGeometry);
+  }
+
+  const positionArray = getDracoAttributeAsFloat32Array(
+    dracoGeometry,
+    positionAttributeId,
+    decoderModule
+  );
+
+  // Read indices
+  const numFaces = dracoGeometry.num_faces();
+  const indices = new Uint32Array(numFaces * 4);
+  const indicesArray = new decoderModule.DracoInt32Array();
+  for (let i = 0; i < numFaces; i++) {
+    decoder.GetFaceFromMesh(dracoGeometry, i, indicesArray);
+    const index = i * 4;
+    indices[index] = 3;
+    indices[index + 1] = indicesArray.GetValue(0);
+    indices[index + 2] = indicesArray.GetValue(1);
+    indices[index + 3] = indicesArray.GetValue(2);
+  }
+
+  // Create polyData and add positions and indinces
+  const cellArray = vtkCellArray.newInstance({ values: indices });
+  const polyData = vtkPolyData.newInstance();
+  polyData.getPoints().setData(positionArray);
+  polyData.setPolys(cellArray);
+
+  // Look for other attributes
+  // Normals
+  const normalAttributeId = decoder.GetAttributeId(
+    dracoGeometry,
+    decoderModule.NORMAL
+  );
+
+  if (normalAttributeId !== -1) {
+    const normalArray = getDracoAttributeAsFloat32Array(
+      dracoGeometry,
+      decoderModule.NORMAL,
+      decoderModule
+    );
+
+    const normals = vtkDataArray.newInstance({
+      numberOfComponents: 3,
+      values: normalArray,
+      name: 'Normals',
+    });
+    polyData.getPointData().setNormals(normals);
+  }
+
+  // Texture coordinates
+  const texCoordAttributeId = decoder.GetAttributeId(
+    dracoGeometry,
+    decoderModule.TEX_COORD
+  );
+
+  if (texCoordAttributeId !== -1) {
+    const texCoordArray = getDracoAttributeAsFloat32Array(
+      dracoGeometry,
+      texCoordAttributeId,
+      decoderModule
+    );
+
+    const texCoords = vtkDataArray.newInstance({
+      numberOfComponents: 2,
+      values: texCoordArray,
+      name: 'TCoords',
+    });
+    polyData.getPointData().setTCoords(texCoords);
+  }
+
+  // Scalars
+  const colorAttributeId = decoder.GetAttributeId(
+    dracoGeometry,
+    decoderModule.COLOR
+  );
+
+  if (colorAttributeId !== -1) {
+    const colorArray = getDracoAttributeAsFloat32Array(
+      dracoGeometry,
+      colorAttributeId,
+      decoder
+    );
+
+    const scalars = vtkDataArray.newInstance({
+      numberOfComponents: 3,
+      values: colorArray,
+      name: 'Scalars',
+    });
+
+    polyData.getPointData().setScalars(scalars);
+  }
+
+  decoderModule.destroy(decoder);
+  return polyData;
+}
+
+function vtkDracoReader(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkDracoReader');
+
+  // Create default dataAccessHelper if not available
+  if (!model.dataAccessHelper) {
+    model.dataAccessHelper = DataAccessHelper.get('http');
+  }
+
+  // Internal method to fetch Array
+  function fetchData(url, option = {}) {
+    const { compression, progressCallback } = model;
+    if (option.binary) {
+      return model.dataAccessHelper.fetchBinary(url, {
+        compression,
+        progressCallback,
+      });
+    }
+    return model.dataAccessHelper.fetchText(publicAPI, url, {
+      compression,
+      progressCallback,
+    });
+  }
+
+  // Set DataSet url
+  publicAPI.setUrl = (url, option = { binary: true }) => {
+    model.url = url;
+
+    // Remove the file in the URL
+    const path = url.split('/');
+    path.pop();
+    model.baseURL = path.join('/');
+
+    model.compression = option.compression;
+
+    // Fetch metadata
+    return publicAPI.loadData({
+      progressCallback: option.progressCallback,
+      binary: !!option.binary,
+    });
+  };
+
+  // Fetch the actual data arrays
+  publicAPI.loadData = (option = {}) => {
+    const promise = fetchData(model.url, option);
+    promise.then(publicAPI.parse);
+    return promise;
+  };
+
+  publicAPI.parse = (content) => {
+    publicAPI.parseAsArrayBuffer(content);
+  };
+
+  publicAPI.parseAsArrayBuffer = (content) => {
+    if (!content) {
+      return;
+    }
+    if (content !== model.parseData) {
+      publicAPI.modified();
+    } else {
+      return;
+    }
+
+    model.parseData = content;
+    const decoderModule = CreateDracoModule({});
+    const dracoGeometry = decodeBuffer(content, decoderModule);
+    const polyData = getPolyDataFromDracoGeometry(dracoGeometry, decoderModule);
+    decoderModule.destroy(dracoGeometry);
+    model.output[0] = polyData;
+  };
+
+  publicAPI.requestData = (inData, outData) => {
+    publicAPI.parse(model.parseData);
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  // baseURL: null,
+  // dataAccessHelper: null,
+  // url: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Build VTK API
+  macro.obj(publicAPI, model);
+  macro.get(publicAPI, model, ['url', 'baseURL']);
+  macro.setGet(publicAPI, model, ['dataAccessHelper']);
+  macro.algo(publicAPI, model, 0, 1);
+
+  // vtkDracoReader methods
+  vtkDracoReader(publicAPI, model);
+
+  // To support destructuring
+  if (!model.compression) {
+    model.compression = null;
+  }
+  if (!model.progressCallback) {
+    model.progressCallback = null;
+  }
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkDracoReader');
+
+// ----------------------------------------------------------------------------
+
+export default { extend, newInstance };

--- a/Sources/IO/Geometry/index.js
+++ b/Sources/IO/Geometry/index.js
@@ -1,5 +1,7 @@
 import vtkSTLReader from './STLReader';
+import vtkDracoReader from './DracoReader';
 
 export default {
   vtkSTLReader,
+  vtkDracoReader,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8840,6 +8840,11 @@
         }
       }
     },
+    "draco3d": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.3.4.tgz",
+      "integrity": "sha512-I7kAKyiSIb++K5VdWGeIC9xXWkoQ1HZ8wSCQhaRMf41KKxYX5jYmy+rRna/o7o3CrunxvCGbZBl6d6bdWVcJXw=="
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -10739,7 +10744,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11154,7 +11160,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11210,6 +11217,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11253,12 +11261,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "blueimp-md5": "2.10.0",
     "commander": "2.11.0",
+    "draco3d": "1.3.4",
     "gl-matrix": "3.0.0",
     "jszip": "3.1.4",
     "pako": "1.0.6",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -106,6 +106,9 @@ const baseConfig = {
       alwaysNotify: true,
     }),
   ],
+  node: {
+    fs: 'empty',
+  },
 };
 
 // vtk-lite.js


### PR DESCRIPTION
This pull requests adds vtkDracoReader, a reader for (triangle) meshes that were compressed using Google's Draco library.

The reader decodes the draco file, and provides the decoded mesh as vtkPolyData. Supports normals and texture coordinates.

This PR has a dependency to the draco3d package. I'm not certain what the best course of action is to add this dependency.

Draco: https://github.com/google/draco
Note: I lack experience with both JS and vtk.js, so any feedback is welcome.