### PR TITLE
fix(PiecewiseFunctionProxy): Deep copy gaussians

### DIFF
--- a/Sources/Proxy/Core/PiecewiseFunctionProxy/index.js
+++ b/Sources/Proxy/Core/PiecewiseFunctionProxy/index.js
@@ -27,6 +27,13 @@ function applyNodesToPiecewiseFunction(nodes, range, pwf) {
 }
 
 // ----------------------------------------------------------------------------
+
+function copyGaussians(gaussians) {
+  // gaussians is assumed to be an array of gaussian objects
+  return gaussians.map((g) => ({ ...g }));
+}
+
+// ----------------------------------------------------------------------------
 // vtkPiecewiseFunctionProxy methods
 // ----------------------------------------------------------------------------
 
@@ -39,9 +46,9 @@ function vtkPiecewiseFunctionProxy(publicAPI, model) {
 
   // Takes an array of gaussians
   publicAPI.setGaussians = (gaussians) => {
-    model.gaussians = (gaussians || []).slice();
+    model.gaussians = copyGaussians(gaussians || []);
     if (model.gaussians.length === 0) {
-      model.gaussians = Defaults.Gaussians.slice();
+      model.gaussians = copyGaussians(Defaults.Gaussians);
     }
     publicAPI.applyMode();
   };

--- a/Sources/Proxy/Core/PiecewiseFunctionProxy/test/testPiecewiseFunctionProxy.js
+++ b/Sources/Proxy/Core/PiecewiseFunctionProxy/test/testPiecewiseFunctionProxy.js
@@ -14,7 +14,7 @@ function listEquals(a, b, equality = 'array') {
     return false;
   }
   for (let i = 0; i < a.length; ++i) {
-    if (!equals(a, b)) {
+    if (!equals(a[i], b[i])) {
       return false;
     }
   }


### PR DESCRIPTION
Gaussians should be deep-copied. If they are modified, then the original
gaussians will also be modified. (This happens when working in tandem
with the piecewise gaussian editor.)