### PR TITLE
Fix azure builds

### DIFF
--- a/Utilities/ci/azure-pipelines.yml
+++ b/Utilities/ci/azure-pipelines.yml
@@ -79,6 +79,7 @@ jobs:
       brew install pkg-config pixman cairo pango fribidi
       npm i -g npm@6.4.1
       npm ci
+      npm i --ignore-scripts # if canvas fails to load, then not all binaries will install
       npm run build:release
     displayName: 'Build'
 

--- a/Utilities/ci/azure-pipelines.yml
+++ b/Utilities/ci/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
     displayName: 'Install Node.js'
 
   - script: |
+      sudo apt install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       npm ci
       npm run build:release
     displayName: 'Build'
@@ -47,8 +48,8 @@ jobs:
       testRunner: JUnit
       testResultsFiles: 'Utilities/TestResults/TESTS-*.xml'
 
-- job: 'BuildTestMacOS'
-  displayName: 'Build and test'
+- job: 'BuildMacOS'
+  displayName: 'Build'
 
   strategy:
     matrix:
@@ -82,8 +83,8 @@ jobs:
       npm run build:release
     displayName: 'Build'
 
-- job: 'BuildTestWindows'
-  displayName: 'Build and test'
+- job: 'BuildWindows'
+  displayName: 'Build'
 
   strategy:
     matrix:

--- a/Utilities/ci/azure-pipelines.yml
+++ b/Utilities/ci/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 jobs:
 
-- job: 'BuildTest'
+- job: 'BuildTestLinux'
   displayName: 'Build and test'
 
   strategy:
@@ -47,8 +47,8 @@ jobs:
       testRunner: JUnit
       testResultsFiles: 'Utilities/TestResults/TESTS-*.xml'
 
-- job: 'Build'
-  displayName: 'Build'
+- job: 'BuildTestMacOS'
+  displayName: 'Build and test'
 
   strategy:
     matrix:
@@ -64,6 +64,29 @@ jobs:
         poolName: 'Hosted macOS'
         imageName: 'macos-10.13'
         nodeVersion: '12'
+
+  pool:
+    name: '$(poolName)'
+    imageName: '$(imageName)'
+
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '$(nodeVersion).x'
+    displayName: 'Install Node.js'
+
+  - script: |
+      brew install pkg-config pixman cairo pango fribidi
+      npm i -g npm@6.4.1
+      npm ci
+      npm run build:release
+    displayName: 'Build'
+
+- job: 'BuildTestWindows'
+  displayName: 'Build and test'
+
+  strategy:
+    matrix:
       WindowsNode8:
         poolName: 'Hosted VS2017'
         imageName: 'vs2017-win2016'

--- a/Utilities/ci/azure-pipelines.yml
+++ b/Utilities/ci/azure-pipelines.yml
@@ -16,8 +16,7 @@ jobs:
         nodeVersion: '12'
 
   pool:
-    name: 'Hosted Ubuntu 1604'
-    imageName: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
 
   steps:
   - task: NodeTool@0
@@ -55,15 +54,15 @@ jobs:
     matrix:
       macOSNode8:
         poolName: 'Hosted macOS'
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         nodeVersion: '8'
       macOSNode10:
         poolName: 'Hosted macOS'
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         nodeVersion: '10'
       macOSNode12:
         poolName: 'Hosted macOS'
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         nodeVersion: '12'
 
   pool:
@@ -90,15 +89,15 @@ jobs:
     matrix:
       WindowsNode8:
         poolName: 'Hosted VS2017'
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         nodeVersion: '8'
       WindowsNode10:
         poolName: 'Hosted VS2017'
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         nodeVersion: '10'
       WindowsNode12:
         poolName: 'Hosted VS2017'
-        imageName: 'vs2017-win2016'
+        imageName: 'windows-2019'
         nodeVersion: '12'
 
   pool:


### PR DESCRIPTION
Installing the canvas package is having some issues, most notably node-pre-gyp isn't pulling prebuilts for it. So, we support fallback build-from-source. But even that doesn't work the first time you run `npm ci`, so run it twice for it to work.

This (hopefully) fixes the build issue where `karma` isn't found on LinuxNode12. That was due to the install being prematurely terminated because of a failed install of canvas.