### PR TITLE
The selection condition was added

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -321,7 +321,11 @@ function vtkWidgetManager(publicAPI, model) {
     );
 
     subscriptions.push(
-      model.interactor.onMouseMove(({ position }) => {
+      model.interactor.onMouseMove((callData) => {
+        const { position, pokedRenderer } = callData;
+        if (model.renderer !== pokedRenderer) {
+          return;
+        }
         if (model.isAnimating || !model.pickingAvailable) {
           return;
         }
@@ -535,7 +539,7 @@ function vtkWidgetManager(publicAPI, model) {
 const DEFAULT_VALUES = {
   viewId: null,
   widgets: [],
-  renderer: [],
+  renderer: null,
   viewType: ViewTypes.DEFAULT,
   pickingAvailable: false,
   isAnimating: false,


### PR DESCRIPTION
When adding a widget to the environment of 1 renderwindow and n renderers, selectedState does not work properly in mouse move event.

I think It compares the pokedRenderer that is passed to the mouse move event and the Renderer that WindgetManager has, and if they are different, it seems that there is no need to handle picking.