### PR TITLE
feat: improve support for webGL2 features

### DIFF
--- a/Sources/Rendering/OpenGL/ShaderProgram/index.js
+++ b/Sources/Rendering/OpenGL/ShaderProgram/index.js
@@ -81,7 +81,7 @@ function vtkShaderProgram(publicAPI, model) {
   };
 
   publicAPI.bind = () => {
-    if (!model.linked && !model.link()) {
+    if (!model.linked && !publicAPI.link()) {
       return false;
     }
 

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -313,10 +313,12 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.getInternalFormat = (vtktype, numComps) => {
-    model.internalFormat = publicAPI.getDefaultInternalFormat(
-      vtktype,
-      numComps
-    );
+    if (!model.internalFormat) {
+      model.internalFormat = publicAPI.getDefaultInternalFormat(
+        vtktype,
+        numComps
+      );
+    }
 
     if (!model.internalFormat) {
       vtkDebugMacro(
@@ -360,7 +362,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.setInternalFormat = (iFormat) => {
-    if (iFormat !== model.context.InternalFormat) {
+    if (iFormat !== model.internalFormat) {
       model.internalFormat = iFormat;
       publicAPI.modified();
     }
@@ -813,7 +815,15 @@ function vtkOpenGLTexture(publicAPI, model) {
     // Now determine the texture parameters using the arguments.
     publicAPI.getOpenGLDataType(dataType);
     model.format = model.context.DEPTH_COMPONENT;
-    model.internalFormat = model.context.DEPTH_COMPONENT;
+    if (model.openGLRenderWindow.getWebgl2()) {
+      if (dataType === VtkDataTypes.FLOAT) {
+        model.internalFormat = model.context.DEPTH_COMPONENT32F;
+      } else {
+        model.internalFormat = model.context.DEPTH_COMPONENT16;
+      }
+    } else {
+      model.internalFormat = model.context.DEPTH_COMPONENT;
+    }
 
     if (!model.internalFormat || !model.format || !model.openGLDataType) {
       vtkErrorMacro('Failed to determine texture parameters.');


### PR DESCRIPTION
This brings a few fixes and features to some of the WebGL utility classes, with a focus on improving
WebGL2 support:

* Allow attaching and detaching multiple color textures to framebuffers if WebGL 2 is enabled
* Allow attaching and detaching a depth texture to framebuffers if WebGL 2 is enabled
* Fix an error in vtkFrameBuffer.releaseGraphicsResources
* Use user-specified internal texture type if present
* Fix an error in ShaderProgram
* Use 32 bit floats for depth textures (when type is Float32Array and with WebGL 2)

