### PR TITLE
perf(OpenGL/Texture): Optimize create3DFilterableFromRaw

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1078,15 +1078,18 @@ function vtkOpenGLTexture(publicAPI, model) {
       // otherwise convert to float
       const newArray = new Float32Array(numPixelsIn * numComps);
       // compute min and max values
-      const res = computeScaleOffsets(numComps, numPixelsIn, data);
-      model.volumeInfo.offset = res.offset;
-      model.volumeInfo.scale = res.scale;
+      const {
+        offset: computedOffset,
+        scale: computedScale,
+      } = computeScaleOffsets(numComps, numPixelsIn, data);
+      model.volumeInfo.offset = computedOffset;
+      model.volumeInfo.scale = computedScale;
       let count = 0;
-      for (let i = 0; i < numPixelsIn; ++i) {
-        for (let nc = 0; nc < numComps; ++nc) {
+      const scaleInverse = computedScale.map((s) => 1 / s);
+      for (let i = 0; i < numPixelsIn; i++) {
+        for (let nc = 0; nc < numComps; nc++) {
           newArray[count] =
-            (data[count] - model.volumeInfo.offset[nc]) /
-            model.volumeInfo.scale[nc];
+            (data[count] - computedOffset[nc]) * scaleInverse[nc];
           count++;
         }
       }


### PR DESCRIPTION
Profiling reduces this from 380 ms to 132 ms.
