### PR TITLE
Rewrite examples for ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const prettierConf = require('./prettier.config.js');
 
 module.exports = {
@@ -36,7 +37,15 @@ module.exports = {
         config: {
           resolve: {
             alias: {
-              'vtk.js': __dirname,
+              // Since vtk.js examples are written as if the vtk.js package is a dependency,
+              // we need to resolve example imports as if they were referencing vtk.js/Sources.
+              // the Examples/Utilities hack allows for imports from those folders, since our
+              // last alias overrides vtk.js/* paths to point to vtk.js/Sources/*.
+              'vtk.js/Data': path.resolve(__dirname, 'Data'),
+              'vtk.js/Examples': path.resolve(__dirname, 'Examples'),
+              'vtk.js/Utilities': path.resolve(__dirname, 'Utilities'),
+              'vtk.js/Sources': path.resolve(__dirname, 'Sources'),
+              'vtk.js': path.resolve(__dirname, 'Sources'),
             },
           },
         },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-var prettierConf = require('./prettier.config.js');
+const prettierConf = require('./prettier.config.js');
 
 module.exports = {
   extends: ['airbnb', 'prettier'],
@@ -9,14 +9,7 @@ module.exports = {
     'no-multi-spaces': ['error', { exceptions: { ImportDeclaration: true } }],
     'no-param-reassign': ['error', { props: false }],
     'no-unused-vars': ['error', { args: 'none' }],
-    'prefer-destructuring': [
-      'error',
-      {
-        VariableDeclarator: { array: false, object: true },
-        AssignmentExpression: { array: false, object: false },
-      },
-      { enforceForRenamedProperties: false },
-    ],
+    'prefer-destructuring': 0,
     'import/no-extraneous-dependencies': 0, // Needed for tests
     // 'no-mixed-operators': 'error', // Wish we can put it back with prettier
 
@@ -26,7 +19,6 @@ module.exports = {
     'no-plusplus': 0,
     'import/no-named-as-default': 0,
     'import/no-named-as-default-member': 0,
-    'prefer-destructuring': 0, // Can have unwanted side effect
 
     // Introduced with new eslint
     // and no time to fix them...

--- a/Documentation/config.js
+++ b/Documentation/config.js
@@ -83,7 +83,16 @@ module.exports = {
       { test: /\\.hson$/, loader: 'hson-loader' },
       `,
     ],
-    alias: ["'vtk.js': `${rootPath}`,"],
+    // Since vtk.js examples are written as if the vtk.js package is a dependency,
+    // we need to resolve example imports as if they were referencing vtk.js/Sources.
+    // the Examples/Utilities hack allows for imports from those folders, since our
+    // last alias overrides vtk.js/* paths to point to vtk.js/Sources/*.
+    alias: [
+      "'vtk.js/Examples': `${rootPath}/Examples`,",
+      "'vtk.js/Utilities': `${rootPath}/Utilities`,",
+      "'vtk.js/Sources': `${rootPath}/Sources`,",
+      "'vtk.js': `${rootPath}/Sources`,",
+    ],
   },
   copy: [{ src: '../Data/*', dest: './build-tmp/public/data' }],
 };

--- a/Examples/Applications/GeometryViewer/index.js
+++ b/Examples/Applications/GeometryViewer/index.js
@@ -1,24 +1,21 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import macro from 'vtk.js/Sources/macro';
-import HttpDataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkColorMaps from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/ColorMaps';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
-import vtkXMLPolyDataReader from 'vtk.js/Sources/IO/XML/XMLPolyDataReader';
-import vtkFPSMonitor from 'vtk.js/Sources/Interaction/UI/FPSMonitor';
+import macro from 'vtk.js/macro';
+import HttpDataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkColorMaps from 'vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkURLExtract from 'vtk.js/Common/Core/URLExtract';
+import vtkXMLPolyDataReader from 'vtk.js/IO/XML/XMLPolyDataReader';
+import vtkFPSMonitor from 'vtk.js/Interaction/UI/FPSMonitor';
 
-import {
-  ColorMode,
-  ScalarMode,
-} from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
+import { ColorMode, ScalarMode } from 'vtk.js/Rendering/Core/Mapper/Constants';
 
 import style from './GeometryViewer.module.css';
 import icon from '../../../Documentation/content/icon/favicon-96x96.png';

--- a/Examples/Applications/OBJViewer/index.js
+++ b/Examples/Applications/OBJViewer/index.js
@@ -1,19 +1,19 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 import JSZip from 'jszip';
 
-import macro from 'vtk.js/Sources/macro';
+import macro from 'vtk.js/macro';
 
-import HttpDataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
+import HttpDataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkURLExtract from 'vtk.js/Common/Core/URLExtract';
 
-import vtkOBJReader from 'vtk.js/Sources/IO/Misc/OBJReader';
-import vtkMTLReader from 'vtk.js/Sources/IO/Misc/MTLReader';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkOBJReader from 'vtk.js/IO/Misc/OBJReader';
+import vtkMTLReader from 'vtk.js/IO/Misc/MTLReader';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
 
 import style from './OBJViewer.module.css';
 

--- a/Examples/Applications/SceneExplorer/SceneExplorerWidget.js
+++ b/Examples/Applications/SceneExplorer/SceneExplorerWidget.js
@@ -1,4 +1,4 @@
-import vtkHttpSceneLoader from 'vtk.js/Sources/IO/Core/HttpSceneLoader';
+import vtkHttpSceneLoader from 'vtk.js/IO/Core/HttpSceneLoader';
 
 const SETTINGS_OPTIONS = {
   defaultSettings: {},

--- a/Examples/Applications/SceneExplorer/index.js
+++ b/Examples/Applications/SceneExplorer/index.js
@@ -1,14 +1,14 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import macro from 'vtk.js/Sources/macro';
-import DataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper';
-import HttpDataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpSceneLoader from 'vtk.js/Sources/IO/Core/HttpSceneLoader';
-import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
+import macro from 'vtk.js/macro';
+import DataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper';
+import HttpDataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpSceneLoader from 'vtk.js/IO/Core/HttpSceneLoader';
+import vtkURLExtract from 'vtk.js/Common/Core/URLExtract';
 
 import controlWidget from './SceneExplorerWidget';
 import style from './SceneExplorer.module.css';

--- a/Examples/Applications/SkyboxViewer/index.js
+++ b/Examples/Applications/SkyboxViewer/index.js
@@ -1,16 +1,16 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import HttpDataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
-import macro from 'vtk.js/Sources/macro';
-import vtkDeviceOrientationToCamera from 'vtk.js/Sources/Interaction/Misc/DeviceOrientationToCamera';
-import vtkForwardPass from 'vtk.js/Sources/Rendering/OpenGL/ForwardPass';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkRadialDistortionPass from 'vtk.js/Sources/Rendering/OpenGL/RadialDistortionPass';
-import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
-import vtkSkybox from 'vtk.js/Sources/Rendering/Core/Skybox';
-import vtkSkyboxReader from 'vtk.js/Sources/IO/Misc/SkyboxReader';
-import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
-// import vtkMobileVR from 'vtk.js/Sources/Common/System/MobileVR';
+import HttpDataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import macro from 'vtk.js/macro';
+import vtkDeviceOrientationToCamera from 'vtk.js/Interaction/Misc/DeviceOrientationToCamera';
+import vtkForwardPass from 'vtk.js/Rendering/OpenGL/ForwardPass';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkRadialDistortionPass from 'vtk.js/Rendering/OpenGL/RadialDistortionPass';
+import vtkRenderer from 'vtk.js/Rendering/Core/Renderer';
+import vtkSkybox from 'vtk.js/Rendering/Core/Skybox';
+import vtkSkyboxReader from 'vtk.js/IO/Misc/SkyboxReader';
+import vtkURLExtract from 'vtk.js/Common/Core/URLExtract';
+// import vtkMobileVR from 'vtk.js/Common/System/MobileVR';
 
 import style from './SkyboxViewer.module.css';
 

--- a/Examples/Applications/TubesViewer/index.js
+++ b/Examples/Applications/TubesViewer/index.js
@@ -1,22 +1,19 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import HttpDataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkColorMaps from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/ColorMaps';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
-import vtkXMLPolyDataReader from 'vtk.js/Sources/IO/XML/XMLPolyDataReader';
-import vtkTubeFilter from 'vtk.js/Sources/Filters/General/TubeFilter';
-import {
-  ColorMode,
-  ScalarMode,
-} from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
-import { VaryRadius } from 'vtk.js/Sources/Filters/General/TubeFilter/Constants';
+import HttpDataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkColorMaps from 'vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkURLExtract from 'vtk.js/Common/Core/URLExtract';
+import vtkXMLPolyDataReader from 'vtk.js/IO/XML/XMLPolyDataReader';
+import vtkTubeFilter from 'vtk.js/Filters/General/TubeFilter';
+import { ColorMode, ScalarMode } from 'vtk.js/Rendering/Core/Mapper/Constants';
+import { VaryRadius } from 'vtk.js/Filters/General/TubeFilter/Constants';
 
 import style from './TubesViewer.module.css';
 import icon from '../../../Documentation/content/icon/favicon-96x96.png';

--- a/Examples/Applications/VolumeViewer/index.js
+++ b/Examples/Applications/VolumeViewer/index.js
@@ -1,20 +1,20 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import macro from 'vtk.js/Sources/macro';
-import HttpDataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
-import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkVolumeController from 'vtk.js/Sources/Interaction/UI/VolumeController';
-import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkXMLImageDataReader from 'vtk.js/Sources/IO/XML/XMLImageDataReader';
-import vtkFPSMonitor from 'vtk.js/Sources/Interaction/UI/FPSMonitor';
+import macro from 'vtk.js/macro';
+import HttpDataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import vtkBoundingBox from 'vtk.js/Common/DataModel/BoundingBox';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkVolumeController from 'vtk.js/Interaction/UI/VolumeController';
+import vtkURLExtract from 'vtk.js/Common/Core/URLExtract';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkXMLImageDataReader from 'vtk.js/IO/XML/XMLImageDataReader';
+import vtkFPSMonitor from 'vtk.js/Interaction/UI/FPSMonitor';
 
 import style from './VolumeViewer.module.css';
 

--- a/Examples/Geometry/Cone/index.js
+++ b/Examples/Geometry/Cone/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { FieldDataTypes } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCalculator from 'vtk.js/Filters/General/Calculator';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import { AttributeTypes } from 'vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes } from 'vtk.js/Common/DataModel/DataSet/Constants';
 
-import vtkFPSMonitor from 'vtk.js/Sources/Interaction/UI/FPSMonitor';
+import vtkFPSMonitor from 'vtk.js/Interaction/UI/FPSMonitor';
 
 import controlPanel from './controller.html';
 

--- a/Examples/Geometry/DepthTest/index.js
+++ b/Examples/Geometry/DepthTest/index.js
@@ -1,23 +1,23 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
 import { mat4, vec3 } from 'gl-matrix';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkSphereMapper from 'vtk.js/Sources/Rendering/Core/SphereMapper';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
-import vtkPixelSpaceCallbackMapper from 'vtk.js/Sources/Rendering/Core/PixelSpaceCallbackMapper';
-import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
-import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
-import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
-import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
-import vtk from 'vtk.js/Sources/vtk';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkSphereMapper from 'vtk.js/Rendering/Core/SphereMapper';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkOpenGLRenderWindow from 'vtk.js/Rendering/OpenGL/RenderWindow';
+import vtkPixelSpaceCallbackMapper from 'vtk.js/Rendering/Core/PixelSpaceCallbackMapper';
+import vtkRenderWindow from 'vtk.js/Rendering/Core/RenderWindow';
+import vtkRenderWindowInteractor from 'vtk.js/Rendering/Core/RenderWindowInteractor';
+import vtkRenderer from 'vtk.js/Rendering/Core/Renderer';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Interaction/Style/InteractorStyleTrackballCamera';
+import vtk from 'vtk.js/vtk';
 
 // Need polydata registered in the vtk factory
-import 'vtk.js/Sources/Common/Core/Points';
-import 'vtk.js/Sources/Common/Core/DataArray';
-import 'vtk.js/Sources/Common/Core/StringArray';
-import 'vtk.js/Sources/Common/DataModel/PolyData';
+import 'vtk.js/Common/Core/Points';
+import 'vtk.js/Common/Core/DataArray';
+import 'vtk.js/Common/Core/StringArray';
+import 'vtk.js/Common/DataModel/PolyData';
 
 import style from './style.module.css';
 

--- a/Examples/Geometry/GlyphRotation/index.js
+++ b/Examples/Geometry/GlyphRotation/index.js
@@ -1,18 +1,15 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
-import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkPolyData from 'vtk.js/Common/DataModel/PolyData';
+import vtkGlyph3DMapper from 'vtk.js/Rendering/Core/Glyph3DMapper';
 
-import {
-  ColorMode,
-  ScalarMode,
-} from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
+import { ColorMode, ScalarMode } from 'vtk.js/Rendering/Core/Mapper/Constants';
 
-import { OrientationModes } from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper/Constants';
+import { OrientationModes } from 'vtk.js/Rendering/Core/Glyph3DMapper/Constants';
 
 import controlPanel from './controller.html';
 

--- a/Examples/Geometry/SimpleCone/index.js
+++ b/Examples/Geometry/SimpleCone/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
-import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
-import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
-import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
-import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkOpenGLRenderWindow from 'vtk.js/Rendering/OpenGL/RenderWindow';
+import vtkRenderWindow from 'vtk.js/Rendering/Core/RenderWindow';
+import vtkRenderWindowInteractor from 'vtk.js/Rendering/Core/RenderWindowInteractor';
+import vtkRenderer from 'vtk.js/Rendering/Core/Renderer';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Interaction/Style/InteractorStyleTrackballCamera';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Examples/Geometry/SpheresAndLabels/index.js
+++ b/Examples/Geometry/SpheresAndLabels/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkSphereMapper from 'vtk.js/Sources/Rendering/Core/SphereMapper';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
-import vtkPixelSpaceCallbackMapper from 'vtk.js/Sources/Rendering/Core/PixelSpaceCallbackMapper';
-import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
-import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
-import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
-import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkSphereMapper from 'vtk.js/Rendering/Core/SphereMapper';
+import vtkOpenGLRenderWindow from 'vtk.js/Rendering/OpenGL/RenderWindow';
+import vtkPixelSpaceCallbackMapper from 'vtk.js/Rendering/Core/PixelSpaceCallbackMapper';
+import vtkRenderWindow from 'vtk.js/Rendering/Core/RenderWindow';
+import vtkRenderWindowInteractor from 'vtk.js/Rendering/Core/RenderWindowInteractor';
+import vtkRenderer from 'vtk.js/Rendering/Core/Renderer';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Interaction/Style/InteractorStyleTrackballCamera';
 
 import style from './style.module.css';
 

--- a/Examples/Geometry/Texture/index.js
+++ b/Examples/Geometry/Texture/index.js
@@ -1,15 +1,15 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
 
-import macro from 'vtk.js/Sources/macro';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkImageGridSource from 'vtk.js/Sources/Filters/Sources/ImageGridSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+import macro from 'vtk.js/macro';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkImageGridSource from 'vtk.js/Filters/Sources/ImageGridSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkPolyData from 'vtk.js/Common/DataModel/PolyData';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
+import vtkTexture from 'vtk.js/Rendering/Core/Texture';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Examples/Geometry/TimeSeries/index.js
+++ b/Examples/Geometry/TimeSeries/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkXMLPolyDataReader from 'vtk.js/Sources/IO/XML/XMLPolyDataReader';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkHttpDataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkPolyData from 'vtk.js/Common/DataModel/PolyData';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkXMLPolyDataReader from 'vtk.js/IO/XML/XMLPolyDataReader';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkHttpDataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
 
 import controlPanel from './controller.html';
 

--- a/Examples/Geometry/VR/index.js
+++ b/Examples/Geometry/VR/index.js
@@ -1,12 +1,12 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { FieldDataTypes } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCalculator from 'vtk.js/Filters/General/Calculator';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import { AttributeTypes } from 'vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes } from 'vtk.js/Common/DataModel/DataSet/Constants';
 
 import controlPanel from './controller.html';
 

--- a/Examples/Rendering/Convolution2DPass/index.js
+++ b/Examples/Rendering/Convolution2DPass/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkForwardPass from 'vtk.js/Sources/Rendering/OpenGL/ForwardPass';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkConvolution2DPass from 'vtk.js/Sources/Rendering/OpenGL/Convolution2DPass';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkForwardPass from 'vtk.js/Rendering/OpenGL/ForwardPass';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkConvolution2DPass from 'vtk.js/Rendering/OpenGL/Convolution2DPass';
 import controlPanel from './controller.html';
 
 // ----------------------------------------------------------------------------

--- a/Examples/Volume/MultiSliceImageMapper/index.js
+++ b/Examples/Volume/MultiSliceImageMapper/index.js
@@ -1,9 +1,7 @@
-import 'vtk.js/Sources/favicon';
-
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
 
 import controlPanel from './controlPanel.html';
 

--- a/Examples/Volume/TestVolumeTypes/index.js
+++ b/Examples/Volume/TestVolumeTypes/index.js
@@ -1,16 +1,16 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import Constants from 'vtk.js/Sources/Rendering/Core/ImageMapper/Constants';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkImageData from 'vtk.js/Common/DataModel/ImageData';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkRenderer from 'vtk.js/Rendering/Core/Renderer';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import Constants from 'vtk.js/Rendering/Core/ImageMapper/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Examples/Volume/VolumeClipPlane/index.js
+++ b/Examples/Volume/VolumeClipPlane/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
-import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkPlane from 'vtk.js/Common/DataModel/Plane';
+import vtkMatrixBuilder from 'vtk.js/Common/Core/MatrixBuilder';
 import controlPanel from './controlPanel.html';
 
 // ----------------------------------------------------------------------------

--- a/Examples/Volume/VolumeContour/index.js
+++ b/Examples/Volume/VolumeContour/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkImageMarchingCubes from 'vtk.js/Sources/Filters/General/ImageMarchingCubes';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkImageMarchingCubes from 'vtk.js/Filters/General/ImageMarchingCubes';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controller.html';
 

--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
 import controlPanel from './controller.html';
 
 // ----------------------------------------------------------------------------

--- a/Examples/Volume/VolumeMapperParallelProjection/index.js
+++ b/Examples/Volume/VolumeMapperParallelProjection/index.js
@@ -1,15 +1,15 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-// import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-// import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-// import vtkColorMaps from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/ColorMaps';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkCubeSource from 'vtk.js/Filters/Sources/CubeSource';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+// import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+// import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+// import vtkColorMaps from 'vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import controlPanel from './controller.html';
 
 // ----------------------------------------------------------------------------

--- a/Examples/Volume/VolumeOutline/index.js
+++ b/Examples/Volume/VolumeOutline/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkInteractorStyleMPRSlice from 'vtk.js/Sources/Interaction/Style/InteractorStyleMPRSlice';
-import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkInteractorStyleMPRSlice from 'vtk.js/Interaction/Style/InteractorStyleMPRSlice';
+import vtkImageData from 'vtk.js/Common/DataModel/ImageData';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
 
 const fullScreenRenderWindow = vtkFullScreenRenderWindow.newInstance({
   background: [0.3, 0.3, 0.3],

--- a/Examples/Volume/ZipHttpReader/index.js
+++ b/Examples/Volume/ZipHttpReader/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Examples/Widgets/Box/BoxWidget.js
+++ b/Examples/Widgets/Box/BoxWidget.js
@@ -1,11 +1,11 @@
-import macro from 'vtk.js/Sources/macro';
-import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidgetFactory';
-import vtkConvexFaceContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ConvexFaceContextRepresentation';
-import vtkPlaneManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
-import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
-import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+import macro from 'vtk.js/macro';
+import vtkAbstractWidgetFactory from 'vtk.js/Widgets/Core/AbstractWidgetFactory';
+import vtkConvexFaceContextRepresentation from 'vtk.js/Widgets/Representations/ConvexFaceContextRepresentation';
+import vtkPlaneManipulator from 'vtk.js/Widgets/Manipulators/PlaneManipulator';
+import vtkSphereHandleRepresentation from 'vtk.js/Widgets/Representations/SphereHandleRepresentation';
+import vtkStateBuilder from 'vtk.js/Widgets/Core/StateBuilder';
 
-import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
+import { ViewTypes } from 'vtk.js/Widgets/Core/WidgetManager/Constants';
 
 // ----------------------------------------------------------------------------
 // Widget linked to a view

--- a/Examples/Widgets/Box/index.js
+++ b/Examples/Widgets/Box/index.js
@@ -1,7 +1,7 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
 import vtkBoxWidget from './BoxWidget';
 import controlPanel from './controlPanel.html';

--- a/Sources/Common/DataModel/ImplicitBoolean/example/index.js
+++ b/Sources/Common/DataModel/ImplicitBoolean/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkImageMarchingCubes from 'vtk.js/Sources/Filters/General/ImageMarchingCubes';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkSampleFunction from 'vtk.js/Sources/Imaging/Hybrid/SampleFunction';
-import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
-import vtkCylinder from 'vtk.js/Sources/Common/DataModel/Cylinder';
-import vtkImplicitBoolean from 'vtk.js/Sources/Common/DataModel/ImplicitBoolean';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkImageMarchingCubes from 'vtk.js/Filters/General/ImageMarchingCubes';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkSampleFunction from 'vtk.js/Imaging/Hybrid/SampleFunction';
+import vtkPlane from 'vtk.js/Common/DataModel/Plane';
+import vtkCylinder from 'vtk.js/Common/DataModel/Cylinder';
+import vtkImplicitBoolean from 'vtk.js/Common/DataModel/ImplicitBoolean';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Filters/Core/Cutter/example/index.js
+++ b/Sources/Filters/Core/Cutter/example/index.js
@@ -1,12 +1,12 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkCutter from 'vtk.js/Sources/Filters/Core/Cutter';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
-import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCubeSource from 'vtk.js/Filters/Sources/CubeSource';
+import vtkCutter from 'vtk.js/Filters/Core/Cutter';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkPlane from 'vtk.js/Common/DataModel/Plane';
+import vtkProperty from 'vtk.js/Rendering/Core/Property';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/General/Calculator/example/index.js
+++ b/Sources/Filters/General/Calculator/example/index.js
@@ -1,17 +1,17 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import macro from 'vtk.js/Sources/macro';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import macro from 'vtk.js/macro';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkDataSet from 'vtk.js/Sources/Common/DataModel/DataSet';
-import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
-import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
-import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
-import vtkWarpScalar from 'vtk.js/Sources/Filters/General/WarpScalar';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCalculator from 'vtk.js/Filters/General/Calculator';
+import vtkDataSet from 'vtk.js/Common/DataModel/DataSet';
+import vtkLookupTable from 'vtk.js/Common/Core/LookupTable';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkPlaneSource from 'vtk.js/Filters/Sources/PlaneSource';
+import vtkPoints from 'vtk.js/Common/Core/Points';
+import vtkPolyData from 'vtk.js/Common/DataModel/PolyData';
+import vtkWarpScalar from 'vtk.js/Filters/General/WarpScalar';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/General/ImageCropFilter/example/index.js
+++ b/Sources/Filters/General/ImageCropFilter/example/index.js
@@ -1,12 +1,12 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkImageCropFilter from 'vtk.js/Sources/Filters/General/ImageCropFilter';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkImageCropFilter from 'vtk.js/Filters/General/ImageCropFilter';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/General/ImageMarchingCubes/example/index.js
+++ b/Sources/Filters/General/ImageMarchingCubes/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkImageMarchingCubes from 'vtk.js/Sources/Filters/General/ImageMarchingCubes';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkSampleFunction from 'vtk.js/Sources/Imaging/Hybrid/SampleFunction';
-import vtkSphere from 'vtk.js/Sources/Common/DataModel/Sphere';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkImageMarchingCubes from 'vtk.js/Filters/General/ImageMarchingCubes';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkSampleFunction from 'vtk.js/Imaging/Hybrid/SampleFunction';
+import vtkSphere from 'vtk.js/Common/DataModel/Sphere';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Filters/General/ImageMarchingSquares/example/index.js
+++ b/Sources/Filters/General/ImageMarchingSquares/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkImageMarchingSquares from 'vtk.js/Sources/Filters/General/ImageMarchingSquares';
-import vtkOutlineFilter from 'vtk.js/Sources/Filters/General/OutlineFilter';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkSampleFunction from 'vtk.js/Sources/Imaging/Hybrid/SampleFunction';
-import vtkSphere from 'vtk.js/Sources/Common/DataModel/Sphere';
-// import vtkPlane                   from 'vtk.js/Sources/Common/DataModel/Plane';
-import vtkImplicitBoolean from 'vtk.js/Sources/Common/DataModel/ImplicitBoolean';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkImageMarchingSquares from 'vtk.js/Filters/General/ImageMarchingSquares';
+import vtkOutlineFilter from 'vtk.js/Filters/General/OutlineFilter';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkSampleFunction from 'vtk.js/Imaging/Hybrid/SampleFunction';
+import vtkSphere from 'vtk.js/Common/DataModel/Sphere';
+// import vtkPlane                   from 'vtk.js/Common/DataModel/Plane';
+import vtkImplicitBoolean from 'vtk.js/Common/DataModel/ImplicitBoolean';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Filters/General/ImageOutlineFilter/example/index.js
+++ b/Sources/Filters/General/ImageOutlineFilter/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
-import vtkImageOutlineFilter from 'vtk.js/Sources/Filters/General/ImageOutlineFilter';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
+import 'vtk.js/favicon';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkImageData from 'vtk.js/Common/DataModel/ImageData';
+import vtkImageOutlineFilter from 'vtk.js/Filters/General/ImageOutlineFilter';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
 import controlPanel from './controlPanel.html';
 
 const fullScreenRenderWindow = vtkFullScreenRenderWindow.newInstance({

--- a/Sources/Filters/General/ImageStreamline/example/index.js
+++ b/Sources/Filters/General/ImageStreamline/example/index.js
@@ -1,15 +1,15 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkOutlineFilter from 'vtk.js/Sources/Filters/General/OutlineFilter';
-import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
-import vtkImageStreamline from 'vtk.js/Sources/Filters/General/ImageStreamline';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
-import macro from 'vtk.js/Sources/macro';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkOutlineFilter from 'vtk.js/Filters/General/OutlineFilter';
+import vtkPlaneSource from 'vtk.js/Filters/Sources/PlaneSource';
+import vtkImageStreamline from 'vtk.js/Filters/General/ImageStreamline';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import { Representation } from 'vtk.js/Rendering/Core/Property/Constants';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkImageData from 'vtk.js/Common/DataModel/ImageData';
+import macro from 'vtk.js/macro';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Filters/General/OutlineFilter/example/index.js
+++ b/Sources/Filters/General/OutlineFilter/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkPointSource from 'vtk.js/Sources/Filters/Sources/PointSource';
-import vtkOutlineFilter from 'vtk.js/Sources/Filters/General/OutlineFilter';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkPointSource from 'vtk.js/Filters/Sources/PointSource';
+import vtkOutlineFilter from 'vtk.js/Filters/General/OutlineFilter';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import * as vtkMath from 'vtk.js/Common/Core/Math';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/General/ScalarToRGBA/example/index.js
+++ b/Sources/Filters/General/ScalarToRGBA/example/index.js
@@ -1,16 +1,16 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkColorMaps from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/ColorMaps';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
-import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
-import vtkImageSliceFilter from 'vtk.js/Sources/Filters/General/ImageSliceFilter';
-import vtkScalarToRGBA from 'vtk.js/Sources/Filters/General/ScalarToRGBA';
-import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkColorMaps from 'vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkTexture from 'vtk.js/Rendering/Core/Texture';
+import vtkRTAnalyticSource from 'vtk.js/Filters/Sources/RTAnalyticSource';
+import vtkImageSliceFilter from 'vtk.js/Filters/General/ImageSliceFilter';
+import vtkScalarToRGBA from 'vtk.js/Filters/General/ScalarToRGBA';
+import vtkPlaneSource from 'vtk.js/Filters/Sources/PlaneSource';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
 
 import controller from './controller.html';
 

--- a/Sources/Filters/General/TriangleFilter/example/index.js
+++ b/Sources/Filters/General/TriangleFilter/example/index.js
@@ -1,9 +1,9 @@
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkTriangleFilter from 'vtk.js/Sources/Filters/General/TriangleFilter';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkTriangleFilter from 'vtk.js/Filters/General/TriangleFilter';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
-import vtk2DShape from 'vtk.js/Sources/Filters/Sources/Arrow2DSource/';
+import vtk2DShape from 'vtk.js/Filters/Sources/Arrow2DSource/';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Filters/General/TubeFilter/example/index.js
+++ b/Sources/Filters/General/TubeFilter/example/index.js
@@ -1,17 +1,17 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import Constants from 'vtk.js/Sources/Filters/General/TubeFilter/Constants';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
-import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
-import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
-import vtkTubeFilter from 'vtk.js/Sources/Filters/General/TubeFilter';
+import Constants from 'vtk.js/Filters/General/TubeFilter/Constants';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import * as vtkMath from 'vtk.js/Common/Core/Math';
+import vtkPoints from 'vtk.js/Common/Core/Points';
+import vtkPolyData from 'vtk.js/Common/DataModel/PolyData';
+import vtkTubeFilter from 'vtk.js/Filters/General/TubeFilter';
 
-import { DesiredOutputPrecision } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
+import { DesiredOutputPrecision } from 'vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { VtkDataTypes } from 'vtk.js/Common/Core/DataArray/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/General/WarpScalar/example/index.js
+++ b/Sources/Filters/General/WarpScalar/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import macro from 'vtk.js/Sources/macro';
-import vtk from 'vtk.js/Sources/vtk';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-import vtkWarpScalar from 'vtk.js/Sources/Filters/General/WarpScalar';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import macro from 'vtk.js/macro';
+import vtk from 'vtk.js/vtk';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCamera from 'vtk.js/Rendering/Core/Camera';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
+import vtkWarpScalar from 'vtk.js/Filters/General/WarpScalar';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Filters/General/WindowedSincPolyDataFilter/example/index.js
+++ b/Sources/Filters/General/WindowedSincPolyDataFilter/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkWindowedSincPolyDataFilter from 'vtk.js/Sources/Filters/General/WindowedSincPolyDataFilter';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCamera from 'vtk.js/Rendering/Core/Camera';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkWindowedSincPolyDataFilter from 'vtk.js/Filters/General/WindowedSincPolyDataFilter';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Filters/Sources/ArrowSource/example/index.js
+++ b/Sources/Filters/Sources/ArrowSource/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkArrowSource from 'vtk.js/Sources/Filters/Sources/ArrowSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkArrowSource from 'vtk.js/Filters/Sources/ArrowSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/CircleSource/example/index.js
+++ b/Sources/Filters/Sources/CircleSource/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCircleSource from 'vtk.js/Sources/Filters/Sources/CircleSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCircleSource from 'vtk.js/Filters/Sources/CircleSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/ConcentricCylinderSource/example/index.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConcentricCylinderSource from 'vtk.js/Sources/Filters/Sources/ConcentricCylinderSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConcentricCylinderSource from 'vtk.js/Filters/Sources/ConcentricCylinderSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
-// import { ColorMode, ScalarMode }    from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
+// import { ColorMode, ScalarMode }    from 'vtk.js/Rendering/Core/Mapper/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/ConeSource/example/index.js
+++ b/Sources/Filters/Sources/ConeSource/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/CubeSource/example/index.js
+++ b/Sources/Filters/Sources/CubeSource/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCubeSource from 'vtk.js/Filters/Sources/CubeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/Cursor3D/example/index.js
+++ b/Sources/Filters/Sources/Cursor3D/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-import vtkCursor3D from 'vtk.js/Sources/Filters/Sources/Cursor3D';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
+import vtkCursor3D from 'vtk.js/Filters/Sources/Cursor3D';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/CylinderSource/example/index.js
+++ b/Sources/Filters/Sources/CylinderSource/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCylinderSource from 'vtk.js/Sources/Filters/Sources/CylinderSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCylinderSource from 'vtk.js/Filters/Sources/CylinderSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/LineSource/example/index.js
+++ b/Sources/Filters/Sources/LineSource/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkLineSource from 'vtk.js/Sources/Filters/Sources/LineSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkLineSource from 'vtk.js/Filters/Sources/LineSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import { Representation } from 'vtk.js/Rendering/Core/Property/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/PlaneSource/example/index.js
+++ b/Sources/Filters/Sources/PlaneSource/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkPlaneSource from 'vtk.js/Filters/Sources/PlaneSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import { Representation } from 'vtk.js/Rendering/Core/Property/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/PointSource/example/index.js
+++ b/Sources/Filters/Sources/PointSource/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkPointSource from 'vtk.js/Sources/Filters/Sources/PointSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkPointSource from 'vtk.js/Filters/Sources/PointSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import * as vtkMath from 'vtk.js/Common/Core/Math';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Filters/Sources/SLICSource/example/index.js
+++ b/Sources/Filters/Sources/SLICSource/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkSLICSource from 'vtk.js/Sources/Filters/Sources/SLICSource';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkSLICSource from 'vtk.js/Filters/Sources/SLICSource';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Filters/Sources/SphereSource/example/index.js
+++ b/Sources/Filters/Sources/SphereSource/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/IO/Core/HttpDataSetReader/example/index.js
+++ b/Sources/IO/Core/HttpDataSetReader/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/IO/Core/HttpDataSetSeriesReader/example/index.js
+++ b/Sources/IO/Core/HttpDataSetSeriesReader/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkHttpDataSetSeriesReader from 'vtk.js/Sources/IO/Core/HttpDataSetSeriesReader';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkHttpDataSetSeriesReader from 'vtk.js/IO/Core/HttpDataSetSeriesReader';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import controlPanel from './controller.html';
 

--- a/Sources/IO/Core/HttpSceneLoader/example/index.js
+++ b/Sources/IO/Core/HttpSceneLoader/example/index.js
@@ -1,7 +1,7 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpSceneLoader from 'vtk.js/Sources/IO/Core/HttpSceneLoader';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpSceneLoader from 'vtk.js/IO/Core/HttpSceneLoader';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/IO/Core/ImageStream/example/index.js
+++ b/Sources/IO/Core/ImageStream/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkOrientationMarkerWidget from 'vtk.js/Sources/Interaction/Widgets/OrientationMarkerWidget';
-import vtkAnnotatedCubeActor from 'vtk.js/Sources/Rendering/Core/AnnotatedCubeActor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkOrientationMarkerWidget from 'vtk.js/Interaction/Widgets/OrientationMarkerWidget';
+import vtkAnnotatedCubeActor from 'vtk.js/Rendering/Core/AnnotatedCubeActor';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
-import vtkImageStream from 'vtk.js/Sources/IO/Core/ImageStream';
+import vtkImageStream from 'vtk.js/IO/Core/ImageStream';
 import SmartConnect from 'wslink/src/SmartConnect';
 
 // ----------------------------------------------------------------------------

--- a/Sources/IO/Geometry/DracoReader/example/index.js
+++ b/Sources/IO/Geometry/DracoReader/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkDracoReader from 'vtk.js/Sources/IO/Geometry/DracoReader';
-import vtkResourceLoader from 'vtk.js/Sources/IO/Core/ResourceLoader';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkDracoReader from 'vtk.js/IO/Geometry/DracoReader';
+import vtkResourceLoader from 'vtk.js/IO/Core/ResourceLoader';
 
 // ----------------------------------------------------------------------------
 // Example code

--- a/Sources/IO/Geometry/PLYReader/example/index.js
+++ b/Sources/IO/Geometry/PLYReader/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkPLYReader from 'vtk.js/Sources/IO/Geometry/PLYReader';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkPLYReader from 'vtk.js/IO/Geometry/PLYReader';
 
 // ----------------------------------------------------------------------------
 // Example code

--- a/Sources/IO/Geometry/STLReader/example/index.js
+++ b/Sources/IO/Geometry/STLReader/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkSTLReader from 'vtk.js/Sources/IO/Geometry/STLReader';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkSTLReader from 'vtk.js/IO/Geometry/STLReader';
 
 // ----------------------------------------------------------------------------
 // Example code

--- a/Sources/IO/Geometry/STLWriter/example/index.js
+++ b/Sources/IO/Geometry/STLWriter/example/index.js
@@ -1,12 +1,12 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
-import vtkSTLWriter from 'vtk.js/Sources/IO/Geometry/STLWriter';
-import vtkSTLReader from 'vtk.js/Sources/IO/Geometry/STLReader';
-import vtkPolyDataReader from 'vtk.js/Sources/IO/Legacy/PolyDataReader';
+import vtkSTLWriter from 'vtk.js/IO/Geometry/STLWriter';
+import vtkSTLReader from 'vtk.js/IO/Geometry/STLReader';
+import vtkPolyDataReader from 'vtk.js/IO/Legacy/PolyDataReader';
 // ----------------------------------------------------------------------------
 // Standard rendering code setup
 // ----------------------------------------------------------------------------

--- a/Sources/IO/Legacy/PolyDataReader/example/index.js
+++ b/Sources/IO/Legacy/PolyDataReader/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkPolyDataReader from 'vtk.js/Sources/IO/Legacy/PolyDataReader';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkPolyDataReader from 'vtk.js/IO/Legacy/PolyDataReader';
 
 const fileName = 'sphere.vtk'; // 'uh60.vtk'; // 'luggaBody.vtk';
 

--- a/Sources/IO/Misc/ElevationReader/example/index.js
+++ b/Sources/IO/Misc/ElevationReader/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkElevationReader from 'vtk.js/Sources/IO/Misc/ElevationReader';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkElevationReader from 'vtk.js/IO/Misc/ElevationReader';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkTexture from 'vtk.js/Rendering/Core/Texture';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/IO/Misc/JSONNucleoReader/example/index.js
+++ b/Sources/IO/Misc/JSONNucleoReader/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkJSONNucleoReader from 'vtk.js/Sources/IO/Misc/JSONNucleoReader';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkJSONNucleoReader from 'vtk.js/IO/Misc/JSONNucleoReader';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/IO/Misc/OBJReader/example/index.js
+++ b/Sources/IO/Misc/OBJReader/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkMTLReader from 'vtk.js/Sources/IO/Misc/MTLReader';
-import vtkOBJReader from 'vtk.js/Sources/IO/Misc/OBJReader';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkMTLReader from 'vtk.js/IO/Misc/MTLReader';
+import vtkOBJReader from 'vtk.js/IO/Misc/OBJReader';
 
 // const objs = ['ferrari-f1-race-car', 'mini-cooper', 'space-shuttle-orbiter', 'blskes-plane'];
 const fileName = 'space-shuttle-orbiter';

--- a/Sources/IO/Misc/PDBReader/example/index.js
+++ b/Sources/IO/Misc/PDBReader/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkPDBReader from 'vtk.js/Sources/IO/Misc/PDBReader';
-import vtkSphereMapper from 'vtk.js/Sources/Rendering/Core/SphereMapper';
-import vtkStickMapper from 'vtk.js/Sources/Rendering/Core/StickMapper';
-import vtkMoleculeToRepresentation from 'vtk.js/Sources/Filters/General/MoleculeToRepresentation';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkPDBReader from 'vtk.js/IO/Misc/PDBReader';
+import vtkSphereMapper from 'vtk.js/Rendering/Core/SphereMapper';
+import vtkStickMapper from 'vtk.js/Rendering/Core/StickMapper';
+import vtkMoleculeToRepresentation from 'vtk.js/Filters/General/MoleculeToRepresentation';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/IO/XML/XMLImageDataWriter/example/index.js
+++ b/Sources/IO/XML/XMLImageDataWriter/example/index.js
@@ -1,15 +1,15 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
 
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkXMLImageDataReader from 'vtk.js/Sources/IO/XML/XMLImageDataReader';
-import vtkXMLImageDataWriter from 'vtk.js/Sources/IO/XML/XMLImageDataWriter';
-import vtkXMLWriter from 'vtk.js/Sources/IO/XML/XMLWriter';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkXMLImageDataReader from 'vtk.js/IO/XML/XMLImageDataReader';
+import vtkXMLImageDataWriter from 'vtk.js/IO/XML/XMLImageDataWriter';
+import vtkXMLWriter from 'vtk.js/IO/XML/XMLWriter';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/IO/XML/XMLPolyDataWriter/example/index.js
+++ b/Sources/IO/XML/XMLPolyDataWriter/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkXMLPolyDataReader from 'vtk.js/Sources/IO/XML/XMLPolyDataReader';
-import vtkXMLPolyDataWriter from 'vtk.js/Sources/IO/XML/XMLPolyDataWriter';
-import vtkXMLWriter from 'vtk.js/Sources/IO/XML/XMLWriter';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkXMLPolyDataReader from 'vtk.js/IO/XML/XMLPolyDataReader';
+import vtkXMLPolyDataWriter from 'vtk.js/IO/XML/XMLPolyDataWriter';
+import vtkXMLWriter from 'vtk.js/IO/XML/XMLWriter';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Interaction/Manipulators/KeyboardCameraManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/KeyboardCameraManipulator/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkElevationReader from 'vtk.js/Sources/IO/Misc/ElevationReader';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/InteractorStyleManipulator';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkElevationReader from 'vtk.js/IO/Misc/ElevationReader';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkInteractorStyleManipulator from 'vtk.js/Interaction/Style/InteractorStyleManipulator';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkTexture from 'vtk.js/Rendering/Core/Texture';
 
-import Manipulators from 'vtk.js/Sources/Interaction/Manipulators';
+import Manipulators from 'vtk.js/Interaction/Manipulators';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Interaction/Manipulators/MouseCameraTrackballFirstPersonManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballFirstPersonManipulator/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkElevationReader from 'vtk.js/Sources/IO/Misc/ElevationReader';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/InteractorStyleManipulator';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkElevationReader from 'vtk.js/IO/Misc/ElevationReader';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkInteractorStyleManipulator from 'vtk.js/Interaction/Style/InteractorStyleManipulator';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkTexture from 'vtk.js/Rendering/Core/Texture';
 
-import Manipulators from 'vtk.js/Sources/Interaction/Manipulators';
+import Manipulators from 'vtk.js/Interaction/Manipulators';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
@@ -1,12 +1,12 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/InteractorStyleManipulator';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkRTAnalyticSource from 'vtk.js/Filters/Sources/RTAnalyticSource';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import vtkInteractorStyleManipulator from 'vtk.js/Interaction/Style/InteractorStyleManipulator';
 
-import Manipulators from 'vtk.js/Sources/Interaction/Manipulators';
+import Manipulators from 'vtk.js/Interaction/Manipulators';
 
 const { SlicingMode } = vtkImageMapper;
 

--- a/Sources/Interaction/Misc/DeviceOrientationToCamera/example/index.js
+++ b/Sources/Interaction/Misc/DeviceOrientationToCamera/example/index.js
@@ -1,12 +1,12 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
-import vtkDeviceOrientationToCamera from 'vtk.js/Sources/Interaction/Misc/DeviceOrientationToCamera';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkCubeSource from 'vtk.js/Filters/Sources/CubeSource';
+import vtkTexture from 'vtk.js/Rendering/Core/Texture';
+import vtkDeviceOrientationToCamera from 'vtk.js/Interaction/Misc/DeviceOrientationToCamera';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkInteractorStyleMPRSlice from 'vtk.js/Sources/Interaction/Style/InteractorStyleMPRSlice';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkInteractorStyleMPRSlice from 'vtk.js/Interaction/Style/InteractorStyleMPRSlice';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Interaction/Style/InteractorStyleManipulator/example/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/example/index.js
@@ -1,21 +1,21 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import macro from 'vtk.js/Sources/macro';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import macro from 'vtk.js/macro';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/InteractorStyleManipulator';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkInteractorStyleManipulator from 'vtk.js/Interaction/Style/InteractorStyleManipulator';
 
-import vtkMouseCameraTrackballMultiRotateManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseCameraTrackballMultiRotateManipulator';
-import vtkMouseCameraTrackballPanManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseCameraTrackballPanManipulator';
-import vtkMouseCameraTrackballRollManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseCameraTrackballRollManipulator';
-import vtkMouseCameraTrackballRotateManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator';
-import vtkMouseCameraTrackballZoomManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseCameraTrackballZoomManipulator';
-import vtkMouseCameraTrackballZoomToMouseManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator';
+import vtkMouseCameraTrackballMultiRotateManipulator from 'vtk.js/Interaction/Manipulators/MouseCameraTrackballMultiRotateManipulator';
+import vtkMouseCameraTrackballPanManipulator from 'vtk.js/Interaction/Manipulators/MouseCameraTrackballPanManipulator';
+import vtkMouseCameraTrackballRollManipulator from 'vtk.js/Interaction/Manipulators/MouseCameraTrackballRollManipulator';
+import vtkMouseCameraTrackballRotateManipulator from 'vtk.js/Interaction/Manipulators/MouseCameraTrackballRotateManipulator';
+import vtkMouseCameraTrackballZoomManipulator from 'vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomManipulator';
+import vtkMouseCameraTrackballZoomToMouseManipulator from 'vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator';
 
-import vtkGestureCameraManipulator from 'vtk.js/Sources/Interaction/Manipulators/GestureCameraManipulator';
+import vtkGestureCameraManipulator from 'vtk.js/Interaction/Manipulators/GestureCameraManipulator';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Interaction/Style/InteractorStyleUnicam/example/index.js
+++ b/Sources/Interaction/Style/InteractorStyleUnicam/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkAxesActor from 'vtk.js/Sources/Rendering/Core/AxesActor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkInteractorStyleUnicam from 'vtk.js/Sources/Interaction/Style/InteractorStyleUnicam';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkMouseCameraTrackballZoomToMouseManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator';
-import vtkOrientationMarkerWidget from 'vtk.js/Sources/Interaction/Widgets/OrientationMarkerWidget';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkAxesActor from 'vtk.js/Rendering/Core/AxesActor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkInteractorStyleUnicam from 'vtk.js/Interaction/Style/InteractorStyleUnicam';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkMouseCameraTrackballZoomToMouseManipulator from 'vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator';
+import vtkOrientationMarkerWidget from 'vtk.js/Interaction/Widgets/OrientationMarkerWidget';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Interaction/Widgets/HandleWidget/example/index.js
+++ b/Sources/Interaction/Widgets/HandleWidget/example/index.js
@@ -1,7 +1,7 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHandleWidget from 'vtk.js/Sources/Interaction/Widgets/HandleWidget';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHandleWidget from 'vtk.js/Interaction/Widgets/HandleWidget';
 
 // ----------------------------------------------------------------------------
 // USER AVAILABLE INTERACTIONS

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
-import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
-import vtkImageCroppingRegionsWidget from 'vtk.js/Sources/Interaction/Widgets/ImageCroppingRegionsWidget';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import vtkInteractorStyleImage from 'vtk.js/Interaction/Style/InteractorStyleImage';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Interaction/Style/InteractorStyleTrackballCamera';
+import vtkImageCroppingRegionsWidget from 'vtk.js/Interaction/Widgets/ImageCroppingRegionsWidget';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Interaction/Widgets/LabelWidget/example/index.js
+++ b/Sources/Interaction/Widgets/LabelWidget/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkLabelWidget from 'vtk.js/Sources/Interaction/Widgets/LabelWidget';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkLabelWidget from 'vtk.js/Interaction/Widgets/LabelWidget';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
 
-import TextAlign from 'vtk.js/Sources/Interaction/Widgets/LabelRepresentation/Constants';
+import TextAlign from 'vtk.js/Interaction/Widgets/LabelRepresentation/Constants';
 
 // ----------------------------------------------------------------------------
 // USER AVAILABLE INTERACTIONS

--- a/Sources/Interaction/Widgets/LineWidget/example/index.js
+++ b/Sources/Interaction/Widgets/LineWidget/example/index.js
@@ -1,7 +1,7 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkLineWidget from 'vtk.js/Sources/Interaction/Widgets/LineWidget';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkLineWidget from 'vtk.js/Interaction/Widgets/LineWidget';
 
 // ----------------------------------------------------------------------------
 // USER AVAILABLE INTERACTIONS

--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/example/index.js
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOrientationMarkerWidget from 'vtk.js/Sources/Interaction/Widgets/OrientationMarkerWidget';
-import vtkAnnotatedCubeActor from 'vtk.js/Sources/Rendering/Core/AnnotatedCubeActor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkOrientationMarkerWidget from 'vtk.js/Interaction/Widgets/OrientationMarkerWidget';
+import vtkAnnotatedCubeActor from 'vtk.js/Rendering/Core/AnnotatedCubeActor';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Interaction/Widgets/PiecewiseGaussianWidget/example/index.js
+++ b/Sources/Interaction/Widgets/PiecewiseGaussianWidget/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkPiecewiseGaussianWidget from 'vtk.js/Sources/Interaction/Widgets/PiecewiseGaussianWidget';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkPiecewiseGaussianWidget from 'vtk.js/Interaction/Widgets/PiecewiseGaussianWidget';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
 
-import vtkColorMaps from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/ColorMaps';
+import vtkColorMaps from 'vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Interaction/Widgets/ResliceCursor/example/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
-import vtkResliceCursor from 'vtk.js/Sources/Interaction/Widgets/ResliceCursor/ResliceCursor';
-import vtkResliceCursorLineRepresentation from 'vtk.js/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorLineRepresentation';
-import vtkResliceCursorWidget from 'vtk.js/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorWidget';
-import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
-import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
-import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
+import vtkImageData from 'vtk.js/Common/DataModel/ImageData';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkOpenGLRenderWindow from 'vtk.js/Rendering/OpenGL/RenderWindow';
+import vtkResliceCursor from 'vtk.js/Interaction/Widgets/ResliceCursor/ResliceCursor';
+import vtkResliceCursorLineRepresentation from 'vtk.js/Interaction/Widgets/ResliceCursor/ResliceCursorLineRepresentation';
+import vtkResliceCursorWidget from 'vtk.js/Interaction/Widgets/ResliceCursor/ResliceCursorWidget';
+import vtkRenderer from 'vtk.js/Rendering/Core/Renderer';
+import vtkRenderWindow from 'vtk.js/Rendering/Core/RenderWindow';
+import vtkRenderWindowInteractor from 'vtk.js/Rendering/Core/RenderWindowInteractor';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Rendering/Core/CellPicker/example/index.js
+++ b/Sources/Rendering/Core/CellPicker/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCellPicker from 'vtk.js/Sources/Rendering/Core/CellPicker';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCellPicker from 'vtk.js/Rendering/Core/CellPicker';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Rendering/Core/Glyph3DMapper/example/index.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCalculator from 'vtk.js/Filters/General/Calculator';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkPlaneSource from 'vtk.js/Filters/Sources/PlaneSource';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkGlyph3DMapper from 'vtk.js/Rendering/Core/Glyph3DMapper';
 
-import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { FieldDataTypes } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
+import { AttributeTypes } from 'vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes } from 'vtk.js/Common/DataModel/DataSet/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Rendering/Core/ImageMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageMapper/example/index.js
@@ -1,13 +1,13 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import Constants from 'vtk.js/Sources/Rendering/Core/ImageMapper/Constants';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
+import Constants from 'vtk.js/Rendering/Core/ImageMapper/Constants';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkRTAnalyticSource from 'vtk.js/Filters/Sources/RTAnalyticSource';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import vtkInteractorStyleImage from 'vtk.js/Interaction/Style/InteractorStyleImage';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
 
 const { SlicingMode } = Constants;
 

--- a/Sources/Rendering/Core/PointPicker/example/index.js
+++ b/Sources/Rendering/Core/PointPicker/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkPointPicker from 'vtk.js/Sources/Rendering/Core/PointPicker';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkPointPicker from 'vtk.js/Rendering/Core/PointPicker';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Rendering/Core/SphereMapper/example/index.js
+++ b/Sources/Rendering/Core/SphereMapper/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
-import vtkSphereMapper from 'vtk.js/Sources/Rendering/Core/SphereMapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCalculator from 'vtk.js/Filters/General/Calculator';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkPlaneSource from 'vtk.js/Filters/Sources/PlaneSource';
+import vtkSphereMapper from 'vtk.js/Rendering/Core/SphereMapper';
 
-import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { FieldDataTypes } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
-import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
+import { AttributeTypes } from 'vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes } from 'vtk.js/Common/DataModel/DataSet/Constants';
+import { Representation } from 'vtk.js/Rendering/Core/Property/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Rendering/Core/StickMapper/example/index.js
+++ b/Sources/Rendering/Core/StickMapper/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
-import vtkStickMapper from 'vtk.js/Sources/Rendering/Core/StickMapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCalculator from 'vtk.js/Filters/General/Calculator';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkPlaneSource from 'vtk.js/Filters/Sources/PlaneSource';
+import vtkStickMapper from 'vtk.js/Rendering/Core/StickMapper';
 
-import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { FieldDataTypes } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
-import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
+import { AttributeTypes } from 'vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes } from 'vtk.js/Common/DataModel/DataSet/Constants';
+import { Representation } from 'vtk.js/Rendering/Core/Property/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Rendering/Core/VolumeMapper/example/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
 import controlPanel from './controller.html';
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/Misc/RemoteView/example/index.js
+++ b/Sources/Rendering/Misc/RemoteView/example/index.js
@@ -1,8 +1,8 @@
-import vtkWSLinkClient from 'vtk.js/Sources/IO/Core/WSLinkClient';
+import vtkWSLinkClient from 'vtk.js/IO/Core/WSLinkClient';
 import SmartConnect from 'wslink/src/SmartConnect';
 import vtkRemoteView, {
   connectImageStream,
-} from 'vtk.js/Sources/Rendering/Misc/RemoteView';
+} from 'vtk.js/Rendering/Misc/RemoteView';
 
 vtkWSLinkClient.setSmartConnectClass(SmartConnect);
 

--- a/Sources/Rendering/Misc/RenderWindowWithControlBar/example/index.js
+++ b/Sources/Rendering/Misc/RenderWindowWithControlBar/example/index.js
@@ -1,10 +1,10 @@
-import vtkRenderWindowWithControlBar from 'vtk.js/Sources/Rendering/Misc/RenderWindowWithControlBar';
-import vtkSlider from 'vtk.js/Sources/Interaction/UI/Slider';
-import vtkCornerAnnotation from 'vtk.js/Sources/Interaction/UI/CornerAnnotation';
+import vtkRenderWindowWithControlBar from 'vtk.js/Rendering/Misc/RenderWindowWithControlBar';
+import vtkSlider from 'vtk.js/Interaction/UI/Slider';
+import vtkCornerAnnotation from 'vtk.js/Interaction/UI/CornerAnnotation';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 // Define container size/position
 const body = document.querySelector('body');

--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/example/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/example/index.js
@@ -1,10 +1,10 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 import JSZip from 'jszip';
 
-import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
-import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
-import vtkSynchronizableRenderWindow from 'vtk.js/Sources/Rendering/Misc/SynchronizableRenderWindow';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Interaction/Style/InteractorStyleTrackballCamera';
+import vtkOpenGLRenderWindow from 'vtk.js/Rendering/OpenGL/RenderWindow';
+import vtkRenderWindowInteractor from 'vtk.js/Rendering/Core/RenderWindowInteractor';
+import vtkSynchronizableRenderWindow from 'vtk.js/Rendering/Misc/SynchronizableRenderWindow';
 
 import style from './SynchronizableRenderWindow.module.css';
 

--- a/Sources/Rendering/OpenGL/HardwareSelector/example/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/example/index.js
@@ -1,21 +1,21 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import { throttle } from 'vtk.js/Sources/macro';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkCylinderSource from 'vtk.js/Sources/Filters/Sources/CylinderSource';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOpenGLHardwareSelector from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import { throttle } from 'vtk.js/macro';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkCylinderSource from 'vtk.js/Filters/Sources/CylinderSource';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkGlyph3DMapper from 'vtk.js/Rendering/Core/Glyph3DMapper';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkOpenGLHardwareSelector from 'vtk.js/Rendering/OpenGL/HardwareSelector';
+import vtkSphereSource from 'vtk.js/Filters/Sources/SphereSource';
 
-import { FieldAssociations } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
-import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
+import { FieldAssociations } from 'vtk.js/Common/DataModel/DataSet/Constants';
+import { Representation } from 'vtk.js/Rendering/Core/Property/Constants';
 
 // ----------------------------------------------------------------------------
 // Constants

--- a/Sources/Testing/Examples/ActorSerialization/example/index.js
+++ b/Sources/Testing/Examples/ActorSerialization/example/index.js
@@ -1,7 +1,7 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtk from 'vtk.js/Sources/vtk';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtk from 'vtk.js/vtk';
 
 import actorJSON from './actor.json';
 

--- a/Sources/Testing/Examples/PipelineExecution/example/index.js
+++ b/Sources/Testing/Examples/PipelineExecution/example/index.js
@@ -1,15 +1,15 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import macro from 'vtk.js/Sources/macro';
-import vtk from 'vtk.js/Sources/vtk';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { FieldDataTypes } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
+import macro from 'vtk.js/macro';
+import vtk from 'vtk.js/vtk';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCalculator from 'vtk.js/Filters/General/Calculator';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkDataArray from 'vtk.js/Common/Core/DataArray';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import { AttributeTypes } from 'vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes } from 'vtk.js/Common/DataModel/DataSet/Constants';
 
 import controlPanel from './controller.html';
 

--- a/Sources/Testing/Examples/PolyDataSerialization/example/index.js
+++ b/Sources/Testing/Examples/PolyDataSerialization/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtk from 'vtk.js/Sources/vtk';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtk from 'vtk.js/vtk';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Testing/Examples/StandaloneSceneLoader/example/SceneControllerWidget.js
+++ b/Sources/Testing/Examples/StandaloneSceneLoader/example/SceneControllerWidget.js
@@ -1,4 +1,4 @@
-import vtkHttpSceneLoader from 'vtk.js/Sources/IO/Core/HttpSceneLoader';
+import vtkHttpSceneLoader from 'vtk.js/IO/Core/HttpSceneLoader';
 
 const SETTINGS_OPTIONS = {
   defaultSettings: {},

--- a/Sources/Testing/Examples/StandaloneSceneLoader/example/index.js
+++ b/Sources/Testing/Examples/StandaloneSceneLoader/example/index.js
@@ -1,16 +1,16 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
 
-import vtkHttpSceneLoader from 'vtk.js/Sources/IO/Core/HttpSceneLoader';
-import DataAccessHelper from 'vtk.js/Sources/IO/Core/DataAccessHelper';
-import vtkURLExtract from 'vtk.js/Sources/Common/Core/URLExtract';
-import vtkOBJReader from 'vtk.js/Sources/IO/Misc/OBJReader';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkHttpSceneLoader from 'vtk.js/IO/Core/HttpSceneLoader';
+import DataAccessHelper from 'vtk.js/IO/Core/DataAccessHelper';
+import vtkURLExtract from 'vtk.js/Common/Core/URLExtract';
+import vtkOBJReader from 'vtk.js/IO/Misc/OBJReader';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
 
 import controlWidget from './SceneControllerWidget';
 import style from './SceneLoader.module.css';

--- a/Sources/Widgets/Core/WidgetManager/example/index.js
+++ b/Sources/Widgets/Core/WidgetManager/example/index.js
@@ -1,16 +1,16 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
-import WidgetManagerConstants from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
+import WidgetManagerConstants from 'vtk.js/Widgets/Core/WidgetManager/Constants';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 import vtkBoxWidget from 'vtk.js/Examples/Widgets/Box/BoxWidget';
-import vtkImplicitPlaneWidget from 'vtk.js/Sources/Widgets/Widgets3D/ImplicitPlaneWidget';
-import vtkPolyLineWidget from 'vtk.js/Sources/Widgets/Widgets3D/PolyLineWidget';
+import vtkImplicitPlaneWidget from 'vtk.js/Widgets/Widgets3D/ImplicitPlaneWidget';
+import vtkPolyLineWidget from 'vtk.js/Widgets/Widgets3D/PolyLineWidget';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Representations/ImplicitPlaneRepresentation/example/index.js
+++ b/Sources/Widgets/Representations/ImplicitPlaneRepresentation/example/index.js
@@ -1,7 +1,7 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkImplicitPlaneRepresentation from 'vtk.js/Sources/Widgets/Representations/ImplicitPlaneRepresentation';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkImplicitPlaneRepresentation from 'vtk.js/Widgets/Representations/ImplicitPlaneRepresentation';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Representations/WidgetRepresentation/example/index.js
+++ b/Sources/Widgets/Representations/WidgetRepresentation/example/index.js
@@ -1,9 +1,9 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkCubeHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/CubeHandleRepresentation';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
-import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+import vtkCubeHandleRepresentation from 'vtk.js/Widgets/Representations/CubeHandleRepresentation';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkSphereHandleRepresentation from 'vtk.js/Widgets/Representations/SphereHandleRepresentation';
+import vtkStateBuilder from 'vtk.js/Widgets/Core/StateBuilder';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Widgets3D/AngleWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkAngleWidget from 'vtk.js/Sources/Widgets/Widgets3D/AngleWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCubeSource from 'vtk.js/Filters/Sources/CubeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkAngleWidget from 'vtk.js/Widgets/Widgets3D/AngleWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Widgets3D/DistanceWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkDistanceWidget from 'vtk.js/Sources/Widgets/Widgets3D/DistanceWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCubeSource from 'vtk.js/Filters/Sources/CubeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkDistanceWidget from 'vtk.js/Widgets/Widgets3D/DistanceWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/example/index.js
@@ -1,14 +1,14 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkImageCroppingWidget from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
-import vtkVolumeMapper from 'vtk.js/Sources/Rendering/Core/VolumeMapper';
-import vtkImageCropFilter from 'vtk.js/Sources/Filters/General/ImageCropFilter';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkImageCroppingWidget from 'vtk.js/Widgets/Widgets3D/ImageCroppingWidget';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkVolume from 'vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from 'vtk.js/Rendering/Core/VolumeMapper';
+import vtkImageCropFilter from 'vtk.js/Filters/General/ImageCropFilter';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/example/index.js
@@ -1,12 +1,12 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkImplicitPlaneWidget from 'vtk.js/Sources/Widgets/Widgets3D/ImplicitPlaneWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkImplicitPlaneWidget from 'vtk.js/Widgets/Widgets3D/ImplicitPlaneWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup

--- a/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/example/index.js
@@ -1,17 +1,17 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkOrientationMarkerWidget from 'vtk.js/Sources/Interaction/Widgets/OrientationMarkerWidget';
-import vtkAxesActor from 'vtk.js/Sources/Rendering/Core/AxesActor';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkOrientationMarkerWidget from 'vtk.js/Interaction/Widgets/OrientationMarkerWidget';
+import vtkAxesActor from 'vtk.js/Rendering/Core/AxesActor';
 
-import vtkInteractiveOrientationWidget from 'vtk.js/Sources/Widgets/Widgets3D/InteractiveOrientationWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkInteractiveOrientationWidget from 'vtk.js/Widgets/Widgets3D/InteractiveOrientationWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
 
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import * as vtkMath from 'vtk.js/Common/Core/Math';
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Widgets/Widgets3D/LineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkLineWidget from 'vtk.js/Sources/Widgets/Widgets3D/LineWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkCubeSource from 'vtk.js/Filters/Sources/CubeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkLineWidget from 'vtk.js/Widgets/Widgets3D/LineWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -1,31 +1,31 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
-import vtkPaintWidget from 'vtk.js/Sources/Widgets/Widgets3D/PaintWidget';
-import vtkRectangleWidget from 'vtk.js/Sources/Widgets/Widgets3D/RectangleWidget';
-import vtkEllipseWidget from 'vtk.js/Sources/Widgets/Widgets3D/EllipseWidget';
-import vtkSplineWidget from 'vtk.js/Sources/Widgets/Widgets3D/SplineWidget';
-import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import vtkPaintFilter from 'vtk.js/Sources/Filters/General/PaintFilter';
-import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
-import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
-import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
+import * as vtkMath from 'vtk.js/Common/Core/Math';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
+import vtkPaintWidget from 'vtk.js/Widgets/Widgets3D/PaintWidget';
+import vtkRectangleWidget from 'vtk.js/Widgets/Widgets3D/RectangleWidget';
+import vtkEllipseWidget from 'vtk.js/Widgets/Widgets3D/EllipseWidget';
+import vtkSplineWidget from 'vtk.js/Widgets/Widgets3D/SplineWidget';
+import vtkInteractorStyleImage from 'vtk.js/Interaction/Style/InteractorStyleImage';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import vtkPaintFilter from 'vtk.js/Filters/General/PaintFilter';
+import vtkColorTransferFunction from 'vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkPiecewiseFunction from 'vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkBoundingBox from 'vtk.js/Common/DataModel/BoundingBox';
 
 import {
   BehaviorCategory,
   ShapeBehavior,
-} from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
+} from 'vtk.js/Widgets/Widgets3D/ShapeWidget/Constants';
 import {
   TextAlign,
   VerticalAlign,
-} from 'vtk.js/Sources/Interaction/Widgets/LabelRepresentation/Constants';
+} from 'vtk.js/Interaction/Widgets/LabelRepresentation/Constants';
 
-import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
+import { ViewTypes } from 'vtk.js/Widgets/Core/WidgetManager/Constants';
 
 import { vec3 } from 'gl-matrix';
 

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkPolyLineWidget from 'vtk.js/Sources/Widgets/Widgets3D/PolyLineWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkActor from 'vtk.js/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Rendering/Core/Mapper';
+import vtkPolyLineWidget from 'vtk.js/Widgets/Widgets3D/PolyLineWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
 import controlPanel from './controlPanel.html';
 

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -1,25 +1,25 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
-import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
-import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
-import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
-import vtkResliceCursorWidget from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
-import vtkOrientationMarkerWidget from 'vtk.js/Sources/Interaction/Widgets/OrientationMarkerWidget';
-import vtkAnnotatedCubeActor from 'vtk.js/Sources/Rendering/Core/AnnotatedCubeActor';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageReslice from 'vtk.js/Sources/Imaging/Core/ImageReslice';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkOpenGLRenderWindow from 'vtk.js/Rendering/OpenGL/RenderWindow';
+import vtkRenderer from 'vtk.js/Rendering/Core/Renderer';
+import vtkRenderWindow from 'vtk.js/Rendering/Core/RenderWindow';
+import vtkRenderWindowInteractor from 'vtk.js/Rendering/Core/RenderWindowInteractor';
+import vtkResliceCursorWidget from 'vtk.js/Widgets/Widgets3D/ResliceCursorWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
+import vtkOrientationMarkerWidget from 'vtk.js/Interaction/Widgets/OrientationMarkerWidget';
+import vtkAnnotatedCubeActor from 'vtk.js/Rendering/Core/AnnotatedCubeActor';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageReslice from 'vtk.js/Imaging/Core/ImageReslice';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import vtkInteractorStyleImage from 'vtk.js/Interaction/Style/InteractorStyleImage';
 
 import {
   ViewTypes,
   CaptureOn,
-} from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
+} from 'vtk.js/Widgets/Core/WidgetManager/Constants';
 
-import { getViewPlaneNameFromViewType } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';
+import { getViewPlaneNameFromViewType } from 'vtk.js/Widgets/Widgets3D/ResliceCursorWidget/helpers';
 
 // ----------------------------------------------------------------------------
 // Define html structure

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -1,15 +1,15 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
-import vtkRectangleWidget from 'vtk.js/Sources/Widgets/Widgets3D/RectangleWidget';
-import vtkEllipseWidget from 'vtk.js/Sources/Widgets/Widgets3D/EllipseWidget';
-import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
-import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
-import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
-import vtkSphere from 'vtk.js/Sources/Common/DataModel/Sphere';
-import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
+import vtkRectangleWidget from 'vtk.js/Widgets/Widgets3D/RectangleWidget';
+import vtkEllipseWidget from 'vtk.js/Widgets/Widgets3D/EllipseWidget';
+import vtkInteractorStyleImage from 'vtk.js/Interaction/Style/InteractorStyleImage';
+import vtkHttpDataSetReader from 'vtk.js/IO/Core/HttpDataSetReader';
+import vtkImageMapper from 'vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Rendering/Core/ImageSlice';
+import vtkSphere from 'vtk.js/Common/DataModel/Sphere';
+import vtkBoundingBox from 'vtk.js/Common/DataModel/BoundingBox';
 
 import {
   BehaviorCategory,
@@ -17,13 +17,13 @@ import {
   HorizontalTextPosition,
   VerticalTextPosition,
   computeTextPosition,
-} from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
+} from 'vtk.js/Widgets/Widgets3D/ShapeWidget/Constants';
 import {
   TextAlign,
   VerticalAlign,
-} from 'vtk.js/Sources/Interaction/Widgets/LabelRepresentation/Constants';
+} from 'vtk.js/Interaction/Widgets/LabelRepresentation/Constants';
 
-import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
+import { ViewTypes } from 'vtk.js/Widgets/Core/WidgetManager/Constants';
 
 import { vec3 } from 'gl-matrix';
 

--- a/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
@@ -1,11 +1,11 @@
-import 'vtk.js/Sources/favicon';
+import 'vtk.js/favicon';
 
-import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
-import vtkInteractorStyleImage from 'vtk.js/Sources/Interaction/Style/InteractorStyleImage';
-import vtkSplineWidget from 'vtk.js/Sources/Widgets/Widgets3D/SplineWidget';
-import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkFullScreenRenderWindow from 'vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkInteractorStyleImage from 'vtk.js/Interaction/Style/InteractorStyleImage';
+import vtkSplineWidget from 'vtk.js/Widgets/Widgets3D/SplineWidget';
+import vtkWidgetManager from 'vtk.js/Widgets/Core/WidgetManager';
 
-import { splineKind } from 'vtk.js/Sources/Common/DataModel/Spline3D/Constants';
+import { splineKind } from 'vtk.js/Common/DataModel/Spline3D/Constants';
 
 import controlPanel from './controlPanel.html';
 

--- a/Utilities/ExampleRunner/template-config.js
+++ b/Utilities/ExampleRunner/template-config.js
@@ -1,8 +1,18 @@
 const path = require('path');
 
-const vtkBasePath = path.resolve('.');
-
 const settings = require('../../webpack.settings.js');
+
+// escapes backslashes
+function escape(s) {
+  return s.replace(/\\/g, '\\\\');
+}
+
+const vtkPaths = {
+  Base: escape(path.resolve('.')),
+  Examples: escape(path.resolve('Examples')),
+  Utilities: escape(path.resolve('Utilities')),
+  Sources: escape(path.resolve('Sources')),
+};
 
 module.exports = function buildConfig(
   name,
@@ -13,6 +23,7 @@ module.exports = function buildConfig(
 ) {
   return `
 var rules = [].concat(require('../config/rules-vtk.js'), require('../config/rules-examples.js'), require('../config/rules-linter.js'));
+var ESLintWebpackPlugin = require('eslint-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpack = require('webpack');
 var path = require('path');
@@ -21,22 +32,37 @@ module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
   plugins: [
+    new ESLintWebpackPlugin({
+      // override vtk.js alias
+      overrideConfig: {
+        settings: {
+          'import/resolver': {
+            webpack: {
+              config: {
+                resolve: {
+                  alias: {
+                    'vtk.js/Examples': '${vtkPaths.Examples}',
+                    'vtk.js/Utilities': '${vtkPaths.Utilities}',
+                    'vtk.js/Sources': '${vtkPaths.Sources}',
+                    'vtk.js': '${vtkPaths.Sources}',
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }),
     new HtmlWebpackPlugin({
-      template: '${root.replace(
-        /\\/g,
-        '\\\\'
-      )}/Utilities/ExampleRunner/template.html',
+      template: '${escape(root)}/Utilities/ExampleRunner/template.html',
     }),
     new webpack.DefinePlugin({
       __BASE_PATH__: "''",
     }),
   ],
-  entry: path.join('${exampleBasePath.replace(
-    /\\/g,
-    '\\\\'
-  )}', '${relPath.replace(/\\/g, '\\\\')}'),
+  entry: path.join('${escape(exampleBasePath)}', '${escape(relPath)}'),
   output: {
-    path: '${destPath.replace(/\\/g, '\\\\')}',
+    path: '${escape(destPath)}',
     filename: '${name}.js',
   },
   module: {
@@ -44,16 +70,24 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'vtk.js': '${vtkBasePath.replace(/\\/g, '\\\\')}',
+      // Since vtk.js examples are written as if the vtk.js package is a dependency,
+      // we need to resolve example imports as if they were referencing vtk.js/Sources.
+      // the Examples/Utilities hack allows for imports from those folders, since our
+      // last alias overrides vtk.js/* paths to point to vtk.js/Sources/*.
+
+      'vtk.js/Examples': '${vtkPaths.Examples}',
+      'vtk.js/Utilities': '${vtkPaths.Utilities}',
+      'vtk.js/Sources': '${vtkPaths.Sources}',
+      'vtk.js': '${vtkPaths.Sources}',
     },
     fallback: {
       fs: false,
-      stream: require.resolve('stream-browserify')
+      stream: require.resolve('stream-browserify'),
     },
   },
 
   devServer: {
-    contentBase: '${root.replace(/\\/g, '\\\\')}',
+    contentBase: '${escape(root)}',
     port: ${settings.devServerConfig.port()},
     host: '${settings.devServerConfig.host()}',
     disableHostCheck: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8204,6 +8204,37 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
+    "eslint-webpack-plugin": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.4.3.tgz",
+      "integrity": "sha512-+15ifHFkGn0gB7lQBe+xgyKcjelxv9xlTutGHEPYBUUj+1Rjrjq3+1REJLJpyAHgpQTatpqkRY1z8gQuyn3Aww==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^7.2.4",
+        "arrify": "^2.0.1",
+        "jest-worker": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        }
+      }
+    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-react": "7.22.0",
+    "eslint-webpack-plugin": "^2.4.3",
     "expose-loader": "1.0.3",
     "glob": "7.1.6",
     "hson-loader": "2.0.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,6 +4,7 @@ const { merge } = require('webpack-merge');
 
 // webpack plugins
 const WebpackNotifierPlugin = require('webpack-notifier');
+const ESLintWebpackPlugin = require('eslint-webpack-plugin');
 
 // config files
 const pkg = require('./package.json');
@@ -21,25 +22,9 @@ const configureEntries = () => {
   return entries;
 };
 
-const configureESLintLoader = ({ lint = true }) => {
-  if (lint) {
-    return [
-      {
-        test: /\.js$/,
-        loader: 'eslint-loader',
-        exclude: /node_modules/,
-        enforce: 'pre',
-        options: { configFile: path.join(__dirname, '.eslintrc.js') },
-      },
-    ];
-  }
-  return [];
-};
-
 // Configure vtk rules
 function configureVtkRules() {
   return [
-    ...configureESLintLoader({ lint: !process.env.NOLINT }),
     {
       test: /\.glsl$/i,
       loader: 'shader-loader',
@@ -110,6 +95,7 @@ const baseConfig = {
     rules: configureVtkRules(),
   },
   plugins: [
+    ...((!process.env.NOLINT && new ESLintWebpackPlugin()) || []),
     new WebpackNotifierPlugin({
       title: 'Webpack - vtk.js',
       excludeWarnings: true,


### PR DESCRIPTION
This rewrites all examples to use vtk.js ESM.

Well, in reality the examples aren't built against the ESM build. We just make it look like they are by (ab)using webpack aliases.