### PR TITLE
fix(vtkResliceCursorWidget): Fix axes disappearing under certain cond…

### DIFF
--- a/Sources/Interaction/Widgets/ResliceCursor/ResliceCursor/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/ResliceCursor/index.js
@@ -118,6 +118,10 @@ function vtkResliceCursor(publicAPI, model) {
     vtkMath.cross(normals[0], normals[1], model.zAxis);
     vtkMath.cross(normals[1], normals[2], model.xAxis);
     vtkMath.cross(normals[2], normals[0], model.yAxis);
+
+    vtkMath.normalize(model.xAxis);
+    vtkMath.normalize(model.yAxis);
+    vtkMath.normalize(model.zAxis);
   };
 
   // Reset cursor to its initial position

--- a/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorActor/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorActor/index.js
@@ -129,10 +129,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   for (let i = 0; i < 3; i++) {
     model.cursorCenterlineMapper[i] = vtkMapper.newInstance();
     model.cursorCenterlineMapper[i].setScalarVisibility(false);
-    model.cursorCenterlineMapper[i].setResolveCoincidentTopology(true);
     model.cursorCenterlineMapper[
       i
-    ].setResolveCoincidentTopologyPolygonOffsetParameters(-1, -1);
+    ].setResolveCoincidentTopologyToPolygonOffset();
+    model.cursorCenterlineMapper[
+      i
+    ].setResolveCoincidentTopologyLineOffsetParameters(-1.0, -1.0);
 
     model.cursorCenterlineActor[i] = vtkActor.newInstance();
     model.cursorCenterlineActor[i].setMapper(model.cursorCenterlineMapper[i]);

--- a/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorRepresentation/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorRepresentation/index.js
@@ -478,7 +478,11 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.newResliceAxes = mat4.create();
   model.imageActor = vtkImageSlice.newInstance();
   model.imageMapper = vtkImageMapper.newInstance();
-
+  model.imageMapper.setResolveCoincidentTopologyToPolygonOffset();
+  model.imageMapper.setRelativeCoincidentTopologyPolygonOffsetParameters(
+    1.0,
+    1.0
+  );
   model.planeInitialized = false;
 
   macro.setGet(publicAPI, model, [


### PR DESCRIPTION
…itions

Fixes two issues where the widget's axes could disappear:

* Coincident topology issues
* If two of the axes were parallel, or close to, some axes could be displayed too short, or disappear (see screenshot). I'm not sure if this is intended, but normalizing the axes fixes that:

![reslicebug](https://user-images.githubusercontent.com/1732912/80396562-1621e680-88b5-11ea-92f2-50de0ebf3a62.png)
