### PR TITLE
fix(OpenGL/Texture): Allow changing internal formats

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -310,19 +310,8 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.getInternalFormat = (vtktype, numComps) => {
-    if (!model.internalFormat) {
-      model.internalFormat = publicAPI.getDefaultInternalFormat(
-        vtktype,
-        numComps
-      );
-    }
-
-    if (!model.internalFormat) {
-      vtkDebugMacro(
-        `Unable to find suitable internal format for T=${vtktype} NC= ${numComps}`
-      );
-    }
-
+    const format = publicAPI.getDefaultInternalFormat(vtktype, numComps);
+    publicAPI.setInternalFormat(format);
     return model.internalFormat;
   };
 
@@ -362,7 +351,9 @@ function vtkOpenGLTexture(publicAPI, model) {
     if (iFormat !== model.internalFormat) {
       model.internalFormat = iFormat;
       publicAPI.modified();
+      return true;
     }
+    return false;
   };
 
   //----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/Texture/test/testChangeInternalFormat.js
+++ b/Sources/Rendering/OpenGL/Texture/test/testChangeInternalFormat.js
@@ -1,0 +1,35 @@
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import vtkOpenGLTexture from 'vtk.js/Sources/Rendering/OpenGL/Texture';
+
+import test from 'tape-catch';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+const { VtkDataTypes } = vtkDataArray;
+
+test.onlyIfWebGL('Changing internal format', (t) => {
+  const gc = testUtils.createGarbageCollector(t);
+
+  const container = document.querySelector('body');
+  const renderWindowContainer = gc.registerDOMElement(
+    document.createElement('div')
+  );
+  container.appendChild(renderWindowContainer);
+
+  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  glwindow.setContainer(renderWindowContainer);
+  glwindow.initialize();
+
+  const oglTex = vtkOpenGLTexture.newInstance({
+    openGLRenderWindow: glwindow,
+  });
+
+  const gl = glwindow.get3DContext();
+  let format = null;
+
+  format = oglTex.getInternalFormat(VtkDataTypes.UNSIGNED_CHAR, 1);
+  t.ok(format === gl.R8);
+
+  format = oglTex.getInternalFormat(VtkDataTypes.FLOAT, 1);
+  t.ok(format === gl.R16F);
+});


### PR DESCRIPTION
ImageMapper has a case where it's possible to switch between
UNSIGNED_CHAR and FLOAT textures, depending on if there is a piecewise
function for opacity (see [here](https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/OpenGL/ImageMapper/index.js#L744)).This commit relaxes a restriction where the
internal format can only be set once.

I'll add a test for this.