### PR TITLE
fix(WidgetManager): Guard against object deletion

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -154,6 +154,9 @@ function vtkWidgetManager(publicAPI, model) {
         }
 
         Promise.all(pendingContent).then((vnodes) => {
+          if (model.deleted) {
+            return;
+          }
           const oldVTree = svgVTrees.get(widget);
           const newVTree = createSvgElement('g');
           for (let ni = 0; ni < vnodes.length; ni++) {


### PR DESCRIPTION
WidgetManager may be deleted between updateSvg() and the promise
resolution callback.

Fixes #1382 @finetjul 