### PR TITLE
fix(ExampleRunner): Fail with nicer error message

### DIFF
--- a/Utilities/ExampleRunner/example-runner-cli.js
+++ b/Utilities/ExampleRunner/example-runner-cli.js
@@ -73,6 +73,10 @@ if (configuration.examples) {
 
   if (exampleCount === 0) {
     examples = null;
+    if (buildExample) {
+      console.error(`=> Error: Did not find any examples matching ${filterExamples[0]}`);
+      process.exit(1);
+    }
   }
 
   if (buildExample) {


### PR DESCRIPTION
Previously, passing in a non-existent example would fail with an opaque
message. This commit clarifies this non-existent case.