### PR TITLE
Add prerelease beta branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
       - master
       - next
       - next-major
+      - beta
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
       "+([0-9])?(.{+([0-9]),x}).x",
       "master",
       "next",
-      "next-major"
+      "next-major",
+      { "name": "beta", "prerelease": true }
     ]
   }
 }


### PR DESCRIPTION
Add a beta pre-release channel. This allows for publishing beta packages for major releases. This differs from next and next-major in that this is a pre-release channel, so releases will be of the form `vX.X.X-beta-#`. This will allow us to merge several breaking PRs into the pre-release channel without affecting the default channel releases and without bumping major versions on every merge.

More info: https://github.com/semantic-release/semantic-release/blob/0ef52e7a5f4f4c2bc3daecf7d71eeb1323491374/docs/recipes/pre-releases.md

@jourdain what do you think?