### PR TITLE
fix(PiecewiseGaussianWidget): Allow for extensibility

### DIFF
--- a/Sources/Interaction/Widgets/PiecewiseGaussianWidget/index.js
+++ b/Sources/Interaction/Widgets/PiecewiseGaussianWidget/index.js
@@ -1200,7 +1200,7 @@ function vtkPiecewiseGaussianWidget(publicAPI, model) {
   };
 
   // Trigger rendering for any modified event
-  publicAPI.onModified(publicAPI.render);
+  publicAPI.onModified(() => publicAPI.render());
   publicAPI.setSize(...model.size);
 }
 


### PR DESCRIPTION
Instead of passing a pointer to render, pass an anonymous function over
render. This allows extending the render function.