### PR TITLE
fix(Rendering): Volume rendering on webgl1

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1209,21 +1209,26 @@ function vtkOpenGLTexture(publicAPI, model) {
     // for stride
     let outIdx = 0;
 
+    const tileWidth = Math.floor(width / xstride);
+    const tileHeight = Math.floor(height / ystride);
+
     for (let yRep = 0; yRep < yreps; yRep++) {
       const xrepsThisRow = Math.min(xreps, depth - yRep * xreps);
       const outXContIncr =
-        model.width - xrepsThisRow * Math.floor(width / xstride);
-      for (let inY = 0; inY < height; inY += ystride) {
+        numComps * (model.width - xrepsThisRow * Math.floor(width / xstride));
+      for (let tileY = 0; tileY < tileHeight; tileY++) {
         for (let xRep = 0; xRep < xrepsThisRow; xRep++) {
           const inOffset =
-            numComps * ((yRep * xreps + xRep) * width * height + inY * width);
-          for (let inX = 0; inX < width; inX += xstride) {
+            numComps *
+            ((yRep * xreps + xRep) * width * height + ystride * tileY * width);
+
+          for (let tileX = 0; tileX < tileWidth; tileX++) {
             // copy value
             for (let nc = 0; nc < numComps; nc++) {
               volCopyData(
                 newArray,
                 outIdx,
-                data[inOffset + inX * numComps + nc],
+                data[inOffset + xstride * tileX * numComps + nc],
                 res.offset[nc],
                 res.scale[nc]
               );
@@ -1231,7 +1236,7 @@ function vtkOpenGLTexture(publicAPI, model) {
             }
           }
         }
-        outIdx += outXContIncr * numComps;
+        outIdx += outXContIncr;
       }
     }
 

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -557,8 +557,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       program.setUniformf('texWidth', model.scalarTexture.getWidth());
       program.setUniformf('texHeight', model.scalarTexture.getHeight());
       program.setUniformi('xreps', volInfo.xreps);
-      program.setUniformf('xstride', volInfo.xstride);
-      program.setUniformf('ystride', volInfo.ystride);
+      program.setUniformi('xstride', volInfo.xstride);
+      program.setUniformi('ystride', volInfo.ystride);
     }
 
     // map normals through normal matrix

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -87,6 +87,10 @@ uniform float gomax3;
 #endif
 #endif
 
+// if you want to see the raw tiled
+// data in webgl1 uncomment the following line
+// #define debugtile
+
 // camera values
 uniform float camThick;
 uniform float camNear;
@@ -212,8 +216,8 @@ uniform sampler2D texture1;
 uniform float texWidth;
 uniform float texHeight;
 uniform int xreps;
-uniform float xstride;
-uniform float ystride;
+uniform int xstride;
+uniform int ystride;
 
 // if computing triliear values from multiple z slices
 #ifdef vtkTriliearOn
@@ -236,12 +240,24 @@ vec4 getTextureValue(vec3 ijk)
 {
   vec3 tdims = vec3(volumeDimensions);
 
+#ifdef debugtile
+  vec2 tpos = vec2(ijk.x, ijk.y);
+  vec4 tmp = texture2D(texture1, tpos);
+  tmp.a = 1.0;
+
+#else
   int z = int(ijk.z * tdims.z);
   int yz = z / xreps;
   int xz = z - yz*xreps;
 
-  float ni = (ijk.x + float(xz)) * tdims.x/xstride;
-  float nj = (ijk.y + float(yz)) * tdims.y/ystride;
+  int tileWidth = volumeDimensions.x/xstride;
+  int tileHeight = volumeDimensions.y/ystride;
+
+  xz *= tileWidth;
+  yz *= tileHeight;
+
+  float ni = float(xz) + (ijk.x*float(tileWidth));
+  float nj = float(yz) + (ijk.y*float(tileHeight));
 
   vec2 tpos = vec2(ni/texWidth, nj/texHeight);
 
@@ -256,6 +272,8 @@ vec4 getTextureValue(vec3 ijk)
 #if vtkNumComponents == 3
   tmp.a = length(tmp.rgb);
 #endif
+#endif
+
   return tmp;
 }
 


### PR DESCRIPTION
Fixed a couple issues that showed up when a large
volume was rendered uising webgl1 specifically when the volume
had to be subsampled.