### PR TITLE
fix(ResliceCursorWidget): Fix view up of resliced image when multiply…

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants.js
@@ -1,3 +1,5 @@
+import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
+
 export const ScrollingMethods = {
   MIDDLE_MOUSE_BUTTON: 0,
   LEFT_MOUSE_BUTTON: 1,
@@ -10,6 +12,12 @@ export const InteractionMethodsName = {
   TranslateAxis: 'translateAxis',
   RotateLine: 'rotateLine',
   TranslateCenter: 'translateCenter',
+};
+
+export const defaultViewUpFromViewType = {
+  [ViewTypes.YZ_PLANE]: [0, 0, 1], // Sagittal
+  [ViewTypes.XZ_PLANE]: [0, 0, 1], // Coronal
+  [ViewTypes.XY_PLANE]: [0, 1, 0], // Axial
 };
 
 export default {

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -13,6 +13,7 @@ import {
   boundPlane,
   updateState,
   getViewPlaneNameFromViewType,
+  transformPlane,
 } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
@@ -399,10 +400,9 @@ function vtkResliceCursorWidget(publicAPI, model) {
     // centered on cursor center.
     const planeSource = computeReslicePlaneOrigin(viewType);
 
-    // Apply rotation onto plane (i.e. origin, p1, p2)
-    planeSource.setNormal(...plane.getNormal());
-    // TBD: isn't it a no-op ?
-    planeSource.setCenter(...plane.getOrigin());
+    // Adapt plane orientation in order to fit the correct viewUp
+    // so that the rotations will be more understandable than now.
+    transformPlane(planeSource, plane, viewType);
 
     // TODO: orient plane on volume.
 


### PR DESCRIPTION
… rotations

@finetjul 
I didn't found out yet how to avoid the short flip when applying 180° rotation. This bug has not been created by this MR. It existed before.
Still in progress.