### PR TITLE
fix(Widgets): Expose missing classes

### DIFF
--- a/Sources/Interaction/Widgets/index.js
+++ b/Sources/Interaction/Widgets/index.js
@@ -12,6 +12,9 @@ import vtkLineWidget from './LineWidget';
 import vtkOrientationMarkerWidget from './OrientationMarkerWidget';
 import vtkPiecewiseGaussianWidget from './PiecewiseGaussianWidget';
 import vtkPointPlacer from './PointPlacer';
+import vtkResliceCursor from './ResliceCursor/ResliceCursor';
+import vtkResliceCursorLineRepresentation from './ResliceCursor/ResliceCursorLineRepresentation';
+import vtkResliceCursorWidget from './ResliceCursor/ResliceCursorWidget';
 import vtkSphereHandleRepresentation from './SphereHandleRepresentation';
 import vtkWidgetRepresentation from './WidgetRepresentation';
 
@@ -30,6 +33,9 @@ export default {
   vtkOrientationMarkerWidget,
   vtkPiecewiseGaussianWidget,
   vtkPointPlacer,
+  vtkResliceCursor,
+  vtkResliceCursorLineRepresentation,
+  vtkResliceCursorWidget,
   vtkSphereHandleRepresentation,
   vtkWidgetRepresentation,
 };


### PR DESCRIPTION
Expose missing Reslice cursor classes to be able to reproduce the example using the vtk.js bundle

fix #1413