### PR TITLE
Display-scaled widget representations

### DIFF
--- a/Documentation/content/docs/concepts_widgets.md
+++ b/Documentation/content/docs/concepts_widgets.md
@@ -107,6 +107,22 @@ Widget representations must generate actors to be added to a scene. Internally,
 all actors should be appended to the `model.actors` array in order to be
 rendered.
 
+### Scaling representations to be fixed in display space
+
+In order to scale a representation such that it retains the same size in display space,
+it must use the `scaleByDisplay` flag and the `getDisplayWorldHeightAt(coord)` method.
+The flag is used to allow users of the representation to choose between display-scaled
+vs world-scaled sizing.
+
+`getDisplayWorldHeightAt(coord)` will return the world height at a particular point that
+corresponds to the viewport height. In other words, it is the height of the rectangle formed
+by the intersection of the plane (defined by the camera normal and coord) and the view
+frustrum. A typical usage of this method is to compute some fraction of this height and
+set that as the representation scale.
+
+Look at the `SphereHandleRepresentation` as an example for how `getDisplayWorldHeightAt`
+is used.
+
 ## Widget Manager
 
 The widget manager manages the lifecycle of a widget associated with a

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -477,8 +477,8 @@ function vtkWidgetManager(publicAPI, model) {
     if (useSvgLayer !== model.useSvgLayer) {
       model.useSvgLayer = useSvgLayer;
 
-      if (useSvgLayer) {
-        if (model.renderer) {
+      if (model.renderer) {
+        if (useSvgLayer) {
           enableSvgLayer();
           // force a render so svg widgets can be drawn
           updateSvg();

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -1,4 +1,5 @@
 import macro from 'vtk.js/Sources/macro';
+import { radiansFromDegrees } from 'vtk.js/Sources/Common/Core/Math';
 import vtkOpenGLHardwareSelector from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector';
 import { FieldAssociations } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
 import Constants from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
@@ -189,6 +190,31 @@ function vtkWidgetManager(publicAPI, model) {
   }
 
   // --------------------------------------------------------------------------
+  // Widget scaling
+  // --------------------------------------------------------------------------
+
+  function updateDisplayScaleParams(camera) {
+    const cameraPosition = camera.getPosition();
+    const cameraDir = camera.getDirectionOfProjection();
+    const isParallel = camera.getParallelProjection();
+    const dispHeightFactor = isParallel
+      ? camera.getParallelScale()
+      : 2 * Math.tan(radiansFromDegrees(camera.getViewAngle()) / 2);
+    model.widgets.forEach((w) => {
+      w.getNestedProps().forEach((r) => {
+        if (r.getScaleByDisplay()) {
+          r.setDisplayScaleParams({
+            dispHeightFactor,
+            cameraPosition,
+            cameraDir,
+            isParallel,
+          });
+        }
+      });
+    });
+  }
+
+  // --------------------------------------------------------------------------
   // API public
   // --------------------------------------------------------------------------
 
@@ -249,6 +275,9 @@ function vtkWidgetManager(publicAPI, model) {
 
     subscriptions.push(model.openGLRenderWindow.onModified(setSvgSize));
     setSvgSize();
+
+    subscriptions.push(model.camera.onModified(updateDisplayScaleParams));
+    updateDisplayScaleParams(model.camera);
 
     subscriptions.push(
       model.interactor.onStartAnimation(() => {

--- a/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
@@ -132,6 +132,10 @@ function vtkSphereHandleRepresentation(publicAPI, model) {
         (!state.isVisible || state.isVisible() ? 1 : 0) *
         (state.getScale1 ? state.getScale1() : model.defaultScale);
 
+      if (publicAPI.getScaleByDisplay()) {
+        typedArray.scale[i] *= publicAPI.getDisplayWorldHeightAt(coord);
+      }
+
       typedArray.color[i] =
         model.useActiveColor && isActive ? model.activeColor : state.getColor();
     }

--- a/Sources/Widgets/Representations/WidgetRepresentation/index.js
+++ b/Sources/Widgets/Representations/WidgetRepresentation/index.js
@@ -1,5 +1,6 @@
 import macro from 'vtk.js/Sources/macro';
 import vtkProp from 'vtk.js/Sources/Rendering/Core/Prop';
+import { subtract, dot } from 'vtk.js/Sources/Common/Core/Math';
 
 import { Behavior } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation/Constants';
 import { RenderingTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
@@ -203,6 +204,21 @@ function vtkWidgetRepresentation(publicAPI, model) {
     });
   };
 
+  publicAPI.getDisplayWorldHeightAt = (worldCoord) => {
+    const {
+      dispHeightFactor,
+      cameraPosition,
+      cameraDir,
+      isParallel,
+    } = model.displayScaleParams;
+    if (isParallel) {
+      return dispHeightFactor;
+    }
+    const worldCoordToCamera = [...worldCoord];
+    subtract(worldCoordToCamera, cameraPosition, worldCoordToCamera);
+    return dot(worldCoordToCamera, cameraDir) * dispHeightFactor;
+  };
+
   // Make sure setting the labels at build time works with string/array...
   publicAPI.setLabels(model.labels);
 }
@@ -229,6 +245,13 @@ const DEFAULT_VALUES = {
       offset: -1.0,
     },
   },
+  scaleByDisplay: false,
+  displayScaleParams: {
+    dispHeightFactor: 1,
+    cameraPosition: [0, 0, 0],
+    cameraDir: [1, 0, 0],
+    isParallel: false,
+  },
 };
 
 // ----------------------------------------------------------------------------
@@ -240,6 +263,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkProp.extend(publicAPI, model, initialValues);
   macro.algo(publicAPI, model, 1, 1);
   macro.get(publicAPI, model, ['labels', 'coincidentTopologyParameters']);
+  macro.set(publicAPI, model, ['displayScaleParams']);
+  macro.setGet(publicAPI, model, ['scaleByDisplay']);
 
   // Object specific methods
   vtkWidgetRepresentation(publicAPI, model);

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/example/controlPanel.html
@@ -1,1 +1,2 @@
 <button>GrabFocus</button>
+<input type="checkbox">Show SVG layer

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/example/index.js
@@ -52,3 +52,9 @@ fullScreenRenderer.addController(controlPanel);
 document.querySelector('button').addEventListener('click', () => {
   widgetManager.grabFocus(widget);
 });
+
+document
+  .querySelector('input[type=checkbox]')
+  .addEventListener('change', (ev) => {
+    widgetManager.setUseSvgLayer(ev.target.checked);
+  });

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
@@ -3,7 +3,6 @@ import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidget
 import vtkPlanePointManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
 import vtkPolyLineRepresentation from 'vtk.js/Sources/Widgets/Representations/PolyLineRepresentation';
 import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
-import vtkSVGLandmarkRepresentation from 'vtk.js/Sources/Widgets/SVG/SVGLandmarkRepresentation';
 
 import widgetBehavior from 'vtk.js/Sources/Widgets/Widgets3D/PolyLineWidget/behavior';
 import stateGenerator from 'vtk.js/Sources/Widgets/Widgets3D/PolyLineWidget/state';
@@ -38,9 +37,20 @@ function vtkPolyLineWidget(publicAPI, model) {
       case ViewTypes.VOLUME:
       default:
         return [
-          { builder: vtkSphereHandleRepresentation, labels: ['handles'] },
-          { builder: vtkSVGLandmarkRepresentation, labels: ['handles'] },
-          { builder: vtkSphereHandleRepresentation, labels: ['moveHandle'] },
+          {
+            builder: vtkSphereHandleRepresentation,
+            labels: ['handles'],
+            initialValues: {
+              scaleByDisplay: true,
+            },
+          },
+          {
+            builder: vtkSphereHandleRepresentation,
+            labels: ['moveHandle'],
+            initialValues: {
+              scaleByDisplay: true,
+            },
+          },
           {
             builder: vtkPolyLineRepresentation,
             labels: ['handles', 'moveHandle'],

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
@@ -3,6 +3,7 @@ import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidget
 import vtkPlanePointManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
 import vtkPolyLineRepresentation from 'vtk.js/Sources/Widgets/Representations/PolyLineRepresentation';
 import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
+import vtkSVGLandmarkRepresentation from 'vtk.js/Sources/Widgets/SVG/SVGLandmarkRepresentation';
 
 import widgetBehavior from 'vtk.js/Sources/Widgets/Widgets3D/PolyLineWidget/behavior';
 import stateGenerator from 'vtk.js/Sources/Widgets/Widgets3D/PolyLineWidget/state';
@@ -51,6 +52,7 @@ function vtkPolyLineWidget(publicAPI, model) {
               scaleByDisplay: true,
             },
           },
+          { builder: vtkSVGLandmarkRepresentation, labels: ['handles'] },
           {
             builder: vtkPolyLineRepresentation,
             labels: ['handles', 'moveHandle'],

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/state.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/state.js
@@ -8,7 +8,8 @@ export default function generateState() {
       mixins: ['origin', 'color', 'scale1', 'visible'],
       name: 'moveHandle',
       initialValues: {
-        scale1: 0.1,
+        // when scaleByDisplay() is set, the handles will be 1/20th of the screen height
+        scale1: 0.05,
         origin: [-1, -1, -1],
         visible: false,
       },
@@ -18,7 +19,7 @@ export default function generateState() {
       mixins: ['origin', 'color', 'scale1'],
       name: 'handle',
       initialValues: {
-        scale1: 0.1,
+        scale1: 0.05,
         origin: [-1, -1, -1],
       },
     })


### PR DESCRIPTION
This sphere handle will scale to keep the same screen-space size. It
requires widgets to invoke `attachScaleListener` to their behaviors for
this to work.

This is more or less copied from what I played with in Glance. Right now the API requires a whole new representation (the ScaledSphereHandleRepresentation), since initially I thought to make the distinction between widget state scale1 and the camera-dependent scaling in this PR. This could technically be achieved by using the regular SphereHandleRepresentation, and having the camera listener call `setScale1(scale)`, but then you wouldn't be able to control the relative size of the sphere handle via the widget state. That's why this is currently in a separate representation.

Another idea is to just merge the `attachScaleListener` into SphereHandleRepresentation, add a `handleScale` property to that class, and throw out this extra ScaledSphereHandleRepresentation class. It'll still work as before, but if you use `attachScaleListener`, then your spheres will start scaling according to the camera. Thoughts?

@agirault @finetjul 