### PR TITLE
fix(OrientationMarkerWidget): Use resize observer

### DIFF
--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
@@ -19,8 +19,12 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
 
   const previousCameraInput = [];
   const selfRenderer = vtkRenderer.newInstance();
+  const resizeObserver = new ResizeObserver((entries) => {
+    if (entries.length === 1) {
+      publicAPI.updateViewport();
+    }
+  });
   let interactorUnsubscribe = null;
-  let viewUnsubscribe = null;
   let selfSubscription = null;
 
   publicAPI.computeViewport = () => {
@@ -136,9 +140,7 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
         publicAPI.updateMarkerOrientation
       ));
 
-      ({ unsubscribe: viewUnsubscribe } = model.interactor
-        .getView()
-        .onModified(publicAPI.updateViewport));
+      resizeObserver.observe(model.interactor.getView().getCanvas());
 
       publicAPI.updateViewport();
       publicAPI.updateMarkerOrientation();
@@ -150,8 +152,7 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
       }
       model.enabled = false;
 
-      viewUnsubscribe();
-      viewUnsubscribe = null;
+      resizeObserver.disconnect();
       interactorUnsubscribe();
       interactorUnsubscribe = null;
 
@@ -216,10 +217,7 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
       interactorUnsubscribe();
       interactorUnsubscribe = null;
     }
-    if (viewUnsubscribe) {
-      viewUnsubscribe();
-      viewUnsubscribe = null;
-    }
+    resizeObserver.disconnect();
   };
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
This avoids unnecessary resize updates when the scene isn't actually resizing.

@laurentmalka @finetjul This should fix your Z buffer issue. Below is a brief summary of what I think is happening.

Prior to this PR, `vtkOrientationMarkerWidget.updateViewport()` gets called every time the interactor view is updated (which includes mouse movement). `updateViewport()` calls `interactor.render()`, which will of course render the scene. Now consider how vtkOpenGLHardwareSelector works. At a high level, it tells the renderer to do a picking render to populate the picking buffer. When moving the mouse over the scene, we trigger calls to the hardware selector to render the picking buffer. Somehow, during the rendering phase of the hardware selector, the interactor `onModified` callbacks are being invoked, and so as a result a regular render happens in the middle of the picking render. (To be more specific, this is a result of onModified listeners being immediately called when a setter is invoked.)