### PR TITLE
fix(ResliceCursorWidget): Flip when adding two rotations on same view…

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -353,17 +353,12 @@ export default function widgetBehavior(publicAPI, model) {
         `get${associatedPlaneName}PlaneNormal`
       ]();
 
-      // Compute previous angle between lines
-      const angleBetweenAssociatedPlanes = vtkMath.angleBetweenVectors(
-        normal,
-        associatedNormal
+      const newAssociatedNormal = rotateVector(
+        associatedNormal,
+        planeNormal,
+        radianAngle
       );
 
-      const newAssociatedNormal = rotateVector(
-        newNormal,
-        planeNormal,
-        angleBetweenAssociatedPlanes
-      );
       model.widgetState[`set${associatedPlaneName}PlaneNormal`](
         newAssociatedNormal
       );


### PR DESCRIPTION
@finetjul 
Issue:
- Keep reslice cursor orthogonality : true
- Move green axis on axial view on clockwise
- Then move red axis on axial view on clockwise
- The green view is flipped when moving red axis
The previous implementations worked like this:
- Move green line
- Red plane normal is computed by applying 90 rotation on green normal
- Move red line
- Green plane normal is computed by applying 90 rotation on red normal which means that, the green normal made 180° rotation and so, is flipped.

Now, we applying the same rotation on both normal instead of recomputing one from the other.