### PR TITLE
Stabilize reslice cursor center on rotation

### DIFF
--- a/Sources/Widgets/Representations/ResliceCursorContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/ResliceCursorContextRepresentation/index.js
@@ -9,6 +9,7 @@ import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
 import vtkWidgetRepresentation from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 
 import { RenderingTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
+import { InteractionMethodsName } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants';
 
 // ----------------------------------------------------------------------------
 // vtkResliceCursorContextRepresentation methods
@@ -256,34 +257,34 @@ function vtkResliceCursorContextRepresentation(publicAPI, model) {
     switch (prop) {
       case model.pipelines.axes[0].line.actor:
         activeLineState = axis1State;
-        methodName = 'translateAxis';
+        methodName = InteractionMethodsName.TranslateAxis;
         break;
       case model.pipelines.axes[1].line.actor:
         activeLineState = axis2State;
-        methodName = 'translateAxis';
+        methodName = InteractionMethodsName.TranslateAxis;
         break;
       case model.pipelines.axes[0].rotation1.actor:
         activeLineState = axis1State;
         activeRotationPointName = 'RotationPoint1';
-        methodName = 'rotateLine';
+        methodName = InteractionMethodsName.RotateLine;
         break;
       case model.pipelines.axes[0].rotation2.actor:
         activeLineState = axis1State;
         activeRotationPointName = 'RotationPoint2';
-        methodName = 'rotateLine';
+        methodName = InteractionMethodsName.RotateLine;
         break;
       case model.pipelines.axes[1].rotation1.actor:
         activeLineState = axis2State;
         activeRotationPointName = 'RotationPoint1';
-        methodName = 'rotateLine';
+        methodName = InteractionMethodsName.RotateLine;
         break;
       case model.pipelines.axes[1].rotation2.actor:
         activeLineState = axis2State;
         activeRotationPointName = 'RotationPoint2';
-        methodName = 'rotateLine';
+        methodName = InteractionMethodsName.RotateLine;
         break;
       default:
-        methodName = 'translateCenter';
+        methodName = InteractionMethodsName.TranslateCenter;
         break;
     }
 

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants.js
@@ -4,7 +4,8 @@ export const ScrollingMethods = {
   RIGHT_MOUSE_BUTTON: 2,
 };
 
-// Note: These strings are exactly method's name in ResliceCursorWidget/behavior.js
+// Note: These strings are used in ResliceCursorWidget/behavior.js
+// as method's names
 export const InteractionMethodsName = {
   TranslateAxis: 'translateAxis',
   RotateLine: 'rotateLine',

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants.js
@@ -4,6 +4,14 @@ export const ScrollingMethods = {
   RIGHT_MOUSE_BUTTON: 2,
 };
 
+// Note: These strings are exactly method's name in ResliceCursorWidget/behavior.js
+export const InteractionMethodsName = {
+  TranslateAxis: 'translateAxis',
+  RotateLine: 'rotateLine',
+  TranslateCenter: 'translateCenter',
+};
+
 export default {
   ScrollingMethods,
+  InteractionMethodsName,
 };

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -200,7 +200,7 @@ export default function widgetBehavior(publicAPI, model) {
     updateState(model.widgetState);
   };
 
-  publicAPI.translateAxis = (calldata) => {
+  publicAPI[InteractionMethodsName.TranslateAxis] = (calldata) => {
     const stateLine = model.widgetState.getActiveLineState();
     const worldCoords = model.planeManipulator.handleEvent(
       calldata,
@@ -264,7 +264,7 @@ export default function widgetBehavior(publicAPI, model) {
     return boundPointOnPlane(newCenter, oldCenter, imageBounds);
   };
 
-  publicAPI.translateCenter = (calldata) => {
+  publicAPI[InteractionMethodsName.TranslateCenter] = (calldata) => {
     let worldCoords = model.planeManipulator.handleEvent(
       calldata,
       model.openGLRenderWindow
@@ -274,7 +274,7 @@ export default function widgetBehavior(publicAPI, model) {
     updateState(model.widgetState);
   };
 
-  publicAPI.rotateLine = (calldata) => {
+  publicAPI[InteractionMethodsName.RotateLine] = (calldata) => {
     const activeLine = model.widgetState.getActiveLineState();
     const planeNormal = model.planeManipulator.getNormal();
     const worldCoords = model.planeManipulator.handleEvent(

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -76,7 +76,7 @@ export default function widgetBehavior(publicAPI, model) {
         );
         model.previousPosition = callData.position;
 
-        publicAPI.invokeInteractionEvent();
+        publicAPI.invokeInternalInteractionEvent();
       }
     }
     return macro.VOID;
@@ -120,7 +120,7 @@ export default function widgetBehavior(publicAPI, model) {
     const step = calldata.spinY;
     publicAPI.translateCenterOnCurrentDirection(step, calldata.pokedRenderer);
 
-    publicAPI.invokeInteractionEvent();
+    publicAPI.invokeInternalInteractionEvent();
 
     return macro.EVENT_ABORT;
   };
@@ -153,10 +153,22 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleEvent = (callData) => {
     if (model.activeState.getActive()) {
       publicAPI[model.activeState.getUpdateMethodName()](callData);
-      publicAPI.invokeInteractionEvent();
+      publicAPI.invokeInternalInteractionEvent();
       return macro.EVENT_ABORT;
     }
     return macro.VOID;
+  };
+
+  publicAPI.invokeInternalInteractionEvent = () => {
+    const methodName = model.activeState.getUpdateMethodName();
+    const computeFocalPointOffset =
+      methodName !== InteractionMethodsName.RotateLine;
+    const canUpdateFocalPoint =
+      methodName !== InteractionMethodsName.TranslateCenter;
+    publicAPI.invokeInteractionEvent({
+      computeFocalPointOffset,
+      canUpdateFocalPoint,
+    });
   };
 
   publicAPI.startInteraction = () => {

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -12,7 +12,10 @@ import {
   updateState,
 } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';
 
-import { ScrollingMethods } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants';
+import {
+  ScrollingMethods,
+  InteractionMethodsName,
+} from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants';
 
 export default function widgetBehavior(publicAPI, model) {
   let isDragging = null;
@@ -20,13 +23,13 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.updateCursor = () => {
     switch (model.activeState.getUpdateMethodName()) {
-      case 'translateCenter':
+      case InteractionMethodsName.TranslateCenter:
         model.openGLRenderWindow.setCursor('move');
         break;
-      case 'rotateLine':
+      case InteractionMethodsName.RotateLine:
         model.openGLRenderWindow.setCursor('alias');
         break;
-      case 'translateAxis':
+      case InteractionMethodsName.TranslateAxis:
         model.openGLRenderWindow.setCursor('pointer');
         break;
       default:

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -209,25 +209,24 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
         // to change slicer
         .forEach((v) => {
           // Interactions in other views may change current plane
-          v.widgetInstance.onInteractionEvent(() => {
-            const activeViewName = widget.getWidgetState().getActiveViewName();
-            const activeMethodName = widget
-              .getWidgetState()
-              .getUpdateMethodName();
-            const currentViewName = getViewPlaneNameFromViewType(viewType);
-            updateReslice({
-              viewType,
-              reslice,
-              actor: obj.resliceActor,
-              renderer: obj.renderer,
-              resetFocalPoint: false,
-              updateFocalPoint:
-                activeViewName !== currentViewName &&
-                activeMethodName !== InteractionMethodsName.TranslateCenter,
-              computeFocalPointOffset:
-                activeMethodName !== InteractionMethodsName.RotateLine,
-            });
-          });
+          v.widgetInstance.onInteractionEvent(
+            ({ computeFocalPointOffset, canUpdateFocalPoint }) => {
+              const activeViewName = widget
+                .getWidgetState()
+                .getActiveViewName();
+              const currentViewName = getViewPlaneNameFromViewType(viewType);
+              updateReslice({
+                viewType,
+                reslice,
+                actor: obj.resliceActor,
+                renderer: obj.renderer,
+                resetFocalPoint: false,
+                updateFocalPoint:
+                  activeViewName !== currentViewName && canUpdateFocalPoint,
+                computeFocalPointOffset,
+              });
+            }
+          );
         });
 
       updateReslice({

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -20,7 +20,6 @@ import {
 } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
 import { getViewPlaneNameFromViewType } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';
-import { InteractionMethodsName } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants';
 
 // ----------------------------------------------------------------------------
 // Define html structure
@@ -157,9 +156,10 @@ function updateReslice(
     reslice: null,
     actor: null,
     renderer: null,
-    resetFocalPoint: false,
-    updateFocalPoint: false,
-    computeFocalPointOffset: false,
+    resetFocalPoint: false, // Reset the focal point to the center of the display image
+    keepFocalPointPosition: false, // Defines if the focal point position is kepts (same display distance from reslice cursor center)
+    computeFocalPointOffset: false, // Defines if the display offset between reslice center and focal point has to be
+    // computed. If so, then this offset will be used to keep the focal point position during rotation.
   }
 ) {
   const modified = widget.updateReslicePlane(
@@ -176,7 +176,7 @@ function updateReslice(
     interactionContext.renderer,
     interactionContext.viewType,
     interactionContext.resetFocalPoint,
-    interactionContext.updateFocalPoint,
+    interactionContext.keepFocalPointPosition,
     interactionContext.computeFocalPointOffset
   );
   return modified;
@@ -210,6 +210,10 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
         .forEach((v) => {
           // Interactions in other views may change current plane
           v.widgetInstance.onInteractionEvent(
+            // computeFocalPointOffset: Boolean which defines if the offset between focal point and
+            // reslice cursor display center has to be recomputed (while translation is applied)
+            // canUpdateFocalPoint: Boolean which defines if the focal point can be updated because
+            // the current interaction is a rotation
             ({ computeFocalPointOffset, canUpdateFocalPoint }) => {
               const activeViewName = widget
                 .getWidgetState()
@@ -221,7 +225,7 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
                 actor: obj.resliceActor,
                 renderer: obj.renderer,
                 resetFocalPoint: false,
-                updateFocalPoint:
+                keepFocalPointPosition:
                   activeViewName !== currentViewName && canUpdateFocalPoint,
                 computeFocalPointOffset,
               });
@@ -234,9 +238,9 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
         reslice,
         actor: obj.resliceActor,
         renderer: obj.renderer,
-        resetFocalPoint: true,
-        updateFocalPoint: false,
-        computeFocalPointOffset: true,
+        resetFocalPoint: true, // At first initilization, center the focal point to the image center
+        keepFocalPointPosition: false, // Don't update the focal point as we already set it to the center of the image
+        computeFocalPointOffset: true, // Allow to compute the current offset between display reslice center and display focal point
       });
       obj.renderWindow.render();
     }

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -20,6 +20,7 @@ import {
 } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
 import { getViewPlaneNameFromViewType } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';
+import { InteractionMethodsName } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants';
 
 // ----------------------------------------------------------------------------
 // Define html structure
@@ -207,8 +208,9 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
             const currentViewName = getViewPlaneNameFromViewType(viewType);
             const updateFocalPoint =
               activeViewName !== currentViewName &&
-              activeMethodName !== 'translateCenter';
-            const computeFocalPointShift = activeMethodName !== 'rotateLine';
+              activeMethodName !== InteractionMethodsName.TranslateCenter;
+            const computeFocalPointShift =
+              activeMethodName !== InteractionMethodsName.RotateLine;
             const resetFocalPoint = false;
             updateReslice(
               viewType,

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
@@ -125,5 +125,6 @@ export default function generateState() {
       name: 'scrollingMethod',
       initialValue: ScrollingMethods.MIDDLE_MOUSE_BUTTON,
     })
+    .addField({ name: 'resliceCenterShift', initialValue: {} })
     .build();
 }

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
@@ -125,6 +125,6 @@ export default function generateState() {
       name: 'scrollingMethod',
       initialValue: ScrollingMethods.MIDDLE_MOUSE_BUTTON,
     })
-    .addField({ name: 'resliceCenterShift', initialValue: {} })
+    .addField({ name: 'cameraOffsets', initialValue: {} })
     .build();
 }


### PR DESCRIPTION
After setting translation on the reslice cursor, then, when applying rotation, keep reslice cursor center and "moves" image instead.
It avoids a reslice cursor translation visual effect.

@finetjul 