### PR TITLE
doc(WidgetManager): Fix invalid example html

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/example/controlPanel.html
+++ b/Sources/Widgets/Core/WidgetManager/example/controlPanel.html
@@ -7,7 +7,7 @@
       <th title="Visibility">V</th>
       <th title="ContextVisibility">C</th>
       <th title="HandleVisibility">H</th>
-      <th"></th>
+      <th></th>
     </tr>
   </thead>
   <tbody class="widgetList">


### PR DESCRIPTION
This was causing builds to fail. Here's a quick post-mortem:
- The issue only manifested when kw-doc was invoked with minify option, so terser was complaining about something.
- Parallel-webpack wasn't logging any webpack errors, hence the build error of "file not found" remained cryptic.
- terser-plugin minifies html, and this html was invalid.