### PR TITLE
fix(vtkOpenGLRenderWindow): Only update canvas size when needed

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -72,11 +72,19 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   model.classHierarchy.push('vtkOpenGLRenderWindow');
 
   // Auto update style
+  const previousSize = [0, 0];
   function updateWindow() {
     // Canvas size
     if (model.renderable) {
-      model.canvas.setAttribute('width', model.size[0]);
-      model.canvas.setAttribute('height', model.size[1]);
+      if (
+        model.size[0] !== previousSize[0] ||
+        model.size[1] !== previousSize[1]
+      ) {
+        previousSize[0] = model.size[0];
+        previousSize[1] = model.size[1];
+        model.canvas.setAttribute('width', model.size[0]);
+        model.canvas.setAttribute('height', model.size[1]);
+      }
     }
 
     // ImageStream size


### PR DESCRIPTION
Firefox 75 introduced a regression in vtk-js. The LabelWidget and HandleWidget examples for example show some strange flickering when moving the cursor over the widgets.

[This](https://hg.mozilla.org/integration/autoland/pushloghtml?fromchange=ae2a8d6e0c958b9d2d27c21b797100994bb488a2&tochange=73572c522da83cb8e8392c723da1f6a01c619250) is the change that introduced the regression.

What the change does is stop presenting the draw buffer when canvas size is modified but the size is the same as the current canvas size.

This affected us in vtk-js because changing cursor type (which widgets do a lot) also caused the canvas sizes to be modified. That's what this commit is preventing, and it seems like an effective workaround.