### PR TITLE
fix(HttpDataSetReader): Only register newly loaded arrays to dataset

### DIFF
--- a/Sources/IO/Core/HttpDataSetReader/index.js
+++ b/Sources/IO/Core/HttpDataSetReader/index.js
@@ -241,9 +241,11 @@ function vtkHttpDataSetReader(publicAPI, model) {
             progressCallback,
           }).then(processNext, error);
         } else if (datasetObj) {
-          // Perform array registration
+          // Perform array registration on new arrays
           model.arrays
-            .filter((array) => array.registration)
+            .filter(
+              (metaArray) => metaArray.registration && !metaArray.array.ref
+            )
             .forEach((metaArray) => {
               const newArray = ARRAY_BUILDERS[
                 metaArray.array.vtkClass


### PR DESCRIPTION
Previously,
```
reader.enableArray('pointData', 'arrayA');
reader.loadData();
```
would not effect the reader's output dataset, because `arrayA` had already been registered through `pointData.addArray`.

This change ensures array registration only occurs when the array data has been fetched by `reader.loadData()`.

It seems to work for my use case, but if I'm missing something please let me know!