### PR TITLE
feat(KeyboardCameraManipulator): Add ability to reset movement speed

### DIFF
--- a/Sources/Interaction/Manipulators/KeyboardCameraManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/KeyboardCameraManipulator/example/index.js
@@ -70,7 +70,9 @@ reader.setUrl(`${__BASE_PATH__}/data/elevation/dem.csv`).then(() => {
   renderWindow.render();
 });
 
-const keyboardManipulator = Manipulators.vtkKeyboardCameraManipulator.newInstance();
+const keyboardManipulator = Manipulators.vtkKeyboardCameraManipulator.newInstance(
+  { movementSpeed: 0.02 }
+);
 const mouseManipulator = Manipulators.vtkMouseCameraTrackballFirstPersonManipulator.newInstance();
 
 const iStyle = vtkInteractorStyleManipulator.newInstance();

--- a/Sources/Interaction/Manipulators/MouseCameraTrackballFirstPersonManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballFirstPersonManipulator/example/index.js
@@ -70,7 +70,9 @@ reader.setUrl(`${__BASE_PATH__}/data/elevation/dem.csv`).then(() => {
   renderWindow.render();
 });
 
-const keyboardManipulator = Manipulators.vtkKeyboardCameraManipulator.newInstance();
+const keyboardManipulator = Manipulators.vtkKeyboardCameraManipulator.newInstance(
+  { movementSpeed: 0.02 }
+);
 const mouseManipulator = Manipulators.vtkMouseCameraTrackballFirstPersonManipulator.newInstance();
 
 const iStyle = vtkInteractorStyleManipulator.newInstance();


### PR DESCRIPTION
resetMovementSpeed() generates a movement speed based upon the longest length of the rendering
bounding box. It is intended to just be a reasonable guess as to what a good movement speed would
be. The user is able to modify the movement speed via setMovementSpeed(). If the movement speed is
not set in the options when the KeyboardCameraManipulator is constructed, upon the first movement,
resetMovementSpeed() will be used to generate a reasonable speed.