### PR TITLE
Fix widget delete

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -313,9 +313,7 @@ function vtkWidgetManager(publicAPI, model) {
     subscriptions.push(
       model.interactor.onEndAnimation(() => {
         model.isAnimating = false;
-        if (model.pickingEnabled) {
-          publicAPI.enablePicking();
-        }
+        publicAPI.renderWidgets();
       })
     );
 
@@ -369,6 +367,7 @@ function vtkWidgetManager(publicAPI, model) {
     publicAPI.modified();
 
     if (model.pickingEnabled) {
+      // also sets pickingAvailable
       publicAPI.enablePicking();
     }
 
@@ -414,7 +413,7 @@ function vtkWidgetManager(publicAPI, model) {
 
   function onWidgetRemoved() {
     model.renderer.getRenderWindow().getInteractor().render();
-    publicAPI.enablePicking();
+    publicAPI.renderWidgets();
   }
 
   publicAPI.removeWidgets = () => {

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -430,12 +430,12 @@ function vtkWidgetManager(publicAPI, model) {
       model.widgets.splice(index, 1);
 
       const isWidgetInFocus = model.widgetInFocus === viewWidget;
-      removeWidgetInternal(viewWidget);
-      onWidgetRemoved();
-
       if (isWidgetInFocus) {
         publicAPI.releaseFocus();
       }
+
+      removeWidgetInternal(viewWidget);
+      onWidgetRemoved();
     }
   };
 


### PR DESCRIPTION
- Fixes ordering of widget delete and unfocus. Unfocus should occur before delete.
- Address each usage of `enablePicking` inside WidgetManager