### PR TITLE
feat(WidgetManager): Split render method out from enablePicking

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -194,18 +194,20 @@ function vtkWidgetManager(publicAPI, model) {
 
   publicAPI.enablePicking = () => {
     model.pickingEnabled = true;
+    model.pickingAvailable = true;
+    publicAPI.renderWidgets();
+  };
 
-    model.renderingType = RenderingTypes.PICKING_BUFFER;
-    model.widgets.forEach(updateWidgetForRender);
+  publicAPI.renderWidgets = () => {
+    if (model.pickingEnabled && model.captureOn === CaptureOn.MOUSE_RELEASE) {
+      model.renderingType = RenderingTypes.PICKING_BUFFER;
+      model.widgets.forEach(updateWidgetForRender);
 
-    if (model.captureOn === CaptureOn.MOUSE_RELEASE) {
       const [w, h] = model.openGLRenderWindow.getSize();
       model.selector.setArea(0, 0, w, h);
       model.selector.releasePixBuffers();
       model.pickingAvailable = model.selector.captureBuffers();
       model.previousSelectedData = null;
-    } else {
-      model.pickingAvailable = true;
     }
 
     model.renderingType = RenderingTypes.FRONT_BUFFER;


### PR DESCRIPTION
This will allow for visually rendering widgets without having picking
enabled. In addition, this creates a clearly named method for rendering
widgets when some representation property has changed, e.g. SVG circle
color.