### PR TITLE
fix(HardwareSelector): Existing framebuffer not being bound to context

### DIFF
--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -35,6 +35,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
       model.framebuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
       model.framebuffer.saveCurrentBindingsAndBuffers();
       model.framebuffer.create(size[0], size[1]);
+      // this calls model.framebuffer.bind()
       model.framebuffer.populateFramebuffer();
     } else {
       model.framebuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
@@ -42,7 +43,10 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
       const fbSize = model.framebuffer.getSize();
       if (fbSize[0] !== size[0] || fbSize[1] !== size[1]) {
         model.framebuffer.create(size[0], size[1]);
+        // this calls model.framebuffer.bind()
         model.framebuffer.populateFramebuffer();
+      } else {
+        model.framebuffer.bind();
       }
     }
 


### PR DESCRIPTION
This fixes an issue where the color picking buffer is antialiased when it shouldn't be, since beginSelection() wasn't binding the existing framebuffer.