### PR TITLE
fix(WidgetManager): Unsubscribe to events when widgetManager is deleted

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -461,6 +461,14 @@ function vtkWidgetManager(publicAPI, model) {
     }
     return false;
   };
+
+  const superDelete = publicAPI.delete;
+  publicAPI.delete = () => {
+    while (subscriptions.length) {
+      subscriptions.pop().unsubscribe();
+    }
+    superDelete();
+  };
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
If the widgetManager is deleted, it does not unsubscribe to events. If an event is triggered
(svgSetSize for example), the vizualization will crash since widgetManager does no longer exist.