### PR TITLE
clean up coordinate system names

### DIFF
--- a/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
+++ b/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
@@ -65,7 +65,7 @@ test.onlyIfWebGL('Test vtkCellPicker image mapper', (t) => {
   t.equal(positions.length, 1);
   const xyz = positions[0];
   t.equal(xyz[0], 64.49344014125458);
-  t.equal(xyz[1], 75.65264146187872);
+  t.equal(xyz[1], 75.65265009452136);
   t.equal(xyz[2], 12.000000145434939);
 
   const ijk = picker.getCellIJK();

--- a/Sources/Rendering/Core/Coordinate/Constants.js
+++ b/Sources/Rendering/Core/Coordinate/Constants.js
@@ -3,9 +3,9 @@ export const Coordinate = {
   NORMALIZED_DISPLAY: 1,
   VIEWPORT: 2,
   NORMALIZED_VIEWPORT: 3,
-  VIEW: 4,
-  WORLD: 5,
-  USERDEFINED: 6,
+  PROJECTION: 4,
+  VIEW: 5,
+  WORLD: 6,
 };
 
 export default {

--- a/Sources/Rendering/Core/Coordinate/api.md
+++ b/Sources/Rendering/Core/Coordinate/api.md
@@ -13,13 +13,25 @@ another coordinate system (e.g., GetComputedWorldValue()).
 The coordinate systems in vtk are as follows:
 
 <PRE>
-  DISPLAY -             x-y pixel values in window
-  NORMALIZED DISPLAY -  x-y (0,1) normalized values
-  VIEWPORT -            x-y pixel values in viewport
-  NORMALIZED VIEWPORT - x-y (0,1) normalized value in viewport
-  VIEW -                x-y-z (-1,1) values in camera coordinates. (z is depth)
-  WORLD -               x-y-z global coordinate values
-  USERDEFINED -         x-y-z in User defined space
+DISPLAY -             x-y pixel values in a window
+NORMALIZED DISPLAY -  x-y (0,1) normalized values
+VIEWPORT -            x-y pixel values in viewport
+NORMALIZED VIEWPORT - x-y (0,1) normalized value in viewport
+PROJECTION -          View coordinates transformed by the ortho/perspective
+                      equations and normalized to -1,1 cube on X and Y. The
+                      z range is defined by the code and may be -1,1
+                      for OpenGL or other values. This is the coordinate system
+                      that is typically coming out of the vertex shader.
+VIEW -                x-y-z values in camera coordinates. The origin is
+                      at the camera position and the orientation is such
+                      that the -Z axis is the view direction, the X axis
+                      is the view right, and Y axis is view up. This is
+                      a translation and rotation from world coordinates
+                      based on the camera settings.
+WORLD -               x-y-z global coordinate values
+MODEL -               The coordinate system specific to a dataaet or
+                      actor. This is normally converted into WORLD coordinates
+                      as part of the rendering process.
 </PRE>
 
 If you cascade vtkCoordinate objects, you refer to another vtkCoordinate
@@ -28,9 +40,19 @@ create composite groups of things like vtkActor2D that are positioned
 relative to one another. Note that in cascaded sequences, each
 vtkCoordinate object may be specified in different coordinate systems!
 
+In shader code coordinate system transformations will often be referenced
+as matricies with common ones being.
+<PRE>
+MCWCMatrix - model to world
+MCPCMatrix - model to projection
+WCVCMatrix - world to view - half of the camera transform
+WCPCMatrix - world to projection
+VCPCMatrix - view to projection - the other part of the camera transform
+</PRE>
+
 ## See Also
 
-[vtkActor2D](./Rendering_Core_Actor2D.html) 
+[vtkActor2D](./Rendering_Core_Actor2D.html)
 
 ### referenceCoordinate
 

--- a/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
+++ b/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
@@ -107,7 +107,7 @@ test('Test vtkCoordinate publicAPI', (t) => {
 
   coord.setCoordinateSystemToView();
   testVal = [0.0, 0.0, 0.0];
-  world = [0.0, 0.0, 0.98];
+  world = [0.0, 0.0, 1.0];
   display = [50.0, 50.0];
   localDisplay = [50.0, 49.0];
   viewPort = [50.0, 50.0];
@@ -158,7 +158,7 @@ test('Test vtkCoordinate publicAPI', (t) => {
 
   coord.setCoordinateSystemToView();
   testVal = [0.0, 0.0, 0.0];
-  world = [0.0, 0.0, 0.98];
+  world = [0.0, 0.0, 1.0];
   display = [50.0, 50.0];
   localDisplay = [50.0, 49.0];
   viewPort = [50.0, 50.0];

--- a/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
+++ b/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
@@ -64,7 +64,7 @@ test.onlyIfWebGL('Test vtkPointPicker image mapper', (t) => {
   t.equal(positions.length, 1);
   const xyz = positions[0];
   t.equal(xyz[0], 64.49344014125458);
-  t.equal(xyz[1], 75.65264146187872);
+  t.equal(xyz[1], 75.65265009452136);
   t.equal(xyz[2], 12.000000145434939);
 
   const ijk = picker.getPointIJK();

--- a/Sources/Rendering/Core/Viewport/api.md
+++ b/Sources/Rendering/Core/Viewport/api.md
@@ -7,12 +7,12 @@ commonly used in rendering.
 
 ## See Also
 
-[vtkActor](./Rendering_Core_Actor.html) 
-[vtkCoordinate](./Rendering_Core_Coordinate.html) 
-[vtkProp](./Rendering_Core_Prop.html) 
-[vtkRenderer](./Rendering_Core_Renderer.html) 
-[vtkRenderWindow](./Rendering_Core_RenderWindow.html) 
-[vtkVolume](./Rendering_Core_Volume.html) 
+[vtkActor](./Rendering_Core_Actor.html)
+[vtkCoordinate](./Rendering_Core_Coordinate.html)
+[vtkProp](./Rendering_Core_Prop.html)
+[vtkRenderer](./Rendering_Core_Renderer.html)
+[vtkRenderWindow](./Rendering_Core_RenderWindow.html)
+[vtkVolume](./Rendering_Core_Volume.html)
 
 ### addViewProp(prop)
 
@@ -42,12 +42,3 @@ Remove all props from the list of props.
 Add/Remove different types of props to the renderer.
 These methods are all synonyms to AddViewProp and RemoveViewProp.
 They are here for convenience and backwards compatibility.
-
-### normalizedDisplayToNormalizedViewport (x, y, z)
-### normalizedViewportToView (x, y, z)
-### viewToNormalizedDisplay (x, y, z)
-### normalizedViewportToNormalizedDisplay (x, y, z) 
-### viewToNormalizedViewport (x, y, z) 
-
-See vtkCoordinate for the definition of these coordinate systems.
-

--- a/Sources/Rendering/Core/Viewport/index.js
+++ b/Sources/Rendering/Core/Viewport/index.js
@@ -75,12 +75,12 @@ function vtkViewport(publicAPI, model) {
     vtkErrorMacro('callviewtodisplay on your view instead');
   publicAPI.getSize = () => vtkErrorMacro('call getSize on your View instead');
 
-  publicAPI.normalizedDisplayToView = (x, y, z) => {
+  publicAPI.normalizedDisplayToProjection = (x, y, z) => {
     // first to normalized viewport
     const nvp = publicAPI.normalizedDisplayToNormalizedViewport(x, y, z);
 
     // then to view
-    return publicAPI.normalizedViewportToView(nvp[0], nvp[1], nvp[2]);
+    return publicAPI.normalizedViewportToProjection(nvp[0], nvp[1], nvp[2]);
   };
 
   publicAPI.normalizedDisplayToNormalizedViewport = (x, y, z) => {
@@ -95,15 +95,15 @@ function vtkViewport(publicAPI, model) {
     ];
   };
 
-  publicAPI.normalizedViewportToView = (x, y, z) => [
+  publicAPI.normalizedViewportToProjection = (x, y, z) => [
     x * 2.0 - 1.0,
     y * 2.0 - 1.0,
     z * 2.0 - 1.0,
   ];
 
-  publicAPI.viewToNormalizedDisplay = (x, y, z) => {
+  publicAPI.projectionToNormalizedDisplay = (x, y, z) => {
     // first to nvp
-    const nvp = publicAPI.viewToNormalizedViewport(x, y, z);
+    const nvp = publicAPI.projectionToNormalizedViewport(x, y, z);
 
     // then to ndp
     return publicAPI.normalizedViewportToNormalizedDisplay(
@@ -125,7 +125,7 @@ function vtkViewport(publicAPI, model) {
     ];
   };
 
-  publicAPI.viewToNormalizedViewport = (x, y, z) => [
+  publicAPI.projectionToNormalizedViewport = (x, y, z) => [
     (x + 1.0) * 0.5,
     (y + 1.0) * 0.5,
     (z + 1.0) * 0.5,

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -64,14 +64,14 @@ function vtkOpenGLCamera(publicAPI, model) {
       const aspectRatio = model.openGLRenderer.getAspectRatio();
 
       mat4.copy(
-        model.keyMatrices.vcdc,
+        model.keyMatrices.vcpc,
         model.renderable.getProjectionMatrix(aspectRatio, -1, 1)
       );
-      mat4.transpose(model.keyMatrices.vcdc, model.keyMatrices.vcdc);
+      mat4.transpose(model.keyMatrices.vcpc, model.keyMatrices.vcpc);
 
       mat4.multiply(
-        model.keyMatrices.wcdc,
-        model.keyMatrices.vcdc,
+        model.keyMatrices.wcpc,
+        model.keyMatrices.vcpc,
         model.keyMatrices.wcvc
       );
 
@@ -107,9 +107,9 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.keyMatrices = {
     normalMatrix: mat3.create(),
-    vcdc: mat4.create(),
+    vcpc: mat4.create(),
     wcvc: mat4.create(),
-    wcdc: mat4.create(),
+    wcpc: mat4.create(),
   };
 
   // Build VTK API

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -272,25 +272,25 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
           [
             'vec4 gVertexMC = gMatrix * vertexMC;',
             'vertexVCVSOutput = MCVCMatrix * gVertexMC;',
-            '  gl_Position = MCDCMatrix * gVertexMC;',
+            '  gl_Position = MCPCMatrix * gVertexMC;',
           ]
         ).result;
         VSSource = vtkShaderProgram.substitute(VSSource, '//VTK::Camera::Dec', [
           'attribute mat4 gMatrix;',
-          'uniform mat4 MCDCMatrix;',
+          'uniform mat4 MCPCMatrix;',
           'uniform mat4 MCVCMatrix;',
         ]).result;
       } else {
         VSSource = vtkShaderProgram.substitute(VSSource, '//VTK::Camera::Dec', [
           'attribute mat4 gMatrix;',
-          'uniform mat4 MCDCMatrix;',
+          'uniform mat4 MCPCMatrix;',
         ]).result;
         VSSource = vtkShaderProgram.substitute(
           VSSource,
           '//VTK::PositionVC::Impl',
           [
             'vec4 gVertexMC = gMatrix * vertexMC;',
-            '  gl_Position = MCDCMatrix * gVertexMC;',
+            '  gl_Position = MCPCMatrix * gVertexMC;',
           ]
         ).result;
       }
@@ -382,11 +382,11 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
     }
     publicAPI.multiply4x4WithOffset(
       model.tmpMat4,
-      model.mcdcMatrix,
+      model.mcpcMatrix,
       garray,
       p * 16
     );
-    program.setUniformMatrix('MCDCMatrix', model.tmpMat4);
+    program.setUniformMatrix('MCPCMatrix', model.tmpMat4);
     if (mcvcMatrixUsed) {
       publicAPI.multiply4x4WithOffset(
         model.tmpMat4,
@@ -421,8 +421,8 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
       actor.getProperty().getEdgeVisibility() &&
       representation === Representation.SURFACE;
 
-    // // [WMVD]C == {world, model, view, display} coordinates
-    // // E.g., WCDC == world to display coordinate transformation
+    // [WMVP]C == {world, model, view, projection} coordinates
+    // E.g., WCPC == world to projection coordinate transformation
     const keyMats = model.openGLCamera.getKeyMatrices(ren);
     const actMats = model.openGLActor.getKeyMatrices();
 
@@ -432,7 +432,7 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
       keyMats.normalMatrix,
       actMats.normalMatrix
     );
-    mat4.multiply(model.mcdcMatrix, keyMats.wcdc, actMats.mcwc);
+    mat4.multiply(model.mcpcMatrix, keyMats.wcpc, actMats.mcwc);
     mat4.multiply(model.mcvcMatrix, keyMats.wcvc, actMats.mcwc);
 
     const garray = model.renderable.getMatrixArray();
@@ -670,7 +670,7 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   normalMatrix: null,
-  mcdcMatrix: null,
+  mcpcMatrix: null,
   mcwcMatrix: null,
 };
 
@@ -684,7 +684,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.tmpMat3 = mat3.create();
   model.normalMatrix = mat3.create();
-  model.mcdcMatrix = mat4.create();
+  model.mcpcMatrix = mat4.create();
   model.mcvcMatrix = mat4.create();
   model.tmpColor = [];
 

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -99,12 +99,12 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     let FSSource = shaders.Fragment;
 
     VSSource = vtkShaderProgram.substitute(VSSource, '//VTK::Camera::Dec', [
-      'uniform mat4 MCDCMatrix;',
+      'uniform mat4 MCPCMatrix;',
     ]).result;
     VSSource = vtkShaderProgram.substitute(
       VSSource,
       '//VTK::PositionVC::Impl',
-      ['  gl_Position = MCDCMatrix * vertexMC;']
+      ['  gl_Position = MCPCMatrix * vertexMC;']
     ).result;
 
     VSSource = vtkShaderProgram.substitute(
@@ -356,7 +356,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     mat4.multiply(model.imagemat, actMats.mcwc, i2wmat4);
 
     const keyMats = model.openGLCamera.getKeyMatrices(ren);
-    mat4.multiply(model.imagemat, keyMats.wcdc, model.imagemat);
+    mat4.multiply(model.imagemat, keyMats.wcpc, model.imagemat);
 
     if (cellBO.getCABO().getCoordShiftAndScaleEnabled()) {
       const inverseShiftScaleMat = cellBO
@@ -365,7 +365,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       mat4.multiply(model.imagemat, model.imagemat, inverseShiftScaleMat);
     }
 
-    program.setUniformMatrix('MCDCMatrix', model.imagemat);
+    program.setUniformMatrix('MCPCMatrix', model.imagemat);
   };
 
   publicAPI.setPropertyShaderParameters = (cellBO, ren, actor) => {

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -639,11 +639,11 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
         '//VTK::PositionVC::Impl',
         [
           'vertexVCVSOutput = MCVCMatrix * vertexMC;',
-          '  gl_Position = MCDCMatrix * vertexMC;',
+          '  gl_Position = MCPCMatrix * vertexMC;',
         ]
       ).result;
       VSSource = vtkShaderProgram.substitute(VSSource, '//VTK::Camera::Dec', [
-        'uniform mat4 MCDCMatrix;',
+        'uniform mat4 MCPCMatrix;',
         'uniform mat4 MCVCMatrix;',
       ]).result;
       GSSource = vtkShaderProgram.substitute(
@@ -668,12 +668,12 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       ).result;
     } else {
       VSSource = vtkShaderProgram.substitute(VSSource, '//VTK::Camera::Dec', [
-        'uniform mat4 MCDCMatrix;',
+        'uniform mat4 MCPCMatrix;',
       ]).result;
       VSSource = vtkShaderProgram.substitute(
         VSSource,
         '//VTK::PositionVC::Impl',
-        ['  gl_Position = MCDCMatrix * vertexMC;']
+        ['  gl_Position = MCPCMatrix * vertexMC;']
       ).result;
     }
     shaders.Vertex = VSSource;
@@ -1501,8 +1501,8 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
   publicAPI.setCameraShaderParameters = (cellBO, ren, actor) => {
     const program = cellBO.getProgram();
 
-    // // [WMVD]C == {world, model, view, display} coordinates
-    // // E.g., WCDC == world to display coordinate transformation
+    // [WMVP]C == {world, model, view, projection} coordinates
+    // E.g., WCPC == world to projection coordinate transformation
     const keyMats = model.openGLCamera.getKeyMatrices(ren);
     const cam = ren.getActiveCamera();
 
@@ -1520,9 +1520,9 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       : model.openGLActor.getKeyMatrices();
 
     program.setUniformMatrix(
-      'MCDCMatrix',
+      'MCPCMatrix',
       safeMatrixMultiply(
-        [keyMats.wcdc, actMats.mcwc, inverseShiftScaleMatrix],
+        [keyMats.wcpc, actMats.mcwc, inverseShiftScaleMatrix],
         mat4,
         model.tmpMat4
       )

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -229,26 +229,38 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     return [x * size[0], y * size[1], z];
   };
 
-  publicAPI.worldToView = (x, y, z, renderer) => {
-    const dims = publicAPI.getViewportSize(renderer);
-    return renderer.worldToView(x, y, z, dims[0] / dims[1]);
-  };
+  publicAPI.worldToView = (x, y, z, renderer) => renderer.worldToView(x, y, z);
 
-  publicAPI.viewToWorld = (x, y, z, renderer) => {
-    const dims = publicAPI.getViewportSize(renderer);
-    return renderer.viewToWorld(x, y, z, dims[0] / dims[1]);
-  };
+  publicAPI.viewToWorld = (x, y, z, renderer) => renderer.viewToWorld(x, y, z);
 
   publicAPI.worldToDisplay = (x, y, z, renderer) => {
-    const val = publicAPI.worldToView(x, y, z, renderer);
-    const val2 = renderer.viewToNormalizedDisplay(val[0], val[1], val[2]);
-    return publicAPI.normalizedDisplayToDisplay(val2[0], val2[1], val2[2]);
+    const val = renderer.worldToView(x, y, z);
+    const dims = publicAPI.getViewportSize(renderer);
+    const val2 = renderer.viewToProjection(
+      val[0],
+      val[1],
+      val[2],
+      dims[0] / dims[1]
+    );
+    const val3 = publicAPI.projectionToNormalizedDisplay(
+      val2[0],
+      val2[1],
+      val2[2]
+    );
+    return publicAPI.normalizedDisplayToDisplay(val3[0], val3[1], val3[2]);
   };
 
   publicAPI.displayToWorld = (x, y, z, renderer) => {
     const val = publicAPI.displayToNormalizedDisplay(x, y, z);
-    const val2 = renderer.normalizedDisplayToView(val[0], val[1], val[2]);
-    return publicAPI.viewToWorld(val2[0], val2[1], val2[2], renderer);
+    const val2 = renderer.normalizedDisplayToProjection(val[0], val[1], val[2]);
+    const dims = publicAPI.getViewportSize(renderer);
+    const val3 = renderer.projectionToView(
+      val2[0],
+      val2[1],
+      val2[2],
+      dims[0] / dims[1]
+    );
+    return renderer.viewToWorld(val3[0], val3[1], val3[2]);
   };
 
   publicAPI.normalizedDisplayToViewport = (x, y, z, renderer) => {

--- a/Sources/Rendering/OpenGL/Skybox/index.js
+++ b/Sources/Rendering/OpenGL/Skybox/index.js
@@ -63,8 +63,8 @@ function vtkOpenGLSkybox(publicAPI, model) {
 
       const keyMats = model.openGLCamera.getKeyMatrices(ren);
       const imat = mat4.create();
-      mat4.invert(imat, keyMats.wcdc);
-      model.tris.getProgram().setUniformMatrix('IMCDCMatrix', imat);
+      mat4.invert(imat, keyMats.wcpc);
+      model.tris.getProgram().setUniformMatrix('IMCPCMatrix', imat);
 
       if (model.lastFormat === 'box') {
         const camPos = ren.getActiveCamera().getPosition();
@@ -142,11 +142,11 @@ function vtkOpenGLSkybox(publicAPI, model) {
           model.openGLRenderWindow.getShaderCache().readyShaderProgramArray(
             `//VTK::System::Dec
              attribute vec3 vertexMC;
-             uniform mat4 IMCDCMatrix;
+             uniform mat4 IMCPCMatrix;
              varying vec3 TexCoords;
              void main () {
               gl_Position = vec4(vertexMC.xyz, 1.0);
-              vec4 wpos = IMCDCMatrix * gl_Position;
+              vec4 wpos = IMCPCMatrix * gl_Position;
               TexCoords = wpos.xyz/wpos.w;
              }`,
             `//VTK::System::Dec
@@ -181,11 +181,11 @@ function vtkOpenGLSkybox(publicAPI, model) {
           model.openGLRenderWindow.getShaderCache().readyShaderProgramArray(
             `//VTK::System::Dec
              attribute vec3 vertexMC;
-             uniform mat4 IMCDCMatrix;
+             uniform mat4 IMCPCMatrix;
              varying vec2 TexCoords;
              void main () {
               gl_Position = vec4(vertexMC.xyz, 1.0);
-              vec4 wpos = IMCDCMatrix * gl_Position;
+              vec4 wpos = IMCPCMatrix * gl_Position;
               TexCoords = vec2(vertexMC.x, vertexMC.y)*0.5 + 0.5;
              }`,
             `//VTK::System::Dec

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -36,7 +36,7 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
     let FSSource = shaders.Fragment;
 
     VSSource = vtkShaderProgram.substitute(VSSource, '//VTK::Camera::Dec', [
-      'uniform mat4 VCDCMatrix;\n',
+      'uniform mat4 VCPCMatrix;\n',
       'uniform mat4 MCVCMatrix;',
     ]).result;
 
@@ -52,14 +52,14 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
       ['vec4 vertexVC = vertexVCVSOutput;\n']
     ).result;
 
-    // for lights kit and positional the VCDC matrix is already defined
+    // for lights kit and positional the VCPC matrix is already defined
     // so don't redefine it
     const replacement = [
       'uniform float invertedDepth;\n',
       'uniform int cameraParallel;\n',
       'varying float radiusVCVSOutput;\n',
       'varying vec3 centerVCVSOutput;\n',
-      'uniform mat4 VCDCMatrix;\n',
+      'uniform mat4 VCPCMatrix;\n',
     ];
     FSSource = vtkShaderProgram.substitute(
       FSSource,
@@ -113,7 +113,7 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
       '    }\n',
       // compute the pixel's depth
       // ' normalVCVSOutput = vec3(0,0,1);\n'
-      '  vec4 pos = VCDCMatrix * vertexVC;\n',
+      '  vec4 pos = VCPCMatrix * vertexVC;\n',
       fragString,
     ]).result;
 
@@ -178,8 +178,8 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
     const cam = ren.getActiveCamera();
     const keyMats = model.openGLCamera.getKeyMatrices(ren);
 
-    if (program.isUniformUsed('VCDCMatrix')) {
-      program.setUniformMatrix('VCDCMatrix', keyMats.vcdc);
+    if (program.isUniformUsed('VCPCMatrix')) {
+      program.setUniformMatrix('VCPCMatrix', keyMats.vcpc);
     }
 
     if (program.isUniformUsed('MCVCMatrix')) {

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -34,7 +34,7 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     let FSSource = shaders.Fragment;
 
     VSSource = vtkShaderProgram.substitute(VSSource, '//VTK::Camera::Dec', [
-      'uniform mat4 VCDCMatrix;\n',
+      'uniform mat4 VCPCMatrix;\n',
       'uniform mat4 MCVCMatrix;',
     ]).result;
 
@@ -52,7 +52,7 @@ function vtkOpenGLStickMapper(publicAPI, model) {
       '  vec4 vertexVC = vertexVCVSOutput;\n'
     ).result;
 
-    // for lights kit and positional the VCDC matrix is already defined
+    // for lights kit and positional the VCPC matrix is already defined
     // so don't redefine it
     const replacement = [
       'uniform int cameraParallel;\n',
@@ -60,7 +60,7 @@ function vtkOpenGLStickMapper(publicAPI, model) {
       'varying vec3 orientVCVSOutput;\n',
       'varying float lengthVCVSOutput;\n',
       'varying vec3 centerVCVSOutput;\n',
-      'uniform mat4 VCDCMatrix;\n',
+      'uniform mat4 VCPCMatrix;\n',
     ];
     FSSource = vtkShaderProgram.substitute(
       FSSource,
@@ -144,7 +144,7 @@ function vtkOpenGLStickMapper(publicAPI, model) {
 
       //    '  vec3 normalVC = vec3(0.0,0.0,1.0);\n'
       // compute the pixel's depth
-      '  vec4 pos = VCDCMatrix * vertexVC;\n',
+      '  vec4 pos = VCPCMatrix * vertexVC;\n',
       fragString,
     ]).result;
 
@@ -238,8 +238,8 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     const cam = ren.getActiveCamera();
     const keyMats = model.openGLCamera.getKeyMatrices(ren);
 
-    if (program.isUniformUsed('VCDCMatrix')) {
-      program.setUniformMatrix('VCDCMatrix', keyMats.vcdc);
+    if (program.isUniformUsed('VCPCMatrix')) {
+      program.setUniformMatrix('VCPCMatrix', keyMats.vcpc);
     }
 
     if (!actor.getIsIdentity()) {

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -417,8 +417,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
   };
 
   publicAPI.setCameraShaderParameters = (cellBO, ren, actor) => {
-    // // [WMVD]C == {world, model, view, display} coordinates
-    // // E.g., WCDC == world to display coordinate transformation
+    // // [WMVP]C == {world, model, view, projection} coordinates
+    // // E.g., WCPC == world to projection coordinate transformation
     const keyMats = model.openGLCamera.getKeyMatrices(ren);
     const actMats = model.openGLVolume.getKeyMatrices();
 
@@ -464,7 +464,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         vec3.scale(pos, dir, t);
       }
       // now convert to DC
-      vec3.transformMat4(pos, pos, keyMats.vcdc);
+      vec3.transformMat4(pos, pos, keyMats.vcpc);
 
       dcxmin = Math.min(pos[0], dcxmin);
       dcxmax = Math.max(pos[0], dcxmax);
@@ -587,9 +587,9 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
         program.setUniformMatrix('vWCtoIDX', worldToIndex);
 
-        // Get the display coordinate to world coordinate transformation matrix.
-        mat4.invert(model.displayToWorld, keyMats.wcdc);
-        program.setUniformMatrix('DCWCMatrix', model.displayToWorld);
+        // Get the projection coordinate to world coordinate transformation matrix.
+        mat4.invert(model.projectionToWorld, keyMats.wcpc);
+        program.setUniformMatrix('PCWCMatrix', model.projectionToWorld);
 
         const size = publicAPI.getRenderTargetSize();
 
@@ -598,8 +598,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       }
     }
 
-    mat4.invert(model.displayToView, keyMats.vcdc);
-    program.setUniformMatrix('DCVCMatrix', model.displayToView);
+    mat4.invert(model.projectionToView, keyMats.vcpc);
+    program.setUniformMatrix('PCVCMatrix', model.projectionToView);
 
     // handle lighting values
     switch (model.lastLightComplexity) {
@@ -1307,7 +1307,7 @@ const DEFAULT_VALUES = {
   idxToView: null,
   idxNormalMatrix: null,
   modelToView: null,
-  displayToView: null,
+  projectionToView: null,
   avgWindowArea: 0.0,
   avgFrameTime: 0.0,
 };
@@ -1335,8 +1335,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.idxToView = mat4.create();
   model.idxNormalMatrix = mat3.create();
   model.modelToView = mat4.create();
-  model.displayToView = mat4.create();
-  model.displayToWorld = mat4.create();
+  model.projectionToView = mat4.create();
+  model.projectionToWorld = mat4.create();
 
   // Build VTK API
   macro.setGet(publicAPI, model, ['context']);

--- a/Sources/Rendering/OpenGL/glsl/vtkSphereMapperVS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkSphereMapperVS.glsl
@@ -71,5 +71,5 @@ void main()
     vertexVCVSOutput.xy = vertexVCVSOutput.xy + offsetMC;
     }
 
-  gl_Position = VCDCMatrix * vertexVCVSOutput;
+  gl_Position = VCPCMatrix * vertexVCVSOutput;
 }

--- a/Sources/Rendering/OpenGL/glsl/vtkStickMapperVS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkStickMapperVS.glsl
@@ -97,5 +97,5 @@ void main()
     radiusVCVSOutput*offsets.y*ybase +
     0.5*lengthVCVSOutput*offsets.z*orientVCVSOutput;
 
-  gl_Position = VCDCMatrix * vertexVCVSOutput;
+  gl_Position = VCPCMatrix * vertexVCVSOutput;
 }

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -43,7 +43,7 @@ varying vec3 vertexVCVSOutput;
 uniform int outlineThickness;
 uniform float vpWidth;
 uniform float vpHeight;
-uniform mat4 DCWCMatrix;
+uniform mat4 PCWCMatrix;
 uniform mat4 vWCtoIDX;
 #endif
 
@@ -290,13 +290,13 @@ vec4 computeNormal(vec3 pos, float scalar, vec3 tstep)
 
 #ifdef vtkImageLabelOutlineOn
 vec3 fragCoordToIndexSpace(vec4 fragCoord) {
-  vec4 ndcPos = vec4(
+  vec4 pcPos = vec4(
     (fragCoord.x / vpWidth - 0.5) * 2.0,
     (fragCoord.y / vpHeight - 0.5) * 2.0,
     (fragCoord.z - 0.5) * 2.0,
     1.0);
 
-  vec4 worldCoord = DCWCMatrix * ndcPos;
+  vec4 worldCoord = PCWCMatrix * pcPos;
   vec4 vertex = (worldCoord/worldCoord.w);
 
   return (vWCtoIDX * vertex).xyz / vec3(volumeDimensions);
@@ -437,7 +437,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
       tColor.a = 1.0;
     }
   }
-  
+
 #else
   // compute the normal and gradient magnitude if needed
   // We compute it as a vec4 if possible otherwise a mat4

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeVS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeVS.glsl
@@ -18,7 +18,7 @@
 attribute vec4 vertexDC;
 
 varying vec3 vertexVCVSOutput;
-uniform mat4 DCVCMatrix;
+uniform mat4 PCVCMatrix;
 
 uniform float dcxmin;
 uniform float dcxmax;
@@ -34,7 +34,7 @@ void main()
     dcymin + 0.5 * (vertexDC.y + 1.0) * (dcymax - dcymin),
     vertexDC.z,
     vertexDC.w);
-  vec4 vcpos = DCVCMatrix * dcsmall;
+  vec4 vcpos = PCVCMatrix * dcsmall;
   vertexVCVSOutput = vcpos.xyz/vcpos.w;
   gl_Position = dcsmall;
 }


### PR DESCRIPTION
view is now consistent between shaders and vtkCoordinate
projection is a new vtkCoordinate value that matches
what shaders used to call device coordinates.

This also makes the camer methods make more sense as
GetViewMatrix actually returns WCVC matrix and
GetProjectionMatrix returns VCPC