### PR TITLE
fix(ImageProperty): Return true/false on set methods

### DIFF
--- a/Sources/Rendering/Core/ImageProperty/index.js
+++ b/Sources/Rendering/Core/ImageProperty/index.js
@@ -111,11 +111,13 @@ function vtkImageProperty(publicAPI, model) {
     return model.componentData[index].componentWeight;
   };
 
-  publicAPI.setInterpolationTypeToNearest = () =>
-    publicAPI.setInterpolationType(InterpolationType.NEAREST);
+  publicAPI.setInterpolationTypeToNearest = () => {
+    return publicAPI.setInterpolationType(InterpolationType.NEAREST);
+  };
 
-  publicAPI.setInterpolationTypeToLinear = () =>
-    publicAPI.setInterpolationType(InterpolationType.LINEAR);
+  publicAPI.setInterpolationTypeToLinear = () => {
+    return publicAPI.setInterpolationType(InterpolationType.LINEAR);
+  };
 
   publicAPI.getInterpolationTypeAsString = () =>
     macro.enumToString(InterpolationType, model.interpolationType);

--- a/Sources/Rendering/Core/ImageProperty/index.js
+++ b/Sources/Rendering/Core/ImageProperty/index.js
@@ -49,7 +49,9 @@ function vtkImageProperty(publicAPI, model) {
     if (model.componentData[idx].rGBTransferFunction !== transferFunc) {
       model.componentData[idx].rGBTransferFunction = transferFunc;
       publicAPI.modified();
+      return true;
     }
+    return false;
   };
 
   // Get the currently set RGB transfer function.
@@ -61,7 +63,9 @@ function vtkImageProperty(publicAPI, model) {
     if (model.componentData[index].piecewiseFunction !== func) {
       model.componentData[index].piecewiseFunction = func;
       publicAPI.modified();
+      return true;
     }
+    return false;
   };
 
   // Get the component weighting function.
@@ -93,7 +97,9 @@ function vtkImageProperty(publicAPI, model) {
     if (model.componentData[index].componentWeight !== val) {
       model.componentData[index].componentWeight = val;
       publicAPI.modified();
+      return true;
     }
+    return false;
   };
 
   publicAPI.getComponentWeight = (index) => {
@@ -105,13 +111,11 @@ function vtkImageProperty(publicAPI, model) {
     return model.componentData[index].componentWeight;
   };
 
-  publicAPI.setInterpolationTypeToNearest = () => {
+  publicAPI.setInterpolationTypeToNearest = () =>
     publicAPI.setInterpolationType(InterpolationType.NEAREST);
-  };
 
-  publicAPI.setInterpolationTypeToLinear = () => {
+  publicAPI.setInterpolationTypeToLinear = () =>
     publicAPI.setInterpolationType(InterpolationType.LINEAR);
-  };
 
   publicAPI.getInterpolationTypeAsString = () =>
     macro.enumToString(InterpolationType, model.interpolationType);

--- a/Sources/Rendering/Core/VolumeProperty/index.js
+++ b/Sources/Rendering/Core/VolumeProperty/index.js
@@ -194,14 +194,17 @@ function vtkVolumeProperty(publicAPI, model) {
     return model.componentData[index].componentWeight;
   };
 
-  publicAPI.setInterpolationTypeToNearest = () =>
-    publicAPI.setInterpolationType(InterpolationType.NEAREST);
+  publicAPI.setInterpolationTypeToNearest = () => {
+    return publicAPI.setInterpolationType(InterpolationType.NEAREST);
+  };
 
-  publicAPI.setInterpolationTypeToLinear = () =>
-    publicAPI.setInterpolationType(InterpolationType.LINEAR);
+  publicAPI.setInterpolationTypeToLinear = () => {
+    return publicAPI.setInterpolationType(InterpolationType.LINEAR);
+  };
 
-  publicAPI.setInterpolationTypeToFastLinear = () =>
-    publicAPI.setInterpolationType(InterpolationType.FAST_LINEAR);
+  publicAPI.setInterpolationTypeToFastLinear = () => {
+    return publicAPI.setInterpolationType(InterpolationType.FAST_LINEAR);
+  };
 
   publicAPI.getInterpolationTypeAsString = () =>
     macro.enumToString(InterpolationType, model.interpolationType);

--- a/Sources/Rendering/Core/VolumeProperty/index.js
+++ b/Sources/Rendering/Core/VolumeProperty/index.js
@@ -66,15 +66,21 @@ function vtkVolumeProperty(publicAPI, model) {
 
   // Set the color of a volume to a gray transfer function
   publicAPI.setGrayTransferFunction = (index, func) => {
+    let modified = false;
     if (model.componentData[index].grayTransferFunction !== func) {
       model.componentData[index].grayTransferFunction = func;
-      publicAPI.modified();
+      modified = true;
     }
 
     if (model.componentData[index].colorChannels !== 1) {
       model.componentData[index].colorChannels = 1;
+      modified = true;
+    }
+
+    if (modified) {
       publicAPI.modified();
     }
+    return modified;
   };
 
   // Get the currently set gray transfer function. Create one if none set.
@@ -96,15 +102,21 @@ function vtkVolumeProperty(publicAPI, model) {
 
   // Set the color of a volume to an RGB transfer function
   publicAPI.setRGBTransferFunction = (index, func) => {
+    let modified = false;
     if (model.componentData[index].rGBTransferFunction !== func) {
       model.componentData[index].rGBTransferFunction = func;
-      publicAPI.modified();
+      modified = true;
     }
 
     if (model.componentData[index].colorChannels !== 3) {
       model.componentData[index].colorChannels = 3;
+      modified = true;
+    }
+
+    if (modified) {
       publicAPI.modified();
     }
+    return modified;
   };
 
   // Get the currently set RGB transfer function. Create one if none set.
@@ -139,7 +151,9 @@ function vtkVolumeProperty(publicAPI, model) {
     if (model.componentData[index].scalarOpacity !== func) {
       model.componentData[index].scalarOpacity = func;
       publicAPI.modified();
+      return true;
     }
+    return false;
   };
 
   // Get the scalar opacity transfer function. Create one if none set.
@@ -166,7 +180,9 @@ function vtkVolumeProperty(publicAPI, model) {
     if (model.componentData[index].componentWeight !== val) {
       model.componentData[index].componentWeight = val;
       publicAPI.modified();
+      return true;
     }
+    return false;
   };
 
   publicAPI.getComponentWeight = (index) => {
@@ -178,17 +194,14 @@ function vtkVolumeProperty(publicAPI, model) {
     return model.componentData[index].componentWeight;
   };
 
-  publicAPI.setInterpolationTypeToNearest = () => {
+  publicAPI.setInterpolationTypeToNearest = () =>
     publicAPI.setInterpolationType(InterpolationType.NEAREST);
-  };
 
-  publicAPI.setInterpolationTypeToLinear = () => {
+  publicAPI.setInterpolationTypeToLinear = () =>
     publicAPI.setInterpolationType(InterpolationType.LINEAR);
-  };
 
-  publicAPI.setInterpolationTypeToFastLinear = () => {
+  publicAPI.setInterpolationTypeToFastLinear = () =>
     publicAPI.setInterpolationType(InterpolationType.FAST_LINEAR);
-  };
 
   publicAPI.getInterpolationTypeAsString = () =>
     macro.enumToString(InterpolationType, model.interpolationType);
@@ -207,7 +220,9 @@ function vtkVolumeProperty(publicAPI, model) {
       if (model.componentData[index][`${val}`] !== value) {
         model.componentData[index][`${val}`] = value;
         publicAPI.modified();
+        return true;
       }
+      return false;
     };
   });
 


### PR DESCRIPTION
I like the new multi-component options for slice rendering, but we have an extension of `vtkImageProperty` and saw some issues because
```
if (superSetRGBTransferFunction(func)) {
  ...
}
```
no longer works.

I went ahead and updated the `vtkVolumeProperty` as well for consistency.