### PR TITLE
Tweak hardware selector picking

### DIFF
--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -191,8 +191,8 @@ function vtkViewProxy(publicAPI, model) {
         return;
       }
       const devicePixelRatio = window.devicePixelRatio || 1;
-      const width = Math.max(10, devicePixelRatio * Math.floor(dims.width));
-      const height = Math.max(10, devicePixelRatio * Math.floor(dims.height));
+      const width = Math.max(10, Math.floor(devicePixelRatio * dims.width));
+      const height = Math.max(10, Math.floor(devicePixelRatio * dims.height));
       model.openglRenderWindow.setSize(width, height);
       publicAPI.invokeResize({ width, height });
       publicAPI.renderLater();

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -396,7 +396,12 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
   publicAPI.getInfoHash = (info) => `${info.propID} ${info.compositeID}`;
 
   //----------------------------------------------------------------------------
-  publicAPI.generateSelection = (x1, y1, x2, y2) => {
+  publicAPI.generateSelection = (fx1, fy1, fx2, fy2) => {
+    const x1 = Math.floor(fx1);
+    const y1 = Math.floor(fy1);
+    const x2 = Math.floor(fx2);
+    const y2 = Math.floor(fy2);
+
     const dataMap = new Map();
 
     const outSelectedPosition = [0, 0];
@@ -427,9 +432,26 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
     return publicAPI.convertSelection(model.fieldAssociation, dataMap);
   };
 
+  //----------------------------------------------------------------------------
+
   publicAPI.attach = (w, r) => {
     model.openGLRenderWindow = w;
     model.renderer = r;
+  };
+
+  //----------------------------------------------------------------------------
+
+  // override
+  const superSetArea = publicAPI.setArea;
+  publicAPI.setArea = (...args) => {
+    if (superSetArea(...args)) {
+      model.area[0] = Math.floor(model.area[0]);
+      model.area[1] = Math.floor(model.area[1]);
+      model.area[2] = Math.floor(model.area[2]);
+      model.area[3] = Math.floor(model.area[3]);
+      return true;
+    }
+    return false;
   };
 }
 

--- a/Sources/Widgets/Core/WidgetManager/Constants.js
+++ b/Sources/Widgets/Core/WidgetManager/Constants.js
@@ -10,7 +10,13 @@ export const RenderingTypes = {
   FRONT_BUFFER: 1,
 };
 
+export const CaptureOn = {
+  MOUSE_MOVE: 0,
+  MOUSE_RELEASE: 1,
+};
+
 export default {
   ViewTypes,
   RenderingTypes,
+  CaptureOn,
 };

--- a/Sources/Widgets/Core/WidgetManager/example/index.js
+++ b/Sources/Widgets/Core/WidgetManager/example/index.js
@@ -76,6 +76,7 @@ renderWindow.render();
 // ----------------------------------------------------------------------------
 
 const widgetManager = vtkWidgetManager.newInstance();
+widgetManager.setDeferredCapture(true);
 widgetManager.setRenderer(renderer);
 
 // -----------------------------------------------------------

--- a/Sources/Widgets/Core/WidgetManager/example/index.js
+++ b/Sources/Widgets/Core/WidgetManager/example/index.js
@@ -2,6 +2,7 @@ import 'vtk.js/Sources/favicon';
 
 import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
 import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import WidgetManagerConstants from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
@@ -12,6 +13,8 @@ import vtkImplicitPlaneWidget from 'vtk.js/Sources/Widgets/Widgets3D/ImplicitPla
 import vtkPolyLineWidget from 'vtk.js/Sources/Widgets/Widgets3D/PolyLineWidget';
 
 import controlPanel from './controlPanel.html';
+
+const { CaptureOn } = WidgetManagerConstants;
 
 const WIDGET_BUILDERS = {
   Box(widgetManager) {
@@ -76,7 +79,7 @@ renderWindow.render();
 // ----------------------------------------------------------------------------
 
 const widgetManager = vtkWidgetManager.newInstance();
-widgetManager.setDeferredCapture(true);
+widgetManager.setCaptureOn(CaptureOn.MOUSE_RELEASE); // default
 widgetManager.setRenderer(renderer);
 
 // -----------------------------------------------------------


### PR DESCRIPTION
Adds `captureOn` option. When it is `CaptureOn.MOUSE_RELEASE`, capture will take place at end of scene animation, and will capture entire buffer. When it is `CaptureOn.MOUSE_MOVE`, capture will take place when mouse moves, and will capture just the pixel under the mouse cursor. Default value is MOUSE_RELEASE.

Addresses https://github.com/Kitware/paraview-glance/issues/270