### PR TITLE
ResliceCursorWidget: Fix jump

### DIFF
--- a/Sources/Common/DataModel/Plane/api.md
+++ b/Sources/Common/DataModel/Plane/api.md
@@ -7,6 +7,7 @@ returning plane normal.
 ### normal (set/get)
 
 Plane normal. Plane is defined by point and normal. Default is [0.0, 0.0, 1.0].
+Must be normalized (magnitude = 1)
 
 ### origin (set/get)
 

--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -98,7 +98,8 @@ function vtkImageReslice(publicAPI, model) {
 
   publicAPI.setResliceAxes = (resliceAxes) => {
     if (!model.resliceAxes) {
-      model.resliceAxes = mat4.create();
+      model.resliceAxes = new Float64Array(16);
+      mat4.identity(model.resliceAxes);
     }
 
     if (!mat4.exactEquals(model.resliceAxes, resliceAxes)) {
@@ -133,11 +134,12 @@ function vtkImageReslice(publicAPI, model) {
     const outWholeExt = [0, 0, 0, 0, 0, 0];
     const outDims = [0, 0, 0];
 
-    let matrix = mat4.create();
+    let matrix = new Float64Array(16);
+    mat4.identity(matrix);
     if (model.resliceAxes) {
       matrix = model.resliceAxes;
     }
-    const imatrix = mat4.create();
+    const imatrix = new Float64Array(16);
     mat4.invert(imatrix, matrix);
 
     const inCenter = [
@@ -683,7 +685,8 @@ function vtkImageReslice(publicAPI, model) {
   publicAPI.getIndexMatrix = (input, output) => {
     // first verify that we have to update the matrix
     if (indexMatrix === null) {
-      indexMatrix = mat4.create();
+      indexMatrix = new Float64Array(16);
+      mat4.identity(indexMatrix);
     }
 
     const inOrigin = input.getOrigin();
@@ -691,9 +694,12 @@ function vtkImageReslice(publicAPI, model) {
     const outOrigin = output.getOrigin();
     const outSpacing = output.getSpacing();
 
-    const transform = mat4.create();
-    const inMatrix = mat4.create();
-    const outMatrix = mat4.create();
+    const transform = new Float64Array(16);
+    mat4.identity(transform);
+    const inMatrix = new Float64Array(16);
+    mat4.identity(inMatrix);
+    const outMatrix = new Float64Array(16);
+    mat4.identity(outMatrix);
 
     if (optimizedTransform) {
       optimizedTransform = null;
@@ -751,9 +757,11 @@ function vtkImageReslice(publicAPI, model) {
     const dims = input.getDimensions();
     const inWholeExt = [0, dims[0] - 1, 0, dims[1] - 1, 0, dims[2] - 1];
 
-    const matrix = mat4.create();
+    const matrix = new Float64Array(16);
     if (model.resliceAxes) {
       mat4.invert(matrix, model.resliceAxes);
+    } else {
+      mat4.identity(matrix);
     }
 
     const bounds = [

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers.js
@@ -23,18 +23,19 @@ const EPSILON = 0.00001;
 export function boundPlane(bounds, origin, p1, p2) {
   const v1 = [];
   vtkMath.subtract(p1, origin, v1);
+  vtkMath.normalize(v1);
 
   const v2 = [];
   vtkMath.subtract(p2, origin, v2);
+  vtkMath.normalize(v2);
 
   const n = [0, 0, 1];
   vtkMath.cross(v1, v2, n);
-  const plane = vtkPlane.newInstance();
-  plane.setOrigin(origin);
-  plane.setNormal(n);
-  vtkMath.normalize(v1);
-  vtkMath.normalize(v2);
   vtkMath.normalize(n);
+
+  const plane = vtkPlane.newInstance();
+  plane.setOrigin(...origin);
+  plane.setNormal(...n);
 
   const cubeSource = vtkCubeSource.newInstance();
   cubeSource.setBounds(bounds);


### PR DESCRIPTION
With very particular dataset, in very particular condition, scrolling axial was making the coronal view "jump" slices. 

Closes #1746 