### PR TITLE
Implicit plane visibility

### DIFF
--- a/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
+++ b/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
@@ -270,17 +270,31 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
     ctxVisible,
     hVisible
   ) => {
+    const {
+      planeVisible,
+      originVisible,
+      normalVisible,
+      outlineVisible,
+    } = model;
     if (renderingType === RenderingTypes.PICKING_BUFFER) {
-      model.pipelines.plane.actor.setVisibility(wVisible);
-      model.pipelines.origin.actor.setVisibility(wVisible);
-      model.pipelines.normal.actor.setVisibility(wVisible);
+      model.pipelines.plane.actor.setVisibility(planeVisible && wVisible);
+      model.pipelines.origin.actor.setVisibility(originVisible && wVisible);
+      model.pipelines.normal.actor.setVisibility(normalVisible && wVisible);
       //
       model.pipelines.plane.actor.getProperty().setOpacity(1);
     } else {
-      model.pipelines.outline.actor.setVisibility(wVisible && ctxVisible);
-      model.pipelines.plane.actor.setVisibility(wVisible && hVisible);
-      model.pipelines.origin.actor.setVisibility(wVisible && hVisible);
-      model.pipelines.normal.actor.setVisibility(wVisible && hVisible);
+      model.pipelines.outline.actor.setVisibility(
+        outlineVisible && wVisible && ctxVisible
+      );
+      model.pipelines.plane.actor.setVisibility(
+        planeVisible && wVisible && hVisible
+      );
+      model.pipelines.origin.actor.setVisibility(
+        originVisible && wVisible && hVisible
+      );
+      model.pipelines.normal.actor.setVisibility(
+        normalVisible && wVisible && hVisible
+      );
       //
       const state = model.inputData[0];
       if (state) {
@@ -336,6 +350,10 @@ const DEFAULT_VALUES = {
   sphereResolution: 24,
   handleSizeRatio: 0.05,
   axisScale: 0.1,
+  normalVisible: true,
+  originVisible: true,
+  planeVisible: true,
+  outlineVisible: true,
 };
 
 // ----------------------------------------------------------------------------
@@ -345,7 +363,14 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   vtkWidgetRepresentation.extend(publicAPI, model, initialValues);
   macro.get(publicAPI, model, ['sphereResolution', 'representationStyle']);
-  macro.setGet(publicAPI, model, ['handleSizeRatio', 'axisScale']);
+  macro.setGet(publicAPI, model, [
+    'handleSizeRatio',
+    'axisScale',
+    'normalVisible',
+    'originVisible',
+    'planeVisible',
+    'outlineVisible',
+  ]);
 
   // Object specific methods
   vtkImplicitPlaneRepresentation(publicAPI, model);

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/api.md
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/api.md
@@ -1,0 +1,18 @@
+This class represents a plane widget.
+
+## set/getNormalVisible(flag)
+
+Sets or gets the visibility of the normal axis.
+
+## set/getOriginVisible(flag)
+
+Sets or gets the visibility of the origin marker.
+
+## set/getPlaneVisible(flag)
+
+Sets or gets the visibility of the plane.
+
+## set/getOutlineVisible(flag)
+
+Sets or gets the visibility of the outline.
+

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
@@ -148,6 +148,10 @@ function vtkImplicitPlaneWidget(publicAPI, model) {
     'sphereResolution',
     'handleSizeRatio',
     'axisScale',
+    'normalVisible',
+    'originVisible',
+    'planeVisible',
+    'outlineVisible',
   ];
 
   publicAPI.getRepresentationsForViewType = (viewType) => {


### PR DESCRIPTION
Adds support for setting and getting the visibility of the normal, plane, origin, and outline components of the ImplicitPlaneWidget.

Closes #1630 