### PR TITLE
feat(vtkViewProxy): Add setters to ViewProxy for interactor styles

### DIFF
--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -604,15 +604,18 @@ function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   macro.obj(publicAPI, model);
-  macro.setGet(publicAPI, model, ['name', 'disableAnimation']);
+  macro.setGet(publicAPI, model, [
+    'name',
+    'disableAnimation',
+    'interactorStyle2D',
+    'interactorStyle3D',
+  ]);
   macro.get(publicAPI, model, [
     'annotationOpacity',
     'camera',
     'container',
     'cornerAnnotation',
     'interactor',
-    'interactorStyle2D',
-    'interactorStyle3D',
     'openglRenderWindow',
     'orientationAxesType',
     'presetToOrientationAxes',


### PR DESCRIPTION
We have a modified `vtkInteractorStyleManipulator` for our project, and would like to be able to use it in `ViewProxy`.

This PR adds setters for `interactorStyle2D` and `interactorStyle3D` to let users set their own manipulators.

Does this seem ok ?