### PR TITLE
fix(ViewProxy): Return Promise from openCaptureImage

### DIFF
--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -259,7 +259,7 @@ function vtkViewProxy(publicAPI, model) {
 
   publicAPI.openCaptureImage = (target = '_blank') => {
     const image = new Image();
-    publicAPI.captureImage().then((imageURL) => {
+    return publicAPI.captureImage().then((imageURL) => {
       image.src = imageURL;
       const w = window.open('', target);
       w.document.write(image.outerHTML);


### PR DESCRIPTION
So the caller can know when the capture is complete.