### PR TITLE
fix(SliceRepresentationProxy): Incorrect level mean

### DIFF
--- a/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/SliceRepresentationProxy/index.js
@@ -88,7 +88,7 @@ function updateDomains(dataset, dataArray, model, updateProp) {
     windowLevel: Math.floor(
       mean(
         propToUpdate.windowLevel.domain.min,
-        propToUpdate.windowWidth.domain.max
+        propToUpdate.windowLevel.domain.max
       )
     ),
   };


### PR DESCRIPTION
Window level average should be using level min/max, not level min/width max.