### PR TITLE
fix(Widgets): Guard against empty worldCoords

### DIFF
--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -82,8 +82,8 @@ export default function widgetBehavior(publicAPI, model) {
       );
 
       if (
-        model.activeState === model.widgetState.getMoveHandle() ||
-        isDragging
+        worldCoords.length &&
+        (model.activeState === model.widgetState.getMoveHandle() || isDragging)
       ) {
         model.activeState.setOrigin(worldCoords);
         publicAPI.invokeInteractionEvent();

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -81,8 +81,8 @@ export default function widgetBehavior(publicAPI, model) {
       );
 
       if (
-        model.activeState === model.widgetState.getMoveHandle() ||
-        isDragging
+        worldCoords.length &&
+        (model.activeState === model.widgetState.getMoveHandle() || isDragging)
       ) {
         model.activeState.setOrigin(worldCoords);
         publicAPI.invokeInteractionEvent();

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -98,8 +98,8 @@ export default function widgetBehavior(publicAPI, model) {
       );
 
       if (
-        model.activeState === model.widgetState.getMoveHandle() ||
-        isDragging
+        worldCoords.length &&
+        (model.activeState === model.widgetState.getMoveHandle() || isDragging)
       ) {
         model.activeState.setOrigin(worldCoords);
         publicAPI.invokeInteractionEvent();

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -295,7 +295,10 @@ export default function widgetBehavior(publicAPI, model) {
       model.lastHandle.setVisible(true);
     }
 
-    if (model.isDragging || model.activeState === model.moveHandle) {
+    if (
+      worldCoords.length &&
+      (model.isDragging || model.activeState === model.moveHandle)
+    ) {
       model.activeState.setOrigin(worldCoords);
       if (model.isDragging) {
         model.draggedPoint = true;


### PR DESCRIPTION
Manipulators may return an empty result, so a guard must be in place.

FYI @laurennlam @finetjul I know you've been doing widgets stuff, so if any of these changes conflict or apply to your PRs, feel free to copy the changes to your PRs as to avoid conflicts.