### PR TITLE
feat: Add coordinate shift/scale to PolyDataMapper

### DIFF
--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/api.md
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/api.md
@@ -40,3 +40,19 @@ The offset in bytes from the start of an element and the color data
 ### colorComponents
 
 The number of components in a color value typically 4
+
+###   getCoordShift = ()
+###   getCoordScale = ()
+###   getInverseShiftAndScaleMatrix = ()
+
+Get the shift and scale vectors computed by createVBO(), as well as the inverse transform to apply to the rendering transform.
+
+###   getCoordShiftAndScaleEnabled = ()
+
+Get a boolean indicating whether the shift and scale vectors are currently being applied to the coordinates.
+createVBO() only applies shift and scale if one of the following conditions are met:
+* If the data is far from the origin relative to its size
+* If the size is huge when not far from the origin
+* If data is a point, but far from the origin
+
+This is necessary as OpenGL ES 2.0 does not support double precision data types.

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -358,6 +358,13 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     const keyMats = model.openGLCamera.getKeyMatrices(ren);
     mat4.multiply(model.imagemat, keyMats.wcdc, model.imagemat);
 
+    if (cellBO.getCABO().getCoordShiftAndScaleEnabled()) {
+      const inverseShiftScaleMat = cellBO
+        .getCABO()
+        .getInverseShiftAndScaleMatrix();
+      mat4.multiply(model.imagemat, model.imagemat, inverseShiftScaleMat);
+    }
+
     program.setUniformMatrix('MCDCMatrix', model.imagemat);
   };
 


### PR DESCRIPTION
This implements coordinate shifting/scaling in vtk-js, similarly to the way it is currently implemented in VTK.

This fixes issues with large coordinates:

Before:
![image](https://user-images.githubusercontent.com/1732912/67304053-937a3200-f4f3-11e9-826b-8243c6444f95.png)

After: 
![image](https://user-images.githubusercontent.com/1732912/67304198-c3c1d080-f4f3-11e9-8d55-7c891250e100.png)

re: #1217

Attached: [test data](https://github.com/Kitware/vtk-js/files/3756779/TestMeshNotFollowingGeometryFix-mesh.vtp.tar.gz)  from #1217

