### PR TITLE
Fix OpenglRenderWindow::SetContainer

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -160,12 +160,12 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       model.el = el;
       if (model.el) {
         model.el.appendChild(model.canvas);
-      }
-
-      // If the renderer is set to use a background
-      // image, attach it to the DOM.
-      if (model.useBackgroundImage) {
-        model.el.appendChild(model.bgImage);
+        
+        // If the renderer is set to use a background
+        // image, attach it to the DOM.
+        if (model.useBackgroundImage) {
+          model.el.appendChild(model.bgImage);
+        }
       }
 
       // Trigger modified()

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -160,7 +160,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       model.el = el;
       if (model.el) {
         model.el.appendChild(model.canvas);
-        
+
         // If the renderer is set to use a background
         // image, attach it to the DOM.
         if (model.useBackgroundImage) {


### PR DESCRIPTION
Do not attach the background image on an undefined container