### PR TITLE
chore(github): Use custom github publish token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Publish docs
         if: github.ref == 'refs/heads/master'
         env:
-          GIT_PUBLISH_URL: https://${{ secrets.GITHUB_TOKEN }}@github.com/Kitware/vtk-js.git
+          GIT_PUBLISH_URL: https://${{ secrets.GH_PUBLISH_CREDS }}@github.com/Kitware/vtk-js.git
         run: npm run doc:publish


### PR DESCRIPTION
I'm pretty sure the default github app token's permissions don't work
for committing to gh-pages branch.