### PR TITLE
fix(Manipulators): Ensure manipulators aren't null

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -179,74 +179,50 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
   };
 
   //-------------------------------------------------------------------------
-  publicAPI.removeMouseManipulator = (index) => {
-    if (model.mouseManipulators.length > index) {
-      model.mouseManipulators[index] = null;
+  const removeManipulator = (manipulator, list) => {
+    const index = list.indexOf(manipulator);
+    if (index === -1) {
+      return false;
     }
+    list.splice(index, 1);
+    publicAPI.modified();
+    return true;
   };
 
   //-------------------------------------------------------------------------
-  publicAPI.removeVRManipulator = (index) => {
-    if (model.vrManipulators.length > index) {
-      model.vrManipulators[index] = null;
+  publicAPI.removeMouseManipulator = (manipulator) =>
+    removeManipulator(manipulator, model.mouseManipulators);
+
+  //-------------------------------------------------------------------------
+  publicAPI.removeVRManipulator = (manipulator) =>
+    removeManipulator(manipulator, model.vrManipulators);
+
+  //-------------------------------------------------------------------------
+  publicAPI.removeGestureManipulator = (manipulator) =>
+    removeManipulator(manipulator, model.gestureManipulators);
+
+  //-------------------------------------------------------------------------
+  const addManipulator = (manipulator, list) => {
+    const index = list.indexOf(manipulator);
+    if (index !== -1) {
+      return false;
     }
+    list.push(manipulator);
+    publicAPI.modified();
+    return true;
   };
 
   //-------------------------------------------------------------------------
-  publicAPI.removeGestureManipulator = (index) => {
-    if (model.gestureManipulators.length > index) {
-      model.gestureManipulators[index] = null;
-    }
-  };
+  publicAPI.addMouseManipulator = (manipulator) =>
+    addManipulator(manipulator, model.mouseManipulators);
 
   //-------------------------------------------------------------------------
-  publicAPI.getMouseManipulator = (index) => {
-    let manipulator = null;
-    if (model.mouseManipulators.length > index) {
-      manipulator = model.mouseManipulators[index];
-    }
-    return manipulator;
-  };
+  publicAPI.addVRManipulator = (manipulator) =>
+    addManipulator(manipulator, model.vrManipulators);
 
   //-------------------------------------------------------------------------
-  publicAPI.getVRManipulator = (index) => {
-    let manipulator = null;
-    if (model.vrManipulators.length > index) {
-      manipulator = model.vrManipulators[index];
-    }
-    return manipulator;
-  };
-
-  //-------------------------------------------------------------------------
-  publicAPI.getGestureManipulator = (index) => {
-    let manipulator = null;
-    if (model.gestureManipulators.length > index) {
-      manipulator = model.gestureManipulators[index];
-    }
-    return manipulator;
-  };
-
-  //-------------------------------------------------------------------------
-  publicAPI.addMouseManipulator = (manipulator) => {
-    const index = model.mouseManipulators.length;
-    model.mouseManipulators.push(manipulator);
-    return index;
-  };
-
-  //-------------------------------------------------------------------------
-  publicAPI.addVRManipulator = (manipulator) => {
-    const index = model.vrManipulators.length;
-    model.vrManipulators.push(manipulator);
-    return index;
-  };
-
-  //-------------------------------------------------------------------------
-  publicAPI.addGestureManipulator = (manipulator) => {
-    const index = model.gestureManipulators.length;
-    model.gestureManipulators.push(manipulator);
-    manipulator.setInteractorStyle(publicAPI);
-    return index;
-  };
+  publicAPI.addGestureManipulator = (manipulator) =>
+    addManipulator(manipulator, model.gestureManipulators);
 
   //-------------------------------------------------------------------------
   publicAPI.getNumberOfMouseManipulators = () => model.mouseManipulators.length;

--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -439,6 +439,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     while (count--) {
       const manip = model.mouseManipulators[count];
       if (
+        manip &&
         manip.isScrollEnabled() &&
         manip.getShift() === callData.shiftKey &&
         manip.getControl() === callData.controlKey &&
@@ -530,7 +531,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let count = model.gestureManipulators.length;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isPinchEnabled()) {
+      if (manipulator && manipulator.isPinchEnabled()) {
         manipulator.onStartPinch(model.interactor, callData.scale);
         manipulator.startInteraction();
       }
@@ -545,7 +546,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let count = model.gestureManipulators.length;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isPinchEnabled()) {
+      if (manipulator && manipulator.isPinchEnabled()) {
         manipulator.onEndPinch(model.interactor);
         manipulator.endInteraction();
       }
@@ -560,7 +561,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let count = model.gestureManipulators.length;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isRotateEnabled()) {
+      if (manipulator && manipulator.isRotateEnabled()) {
         manipulator.onStartRotate(model.interactor, callData.rotation);
         manipulator.startInteraction();
       }
@@ -575,7 +576,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let count = model.gestureManipulators.length;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isRotateEnabled()) {
+      if (manipulator && manipulator.isRotateEnabled()) {
         manipulator.onEndRotate(model.interactor);
         manipulator.endInteraction();
       }
@@ -590,7 +591,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let count = model.gestureManipulators.length;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isPanEnabled()) {
+      if (manipulator && manipulator.isPanEnabled()) {
         manipulator.onStartPan(model.interactor, callData.translation);
         manipulator.startInteraction();
       }
@@ -605,7 +606,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let count = model.gestureManipulators.length;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isPanEnabled()) {
+      if (manipulator && manipulator.isPanEnabled()) {
         manipulator.onEndPan(model.interactor);
         manipulator.endInteraction();
       }
@@ -620,7 +621,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let actionCount = 0;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isPinchEnabled()) {
+      if (manipulator && manipulator.isPinchEnabled()) {
         manipulator.onPinch(
           model.interactor,
           callData.pokedRenderer,
@@ -640,7 +641,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let actionCount = 0;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isPanEnabled()) {
+      if (manipulator && manipulator.isPanEnabled()) {
         manipulator.onPan(
           model.interactor,
           callData.pokedRenderer,
@@ -660,7 +661,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     let actionCount = 0;
     while (count--) {
       const manipulator = model.gestureManipulators[count];
-      if (manipulator.isRotateEnabled()) {
+      if (manipulator && manipulator.isRotateEnabled()) {
         manipulator.onRotate(
           model.interactor,
           callData.pokedRenderer,


### PR DESCRIPTION
The array of manipulators can have `null` values since[ removing a manipulator will not remove its key from the list, but only set its value to `null`](https://github.com/Kitware/vtk-js/blob/a96658a/Sources/Interaction/Style/InteractorStyleManipulator/index.js#L181-L200).


Another fix instead would be to change the behavior of those `removeGesture` functions to actually remove the key/value and not just set the value to `null`, I can do that if you'd prefer @jourdain.