### PR TITLE
fix(vtkOpenGLRenderWindow): Fix wrong call to projectionToNormalizedDisplay

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -242,7 +242,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       val[2],
       dims[0] / dims[1]
     );
-    const val3 = publicAPI.projectionToNormalizedDisplay(
+    const val3 = renderer.projectionToNormalizedDisplay(
       val2[0],
       val2[1],
       val2[2]


### PR DESCRIPTION
Fixes a small bug where a call to projectionToNormalizedDisplay was done as a member of the renderWindow (method doesn't exist) instead of the renderer.