### PR TITLE
1. fix scalars.data is undefined when trying to get image data from s…

### DIFF
--- a/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
+++ b/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
@@ -37,11 +37,11 @@ function vtkImageDataToCornerstoneImage(publicAPI, model) {
     // FIXME probably need to expand to RGBA
     let pixelData = null;
     if (dims[2] === 1) {
-      pixelData = (scalars.data === null || scalars.data === undefined) ? rawData : scalars.data;
+      pixelData = !scalars.data ? rawData : scalars.data;
     } else {
       const offset =
         model.sliceIndex * dims[0] * dims[1] * rawData.BYTES_PER_ELEMENT;
-      pixelData = new macro.TYPED_ARRAYS[(scalars.getDataType())](
+      pixelData = new macro.TYPED_ARRAYS[scalars.getDataType()](
         rawData.buffer,
         offset,
         dims[0] * dims[1]

--- a/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
+++ b/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
@@ -41,7 +41,7 @@ function vtkImageDataToCornerstoneImage(publicAPI, model) {
     } else {
       const offset =
         model.sliceIndex * dims[0] * dims[1] * rawData.BYTES_PER_ELEMENT;
-      pixelData = new macro.TYPED_ARRAYS[scalars.getDataType()](
+      pixelData = new macro.TYPED_ARRAYS[(scalars.getDataType())](
         rawData.buffer,
         offset,
         dims[0] * dims[1]

--- a/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
+++ b/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
@@ -37,7 +37,7 @@ function vtkImageDataToCornerstoneImage(publicAPI, model) {
     // FIXME probably need to expand to RGBA
     let pixelData = null;
     if (dims[2] === 1) {
-      pixelData = scalars.data;
+      pixelData = (scalars.data === null || scalars.data === undefined) ? rawData : scalars.data;
     } else {
       const offset =
         model.sliceIndex * dims[0] * dims[1] * rawData.BYTES_PER_ELEMENT;
@@ -52,13 +52,13 @@ function vtkImageDataToCornerstoneImage(publicAPI, model) {
       imageId: model.imageId,
       color: scalars.getNumberOfComponents() > 1,
 
-      columnPixelSpacing: spacing[1],
-      columns: dims[1],
-      width: dims[1],
+      columnPixelSpacing: spacing[0],
+      columns: dims[0],
+      width: dims[0],
 
-      rowPixelSpacing: spacing[0],
-      rows: dims[0],
-      height: dims[0],
+      rowPixelSpacing: spacing[1],
+      rows: dims[1],
+      height: dims[1],
 
       intercept: 0,
       invert: false,


### PR DESCRIPTION
…calar object
  -- object [scalars] provides get/set member functions to get/set its internal parameter,  not export its internal parameters directly ;

2. fix mistake setting ImageDataToCornerstoneImage rows&columns values
  -- According Dicom Standar, ROWS means image height, COLUMNS means image width
  -- Dimensions in vtkImageData encode order is [row, column, z-depth]; so as spacing value in vtkImageData.