### PR TITLE
fix(LookupTableProxy): Support midpoint/sharpness in rgbpoints

### DIFF
--- a/Sources/Proxy/Core/LookupTableProxy/index.js
+++ b/Sources/Proxy/Core/LookupTableProxy/index.js
@@ -30,7 +30,7 @@ function vtkLookupTableProxy(publicAPI, model) {
     }
   };
 
-  // Takes an array of points [x, r, g, b]
+  // Takes an array of points [x, r, g, b, m=0.5, s=0.0]
   publicAPI.setRGBPoints = (rgbPoints) => {
     if (model.rgbPoints !== rgbPoints) {
       model.rgbPoints = (rgbPoints || Defaults.RGBPoints).slice();
@@ -38,7 +38,7 @@ function vtkLookupTableProxy(publicAPI, model) {
     }
   };
 
-  // Takes an array of points [x, h, s, v]
+  // Takes an array of points [x, h, s, v, m=0.5, s=0.0]
   publicAPI.setHSVPoints = (hsvPoints) => {
     if (model.hsvPoints !== hsvPoints) {
       model.hsvPoints = (hsvPoints || Defaults.HSVPoints).slice();
@@ -75,14 +75,14 @@ function vtkLookupTableProxy(publicAPI, model) {
       case Mode.RGBPoints:
         model.lookupTable.removeAllPoints();
         model.rgbPoints.forEach((point) =>
-          model.lookupTable.addRGBPoint(...point)
+          model.lookupTable.addRGBPointLong(...point)
         );
         break;
 
       case Mode.HSVPoints:
         model.lookupTable.removeAllPoints();
         model.hsvPoints.forEach((point) =>
-          model.lookupTable.addHSVPoint(...point)
+          model.lookupTable.addHSVPointLong(...point)
         );
         break;
 

--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -147,7 +147,7 @@ function vtkColorTransferFunction(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   // Add a point defined in RGB
-  publicAPI.addRGBPointLong = (x, r, g, b, midpoint, sharpness) => {
+  publicAPI.addRGBPointLong = (x, r, g, b, midpoint = 0.5, sharpness = 0.0) => {
     // Error check
     if (midpoint < 0.0 || midpoint > 1.0) {
       vtkErrorMacro('Midpoint outside range [0.0, 1.0]');
@@ -196,7 +196,7 @@ function vtkColorTransferFunction(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   // Add a point defined in HSV
-  publicAPI.addHSVPointLong = (x, h, s, v, midpoint, sharpness) => {
+  publicAPI.addHSVPointLong = (x, h, s, v, midpoint = 0.5, sharpness = 0.0) => {
     const rgb = [];
     const hsv = [h, s, v];
 


### PR DESCRIPTION
Currently the `vtkLookupTableProxy` ignores the midpoint and sharpness values we might provide when calling `setRGBPoints`.  This PR allows us to do the following:

```
rgbPoints = [];
rgbPoints.push([v, r, g, b, mid, sharp]);
...
lutProxy.setRGBPoints(rgbPoints);
```