### PR TITLE
fix(ResliceCursorWidget): update how to move center when scrolling

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -218,11 +218,17 @@ export default function widgetBehavior(publicAPI, model) {
     const image = model.widgetState.getImage();
     const imageSpacing = image.getSpacing();
 
+    // Use Chebyshev norm
+    // https://math.stackexchange.com/questions/71423/what-is-the-term-for-the-projection-of-a-vector-onto-the-unit-cube
+    const absDirProj = dirProj.map((value) => Math.abs(value));
+    const index = absDirProj.indexOf(Math.max(...absDirProj));
+    const movingFactor = nbSteps * (imageSpacing[index] / dirProj[index]);
+
     // Define the potentially new center
     let newCenter = [
-      oldCenter[0] + nbSteps * direction[0] * imageSpacing[0],
-      oldCenter[1] + nbSteps * direction[1] * imageSpacing[1],
-      oldCenter[2] + nbSteps * direction[2] * imageSpacing[2],
+      oldCenter[0] + movingFactor * direction[0],
+      oldCenter[1] + movingFactor * direction[1],
+      oldCenter[2] + movingFactor * direction[2],
     ];
     newCenter = publicAPI.getBoundedCenter(newCenter);
 


### PR DESCRIPTION
@finetjul 

Issue:
- rotate sagittal view
- scroll on axial view
Result: both axis are moving instead of one.

ImageSpacing was badly used when computing the new center.
When we are not axis aligned, we cannot use the spacing because it transformed the moving direction.