### PR TITLE
fix(package): Manually create npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
         run: npm run validate
       - name: Test
         run: npm run test:headless
+      - name: Create package folder
+        run: npm run release:create-package
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Utilities/ci/build-npm-package.js
+++ b/Utilities/ci/build-npm-package.js
@@ -1,0 +1,30 @@
+const fs = require('fs-extra');
+const path = require('path');
+const glob = require('glob');
+
+// assumes src and dst are directories
+// copyDirSync('/a/b/c', 'd/e/f') results in d/e/f/c
+function copyDirSync(src, dst) {
+  const dirname = path.basename(src);
+  return fs.copySync(src, path.join(dst, dirname));
+}
+const pkgdir = 'pkg';
+
+fs.removeSync(pkgdir);
+fs.ensureDirSync(pkgdir);
+
+copyDirSync('./Sources', pkgdir);
+copyDirSync('./Utilities', pkgdir);
+copyDirSync('./dist', pkgdir);
+
+// make ESM exports available at top-level
+fs.copySync('./dist/esm', pkgdir);
+
+for (const entry of [
+  ...glob.sync('*.txt'),
+  ...glob.sync('*.md'),
+  'LICENSE',
+  'package.json',
+]) {
+  fs.copyFileSync(entry, path.join(pkgdir, entry));
+}

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "build:esm": "rollup -c rollup.config.js",
     "build:umd": "webpack --config webpack.prod.js --progress",
     "build:release": "npm run lint && cross-env NOLINT=1 npm run build:esm && cross-env NOLINT=1 npm run build:umd",
+    "release:create-package": "node ./Utilities/ci/build-npm-package.js",
     "test": "karma start ./karma.conf.js",
     "test:headless": "karma start ./karma.conf.js --browsers ChromeHeadlessNoSandbox --single-run",
     "test:debug": "karma start ./karma.conf.js --no-single-run",
@@ -182,6 +183,17 @@
         "name": "beta",
         "prerelease": true
       }
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/npm",
+        {
+          "pkgRoot": "./pkg"
+        }
+      ],
+      "@semantic-release/github"
     ]
   }
 }


### PR DESCRIPTION
The create-package script constructs a package separately from the
project root.
In particular, this is designed to help webpack v4 support vtk.js ESM,
since webpack v4 does not process the package.json exports field.