### PR TITLE
fix(VolumeRepresentationProxy): Adjust on a log scale

### DIFF
--- a/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/VolumeRepresentationProxy/index.js
@@ -292,17 +292,29 @@ function vtkVolumeRepresentationProxy(publicAPI, model) {
           const dataRange = dataArray.getRange(component);
           model.volume.getProperty().setUseGradientOpacity(component, true);
           const minV = Math.max(0.0, edgeGradient - 0.3) / 0.7;
-          model.volume
-            .getProperty()
-            .setGradientOpacityMinimumValue(
-              component,
-              (dataRange[1] - dataRange[0]) * 0.2 * minV * minV
-            );
+          if (minV > 0.0) {
+            model.volume
+              .getProperty()
+              .setGradientOpacityMinimumValue(
+                component,
+                Math.exp(
+                  Math.log((dataRange[1] - dataRange[0]) * 0.2) * minV * minV
+                )
+              );
+          } else {
+            model.volume
+              .getProperty()
+              .setGradientOpacityMinimumValue(component, 0.0);
+          }
           model.volume
             .getProperty()
             .setGradientOpacityMaximumValue(
               component,
-              (dataRange[1] - dataRange[0]) * 1.0 * edgeGradient * edgeGradient
+              Math.exp(
+                Math.log((dataRange[1] - dataRange[0]) * 1.0) *
+                  edgeGradient *
+                  edgeGradient
+              )
             );
         }
       }


### PR DESCRIPTION
Gradient magnitudes for natural images are likely to have a power-law
distribution. To provide linear scale to a user adjusting gradient
opacity with a slider, make gradient opacity maximum and minimum steps
on a log scale.