### PR TITLE
fix(Math): Cross results incorrect when doing in-place

### DIFF
--- a/Sources/Common/Core/Math/api.md
+++ b/Sources/Common/Core/Math/api.md
@@ -117,6 +117,7 @@ Returns out.
 
 Computes cross product of 3D vectors x and y.
 Returns out.
+It is safe to x or y as out.
 
 ### norm(x, n = 3)
 

--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -206,9 +206,12 @@ export function outer(x, y, out_3x3) {
 }
 
 export function cross(x, y, out) {
-  out[0] = x[1] * y[2] - x[2] * y[1];
-  out[1] = x[2] * y[0] - x[0] * y[2];
-  out[2] = x[0] * y[1] - x[1] * y[0];
+  const Zx = x[1] * y[2] - x[2] * y[1];
+  const Zy = x[2] * y[0] - x[0] * y[2];
+  const Zz = x[0] * y[1] - x[1] * y[0];
+  out[0] = Zx;
+  out[1] = Zy;
+  out[2] = Zz;
   return out;
 }
 


### PR DESCRIPTION
If x or y is the same array as out, then the result will be wrong due to
inter-dependence between components.

Fixes #1594 