### PR TITLE
feat(Rendering): add wide line support

### DIFF
--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1661,6 +1661,8 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       actor.getProperty().getEdgeVisibility() &&
       representation === Representation.SURFACE;
 
+    gl.lineWidth(actor.getProperty().getLineWidth());
+
     // for every primitive type
     for (let i = primTypes.Start; i < primTypes.End; i++) {
       // if there are entries
@@ -1680,6 +1682,8 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
         model.primitiveIDOffset += cabo.getElementCount() / stride;
       }
     }
+    // reset the line width
+    gl.lineWidth(1);
   };
 
   publicAPI.getOpenGLMode = (rep, type) => {


### PR DESCRIPTION
Add basic wide line support that relies on the lineWidth
function in webgl. Note that lineWidth in webgl is only
required to support a width of 1.0 (how dumb is that) so
this implementation may not work on your system. Support
for other lineWidths is vendor dependent.