### PR TITLE
fix(JSZipDataAccessHelper): Downgrade JSZip version

### DIFF
--- a/Utilities/ExampleRunner/template-config.js
+++ b/Utilities/ExampleRunner/template-config.js
@@ -1,5 +1,6 @@
-var path = require('path');
-var vtkBasePath = path.resolve('.');
+const path = require('path');
+
+const vtkBasePath = path.resolve('.');
 
 const settings = require('../../webpack.settings.js');
 
@@ -47,6 +48,7 @@ module.exports = {
     },
     fallback: {
       fs: false,
+      stream: require.resolve('stream-browserify')
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14447,9 +14447,9 @@
       }
     },
     "jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.0.tgz",
+      "integrity": "sha512-4WjbsaEtBK/DHeDZOPiPw5nzSGLDEDDreFRDEgnoMwmknPjTqa+23XuYFk6NiGbeiAeZCctiQ/X/z0lQBmDVOQ==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -14474,14 +14474,6 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -24793,7 +24785,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "blueimp-md5": "2.18.0",
     "commander": "6.2.0",
     "gl-matrix": "3.3.0",
-    "jszip": "3.5.0",
+    "jszip": "3.2.0",
     "pako": "1.0.11",
     "seedrandom": "3.0.5",
     "shelljs": "0.8.4",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -77,9 +77,7 @@ function configureVtkRules() {
     },
     {
       test: /\.worker\.js$/,
-      use: [
-        { loader: 'worker-loader', options: { inline: 'no-fallback' } },
-      ],
+      use: [{ loader: 'worker-loader', options: { inline: 'no-fallback' } }],
     },
   ];
 }
@@ -97,6 +95,7 @@ const baseConfig = {
     alias: {
       'vtk.js': __dirname,
     },
+    fallback: { stream: require.resolve('stream-browserify') },
   },
   module: {
     rules: configureVtkRules(),
@@ -148,6 +147,7 @@ const liteConfig = merge(
           'Sources/Rendering/Core/ColorTransferFunction/LiteColorMaps.json'
         ),
       },
+      fallback: { stream: require.resolve('stream-browserify') },
     },
   },
   baseConfig,


### PR DESCRIPTION
The latest versions of JSZip seem to have broken the JSZipDataAccessHelper.

Calling JSRoot.file().async() returns a promise that never resolves. This breaks .vtkjs loading functionality.

People having the same issue:

https://github.com/Stuk/jszip/issues/724

https://github.com/Stuk/jszip/issues/712

Downgrading to 3.2.0 fixes the issue.