### PR TITLE
fix(PaintFilter): fix polygon paint filter painting the wrong slice

### DIFF
--- a/Sources/Filters/General/PaintFilter/PaintFilter.worker.js
+++ b/Sources/Filters/General/PaintFilter/PaintFilter.worker.js
@@ -157,9 +157,9 @@ function handlePaintTriangles({ triangleList }) {
         vec3.scaleAndAdd(point, point, step1, u);
         vec3.scaleAndAdd(point, point, step2, v);
 
-        point[0] = Math.floor(point[0]);
-        point[1] = Math.floor(point[1]);
-        point[2] = Math.floor(point[2]);
+        point[0] = Math.round(point[0]);
+        point[1] = Math.round(point[1]);
+        point[2] = Math.round(point[2]);
 
         if (
           point[0] >= 0 &&


### PR DESCRIPTION
The polygon paint filter would sometimes paint to the slice above the current slice.