### PR TITLE
fix(macro): Perform shallow equals

### DIFF
--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -148,6 +148,30 @@ function safeArrays(model) {
 }
 
 // ----------------------------------------------------------------------------
+// shallow equals
+// ----------------------------------------------------------------------------
+
+function shallowEquals(a, b) {
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+// ----------------------------------------------------------------------------
 
 function enumToString(e, value) {
   return Object.keys(e).find((key) => e[key] === value);
@@ -1155,7 +1179,7 @@ export function proxy(publicAPI, model) {
       const newValue = sourceLink.instance[
         `get${capitalize(sourceLink.propertyName)}`
       ]();
-      if (newValue !== value || force) {
+      if (!shallowEquals(newValue, value) || force) {
         value = newValue;
         updateInProgress = true;
         while (needUpdate.length) {


### PR DESCRIPTION
Without shallow equality, we may end up with excess update calls when
lists are checked. (Right now shallow object checking isn't done, but
macro getters don't clone objects, unlike the array getter.)