### PR TITLE
Spline widget fixes and improvements

### DIFF
--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -250,14 +250,6 @@ export default function widgetBehavior(publicAPI, model) {
       model.widgetState.deactivate();
     }
 
-    if (
-      (model.hasFocus && !model.activeState) ||
-      (model.activeState && !model.activeState.getActive())
-    ) {
-      model.widgetManager.enablePicking();
-      model.interactor.render();
-    }
-
     model.freeHand = false;
     model.isDragging = false;
     model.draggedPoint = false;
@@ -378,7 +370,6 @@ export default function widgetBehavior(publicAPI, model) {
     model.moveHandle.setVisible(false);
     model.activeState = null;
     model.interactor.render();
-    model.widgetManager.enablePicking();
 
     model.hasFocus = false;
   };

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -205,6 +205,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.isDragging = true;
       model.openGLRenderWindow.setCursor('grabbing');
       model.interactor.requestAnimation(publicAPI);
+      publicAPI.invokeStartInteractionEvent();
     }
 
     return macro.EVENT_ABORT;
@@ -220,6 +221,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.openGLRenderWindow.setCursor(model.defaultCursor);
         model.widgetState.deactivate();
         model.interactor.cancelAnimation(publicAPI);
+        publicAPI.invokeEndInteractionEvent();
       } else {
         model.moveHandle.setOrigin(...model.activeState.getOrigin());
         model.activeState.deactivate();

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -272,11 +272,14 @@ export default function widgetBehavior(publicAPI, model) {
     if (
       !model.activeState ||
       !model.activeState.getActive() ||
-      !model.pickable
+      !model.pickable ||
+      !model.manipulator
     ) {
       return macro.VOID;
     }
 
+    model.manipulator.setOrigin(model.activeState.getOrigin());
+    model.manipulator.setNormal(model.camera.getDirectionOfProjection());
     const worldCoords = model.manipulator.handleEvent(
       callData,
       model.openGLRenderWindow
@@ -290,9 +293,6 @@ export default function widgetBehavior(publicAPI, model) {
       model.moveHandle.setVisible(true);
       model.openGLRenderWindow.setCursor(model.defaultCursor);
     }
-
-    model.manipulator.setOrigin(worldCoords);
-    model.manipulator.setNormal(model.camera.getDirectionOfProjection());
 
     if (model.lastHandle) {
       model.lastHandle.setVisible(true);

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -5,28 +5,10 @@ export default function widgetBehavior(publicAPI, model) {
   model.classHierarchy.push('vtkSplineWidgetProp');
 
   // --------------------------------------------------------------------------
-  // Display 2D
+  // Private methods
   // --------------------------------------------------------------------------
 
-  publicAPI.setDisplayCallback = (callback) =>
-    model.representations[0].setDisplayCallback(callback);
-
-  // --------------------------------------------------------------------------
-  // Public methods
-  // --------------------------------------------------------------------------
-
-  publicAPI.getPoints = () =>
-    model.representations[1].getOutputData().getPoints().getData();
-
-  // --------------------------------------------------------------------------
-
-  publicAPI.sethandleSizeInPixels = (handleSizeInPixels) => {
-    model.handleSizeInPixels = handleSizeInPixels;
-  };
-
-  // --------------------------------------------------------------------------
-
-  publicAPI.updateHandlesSize = () => {
+  const updateHandlesSize = () => {
     if (model.handleSizeInPixels !== null) {
       const scale =
         model.handleSizeInPixels *
@@ -44,24 +26,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
-  publicAPI.reset = () => {
-    model.widgetState.clearHandleList();
-
-    model.lastHandle = null;
-    model.firstHandle = null;
-  };
-
-  // --------------------------------------------------------------------------
-
-  publicAPI.setFreehandMinDistance = (distance) => {
-    model.freehandMinDistance = distance;
-  };
-
-  // --------------------------------------------------------------------------
-  // Private methods
-  // --------------------------------------------------------------------------
-
-  publicAPI.addPoint = () => {
+  const addPoint = () => {
     // Commit handle to location
     if (
       !model.lastHandle ||
@@ -88,22 +53,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
-  publicAPI.updateResolution = () => {
-    if (
-      (model.keysDown[model.renderPoly.key] &&
-        model.renderPoly.status === 'down') ||
-      (!model.keysDown[model.renderPoly.key] &&
-        model.renderPoly.status === 'up')
-    ) {
-      model.representations[1].setResolution(1);
-    } else {
-      model.representations[1].setResolution(model.resolution);
-    }
-  };
-
-  // --------------------------------------------------------------------------
-
-  publicAPI.getHoveredHandle = () => {
+  const getHoveredHandle = () => {
     const handles = model.widgetState.getHandleList();
 
     return handles.reduce(
@@ -134,6 +84,57 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   // --------------------------------------------------------------------------
+  // Display 2D
+  // --------------------------------------------------------------------------
+
+  publicAPI.setDisplayCallback = (callback) =>
+    model.representations[0].setDisplayCallback(callback);
+
+  // --------------------------------------------------------------------------
+  // Public methods
+  // --------------------------------------------------------------------------
+
+  macro.setGet(publicAPI, model, [
+    'freehandMinDistance',
+    'allowFreehand',
+    'resolution',
+    'defaultCursor',
+    'handleSizeInPixels',
+  ]);
+
+  // --------------------------------------------------------------------------
+
+  const superSetHandleSizeInPixels = publicAPI.setHandleSizeInPixels;
+  publicAPI.setHandleSizeInPixels = (size) => {
+    superSetHandleSizeInPixels(size);
+    updateHandlesSize();
+  };
+  publicAPI.setHandleSizeInPixels(model.handleSizeInPixels); // set initial value
+
+  // --------------------------------------------------------------------------
+
+  const superSetResolution = publicAPI.setResolution;
+  publicAPI.setResolution = (resolution) => {
+    superSetResolution(resolution);
+    model.representations[1].setResolution(model.resolution);
+  };
+  publicAPI.setResolution(model.resolution); // set initial value
+
+  // --------------------------------------------------------------------------
+
+  publicAPI.getPoints = () =>
+    model.representations[1].getOutputData().getPoints().getData();
+
+  // --------------------------------------------------------------------------
+
+  publicAPI.reset = () => {
+    model.widgetState.clearHandleList();
+
+    model.lastHandle = null;
+    model.firstHandle = null;
+  };
+
+  // --------------------------------------------------------------------------
   // Right click: Delete handle
   // --------------------------------------------------------------------------
 
@@ -153,7 +154,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState = null;
       model.interactor.cancelAnimation(publicAPI);
     } else {
-      const handle = publicAPI.getHoveredHandle();
+      const handle = getHoveredHandle();
       if (handle) {
         model.widgetState.removeHandle(handle);
       } else if (model.lastHandle) {
@@ -184,9 +185,9 @@ export default function widgetBehavior(publicAPI, model) {
     if (model.activeState === model.moveHandle) {
       if (model.widgetState.getHandleList().length === 0) {
         publicAPI.invokeStartInteractionEvent();
-        publicAPI.addPoint();
+        addPoint();
       } else {
-        const hoveredHandle = publicAPI.getHoveredHandle();
+        const hoveredHandle = getHoveredHandle();
         if (hoveredHandle && !model.keysDown.Control) {
           model.moveHandle.deactivate();
           model.moveHandle.setVisible(false);
@@ -195,7 +196,7 @@ export default function widgetBehavior(publicAPI, model) {
           model.isDragging = true;
           model.lastHandle.setVisible(true);
         } else {
-          publicAPI.addPoint();
+          addPoint();
         }
       }
 
@@ -239,7 +240,7 @@ export default function widgetBehavior(publicAPI, model) {
               model.moveHandle.getScale1() * model.moveHandle.getScale1()
           ) {
             model.lastHandle.setVisible(true);
-            publicAPI.invokeEndInteractionEvent();
+            publicAPI.loseFocus();
           }
         }
 
@@ -285,10 +286,12 @@ export default function widgetBehavior(publicAPI, model) {
       model.openGLRenderWindow
     );
 
-    const hoveredHandle = publicAPI.getHoveredHandle();
+    const hoveredHandle = getHoveredHandle();
     if (hoveredHandle) {
       model.moveHandle.setVisible(false);
-      model.openGLRenderWindow.setCursor('grabbing');
+      if (hoveredHandle !== model.firstHandle) {
+        model.openGLRenderWindow.setCursor('grabbing');
+      }
     } else if (!model.isDragging && model.hasFocus) {
       model.moveHandle.setVisible(true);
       model.openGLRenderWindow.setCursor(model.defaultCursor);
@@ -304,7 +307,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.draggedPoint = true;
       }
       if (model.freeHand && model.activeState === model.moveHandle) {
-        publicAPI.addPoint();
+        addPoint();
       }
     }
 
@@ -317,24 +320,24 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleKeyDown = ({ key }) => {
     model.keysDown[key] = true;
-    publicAPI.updateResolution();
+
+    if (!model.hasFocus) {
+      return;
+    }
 
     if (key === 'Enter') {
       if (model.widgetState.getHandleList().length > 0) {
-        publicAPI.invokeEndInteractionEvent();
-        model.interactor.render();
-      }
-    } else if (model.hasFocus) {
-      if (key === 'Escape') {
-        publicAPI.reset();
         publicAPI.loseFocus();
-      } else if (key === 'Delete' || key === 'Backspace') {
-        if (model.lastHandle) {
-          model.widgetState.removeHandle(model.lastHandle);
+      }
+    } else if (key === 'Escape') {
+      publicAPI.reset();
+      publicAPI.loseFocus();
+    } else if (key === 'Delete' || key === 'Backspace') {
+      if (model.lastHandle) {
+        model.widgetState.removeHandle(model.lastHandle);
 
-          const handleList = model.widgetState.getHandleList();
-          model.lastHandle = handleList[handleList.length - 1];
-        }
+        const handleList = model.widgetState.getHandleList();
+        model.lastHandle = handleList[handleList.length - 1];
       }
     }
   };
@@ -343,7 +346,6 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleKeyUp = ({ key }) => {
     model.keysDown[key] = false;
-    publicAPI.updateResolution();
   };
 
   // --------------------------------------------------------------------------
@@ -352,12 +354,12 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.grabFocus = () => {
     if (!model.hasFocus) {
-      model.moveHandle.activate();
-      model.moveHandle.setVisible(true);
       model.activeState = model.moveHandle;
+      model.activeState.activate();
+      model.activeState.setVisible(true);
       model.interactor.requestAnimation(publicAPI);
-      publicAPI.updateResolution();
-      publicAPI.updateHandlesSize();
+      publicAPI.invokeStartInteractionEvent();
+      updateHandlesSize();
     }
 
     model.hasFocus = true;
@@ -368,6 +370,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
       model.interactor.cancelAnimation(publicAPI);
+      publicAPI.invokeEndInteractionEvent();
     }
 
     model.widgetState.deactivate();

--- a/Sources/Widgets/Widgets3D/SplineWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/SplineWidget/example/controlPanel.html
@@ -1,1 +1,30 @@
-<button>GrabFocus</button>
+<table>
+  <tr>
+    <td>Resolution</td>
+    <td></td>
+    <td>
+      <input class="resolution" type="range" min="1" max="32" step="1" value="20">
+    </td>
+  </tr>
+  <tr>
+    <td>Handles size</td>
+    <td></td>
+    <td>
+      <input class="handleSize" type="range" min="10" max="50" step="1" value="20">
+    </td>
+  </tr>
+  <tr>
+    <td>Drag (freehand)</td>
+    <td>
+      <input class="allowFreehand" type="checkbox" checked>
+    </td>
+    <td>
+      <input class="freehandDistance" type="range" min="0.05" max="1.0" step="0.05" value="0.2">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <button class="placeWidget" >Place Widget</button>
+    </td>
+  </tr>
+</table>

--- a/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
@@ -1,6 +1,7 @@
 import 'vtk.js/Sources/favicon';
 
 import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
 import vtkSplineWidget from 'vtk.js/Sources/Widgets/Widgets3D/SplineWidget';
 import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
 
@@ -14,6 +15,9 @@ const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
   background: [0, 0, 0],
 });
 const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+const iStyle = vtkInteractorStyleImage.newInstance();
+renderWindow.getInteractor().setInteractorStyle(iStyle);
 
 // ----------------------------------------------------------------------------
 // Widget manager
@@ -24,10 +28,9 @@ widgetManager.setRenderer(renderer);
 
 const widget = vtkSplineWidget.newInstance();
 
-widgetManager.addWidget(widget);
+const widgetRepresentation = widgetManager.addWidget(widget);
 
 renderer.resetCamera();
-widgetManager.enablePicking();
 
 // -----------------------------------------------------------
 // UI control handling
@@ -35,6 +38,39 @@ widgetManager.enablePicking();
 
 fullScreenRenderer.addController(controlPanel);
 
-document.querySelector('button').addEventListener('click', () => {
+const resolutionInput = document.querySelector('.resolution');
+const onResolutionChanged = () => {
+  widgetRepresentation.setResolution(resolutionInput.value);
+  renderWindow.render();
+};
+resolutionInput.addEventListener('input', onResolutionChanged);
+onResolutionChanged();
+
+const handleSizeInput = document.querySelector('.handleSize');
+const onHandleSizeChanged = () => {
+  widgetRepresentation.setHandleSizeInPixels(handleSizeInput.value);
+  renderWindow.render();
+};
+handleSizeInput.addEventListener('input', onHandleSizeChanged);
+onHandleSizeChanged();
+
+const allowFreehandCheckBox = document.querySelector('.allowFreehand');
+const onFreehandEnabledChanged = () => {
+  widgetRepresentation.setAllowFreehand(allowFreehandCheckBox.checked);
+};
+allowFreehandCheckBox.addEventListener('click', onFreehandEnabledChanged);
+onFreehandEnabledChanged();
+
+const freehandDistanceInput = document.querySelector('.freehandDistance');
+const onFreehandDistanceChanged = () => {
+  widgetRepresentation.setFreehandMinDistance(freehandDistanceInput.value);
+};
+freehandDistanceInput.addEventListener('input', onFreehandDistanceChanged);
+onFreehandDistanceChanged();
+
+const placeWidgetButton = document.querySelector('.placeWidget');
+placeWidgetButton.addEventListener('click', () => {
+  widgetRepresentation.reset();
   widgetManager.grabFocus(widget);
+  placeWidgetButton.blur();
 });

--- a/Sources/Widgets/Widgets3D/SplineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/index.js
@@ -58,10 +58,6 @@ const DEFAULT_VALUES = {
   freehandMinDistance: 0.1,
   allowFreehand: true,
   resolution: 32,
-  renderPoly: {
-    key: 'Shift',
-    status: 'down',
-  },
   defaultCursor: 'pointer',
   handleSizeInPixels: 10,
 };


### PR DESCRIPTION
_Extracted from #1422_

- The normal and origin of the plane manipulator should be set before searching for an intersection. Fixes #1423
- Improve the API
  - Make private methods actually private (updateHandlesSize, addPoint,
getHoveredHandle)
  - Use `macro.setGet` to add public APIs around the model properties, and
remove manual setters (sethandleSizeInPixels and setFreehandMinDistance)
  - Override setHandleSizeInPixels and setResolution to update the model
representations
  - Remove updateResolution which hardcoded a non-standard behavior when
pressing "Shift". Instead, the setResolution API can be used by the
application with a custom keyDown listener.
  - Add missing event callbacks in grab/loseFocus
- Improve the example:
  - Improve the control Panel to interact with most spline parameters

<img width="760" alt="Screen Shot 2020-04-30 at 3 25 34 PM" src="https://user-images.githubusercontent.com/4910855/80750875-dc402280-8af6-11ea-8e77-8a62b55c6b80.png">

Notes:
- color, scale and visibility of the handles should probably be a property
of the viewWidgets and not of the state.
- there are confusions between the model properties on the widget
(widget factory) and the behavior (view widget). The former can be set to
define the default values when instantiating a view widget, but the later
should be used to edit the properties of a view widget instance.