### PR TITLE
Orientation support for ShapeWidget

### DIFF
--- a/Sources/Rendering/Core/Glyph3DMapper/Constants.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/Constants.js
@@ -1,6 +1,7 @@
 export const OrientationModes = {
   DIRECTION: 0,
   ROTATION: 1,
+  MATRIX: 2,
 };
 
 export const ScaleModes = {

--- a/Sources/Rendering/Core/Glyph3DMapper/index.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.js
@@ -34,6 +34,8 @@ function vtkGlyph3DMapper(publicAPI, model) {
     publicAPI.setOrientationMode(OrientationModes.DIRECTION);
   publicAPI.setOrientationModeToRotation = () =>
     publicAPI.setOrientationMode(OrientationModes.ROTATION);
+  publicAPI.setOrientationModeToMatrix = () =>
+    publicAPI.setOrientationMode(OrientationModes.MATRIX);
   publicAPI.getOrientationArrayData = () => {
     const idata = publicAPI.getInputData(0);
     if (!idata || !idata.getPointData()) {
@@ -143,6 +145,17 @@ function vtkGlyph3DMapper(publicAPI, model) {
           const orientation = [];
           oArray.getTuple(i, orientation);
           switch (model.orientationMode) {
+            case OrientationModes.MATRIX: {
+              // prettier-ignore
+              const rotMat4 = [
+                ...orientation.slice(0, 3), 0,
+                ...orientation.slice(3, 6), 0,
+                ...orientation.slice(6, 9), 0,
+                0, 0, 0, 1,
+              ];
+              mat4.multiply(z, z, rotMat4);
+              break;
+            }
             case OrientationModes.ROTATION:
               mat4.rotateZ(z, z, orientation[2]);
               mat4.rotateX(z, z, orientation[0]);

--- a/Sources/Widgets/Core/StateBuilder/cornerMixin.js
+++ b/Sources/Widgets/Core/StateBuilder/cornerMixin.js
@@ -1,0 +1,28 @@
+import macro from 'vtk.js/Sources/macro';
+
+// ----------------------------------------------------------------------------
+
+function vtkCornerMixin(publicAPI, model) {
+  publicAPI.translate = (dx, dy, dz) => {
+    const [x, y, z] = publicAPI.getCornerByReference();
+    publicAPI.setCorner(x + dx, y + dy, z + dz);
+  };
+}
+
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  corner: [0, 0, 0],
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+  macro.setGetArray(publicAPI, model, ['corner'], 3);
+  vtkCornerMixin(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export default { extend };

--- a/Sources/Widgets/Core/StateBuilder/index.js
+++ b/Sources/Widgets/Core/StateBuilder/index.js
@@ -4,6 +4,7 @@ import vtkWidgetState from 'vtk.js/Sources/Widgets/Core/WidgetState';
 
 import bounds from 'vtk.js/Sources/Widgets/Core/StateBuilder/boundsMixin';
 import color from 'vtk.js/Sources/Widgets/Core/StateBuilder/colorMixin';
+import corner from 'vtk.js/Sources/Widgets/Core/StateBuilder/cornerMixin';
 import direction from 'vtk.js/Sources/Widgets/Core/StateBuilder/directionMixin';
 import manipulator from 'vtk.js/Sources/Widgets/Core/StateBuilder/manipulatorMixin';
 import name from 'vtk.js/Sources/Widgets/Core/StateBuilder/nameMixin';
@@ -22,6 +23,7 @@ const { vtkErrorMacro } = macro;
 const MIXINS = {
   bounds,
   color,
+  corner,
   direction,
   manipulator,
   name,

--- a/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
@@ -59,9 +59,8 @@ function vtkRectangleContextRepresentation(publicAPI, model) {
     const dataset = vtkPolyData.newInstance();
 
     if (state.getVisible()) {
-      const bounds = state.getBounds();
-      const point1 = [bounds[0], bounds[2], bounds[4]]; // so wrong, can't guess points from bounds
-      const point2 = [bounds[1], bounds[3], bounds[5]]; // so wrong, can't guess points from bounds
+      const point1 = state.getOrigin();
+      const point2 = state.getCorner();
       const diagonal = [0, 0, 0];
       vec3.subtract(diagonal, point2, point1);
       const up = state.getUp();

--- a/Sources/Widgets/Widgets3D/EllipseWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/behavior.js
@@ -1,6 +1,5 @@
 import shapeBehavior from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/behavior';
 import { vec3 } from 'gl-matrix';
-import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 
 export default function widgetBehavior(publicAPI, model) {
   // We inherit shapeBehavior
@@ -9,38 +8,28 @@ export default function widgetBehavior(publicAPI, model) {
 
   model.classHierarchy.push('vtkEllipseWidgetProp');
 
-  publicAPI.setBounds = (bounds) => {
-    if (superClass.setBounds) {
-      superClass.setBounds(bounds);
+  publicAPI.setCorners = (point1, point2) => {
+    if (superClass.setCorners) {
+      superClass.setCorners(point1, point2);
     }
 
-    const center = vtkBoundingBox.getCenter(bounds);
-    const scale3 = vtkBoundingBox.computeScale3(bounds);
-
-    model.shapeHandle.setOrigin(center);
-    model.shapeHandle.setScale3(scale3);
-  };
-
-  publicAPI.setBoundsFromRadius = (center, pointOnCircle) => {
-    const radius = vec3.distance(center, pointOnCircle);
-
-    publicAPI.setBounds([
-      center[0] - radius,
-      center[0] + radius,
-      center[1] - radius,
-      center[1] + radius,
-      center[2] - radius,
-      center[2] + radius,
-    ]);
-  };
-
-  publicAPI.setBoundsFromDiameter = (point1, point2) => {
     const center = [
       0.5 * (point1[0] + point2[0]),
       0.5 * (point1[1] + point2[1]),
       0.5 * (point1[2] + point2[2]),
     ];
 
-    publicAPI.setBoundsFromRadius(center, point1);
+    const diagonal = [0, 0, 0];
+    vec3.subtract(diagonal, point2, center);
+
+    const right = model.shapeHandle.getRight();
+    const up = model.shapeHandle.getUp();
+    const dir = model.shapeHandle.getDirection();
+    const rightComponent = vec3.dot(diagonal, right);
+    const upComponent = vec3.dot(diagonal, up);
+    const dirComponent = vec3.dot(diagonal, dir);
+
+    model.shapeHandle.setOrigin(center);
+    model.shapeHandle.setScale3([rightComponent, upComponent, dirComponent]);
   };
 }

--- a/Sources/Widgets/Widgets3D/EllipseWidget/state.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/state.js
@@ -25,11 +25,10 @@ export default function generateState() {
     })
     .addStateFromMixin({
       labels: ['ellipseHandle'],
-      mixins: ['origin', 'color', 'scale3', 'visible', 'direction'],
+      mixins: ['origin', 'color', 'scale3', 'visible', 'orientation'],
       name: 'ellipseHandle',
       initialValues: {
         visible: false,
-        direction: [0, 0, 1],
         scale3: [1, 1, 1],
       },
     })

--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -222,23 +222,6 @@ reader
 
     updateControlPanel(image.imageMapper, data);
 
-    // give axis information to widgets
-    let axis = [0, 0, 0];
-    data.indexToWorldVec3([1, 0, 0], axis);
-    scene.rectangleHandle.setXAxis(axis);
-    scene.ellipseHandle.setXAxis(axis);
-    scene.circleHandle.setXAxis(axis);
-    axis = [0, 0, 0];
-    data.indexToWorldVec3([0, 1, 0], axis);
-    scene.rectangleHandle.setYAxis(axis);
-    scene.ellipseHandle.setYAxis(axis);
-    scene.circleHandle.setYAxis(axis);
-    axis = [0, 0, 0];
-    data.indexToWorldVec3([0, 0, 1], axis);
-    scene.rectangleHandle.setZAxis(axis);
-    scene.ellipseHandle.setZAxis(axis);
-    scene.circleHandle.setZAxis(axis);
-
     scene.circleHandle.setLabelTextCallback((worldBounds, screenBounds) => {
       const center = vtkBoundingBox.getCenter(screenBounds);
       const radius =
@@ -310,9 +293,6 @@ reader
         widgets.polygonWidget.getManipulator().setOrigin(position);
         widgets.polygonWidget.getManipulator().setNormal(normal);
 
-        scene.rectangleHandle.setSlicingMode(slicingMode);
-        scene.ellipseHandle.setSlicingMode(slicingMode);
-        scene.circleHandle.setSlicingMode(slicingMode);
         painter.setSlicingMode(slicingMode);
 
         scene.paintHandle.updateRepresentationForRender();
@@ -365,9 +345,6 @@ document.querySelector('.axis').addEventListener('input', (ev) => {
   const direction = [0, 0, 0];
   direction[sliceMode] = 1;
   scene.paintHandle.getWidgetState().getHandle().setDirection(direction);
-  scene.rectangleHandle.setSlicingMode(sliceMode);
-  scene.ellipseHandle.setSlicingMode(sliceMode);
-  scene.circleHandle.setSlicingMode(sliceMode);
 
   setCamera(sliceMode, scene.renderer, image.data);
   scene.renderWindow.render();
@@ -429,13 +406,13 @@ scene.paintHandle.onInteractionEvent(() => {
 initializeHandle(scene.rectangleHandle);
 
 scene.rectangleHandle.onInteractionEvent(() => {
-  const bounds = scene.rectangleHandle
+  const rectangleHandle = scene.rectangleHandle
     .getWidgetState()
-    .getRectangleHandle()
-    .getBounds();
-  const point1 = [bounds[0], bounds[2], bounds[4]];
-  const point2 = [bounds[1], bounds[3], bounds[5]];
-  painter.paintRectangle(point1, point2);
+    .getRectangleHandle();
+  painter.paintRectangle(
+    rectangleHandle.getOrigin(),
+    rectangleHandle.getCorner()
+  );
 });
 
 initializeHandle(scene.ellipseHandle);

--- a/Sources/Widgets/Widgets3D/RectangleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/behavior.js
@@ -7,11 +7,11 @@ export default function widgetBehavior(publicAPI, model) {
 
   model.classHierarchy.push('vtkRectangleWidgetProp');
 
-  publicAPI.setBounds = (bounds) => {
-    if (superClass.setBounds) {
-      superClass.setBounds(bounds);
+  publicAPI.setCorners = (point1, point2) => {
+    if (superClass.setCorners) {
+      superClass.setCorners(point1, point2);
     }
-
-    model.shapeHandle.setBounds(bounds);
+    model.shapeHandle.setOrigin(point1);
+    model.shapeHandle.setCorner(point2);
   };
 }

--- a/Sources/Widgets/Widgets3D/RectangleWidget/state.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/state.js
@@ -25,10 +25,9 @@ export default function generateState() {
     })
     .addStateFromMixin({
       labels: ['rectangleHandle'],
-      mixins: ['bounds', 'color', 'visible', 'orientation'],
+      mixins: ['origin', 'corner', 'color', 'visible', 'orientation'],
       name: 'rectangleHandle',
       initialValues: {
-        bounds: [0, 0, 0, 0, 0, 0],
         visible: false,
       },
     })

--- a/Sources/Widgets/Widgets3D/RectangleWidget/state.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/state.js
@@ -25,12 +25,11 @@ export default function generateState() {
     })
     .addStateFromMixin({
       labels: ['rectangleHandle'],
-      mixins: ['bounds', 'color', 'visible', 'direction'],
+      mixins: ['bounds', 'color', 'visible', 'orientation'],
       name: 'rectangleHandle',
       initialValues: {
         bounds: [0, 0, 0, 0, 0, 0],
         visible: false,
-        direction: [0, 0, 1],
       },
     })
     .build();

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -372,14 +372,18 @@ export default function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
 
-    const normal = model.camera.getDirectionOfProjection();
-    const up = model.camera.getViewUp();
-    const right = [0, 0, 0];
-    vec3.cross(right, up, normal);
-    model.shapeHandle.setUp(up);
-    model.shapeHandle.setRight(right);
-    model.shapeHandle.setDirection(normal);
-    model.manipulator.setNormal(normal);
+    if (!model.point2) {
+      // Update orientation to match the camera's plane
+      // if the corners are not yet placed
+      const normal = model.camera.getDirectionOfProjection();
+      const up = model.camera.getViewUp();
+      const right = [];
+      vec3.cross(right, up, normal);
+      model.shapeHandle.setUp(up);
+      model.shapeHandle.setRight(right);
+      model.shapeHandle.setDirection(normal);
+      model.manipulator.setNormal(normal);
+    }
     model.manipulator.setOrigin(model.activeState.getOrigin());
 
     const worldCoords = model.manipulator.handleEvent(

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -41,14 +41,6 @@ export default function widgetBehavior(publicAPI, model) {
   // Public methods
   // --------------------------------------------------------------------------
 
-  publicAPI.setSlicingMode = (slicingMode) => {
-    publicAPI.reset();
-    const direction = [0, 0, 0];
-    direction[slicingMode % 3] = 1;
-    model.shapeHandle.setDirection(direction);
-    model.manipulator.setNormal(direction);
-  };
-
   publicAPI.setModifierBehavior = (behavior) => {
     Object.assign(model.modifierBehavior, behavior);
   };
@@ -410,6 +402,14 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleMouseMove = (callData) => {
     if (model.manipulator) {
+      const direction = model.camera.getDirectionOfProjection();
+      model.shapeHandle.setDirection(direction);
+      model.manipulator.setNormal(direction);
+
+      if (model.activeState) {
+        model.manipulator.setOrigin(model.activeState.getOrigin());
+      }
+
       const worldCoords = model.manipulator.handleEvent(
         callData,
         model.openGLRenderWindow

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -7,7 +7,6 @@ import {
 
 import vtkLabelRepresentation from 'vtk.js/Sources/Interaction/Widgets/LabelRepresentation';
 
-import { SlicingMode } from 'vtk.js/Sources/Rendering/Core/ImageMapper/Constants';
 import { vec3 } from 'gl-matrix';
 
 const { vtkErrorMacro } = macro;
@@ -93,18 +92,6 @@ export default function widgetBehavior(publicAPI, model) {
     model.visibleOnFocus = visibleOnFocus;
   };
 
-  publicAPI.setXAxis = (xAxis) => {
-    vec3.normalize(model.xAxis, xAxis);
-  };
-
-  publicAPI.setYAxis = (yAxis) => {
-    vec3.normalize(model.yAxis, yAxis);
-  };
-
-  publicAPI.setZAxis = (zAxis) => {
-    vec3.normalize(model.zAxis, zAxis);
-  };
-
   publicAPI.setLabelTextCallback = (callback) => {
     model.labelTextCallback = callback;
   };
@@ -155,7 +142,6 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.placePoint2 = (point2) => {
     if (model.hasFocus) {
       model.point2 = point2;
-
       model.point2Handle.setOrigin(model.point2);
 
       publicAPI.updateShapeBounds();
@@ -215,64 +201,40 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.makeSquareFromPoints = (point1, point2) => {
-    const d = [0, 0, 0];
-    vec3.subtract(d, point2, point1);
+    const diagonal = [0, 0, 0];
+    vec3.subtract(diagonal, point2, point1);
+    const dir = model.shapeHandle.getDirection();
+    const right = model.shapeHandle.getRight();
+    const up = model.shapeHandle.getUp();
+    const dirComponent = vec3.dot(diagonal, dir);
+    let rightComponent = vec3.dot(diagonal, right);
+    let upComponent = vec3.dot(diagonal, up);
+    const absRightComponent = Math.abs(rightComponent);
+    const absUpComponent = Math.abs(upComponent);
 
-    let sx = vec3.dot(d, model.xAxis);
-    let sy = vec3.dot(d, model.yAxis);
-    let sz = vec3.dot(d, model.zAxis);
-
-    const absSx = Math.abs(sx);
-    const absSy = Math.abs(sy);
-    const absSz = Math.abs(sz);
-
-    const slicingMode = model.shapeHandle.getDirection().indexOf(1);
-
-    if (slicingMode === SlicingMode.I) {
-      if (absSy < EPSILON) {
-        sy = sz;
-      } else if (absSz < EPSILON) {
-        sz = sy;
-      } else if (absSy > absSz) {
-        sz = (sz / absSz) * absSy;
-      } else {
-        sy = (sy / absSy) * absSz;
-      }
-    } else if (slicingMode === SlicingMode.J) {
-      if (absSx < EPSILON) {
-        sx = sz;
-      } else if (absSz < EPSILON) {
-        sz = sx;
-      } else if (absSx > absSz) {
-        sz = (sz / absSz) * absSx;
-      } else {
-        sx = (sx / absSx) * absSz;
-      }
-    } else if (slicingMode === SlicingMode.K) {
-      if (absSx < EPSILON) {
-        sx = sy;
-      } else if (absSy < EPSILON) {
-        sy = sx;
-      } else if (absSx > absSy) {
-        sy = (sy / absSy) * absSx;
-      } else {
-        sx = (sx / absSx) * absSy;
-      }
+    if (absRightComponent < EPSILON) {
+      rightComponent = upComponent;
+    } else if (absUpComponent < EPSILON) {
+      upComponent = rightComponent;
+    } else if (absRightComponent > absUpComponent) {
+      upComponent = (upComponent / absUpComponent) * absRightComponent;
+    } else {
+      rightComponent = (rightComponent / absRightComponent) * absUpComponent;
     }
 
     return [
       point1[0] +
-        sx * model.xAxis[0] +
-        sy * model.yAxis[0] +
-        sz * model.zAxis[0],
+        rightComponent * right[0] +
+        upComponent * up[0] +
+        dirComponent * dir[0],
       point1[1] +
-        sx * model.xAxis[1] +
-        sy * model.yAxis[1] +
-        sz * model.zAxis[1],
+        rightComponent * right[1] +
+        upComponent * up[1] +
+        dirComponent * dir[1],
       point1[2] +
-        sx * model.xAxis[2] +
-        sy * model.yAxis[2] +
-        sz * model.zAxis[2],
+        rightComponent * right[2] +
+        upComponent * up[2] +
+        dirComponent * dir[2],
     ];
   };
 
@@ -401,55 +363,54 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleMouseMove = (callData) => {
-    if (model.manipulator) {
-      const direction = model.camera.getDirectionOfProjection();
-      model.shapeHandle.setDirection(direction);
-      model.manipulator.setNormal(direction);
-
-      if (model.activeState) {
-        model.manipulator.setOrigin(model.activeState.getOrigin());
-      }
-
-      const worldCoords = model.manipulator.handleEvent(
-        callData,
-        model.openGLRenderWindow
-      );
-
-      if (model.hasFocus && model.pickable) {
-        if (worldCoords.length) {
-          if (!model.point1) {
-            model.point1Handle.setOrigin(worldCoords);
-          } else {
-            model.point2Handle.setOrigin(worldCoords);
-          }
-        }
-
-        if (model.point1) {
-          model.point2 = worldCoords;
-          publicAPI.updateShapeBounds();
-        }
-
-        return macro.EVENT_ABORT;
-      }
-
-      if (model.useHandles && model.isDragging) {
-        if (model.activeState === model.point1Handle) {
-          model.point1Handle.setOrigin(worldCoords);
-          model.point1 = worldCoords;
-        } else {
-          model.point2Handle.setOrigin(worldCoords);
-
-          model.point2 = worldCoords;
-        }
-        publicAPI.updateShapeBounds();
-
-        publicAPI.invokeInteractionEvent();
-
-        return macro.EVENT_ABORT;
-      }
+    if (
+      !model.activeState ||
+      !model.activeState.getActive() ||
+      !model.pickable ||
+      !model.manipulator
+    ) {
+      return macro.VOID;
     }
 
-    return macro.VOID;
+    const normal = model.camera.getDirectionOfProjection();
+    const up = model.camera.getViewUp();
+    const right = [0, 0, 0];
+    vec3.cross(right, up, normal);
+    model.shapeHandle.setUp(up);
+    model.shapeHandle.setRight(right);
+    model.shapeHandle.setDirection(normal);
+    model.manipulator.setNormal(normal);
+    model.manipulator.setOrigin(model.activeState.getOrigin());
+
+    const worldCoords = model.manipulator.handleEvent(
+      callData,
+      model.openGLRenderWindow
+    );
+    if (!worldCoords.length) {
+      return macro.VOID;
+    }
+
+    if (model.hasFocus) {
+      if (!model.point1) {
+        model.point1Handle.setOrigin(worldCoords);
+      } else {
+        model.point2Handle.setOrigin(worldCoords);
+        model.point2 = worldCoords;
+        publicAPI.updateShapeBounds();
+      }
+    } else if (model.useHandles && model.isDragging) {
+      if (model.activeState === model.point1Handle) {
+        model.point1Handle.setOrigin(worldCoords);
+        model.point1 = worldCoords;
+      } else {
+        model.point2Handle.setOrigin(worldCoords);
+        model.point2 = worldCoords;
+      }
+      publicAPI.updateShapeBounds();
+      publicAPI.invokeInteractionEvent();
+    }
+
+    return model.hasFocus ? macro.EVENT_ABORT : macro.VOID;
   };
 
   // --------------------------------------------------------------------------
@@ -526,13 +487,7 @@ export default function widgetBehavior(publicAPI, model) {
 
       if (publicAPI.isDraggingEnabled()) {
         const distance = vec3.squaredDistance(model.point1, model.point2);
-        const maxDistance =
-          100 *
-          Math.max(
-            vec3.squaredLength(model.xAxis),
-            vec3.squaredLength(model.yAxis),
-            vec3.squaredLength(model.zAxis)
-          );
+        const maxDistance = 100;
 
         if (distance > maxDistance || publicAPI.isDraggingForced()) {
           publicAPI.invokeInteractionEvent();

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -319,10 +319,6 @@ reader
         widgets.circleWidget.getManipulator().setOrigin(position);
         widgets.circleWidget.getManipulator().setNormal(normal);
 
-        scene.rectangleHandle.setSlicingMode(slicingMode);
-        scene.ellipseHandle.setSlicingMode(slicingMode);
-        scene.circleHandle.setSlicingMode(slicingMode);
-
         scene.rectangleHandle.updateRepresentationForRender();
         scene.ellipseHandle.updateRepresentationForRender();
         scene.circleHandle.updateRepresentationForRender();
@@ -348,6 +344,13 @@ readyAll();
 // UI logic
 // ----------------------------------------------------------------------------
 
+function resetWidgets() {
+  scene.rectangleHandle.reset();
+  scene.ellipseHandle.reset();
+  scene.circleHandle.reset();
+  scene.widgetManager.grabFocus(widgets[activeWidget]);
+}
+
 document.querySelector('.slice').addEventListener('input', (ev) => {
   image.imageMapper.setSlice(Number(ev.target.value));
 });
@@ -355,14 +358,8 @@ document.querySelector('.slice').addEventListener('input', (ev) => {
 document.querySelector('.axis').addEventListener('input', (ev) => {
   const sliceMode = 'IJKXYZ'.indexOf(ev.target.value) % 3;
   image.imageMapper.setSlicingMode(sliceMode);
-
-  const direction = [0, 0, 0];
-  direction[sliceMode] = 1;
-  scene.rectangleHandle.setSlicingMode(sliceMode);
-  scene.ellipseHandle.setSlicingMode(sliceMode);
-  scene.circleHandle.setSlicingMode(sliceMode);
-
   setCamera(sliceMode, scene.renderer, image.data);
+  resetWidgets();
   scene.renderWindow.render();
 });
 
@@ -372,10 +369,7 @@ document.querySelector('.widget').addEventListener('input', (ev) => {
 });
 
 document.querySelector('.reset').addEventListener('click', () => {
-  scene.rectangleHandle.reset();
-  scene.ellipseHandle.reset();
-  scene.circleHandle.reset();
-  scene.widgetManager.grabFocus(widgets[activeWidget]);
+  resetWidgets();
   scene.renderWindow.render();
 });
 

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -1,6 +1,5 @@
 import 'vtk.js/Sources/favicon';
 
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
 import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
 import vtkRectangleWidget from 'vtk.js/Sources/Widgets/Widgets3D/RectangleWidget';
@@ -180,23 +179,6 @@ reader
 
     updateControlPanel(image.imageMapper, data);
 
-    // give axis information to widgets
-    let axis = [0, 0, 0];
-    data.indexToWorldVec3([1, 0, 0], axis);
-    scene.rectangleHandle.setXAxis(axis);
-    scene.ellipseHandle.setXAxis(axis);
-    scene.circleHandle.setXAxis(axis);
-    axis = [0, 0, 0];
-    data.indexToWorldVec3([0, 1, 0], axis);
-    scene.rectangleHandle.setYAxis(axis);
-    scene.ellipseHandle.setYAxis(axis);
-    scene.circleHandle.setYAxis(axis);
-    axis = [0, 0, 0];
-    data.indexToWorldVec3([0, 0, 1], axis);
-    scene.rectangleHandle.setZAxis(axis);
-    scene.ellipseHandle.setZAxis(axis);
-    scene.circleHandle.setZAxis(axis);
-
     scene.rectangleHandle.getRepresentations()[1].setDrawBorder(true);
     scene.rectangleHandle.getRepresentations()[1].setDrawFace(false);
     scene.rectangleHandle.getRepresentations()[1].setOpacity(1);
@@ -298,27 +280,6 @@ reader
       const slicingMode = image.imageMapper.getSlicingMode() % 3;
 
       if (slicingMode > -1) {
-        const ijk = [0, 0, 0];
-        const position = [0, 0, 0];
-        const normal = [0, 0, 0];
-
-        // position
-        ijk[slicingMode] = image.imageMapper.getSlice();
-        data.indexToWorldVec3(ijk, position);
-
-        // circle/slice normal
-        ijk[slicingMode] = 1;
-        data.indexToWorldVec3(ijk, normal);
-        vtkMath.subtract(normal, data.getOrigin(), normal);
-        vtkMath.normalize(normal);
-
-        widgets.rectangleWidget.getManipulator().setOrigin(position);
-        widgets.rectangleWidget.getManipulator().setNormal(normal);
-        widgets.ellipseWidget.getManipulator().setOrigin(position);
-        widgets.ellipseWidget.getManipulator().setNormal(normal);
-        widgets.circleWidget.getManipulator().setOrigin(position);
-        widgets.circleWidget.getManipulator().setNormal(normal);
-
         scene.rectangleHandle.updateRepresentationForRender();
         scene.ellipseHandle.updateRepresentationForRender();
         scene.circleHandle.updateRepresentationForRender();

--- a/Sources/Widgets/Widgets3D/ShapeWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/index.js
@@ -5,9 +5,6 @@ import {
 
 export const DEFAULT_VALUES = {
   manipulator: null,
-  xAxis: [0, 0, 0],
-  yAxis: [0, 0, 0],
-  zAxis: [0, 0, 0],
   visibleOnFocus: true,
   modifierBehavior: {
     None: {


### PR DESCRIPTION
The widget was constrained to face the X, Y, or Z axis using the `setSlicingMode` API, which was limiting when wanting to create the widget on an arbitrary plane (example: IJK slicing of a dataset with a non-identity direction matrix).

The widgets now face the camera like other 2D widgets (SplineWidget, DistanceWidget) when being placed. It then holds on to its initial plane when being manipulated, even if the camera axis changes.
