### PR TITLE
Tube filter copy celldata

### DIFF
--- a/Sources/Common/DataModel/DataSetAttributes/index.js
+++ b/Sources/Common/DataModel/DataSetAttributes/index.js
@@ -167,7 +167,6 @@ function vtkDataSetAttributes(publicAPI, model) {
         value
       );
     publicAPI[`copy${value}Off`] = () => {
-      publicAPI.initialize();
       const attType = value.toUpperCase();
       model.copyAttributeFlags[AttributeCopyOperations.PASSDATA][
         AttributeTypes[attType]
@@ -175,7 +174,7 @@ function vtkDataSetAttributes(publicAPI, model) {
     };
   });
 
-  publicAPI.initialize = macro.chain(publicAPI.initialize, () => {
+  publicAPI.initializeAttributeCopyFlags = () => {
     // Default to copying all attributes in every circumstance:
     model.copyAttributeFlags = [];
     Object.keys(AttributeCopyOperations)
@@ -200,7 +199,12 @@ function vtkDataSetAttributes(publicAPI, model) {
     model.copyAttributeFlags[AttributeCopyOperations.COPYTUPLE][
       AttributeTypes.PEDIGREEIDS
     ] = false;
-  });
+  };
+
+  publicAPI.initialize = macro.chain(
+    publicAPI.initialize,
+    publicAPI.initializeAttributeCopyFlags
+  );
 
   // Process dataArrays if any
   if (model.dataArrays && Object.keys(model.dataArrays).length) {
@@ -223,6 +227,8 @@ function vtkDataSetAttributes(publicAPI, model) {
       return { data: arrNew };
     });
   };
+
+  publicAPI.initializeAttributeCopyFlags();
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/General/TubeFilter/index.js
+++ b/Sources/Filters/General/TubeFilter/index.js
@@ -707,6 +707,24 @@ function vtkTubeFilter(publicAPI, model) {
       output.getPointData().addArray(newArray); // concat newArray to end
     }
 
+    // loop over cellData arrays and resize based on numNewCells
+    let numNewCells = inLines.getNumberOfCells() * model.numberOfSides;
+    if (model.capping) {
+      numNewCells += 2;
+    }
+    const numCellArrays = input.getCellData().getNumberOfArrays();
+    for (let i = 0; i < numCellArrays; i++) {
+      oldArray = input.getCellData().getArrayByIndex(i);
+      newArray = vtkDataArray.newInstance({
+        name: oldArray.getName(),
+        dataType: oldArray.getDataType(),
+        numberOfComponents: oldArray.getNumberOfComponents(),
+        size: numNewCells * oldArray.getNumberOfComponents(),
+      });
+      output.getCellData().removeArrayByIndex(0); // remove oldArray from beginning
+      output.getCellData().addArray(newArray); // concat newArray to end
+    }
+
     const inScalars = publicAPI.getInputArrayToProcess(0);
     let outScalars = null;
     let range = [];


### PR DESCRIPTION
- Copy cell data from tube filter
- initialize attribute copy flags on DataSetAttributes creation
- Remove a call to `initialize` in `copy<NAME>Off`, since `initialize` clears `model.arrays`, which is not desired behavior when turning copy off