### PR TITLE
fix(OpenGL/ImageMapper): Reset texture format for pwf

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -716,6 +716,8 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       const pwfSize = pwfWidth * textureHeight;
       const pwfTable = new Uint8Array(pwfSize);
       let pwfun = actorProperty.getPiecewiseFunction();
+      // support case where pwfun is added/removed
+      model.pwfTexture.resetFormatAndType();
       if (pwfun) {
         const pwfFloatTable = new Float32Array(pwfSize);
         const tmpTable = new Float32Array(pwfWidth);


### PR DESCRIPTION
Before, adding a piecewise function to a texture after the texture has been rendered would not do anything. Now, piecewise functions added/removed during the lifetime of the texture will be used appropriately.