### PR TITLE
fix(Widgets): Apply coincident topology parameters

### DIFF
--- a/Sources/Widgets/Core/AbstractWidgetFactory/index.js
+++ b/Sources/Widgets/Core/AbstractWidgetFactory/index.js
@@ -45,10 +45,13 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
 
       // Create representations for that view
       /* eslint-disable no-shadow */
+      const widgetInitialValues = initialValues; // Avoid shadowing
       widgetModel.representations = publicAPI
         .getRepresentationsForViewType(viewType)
         .map(({ builder, labels, initialValues }) =>
-          builder.newInstance(Object.assign({ labels }, initialValues))
+          builder.newInstance(
+            Object.assign({ labels }, initialValues, widgetInitialValues)
+          )
         );
       /* eslint-enable no-shadow */
 
@@ -60,10 +63,9 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
       });
 
       model.behavior(widgetPublicAPI, widgetModel);
-
       // Forward representation methods
-      if (model.methodsToLink) {
-        model.methodsToLink.forEach((methodName) => {
+      ['coincidentTopologyParameters', ...(model.methodsToLink || [])].forEach(
+        (methodName) => {
           const set = `set${macro.capitalize(methodName)}`;
           const get = `get${macro.capitalize(methodName)}`;
           const methods = {
@@ -91,8 +93,8 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
               widgetPublicAPI[name] = macro.chain(...calls);
             }
           });
-        });
-      }
+        }
+      );
 
       // Custom delete to detach from parent
       widgetPublicAPI.delete = macro.chain(() => {

--- a/Sources/Widgets/Core/WidgetManager/example/index.js
+++ b/Sources/Widgets/Core/WidgetManager/example/index.js
@@ -31,6 +31,20 @@ const WIDGET_BUILDERS = {
         label: 'Polyline',
       })
     );
+    instance.setCoincidentTopologyParameters({
+      Point: {
+        factor: -1.0,
+        offset: -1.0,
+      },
+      Line: {
+        factor: -1.5,
+        offset: -1.5,
+      },
+      Polygon: {
+        factor: -2.0,
+        offset: -2.0,
+      },
+    });
     instance.setActiveScaleFactor(0.9);
     instance.setGlyphResolution(60);
     return instance;
@@ -39,7 +53,24 @@ const WIDGET_BUILDERS = {
     const instance = widgetManager.addWidget(
       vtkPolyLineWidget.newInstance({
         label: 'Closed Polyline',
-      })
+      }),
+      null,
+      {
+        coincidentTopologyParameters: {
+          Point: {
+            factor: -1.0,
+            offset: -1.0,
+          },
+          Line: {
+            factor: -1.5,
+            offset: -1.5,
+          },
+          Polygon: {
+            factor: -2.0,
+            offset: -2.0,
+          },
+        },
+      }
     );
     instance.setActiveScaleFactor(1.1);
     instance.setGlyphResolution(30);

--- a/Sources/Widgets/Representations/CircleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/CircleContextRepresentation/index.js
@@ -82,7 +82,7 @@ function vtkCircleContextRepresentation(publicAPI, model) {
 
   vtkWidgetRepresentation.connectPipeline(model.pipelines.circle);
 
-  model.actors.push(model.pipelines.circle.actor);
+  publicAPI.addActor(model.pipelines.circle.actor);
 
   model.transform = vtkMatrixBuilder.buildFromDegree();
 

--- a/Sources/Widgets/Representations/ConvexFaceContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/ConvexFaceContextRepresentation/index.js
@@ -52,7 +52,7 @@ function vtkConvexFaceContextRepresentation(publicAPI, model) {
   model.mapper.setInputConnection(publicAPI.getOutputPort());
   model.actor.setMapper(model.mapper);
 
-  model.actors.push(model.actor);
+  publicAPI.addActor(model.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/CroppingOutlineRepresentation/index.js
+++ b/Sources/Widgets/Representations/CroppingOutlineRepresentation/index.js
@@ -54,7 +54,7 @@ function vtkCroppingOutlineRepresentation(publicAPI, model) {
   model.mapper.setInputConnection(publicAPI.getOutputPort());
   model.actor.setMapper(model.mapper);
 
-  model.actors.push(model.actor);
+  publicAPI.addActor(model.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/CubeHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/CubeHandleRepresentation/index.js
@@ -53,7 +53,7 @@ function vtkCubeHandleRepresentation(publicAPI, model) {
   model.mapper.setInputConnection(model.glyph.getOutputPort(), 1);
   model.actor.setMapper(model.mapper);
 
-  model.actors.push(model.actor);
+  publicAPI.addActor(model.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
+++ b/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
@@ -145,11 +145,11 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
   vtkWidgetRepresentation.connectPipeline(model.pipelines.normal);
   vtkWidgetRepresentation.connectPipeline(model.pipelines.display2D);
 
-  model.actors.push(model.pipelines.outline.actor);
-  model.actors.push(model.pipelines.plane.actor);
-  model.actors.push(model.pipelines.origin.actor);
-  model.actors.push(model.pipelines.normal.actor);
-  model.actors.push(model.pipelines.display2D.actor);
+  publicAPI.addActor(model.pipelines.outline.actor);
+  publicAPI.addActor(model.pipelines.plane.actor);
+  publicAPI.addActor(model.pipelines.origin.actor);
+  publicAPI.addActor(model.pipelines.normal.actor);
+  publicAPI.addActor(model.pipelines.display2D.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/OutlineContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/OutlineContextRepresentation/index.js
@@ -45,7 +45,7 @@ function vtkOutlineContextRepresentation(publicAPI, model) {
   model.mapper.setInputConnection(publicAPI.getOutputPort());
   model.actor.setMapper(model.mapper);
 
-  model.actors.push(model.actor);
+  publicAPI.addActor(model.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/PolyLineRepresentation/index.js
+++ b/Sources/Widgets/Representations/PolyLineRepresentation/index.js
@@ -59,7 +59,7 @@ function vtkPolyLineRepresentation(publicAPI, model) {
   model.mapper.setInputConnection(publicAPI.getOutputPort());
   model.actor.setMapper(model.mapper);
 
-  model.actors.push(model.actor);
+  publicAPI.addActor(model.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
@@ -26,7 +26,7 @@ function vtkRectangleContextRepresentation(publicAPI, model) {
   model.actor.getProperty().setOpacity(0.2);
   model.actor.getProperty().setColor(0, 1, 0);
 
-  model.actors.push(model.actor);
+  publicAPI.addActor(model.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
@@ -47,7 +47,7 @@ function vtkSphereHandleRepresentation(publicAPI, model) {
   // model.displayActor.getProperty().setOpacity(0); // don't show in 3D
   model.displayActor.setMapper(model.displayMapper);
   model.displayMapper.setInputConnection(publicAPI.getOutputPort());
-  model.actors.push(model.displayActor);
+  publicAPI.addActor(model.displayActor);
   model.alwaysVisibleActors = [model.displayActor];
 
   model.mapper = vtkGlyph3DMapper.newInstance({
@@ -65,7 +65,7 @@ function vtkSphereHandleRepresentation(publicAPI, model) {
   model.mapper.setInputConnection(model.glyph.getOutputPort(), 1);
   model.actor.setMapper(model.mapper);
 
-  model.actors.push(model.actor);
+  publicAPI.addActor(model.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/SplineContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/SplineContextRepresentation/index.js
@@ -43,7 +43,7 @@ function vtkSplineContextRepresentation(publicAPI, model) {
   model.pipelines.area.actor.setMapper(model.pipelines.area.mapper);
   model.pipelines.area.actor.getProperty().setOpacity(0.2);
   model.pipelines.area.actor.getProperty().setColor(0, 1, 0);
-  model.actors.push(model.pipelines.area.actor);
+  publicAPI.addActor(model.pipelines.area.actor);
 
   model.pipelines.border.lineFilter.setInputConnection(
     publicAPI.getOutputPort()
@@ -56,7 +56,7 @@ function vtkSplineContextRepresentation(publicAPI, model) {
   model.pipelines.border.actor.getProperty().setColor(0.1, 1, 0.1);
   model.pipelines.border.actor.setVisibility(model.outputBorder);
 
-  model.actors.push(model.pipelines.border.actor);
+  publicAPI.addActor(model.pipelines.border.actor);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Widgets/Representations/WidgetRepresentation/api.md
+++ b/Sources/Widgets/Representations/WidgetRepresentation/api.md
@@ -18,4 +18,7 @@ Used internally to set the target labels. When requestData is invoked,
 `getRepresentationStates(inData[0])` can be used to retrieve the list of states
 that match the target labels.
 
+## addActor(actor)
+
+Should be used when creating an actor for the representation. It will apply widget-wide configuration such as coincident topology parameters to the mapper.
 

--- a/Sources/Widgets/SVG/SVGRepresentation/index.js
+++ b/Sources/Widgets/SVG/SVGRepresentation/index.js
@@ -84,7 +84,7 @@ function vtkSVGRepresentation(publicAPI, model) {
     }
   });
 
-  model.actors.push(model.psActor);
+  publicAPI.addActor(model.psActor);
 
   // --------------------------------------------------------------------------
 


### PR DESCRIPTION
Applies coincident topology parameters to mappers created by widget representations.

Default values are -1.0, -1.0, but users can change those (see Sources/Widgets/Core/WidgetManager/example/index.js)
