### PR TITLE
fix(OpenGL): Add missing export of PixelSpaceCallbackMapper

### DIFF
--- a/Sources/Rendering/OpenGL/index.js
+++ b/Sources/Rendering/OpenGL/index.js
@@ -9,6 +9,7 @@ import vtkHardwareSelector from './HardwareSelector';
 import vtkHelper from './Helper';
 import vtkImageMapper from './ImageMapper';
 import vtkImageSlice from './ImageSlice';
+import vtkPixelSpaceCallbackMapper from './PixelSpaceCallbackMapper';
 import vtkPolyDataMapper from './PolyDataMapper';
 import vtkRenderer from './Renderer';
 import vtkRenderWindow from './RenderWindow';
@@ -37,6 +38,7 @@ export default {
   vtkHelper,
   vtkImageMapper,
   vtkImageSlice,
+  vtkPixelSpaceCallbackMapper,
   vtkPolyDataMapper,
   vtkRenderer,
   vtkRenderWindow,


### PR DESCRIPTION
Add missing export of PixelSpaceCallbackMapper

For users who use dist-ready vtk.js, not webpack