### PR TITLE
fix(OpenGL/CellArrayBufferObject): in some scenarios, the value of ca…

### DIFF
--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -224,6 +224,11 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
       index += array[index] + 1;
     }
 
+    if (caboCount <= 0) {
+      model.elementCount = 0;
+      return 0;
+    }
+    
     let packedUCVBO = null;
     const packedVBO = new Float32Array(caboCount * model.blockSize);
     if (colorData) {


### PR DESCRIPTION
In some scenarios, the value of caboCount is negative, causing array allocation to fail