### PR TITLE
fix(WidgetManager): Better handling of svg layer CSS

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -97,7 +97,8 @@ function vtkWidgetManager(publicAPI, model) {
     const container = model.openGLRenderWindow.getReferenceByName('el');
     const canvas = model.openGLRenderWindow.getCanvas();
     container.insertBefore(model.svgRoot, canvas.nextSibling);
-    if (!container.style.position || container.style.position === 'static') {
+    const containerStyles = window.getComputedStyle(container);
+    if (containerStyles.position === 'static') {
       container.style.position = 'relative';
     }
   }


### PR DESCRIPTION
Uses computed styles to determine if we need to update the vtk.js container's styles. @agirault 