### PR TITLE
Fix cropping outline

### DIFF
--- a/Sources/Filters/General/OutlineFilter/index.js
+++ b/Sources/Filters/General/OutlineFilter/index.js
@@ -4,7 +4,7 @@ import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 const { vtkErrorMacro } = macro;
 
 // prettier-ignore
-const BOUNDS_MAP = [
+export const BOUNDS_MAP = [
   0, 2, 4, // pt 0
   1, 2, 4, // pt 1
   0, 3, 4, // pt 2
@@ -16,7 +16,7 @@ const BOUNDS_MAP = [
 ];
 
 // prettier-ignore
-const LINE_ARRAY = [
+export const LINE_ARRAY = [
   2, 0, 1,
   2, 2, 3,
   2, 4, 5,
@@ -87,4 +87,4 @@ export const newInstance = macro.newInstance(extend, 'vtkOutlineFilter');
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend };
+export default { newInstance, extend, BOUNDS_MAP, LINE_ARRAY };

--- a/Sources/Widgets/Representations/CroppingOutlineRepresentation/index.js
+++ b/Sources/Widgets/Representations/CroppingOutlineRepresentation/index.js
@@ -1,0 +1,111 @@
+import macro from 'vtk.js/Sources/macro';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ContextRepresentation';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+
+const { vtkErrorMacro } = macro;
+
+// prettier-ignore
+const OUTLINE_ARRAY = [
+  2, 0, 1,
+  2, 0, 2,
+  2, 0, 4,
+  2, 1, 3,
+  2, 1, 5,
+  2, 2, 3,
+  2, 2, 6,
+  2, 3, 7,
+  2, 4, 5,
+  2, 4, 6,
+  2, 5, 7,
+  2, 6, 7,
+];
+
+// ----------------------------------------------------------------------------
+// vtkCroppingOutlineRepresentation methods
+// ----------------------------------------------------------------------------
+
+// Represents a box outline given 8 points as corners.
+// Does not work with an arbitrary set of points. An oriented bounding box
+// algorithm may be implemented in the future.
+function vtkCroppingOutlineRepresentation(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkCroppingOutlineRepresentation');
+
+  // --------------------------------------------------------------------------
+  // Internal polydata dataset
+  // --------------------------------------------------------------------------
+
+  model.internalPolyData = vtkPolyData.newInstance({ mtime: 0 });
+  model.points = new Float32Array(8 * 3);
+  model.internalPolyData.getPoints().setData(model.points, 3);
+  model.internalPolyData.getLines().setData(Uint16Array.from(OUTLINE_ARRAY));
+
+  // --------------------------------------------------------------------------
+  // Generic rendering pipeline
+  // --------------------------------------------------------------------------
+
+  model.mapper = vtkMapper.newInstance({
+    scalarVisibility: false,
+  });
+  model.actor = vtkActor.newInstance();
+  model.actor.getProperty().setEdgeColor(...model.edgeColor);
+  model.mapper.setInputConnection(publicAPI.getOutputPort());
+  model.actor.setMapper(model.mapper);
+
+  model.actors.push(model.actor);
+
+  // --------------------------------------------------------------------------
+
+  publicAPI.requestData = (inData, outData) => {
+    const list = publicAPI.getRepresentationStates(inData[0]);
+    if (list.length === 8) {
+      let pi = 0;
+      for (let i = 0; i < list.length; i++) {
+        const pt = list[i].getOrigin();
+        model.points[pi++] = pt[0];
+        model.points[pi++] = pt[1];
+        model.points[pi++] = pt[2];
+      }
+      model.internalPolyData.getPoints().modified();
+      model.internalPolyData.modified();
+
+      outData[0] = model.internalPolyData;
+    } else {
+      vtkErrorMacro('CroppingOutlineRepresentation did not get 8 states');
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  edgeColor: [1, 1, 1],
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  vtkContextRepresentation.extend(publicAPI, model, initialValues);
+  macro.setGetArray(publicAPI, model, ['edgeColor'], 3);
+  macro.get(publicAPI, model, ['mapper', 'actor']);
+
+  // Object specific methods
+  vtkCroppingOutlineRepresentation(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(
+  extend,
+  'vtkCroppingOutlineRepresentation'
+);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
@@ -1,0 +1,127 @@
+import macro from 'vtk.js/Sources/macro';
+
+import {
+  AXES,
+  transformVec3,
+  handleTypeFromName,
+} from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers';
+
+export default function widgetBehavior(publicAPI, model) {
+  let isDragging = null;
+
+  publicAPI.setDisplayCallback = (callback) =>
+    model.representations[0].setDisplayCallback(callback);
+
+  publicAPI.handleLeftButtonPress = () => {
+    if (
+      !model.activeState ||
+      !model.activeState.getActive() ||
+      !model.pickable
+    ) {
+      return macro.VOID;
+    }
+    isDragging = true;
+    model.interactor.requestAnimation(publicAPI);
+    return macro.EVENT_ABORT;
+  };
+
+  publicAPI.handleMouseMove = (callData) => {
+    if (isDragging && model.pickable) {
+      return publicAPI.handleEvent(callData);
+    }
+    return macro.VOID;
+  };
+
+  publicAPI.handleLeftButtonRelease = () => {
+    if (isDragging && model.pickable) {
+      isDragging = false;
+      model.interactor.cancelAnimation(publicAPI);
+      model.widgetState.deactivate();
+    }
+  };
+
+  publicAPI.handleEvent = (callData) => {
+    if (model.pickable && model.activeState && model.activeState.getActive()) {
+      const manipulator = model.activeState.getManipulator();
+      if (manipulator) {
+        const name = model.activeState.getName();
+        const type = handleTypeFromName(name);
+        const index = name.split('').map((l) => AXES.indexOf(l));
+        const planes = model.widgetState.getCroppingPlanes().getPlanes();
+        const indexToWorldT = model.widgetState.getIndexToWorldT();
+
+        let worldCoords = [];
+
+        if (type === 'corners') {
+          // manipulator should be a plane manipulator
+          manipulator.setNormal(model.camera.getDirectionOfProjection());
+          worldCoords = manipulator.handleEvent(
+            callData,
+            model.openGLRenderWindow
+          );
+        }
+
+        if (type === 'faces') {
+          // constraint axis is line defined by the index and center point.
+          // Since our index point is defined inside a box [0, 2, 0, 2, 0, 2],
+          // center point is [1, 1, 1].
+          const constraintAxis = [1 - index[0], 1 - index[1], 1 - index[2]];
+
+          // get center of current crop box
+          const center = [
+            (planes[0] + planes[1]) / 2,
+            (planes[2] + planes[3]) / 2,
+            (planes[4] + planes[5]) / 2,
+          ];
+
+          // manipulator should be a line manipulator
+          manipulator.setOrigin(transformVec3(center, indexToWorldT));
+          manipulator.setNormal(transformVec3(constraintAxis, indexToWorldT));
+          worldCoords = manipulator.handleEvent(
+            callData,
+            model.openGLRenderWindow
+          );
+        }
+
+        if (type === 'edges') {
+          // constrain to a plane with a normal parallel to the edge
+          const edgeAxis = index.map((a) => (a === 1 ? a : 0));
+
+          manipulator.setNormal(transformVec3(edgeAxis, indexToWorldT));
+          worldCoords = manipulator.handleEvent(
+            callData,
+            model.openGLRenderWindow
+          );
+        }
+
+        if (worldCoords.length) {
+          // transform worldCoords to indexCoords, and then update the croppingPlanes() state with setPlanes().
+          const worldToIndexT = model.widgetState.getWorldToIndexT();
+          const indexCoords = transformVec3(worldCoords, worldToIndexT);
+
+          for (let i = 0; i < 3; i++) {
+            if (index[i] === 0) {
+              planes[i * 2] = indexCoords[i];
+            } else if (index[i] === 2) {
+              planes[i * 2 + 1] = indexCoords[i];
+            }
+          }
+
+          model.activeState.setOrigin(...worldCoords);
+          model.widgetState.getCroppingPlanes().setPlanes(...planes);
+
+          return macro.EVENT_ABORT;
+        }
+      }
+    }
+    return macro.VOID;
+  };
+
+  // --------------------------------------------------------------------------
+  // initialization
+  // --------------------------------------------------------------------------
+
+  model.camera = model.renderer.getActiveCamera();
+
+  model.classHierarchy.push('vtkImageCroppingWidgetProp');
+}

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers.js
@@ -1,0 +1,26 @@
+import { vec3 } from 'gl-matrix';
+
+// Labels used to encode handle position in the handle state's name property
+export const AXES = ['-', '=', '+'];
+
+// ----------------------------------------------------------------------------
+
+export function transformVec3(ain, transform) {
+  const vin = vec3.fromValues(ain[0], ain[1], ain[2]);
+  const vout = vec3.create();
+  vec3.transformMat4(vout, vin, transform);
+  return [vout[0], vout[1], vout[2]];
+}
+
+// ----------------------------------------------------------------------------
+
+export function handleTypeFromName(name) {
+  const [i, j, k] = name.split('').map((l) => AXES.indexOf(l) - 1);
+  if (i * j * k !== 0) {
+    return 'corners';
+  }
+  if (i * j !== 0 || j * k !== 0 || k * i !== 0) {
+    return 'edges';
+  }
+  return 'faces';
+}

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
@@ -1,163 +1,21 @@
-import { vec3 } from 'gl-matrix';
-
 import macro from 'vtk.js/Sources/macro';
 import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidgetFactory';
 import vtkPlaneManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
 import vtkLineManipulator from 'vtk.js/Sources/Widgets/Manipulators/LineManipulator';
 import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
 import vtkCroppingOutlineRepresentation from 'vtk.js/Sources/Widgets/Representations/CroppingOutlineRepresentation';
-import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+
+import behavior from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior';
+import state from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget/state';
+
+import {
+  AXES,
+  transformVec3,
+} from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers';
 
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
-// Labels used to encode handle position in the handle state's name property
-const AXES = ['-', '=', '+'];
-
 // ----------------------------------------------------------------------------
-
-function transformVec3(ain, transform) {
-  const vin = vec3.fromValues(ain[0], ain[1], ain[2]);
-  const vout = vec3.create();
-  vec3.transformMat4(vout, vin, transform);
-  return [vout[0], vout[1], vout[2]];
-}
-
-// ----------------------------------------------------------------------------
-
-function handleTypeFromName(name) {
-  const [i, j, k] = name.split('').map((l) => AXES.indexOf(l) - 1);
-  if (i * j * k !== 0) {
-    return 'corners';
-  }
-  if (i * j !== 0 || j * k !== 0 || k * i !== 0) {
-    return 'edges';
-  }
-  return 'faces';
-}
-
-// ----------------------------------------------------------------------------
-// Widget linked to a view
-// ----------------------------------------------------------------------------
-
-function widgetBehavior(publicAPI, model) {
-  let isDragging = null;
-
-  publicAPI.setDisplayCallback = (callback) =>
-    model.representations[0].setDisplayCallback(callback);
-
-  publicAPI.handleLeftButtonPress = () => {
-    if (
-      !model.activeState ||
-      !model.activeState.getActive() ||
-      !model.pickable
-    ) {
-      return macro.VOID;
-    }
-    isDragging = true;
-    model.interactor.requestAnimation(publicAPI);
-    return macro.EVENT_ABORT;
-  };
-
-  publicAPI.handleMouseMove = (callData) => {
-    if (isDragging && model.pickable) {
-      return publicAPI.handleEvent(callData);
-    }
-    return macro.VOID;
-  };
-
-  publicAPI.handleLeftButtonRelease = () => {
-    if (isDragging && model.pickable) {
-      isDragging = false;
-      model.interactor.cancelAnimation(publicAPI);
-      model.widgetState.deactivate();
-    }
-  };
-
-  publicAPI.handleEvent = (callData) => {
-    if (model.pickable && model.activeState && model.activeState.getActive()) {
-      const manipulator = model.activeState.getManipulator();
-      if (manipulator) {
-        const name = model.activeState.getName();
-        const type = handleTypeFromName(name);
-        const index = name.split('').map((l) => AXES.indexOf(l));
-        const planes = model.widgetState.getCroppingPlanes().getPlanes();
-        const indexToWorldT = model.widgetState.getIndexToWorldT();
-
-        let worldCoords = [];
-
-        if (type === 'corners') {
-          // manipulator should be a plane manipulator
-          manipulator.setNormal(model.camera.getDirectionOfProjection());
-          worldCoords = manipulator.handleEvent(
-            callData,
-            model.openGLRenderWindow
-          );
-        }
-
-        if (type === 'faces') {
-          // constraint axis is line defined by the index and center point.
-          // Since our index point is defined inside a box [0, 2, 0, 2, 0, 2],
-          // center point is [1, 1, 1].
-          const constraintAxis = [1 - index[0], 1 - index[1], 1 - index[2]];
-
-          // get center of current crop box
-          const center = [
-            (planes[0] + planes[1]) / 2,
-            (planes[2] + planes[3]) / 2,
-            (planes[4] + planes[5]) / 2,
-          ];
-
-          // manipulator should be a line manipulator
-          manipulator.setOrigin(transformVec3(center, indexToWorldT));
-          manipulator.setNormal(transformVec3(constraintAxis, indexToWorldT));
-          worldCoords = manipulator.handleEvent(
-            callData,
-            model.openGLRenderWindow
-          );
-        }
-
-        if (type === 'edges') {
-          // constrain to a plane with a normal parallel to the edge
-          const edgeAxis = index.map((a) => (a === 1 ? a : 0));
-
-          manipulator.setNormal(transformVec3(edgeAxis, indexToWorldT));
-          worldCoords = manipulator.handleEvent(
-            callData,
-            model.openGLRenderWindow
-          );
-        }
-
-        if (worldCoords.length) {
-          // transform worldCoords to indexCoords, and then update the croppingPlanes() state with setPlanes().
-          const worldToIndexT = model.widgetState.getWorldToIndexT();
-          const indexCoords = transformVec3(worldCoords, worldToIndexT);
-
-          for (let i = 0; i < 3; i++) {
-            if (index[i] === 0) {
-              planes[i * 2] = indexCoords[i];
-            } else if (index[i] === 2) {
-              planes[i * 2 + 1] = indexCoords[i];
-            }
-          }
-
-          model.activeState.setOrigin(...worldCoords);
-          model.widgetState.getCroppingPlanes().setPlanes(...planes);
-
-          return macro.EVENT_ABORT;
-        }
-      }
-    }
-    return macro.VOID;
-  };
-
-  // --------------------------------------------------------------------------
-  // initialization
-  // --------------------------------------------------------------------------
-
-  model.camera = model.renderer.getActiveCamera();
-
-  model.classHierarchy.push('vtkImageCroppingWidgetProp');
-}
 
 // ----------------------------------------------------------------------------
 // Factory
@@ -209,12 +67,13 @@ function vtkImageCroppingWidget(publicAPI, model) {
     const kAxis = [planes[4], midpts[2], planes[5]];
 
     const indexToWorldT = model.widgetState.getIndexToWorldT();
+    const getAxis = (a) => AXES[a];
     for (let i = 0; i < 3; i++) {
       for (let j = 0; j < 3; j++) {
         for (let k = 0; k < 3; k++) {
           // skip center of box
           if (i !== 1 || j !== 1 || k !== 1) {
-            const name = [i, j, k].map((a) => AXES[a]).join('');
+            const name = [i, j, k].map(getAxis).join('');
             const coord = transformVec3(
               [iAxis[i], jAxis[j], kAxis[k]],
               indexToWorldT
@@ -229,7 +88,9 @@ function vtkImageCroppingWidget(publicAPI, model) {
   };
 
   // --- Widget Requirement ---------------------------------------------------
-  model.behavior = widgetBehavior;
+
+  model.behavior = behavior;
+  model.widgetState = state();
 
   // Given a view type (geometry, slice, volume), return a description
   // of what representations to create and what widget state to pass
@@ -255,80 +116,8 @@ function vtkImageCroppingWidget(publicAPI, model) {
     }
   };
 
-  // --- Widget Requirement ---------------------------------------------------
-
-  // create our state builder
-  const builder = vtkStateBuilder.createBuilder();
-
-  // add image data description fields
-  builder
-    .addField({
-      name: 'indexToWorldT',
-      initialValue: Array(16).fill(0),
-    })
-    .addField({
-      name: 'worldToIndexT',
-      initialValue: Array(16).fill(0),
-    });
-
-  // make cropping planes a sub-state so we can listen to it
-  // separately from the rest of the widget state.
-  const croppingState = vtkStateBuilder
-    .createBuilder()
-    .addField({
-      name: 'planes',
-      // index space
-      initialValue: [0, 1, 0, 1, 0, 1],
-    })
-    .build();
-
-  // add cropping planes state to our primary state
-  builder.addStateFromInstance({
-    labels: ['croppingPlanes'],
-    name: 'croppingPlanes',
-    instance: croppingState,
-  });
-
-  // add all handle states
-  // default bounds is [-1, 1] in all dimensions
-  for (let i = -1; i < 2; i++) {
-    for (let j = -1; j < 2; j++) {
-      for (let k = -1; k < 2; k++) {
-        // skip center of box
-        if (i !== 0 || j !== 0 || k !== 0) {
-          const name = AXES[i + 1] + AXES[j + 1] + AXES[k + 1];
-          const type = handleTypeFromName(name);
-
-          // since handle states are rendered via vtkSphereHandleRepresentation,
-          // we can dictate the handle origin, size (scale1), color, and visibility.
-          builder.addStateFromMixin({
-            labels: ['handles', name, type],
-            mixins: [
-              'name',
-              'origin',
-              'color',
-              'scale1',
-              'visible',
-              'manipulator',
-            ],
-            name,
-            initialValues: {
-              scale1: 10,
-              origin: [i, j, k],
-              visible: true,
-              name,
-            },
-          });
-        }
-      }
-    }
-  }
-
-  // construct our state from the fields and sub-state descriptions.
-  model.widgetState = builder.build();
-
   // Update handle positions when cropping planes update
-  croppingState.onModified(publicAPI.updateHandles);
+  model.widgetState.getCroppingPlanes().onModified(publicAPI.updateHandles);
 
   // Add manipulators to our widgets.
   const planeManipulator = vtkPlaneManipulator.newInstance();

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
@@ -5,7 +5,7 @@ import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidget
 import vtkPlaneManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
 import vtkLineManipulator from 'vtk.js/Sources/Widgets/Manipulators/LineManipulator';
 import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
-import vtkOutlineContextRepresentation from 'vtk.js/Sources/Widgets/Representations/OutlineContextRepresentation';
+import vtkCroppingOutlineRepresentation from 'vtk.js/Sources/Widgets/Representations/CroppingOutlineRepresentation';
 import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
 
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
@@ -247,7 +247,7 @@ function vtkImageCroppingWidget(publicAPI, model) {
           // a list of all handle states (which have the label "handles").
           { builder: vtkSphereHandleRepresentation, labels: ['handles'] },
           {
-            builder: vtkOutlineContextRepresentation,
+            builder: vtkCroppingOutlineRepresentation,
             // outline is defined by corner points
             labels: ['corners'],
           },

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/state.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/state.js
@@ -1,0 +1,75 @@
+import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+
+import {
+  AXES,
+  handleTypeFromName,
+} from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers';
+
+// create our state builder
+const builder = vtkStateBuilder.createBuilder();
+
+// add image data description fields
+builder
+  .addField({
+    name: 'indexToWorldT',
+    initialValue: Array(16).fill(0),
+  })
+  .addField({
+    name: 'worldToIndexT',
+    initialValue: Array(16).fill(0),
+  });
+
+// make cropping planes a sub-state so we can listen to it
+// separately from the rest of the widget state.
+const croppingState = vtkStateBuilder
+  .createBuilder()
+  .addField({
+    name: 'planes',
+    // index space
+    initialValue: [0, 1, 0, 1, 0, 1],
+  })
+  .build();
+
+// add cropping planes state to our primary state
+builder.addStateFromInstance({
+  labels: ['croppingPlanes'],
+  name: 'croppingPlanes',
+  instance: croppingState,
+});
+
+// add all handle states
+// default bounds is [-1, 1] in all dimensions
+for (let i = -1; i < 2; i++) {
+  for (let j = -1; j < 2; j++) {
+    for (let k = -1; k < 2; k++) {
+      // skip center of box
+      if (i !== 0 || j !== 0 || k !== 0) {
+        const name = AXES[i + 1] + AXES[j + 1] + AXES[k + 1];
+        const type = handleTypeFromName(name);
+
+        // since handle states are rendered via vtkSphereHandleRepresentation,
+        // we can dictate the handle origin, size (scale1), color, and visibility.
+        builder.addStateFromMixin({
+          labels: ['handles', name, type],
+          mixins: [
+            'name',
+            'origin',
+            'color',
+            'scale1',
+            'visible',
+            'manipulator',
+          ],
+          name,
+          initialValues: {
+            scale1: 10,
+            origin: [i, j, k],
+            visible: true,
+            name,
+          },
+        });
+      }
+    }
+  }
+}
+
+export default () => builder.build();


### PR DESCRIPTION
This creates CroppingOutlineRepresentation just for the ImageCroppingWidget and makes OutlineContextRepresentation use bounding box.

Bounding box doesn't work for oriented images, so we have CroppingOutlineRepresentation to show the cropping for an oriented image.

Also exports the bounds map and line array from outline filter.