### PR TITLE
feat: 🎸 setRange functionality for DataArray

### DIFF
--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -162,6 +162,19 @@ function vtkDataArray(publicAPI, model) {
     return model.rangeTuple;
   };
 
+  publicAPI.setRange = (rangeValue, componentIndex) => {
+    if (!model.ranges) {
+      model.ranges = ensureRangeSize(model.ranges, model.numberOfComponents);
+    }
+    const range = { min: rangeValue.min, max: rangeValue.max };
+
+    model.ranges[componentIndex] = range;
+    model.rangeTuple[0] = range.min;
+    model.rangeTuple[1] = range.max;
+
+    return model.rangeTuple;
+  };
+
   publicAPI.setTuple = (idx, tuple) => {
     const offset = idx * model.numberOfComponents;
     for (let i = 0; i < model.numberOfComponents; i++) {


### PR DESCRIPTION
Allows a provider to set the range of a DataArray after its construction. This is useful if you are don't know the value a priori, so can't set it on construction, but have it external to vtkjs by the time you wish to make calls to `getRange`.

For example in my current usecase I am filling up the data array as it comes from an external source, and wish to set the range as the buffer is filled.