### PR TITLE
feat(RectangleWidget): add option to keep the representation plane ort..

### DIFF
--- a/Sources/Widgets/Core/StateBuilder/index.js
+++ b/Sources/Widgets/Core/StateBuilder/index.js
@@ -7,6 +7,7 @@ import color from 'vtk.js/Sources/Widgets/Core/StateBuilder/colorMixin';
 import direction from 'vtk.js/Sources/Widgets/Core/StateBuilder/directionMixin';
 import manipulator from 'vtk.js/Sources/Widgets/Core/StateBuilder/manipulatorMixin';
 import name from 'vtk.js/Sources/Widgets/Core/StateBuilder/nameMixin';
+import normal from 'vtk.js/Sources/Widgets/Core/StateBuilder/normalMixin';
 import orientation from 'vtk.js/Sources/Widgets/Core/StateBuilder/orientationMixin';
 import origin from 'vtk.js/Sources/Widgets/Core/StateBuilder/originMixin';
 import scale1 from 'vtk.js/Sources/Widgets/Core/StateBuilder/scale1Mixin';
@@ -25,6 +26,7 @@ const MIXINS = {
   direction,
   manipulator,
   name,
+  normal,
   orientation,
   origin,
   scale1,

--- a/Sources/Widgets/Core/StateBuilder/normalMixin.js
+++ b/Sources/Widgets/Core/StateBuilder/normalMixin.js
@@ -1,0 +1,18 @@
+import macro from 'vtk.js/Sources/macro';
+
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  normal: [0, 0, -1],
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+  macro.setGetArray(publicAPI, model, ['normal'], 3);
+}
+
+// ----------------------------------------------------------------------------
+
+export default { extend };

--- a/Sources/Widgets/Widgets3D/RectangleWidget/state.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/state.js
@@ -25,12 +25,13 @@ export default function generateState() {
     })
     .addStateFromMixin({
       labels: ['rectangleHandle'],
-      mixins: ['bounds', 'color', 'visible', 'direction'],
+      mixins: ['bounds', 'color', 'visible', 'direction', 'normal'],
       name: 'rectangleHandle',
       initialValues: {
         bounds: [0, 0, 0, 0, 0, 0],
         visible: false,
         direction: [0, 0, 1],
+        normal: [0, 0, -1],
       },
     })
     .build();

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -471,6 +471,9 @@ export default function widgetBehavior(publicAPI, model) {
       } else {
         publicAPI.placePoint2(model.point2Handle.getOrigin());
       }
+      if (model.shapeHandle.setNormal) {
+        model.shapeHandle.setNormal(model.manipulator.getNormal());
+      }
 
       return macro.EVENT_ABORT;
     }


### PR DESCRIPTION
…hogonal to the manipulator's normal

The widget can have two points with different heights (usually when used with the imagemapper).
This can cause parts of the representation to be hidden when one of the two points is below the current slice. 
This change adds an option to use the highest of the two points to set the representation plane's height, to make sure that the representation stays on top of the ImageMapper.