### PR TITLE
fix(ImageData): Support setDirection with Float32Array

### DIFF
--- a/Sources/Common/DataModel/ImageData/index.js
+++ b/Sources/Common/DataModel/ImageData/index.js
@@ -276,7 +276,12 @@ function vtkImageData(publicAPI, model) {
 
     let array = args;
     // allow an array passed as a single arg.
-    if (array.length === 1 && Array.isArray(array[0])) {
+    if (
+      array.length === 1 &&
+      (Array.isArray(array[0]) ||
+        array[0].constructor === Float32Array ||
+        array[0].constructor === Float64Array)
+    ) {
       array = array[0];
     }
 


### PR DESCRIPTION
Enables the use case:

  image2.setDirection(image1.getDirection())