### PR TITLE
fix(RenderWindowInteractor): Reset lastFrameStart with tab switch

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -932,14 +932,35 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
   };
 
+  publicAPI.handleVisibilityChange = () => {
+    model.lastFrameStart = Date.now();
+  };
+
   // Stop animating if the renderWindowInteractor is deleted.
   const superDelete = publicAPI.delete;
   publicAPI.delete = () => {
     while (animationRequesters.size) {
       publicAPI.cancelAnimation(animationRequesters.values().next().value);
     }
+    if (typeof document.hidden !== 'undefined') {
+      document.removeEventListener(
+        'visibilitychange',
+        publicAPI.handleVisibilityChange
+      );
+    }
     superDelete();
   };
+
+  // Use the Page Visibility API to detect when we switch away from or back to
+  // this tab, and reset the lastFrameStart. When tabs are not active, browsers
+  // will stop calling requestAnimationFrame callbacks.
+  if (typeof document.hidden !== 'undefined') {
+    document.addEventListener(
+      'visibilitychange',
+      publicAPI.handleVisibilityChange,
+      false
+    );
+  }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
When tabs are not active browser will step calling
requestAnimationFrame callbacks. See:

  https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame

This causes the RenderWindowInteractor lastFrameStart to be inaccurate,
which results in an incorrect lastFrameTime. This can cause the
VolumeMapper, which adjusts its the sampling distance based on the
framerate, to assume too low of a frame rate and produce poor quality
renderings.

Use the Page Visibility API:

  https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API

to detected when tabs are switched, and reset the RenderWindowInteractor
lastFrameStart.

Co-authored-by: Ken Martin <ken.martin@kitware.com>