### PR TITLE
fix(OpenGL/Framebuffer): Set framebuffer when complete

### DIFF
--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -60,7 +60,12 @@ function vtkFramebuffer(publicAPI, model) {
     if (model.colorTexture) {
       model.colorTexture.bind();
     }
-    model.openGLRenderWindow.setActiveFramebuffer(publicAPI);
+    if (
+      model.context.checkFramebufferStatus(model.context.FRAMEBUFFER) ===
+      model.context.FRAMEBUFFER_COMPLETE
+    ) {
+      model.openGLRenderWindow.setActiveFramebuffer(publicAPI);
+    }
   };
 
   publicAPI.create = (width, height) => {


### PR DESCRIPTION
Previously, the framebuffer would get set even when the framebuffer was
incomplete, resulting in "incomplete framebuffer" warnings.

Fixes #1381 (from what I've tested)

@martinken are there any cases where this would break something? Also, if the framebuffer is incomplete, would it make sense to call `setActiveFramebuffer(null)`?