### PR TITLE
fix(ImageMapper): Ignore piecewise function for single components

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -231,7 +231,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       switch (tNumComp) {
         case 1:
           tcoordImpl = tcoordImpl.concat([
-            'gl_FragData[0] = vec4(tcolor0.rgb * compWeight0, opacity);',
+            'gl_FragData[0] = vec4(tcolor0.rgb, opacity);',
           ]);
           break;
         case 2:


### PR DESCRIPTION
Fixes #310, which is caused by discontinuities the user can build
into the piecewise function.  Respecting the transfer function for
single components was added to support images with only a label
map, where we would like to highlight certain labels.  Support for
that will be added back using another approach.