### PR TITLE
fix(SliceRepresentationProxy): Use spacing in slice values

### DIFF
--- a/Sources/Proxy/Core/View2DProxy/index.js
+++ b/Sources/Proxy/Core/View2DProxy/index.js
@@ -201,13 +201,13 @@ function vtkView2DProxy(publicAPI, model) {
         update();
         nbListeners++;
       }
-      if (representation.getSlice && representation.getSliceValues) {
+      const domain = representation.getPropertyDomainByName('slice');
+      if (representation.getSlice && domain) {
         const update = () => setSlice(representation.getSlice());
-        const values = representation.getSliceValues();
         model.rangeManipulator.setScrollListener(
-          values[0],
-          values[values.length - 1],
-          values[1] - values[0] || 1,
+          domain.min,
+          domain.max,
+          domain.step,
           representation.getSlice,
           setSlice
         );

--- a/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
@@ -245,24 +245,6 @@ function vtkSliceRepresentationProxy(publicAPI, model) {
     };
   };
 
-  // Used for UI
-  publicAPI.getSliceValues = (slicingMode = model.slicingMode) => {
-    const ds = publicAPI.getInputDataSet();
-    if (!ds) {
-      return [];
-    }
-    const values = [];
-    const bds = ds.getBounds();
-    const axisIndex = 'XYZ'.indexOf(slicingMode);
-    const endValue = bds[axisIndex * 2 + 1];
-    let currentValue = bds[axisIndex * 2];
-    while (currentValue <= endValue) {
-      values.push(currentValue);
-      currentValue++;
-    }
-    return values;
-  };
-
   const parentSetColorBy = publicAPI.setColorBy;
   publicAPI.setColorBy = (arrayName, arrayLocation, componentIndex = -1) => {
     if (arrayName === null) {

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -1260,7 +1260,8 @@ export function proxy(publicAPI, model) {
   publicAPI.getPropertyByName = (name) =>
     getProperties().find((p) => p.name === name);
 
-  publicAPI.getPropertyDomainByName = (name) => propertyMap[name].domain;
+  publicAPI.getPropertyDomainByName = (name) =>
+    (propertyMap[name] || {}).domain;
 
   // ui section
   publicAPI.getProxySection = () => ({


### PR DESCRIPTION
When an image's spacing is not 1, then we may either skip slices or have too many slice values map to the same slice. This fixes that issue.