### PR TITLE
fix(renderwindowinteractor): return first interactive renderer viewpo…

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -668,14 +668,8 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     if (!model.view) {
       return null;
     }
-    const rc = model.view
-      .getRenderable()
-      .getRenderersByReference()
-      .sort((a, b) => {
-        if (a.getLayer() < b.getLayer()) return -1;
-        if (a.getLayer() > b.getLayer()) return 1;
-        return 0;
-      });
+    const rc = model.view.getRenderable().getRenderersByReference();
+    rc.sort((a, b) => a.getLayer() - b.getLayer());
     let interactiveren = null;
     let viewportren = null;
     let currentRenderer = null;

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -678,6 +678,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       const aren = rc[count];
       if (model.view.isInViewport(x, y, aren) && aren.getInteractive()) {
         currentRenderer = aren;
+        break;
       }
 
       if (interactiveren === null && aren.getInteractive()) {

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -668,7 +668,14 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     if (!model.view) {
       return null;
     }
-    const rc = model.view.getRenderable().getRenderersByReference();
+    const rc = model.view
+      .getRenderable()
+      .getRenderersByReference()
+      .sort((a, b) => {
+        if (a.getLayer() < b.getLayer()) return -1;
+        if (a.getLayer() > b.getLayer()) return 1;
+        return 0;
+      });
     let interactiveren = null;
     let viewportren = null;
     let currentRenderer = null;


### PR DESCRIPTION
…rt found as pokedRenderer

Fix the problem when multiple viewports overlay one over the other. The actual behavior iterate over
all renderer and return the last one instead the first one

fix #1487