### PR TITLE
fix(DistanceWidget): Do not follow camera

### DIFF
--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -75,8 +75,6 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState.getActive() &&
       !ignoreKey(callData)
     ) {
-      model.manipulator.setOrigin(model.activeState.getOrigin());
-      model.manipulator.setNormal(model.camera.getDirectionOfProjection());
       const worldCoords = model.manipulator.handleEvent(
         callData,
         model.openGLRenderWindow


### PR DESCRIPTION
This prevents users from setting the manipulator themselves. The user
should sync the camera normal as necessary.