### PR TITLE
fix(LegacyAsciiParser): Use default value for numberOfComponents

### DIFF
--- a/Sources/IO/Legacy/LegacyAsciiParser/index.js
+++ b/Sources/IO/Legacy/LegacyAsciiParser/index.js
@@ -140,7 +140,8 @@ const TYPE_PARSER = {
   SCALARS: {
     init(line, dataModel) {
       const [type, name, dataType, numComp] = line.split(' ');
-      const size = dataModel[dataModel.activeFieldLocation] * Number(numComp);
+      const numOfComp = Number(numComp) > 0 ? Number(numComp) : 1;
+      const size = dataModel[dataModel.activeFieldLocation] * numOfComp;
       const array = new DATATYPES[dataType](size);
       const dataArray = vtkDataArray.newInstance({ name, empty: true });
       dataModel.dataset[METHOD_MAPPING[dataModel.activeFieldLocation]]()[
@@ -149,7 +150,7 @@ const TYPE_PARSER = {
       dataModel.arrayHandler = createArrayHandler(
         array,
         dataArray.setData,
-        Number(numComp)
+        numOfComp
       );
       return true;
     },
@@ -163,7 +164,8 @@ const TYPE_PARSER = {
   COLOR_SCALARS: {
     init(line, dataModel) {
       const [type, name, numComp] = line.split(' ');
-      const size = dataModel[dataModel.activeFieldLocation] * Number(numComp);
+      const numOfComp = Number(numComp) > 0 ? Number(numComp) : 1;
+      const size = dataModel[dataModel.activeFieldLocation] * numOfComp;
       const array = new Uint8Array(size);
       const dataArray = vtkDataArray.newInstance({ name, empty: true });
       dataModel.dataset[METHOD_MAPPING[dataModel.activeFieldLocation]]()[
@@ -172,7 +174,7 @@ const TYPE_PARSER = {
       dataModel.arrayHandler = createArrayHandler(
         array,
         dataArray.setData,
-        Number(numComp)
+        numOfComp
       );
       return true;
     },


### PR DESCRIPTION
Use default value for numberOfComponents if not present

Some tools export legacy vtk without numberOfComponents if it is equal to 1. This is allowed, but vtk.js does not take it into account. 
On page 5 in the file-formats.pdf: "... the numComp variable is optional—by default the number of components is equal to one"
