### PR TITLE
fix(vtkforwardpass): check to see if a renderer should be drawn

### DIFF
--- a/Sources/Rendering/OpenGL/ForwardPass/index.js
+++ b/Sources/Rendering/OpenGL/ForwardPass/index.js
@@ -32,7 +32,8 @@ function vtkForwardPass(publicAPI, model) {
       for (let index = 0; index < renderers.length; index++) {
         const renNode = renderers[index];
         const ren = viewNode.getRenderable().getRenderers()[index];
-        if (ren.getLayer() === i) {
+
+        if (ren.getDraw() && ren.getLayer() === i) {
           // check for both opaque and volume actors
           model.opaqueActorCount = 0;
           model.translucentActorCount = 0;


### PR DESCRIPTION
Hey,

Renderers currenlty have a `draw` property, which the api docs show should prevent a redraw if set to false, however this is never checked.

I've added the check to the forwardPass, confirmed locally it works when you have multiple `renderer`s on a single `renderWindow`.