### PR TITLE
Fixing node_modules/css-loader/dist/cjs.js

### DIFF
--- a/Utilities/config/dependency.js
+++ b/Utilities/config/dependency.js
@@ -57,8 +57,9 @@ module.exports = {
             {
               loader: 'css-loader',
               options: {
-                localIdentName: '[name]-[local]_[sha512:hash:base64:5]',
-                modules: true,
+                modules: {
+                    localIdentName: "[name]-[local]_[sha512:hash:base64:5]"
+                }
               },
             },
             {


### PR DESCRIPTION
Thiis commit fix issue in webpack loader which call css file, the build will return fail with these error: 

> ERROR in ./src/VolumeViewer.module.css (./node_modules/css-loader/dist/cjs.js??ref--11-1!./node_modules/postcss-loader/src??ref--11-2!./src/VolumeViewer.module.css)
> Module build failed (from ./node_modules/css-loader/dist/cjs.js):
> ValidationError: Invalid options object. CSS Loader has been initialised using an options object that does not match the API schema.
>  - options has an unknown property 'localIdentName'. These properties are valid:
>    object { url?, import?, modules?, sourceMap?, importLoaders?, localsConvention?, onlyLocals?, esModule? }


This error seen when I clone volume viewer example and try run it after execute steps in this [page](https://kitware.github.io/vtk-js/docs/intro_vtk_as_es6_dependency.html).

> Note: these all package.json devDependencies & dependencies with versions: 

```
    "css-loader": "^3.4.0",
    "itk": "^10.2.1",
    "raw-loader": "^4.0.0",
    "style-loader": "^1.1.1",
    "url-loader": "^3.0.0",
    "vtk.js": "^13.2.1",
    "@babel/core": "^7.7.7",
    "@babel/preset-env": "^7.7.7",
    "babel-loader": "^8.0.6",
    "copy-webpack-plugin": "^5.1.1",
    "curry": "^1.2.0",
    "kw-web-suite": "^9.0.0",
    "webpack": "^4.41.4",
    "webpack-cli": "^3.3.10",
    "webpack-dev-server": "^3.10.1",
    "worker-loader": "^2.0.0"
```

You can see error before I update code, and the success after updated it: 

![Screenshot from 2019-12-23 13-26-57](https://user-images.githubusercontent.com/7778796/71355559-1cf7c000-2588-11ea-84e9-dd063a54637a.png)

![Screenshot from 2019-12-23 13-27-26](https://user-images.githubusercontent.com/7778796/71355558-1c5f2980-2588-11ea-9adb-3e59c0a148e4.png)
