### PR TITLE
feat(InteractionPresets): Add first person interaction preset

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleManipulator/Presets.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/Presets.js
@@ -11,6 +11,8 @@ const MANIPULTOR_TYPES = {
   range: Manipulators.vtkMouseRangeManipulator,
   vrPan: Manipulators.vtkVRButtonPanManipulator,
   gestureCamera: Manipulators.vtkGestureCameraManipulator,
+  movement: Manipulators.vtkKeyboardCameraManipulator,
+  freeLook: Manipulators.vtkMouseCameraTrackballFirstPersonManipulator,
 };
 
 const STYLES = {
@@ -38,6 +40,7 @@ const STYLES = {
     { type: 'vrPan' },
     { type: 'gestureCamera' },
   ],
+  FirstPerson: [{ type: 'movement' }, { type: 'freeLook' }],
 };
 
 function applyDefinitions(definitions, manipulatorStyle) {
@@ -51,6 +54,8 @@ function applyDefinitions(definitions, manipulatorStyle) {
       manipulatorStyle.addVRManipulator(instance);
     } else if (instance.isA('vtkCompositeGestureManipulator')) {
       manipulatorStyle.addGestureManipulator(instance);
+    } else if (instance.isA('vtkCompositeKeyboardManipulator')) {
+      manipulatorStyle.addKeyboardManipulator(instance);
     } else {
       manipulatorStyle.addMouseManipulator(instance);
     }

--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -723,6 +723,12 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Create get-set macros
   macro.setGet(publicAPI, model, ['rotationFactor']);
+  macro.get(publicAPI, model, [
+    'mouseManipulators',
+    'keyboardManipulators',
+    'vrManipulators',
+    'gestureManipulators',
+  ]);
 
   macro.setGetArray(publicAPI, model, ['centerOfRotation'], 3);
 


### PR DESCRIPTION
The first person interaction preset uses the keyboard for movement, and the mouse for "free look"
style camera interactions. This PR also provides a way to access the keyboard manipulator so that the movement speed can be set externally.