### PR TITLE
fix(OrientationMarkerWidget): Update viewport on modified

### DIFF
--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
@@ -13,12 +13,15 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOrientationMarkerWidget');
 
+  const superClass = { ...publicAPI };
+
   // Private variables
 
   const previousCameraInput = [];
   const selfRenderer = vtkRenderer.newInstance();
   let interactorUnsubscribe = null;
   let viewUnsubscribe = null;
+  let selfSubscription = null;
 
   publicAPI.computeViewport = () => {
     const [viewXSize, viewYSize] = model.interactor.getView().getSize();
@@ -202,6 +205,27 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
   };
 
   publicAPI.getRenderer = () => selfRenderer;
+
+  publicAPI.delete = () => {
+    superClass.delete();
+    if (selfSubscription) {
+      selfSubscription.unsubscribe();
+      selfSubscription = null;
+    }
+    if (interactorUnsubscribe) {
+      interactorUnsubscribe();
+      interactorUnsubscribe = null;
+    }
+    if (viewUnsubscribe) {
+      viewUnsubscribe();
+      viewUnsubscribe = null;
+    }
+  };
+
+  // --------------------------------------------------------------------------
+
+  // update viewport whenever we are updated
+  selfSubscription = publicAPI.onModified(publicAPI.updateViewport);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Previously, the viewport was not being re-computed when min/max sizes
were set.

Fixes the second issue mentioned in #1381