### PR TITLE
fix(package): Manually create npm packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,5 +59,7 @@ module.exports = {
   ignorePatterns: [
     // ignore old Actor example
     '**/example_/*.js',
+    // ignore js files in utilities
+    'Utilities/**/*.js',
   ],
 };

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
         run: npm run validate
       - name: Test
         run: npm run test:headless
+      - name: Create package folder
+        run: npm run release:create-packages
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 coverage/
 .env
 Utilities/TestResults
+pkg

--- a/Utilities/ci/build-npm-package.js
+++ b/Utilities/ci/build-npm-package.js
@@ -1,0 +1,84 @@
+const fs = require('fs-extra');
+const path = require('path');
+const glob = require('glob');
+
+const rootdir = 'pkg';
+
+// assumes src and dst are directories
+// copyDirSync('/a/b/c', 'd/e/f') results in d/e/f/c
+function copyDirSync(src, dst) {
+  const dirname = path.basename(src);
+  return fs.copySync(src, path.join(dst, dirname));
+}
+
+function prepareESM() {
+  const pkgdir = path.join(rootdir, 'esm');
+  fs.ensureDirSync(pkgdir);
+
+  copyDirSync('./Utilities', pkgdir);
+
+  // make ESM exports available at top-level
+  fs.copySync('./dist/esm', pkgdir);
+
+  // copy misc files
+  for (const entry of [
+    ...glob.sync('*.txt'),
+    ...glob.sync('*.md'),
+    'LICENSE',
+    'package.json',
+    '.npmignore',
+  ]) {
+    fs.copyFileSync(entry, path.join(pkgdir, entry));
+  }
+
+  // modify package.json
+  const packageJson = path.join(pkgdir, 'package.json');
+  const pkgInfo = JSON.parse(
+    fs.readFileSync(packageJson, { encoding: 'utf8' })
+  );
+
+  pkgInfo.name = '@kitware/vtk.js';
+  pkgInfo.main = './index.js';
+  pkgInfo.module = './index.js';
+
+  fs.writeFileSync(packageJson, JSON.stringify(pkgInfo, null, 2));
+}
+
+function prepareUMD() {
+  const pkgdir = path.join(rootdir, 'umd');
+  fs.ensureDirSync(pkgdir);
+
+  copyDirSync('./Sources', pkgdir);
+  copyDirSync('./Utilities', pkgdir);
+
+  fs.copySync('./dist/umd', pkgdir);
+
+  // copy misc files
+  for (const entry of [
+    ...glob.sync('*.txt'),
+    ...glob.sync('*.md'),
+    'LICENSE',
+    'package.json',
+    '.npmignore',
+  ]) {
+    fs.copyFileSync(entry, path.join(pkgdir, entry));
+  }
+
+  // modify package.json
+  const packageJson = path.join(pkgdir, 'package.json');
+  const pkgInfo = JSON.parse(
+    fs.readFileSync(packageJson, { encoding: 'utf8' })
+  );
+
+  pkgInfo.name = 'vtk.js';
+  pkgInfo.main = './vtk.js';
+  delete pkgInfo.module;
+
+  fs.writeFileSync(packageJson, JSON.stringify(pkgInfo, null, 2));
+}
+
+fs.removeSync(rootdir);
+fs.ensureDirSync(rootdir);
+
+prepareESM();
+prepareUMD();

--- a/package.json
+++ b/package.json
@@ -29,12 +29,6 @@
   "homepage": "https://github.com/kitware/vtk-js#readme",
   "main": "./dist/umd/vtk.js",
   "module": "./dist/esm/index.js",
-  "exports": {
-    ".": "./dist/esm/index.js",
-    "./*": "./dist/esm/*",
-    "./Sources/*": "./Sources/*",
-    "./Utilities/*": "./Utilities/*"
-  },
   "dependencies": {
     "@babel/runtime": "7.12.5",
     "blueimp-md5": "2.18.0",
@@ -147,6 +141,7 @@
     "build:esm": "rollup -c rollup.config.js",
     "build:umd": "webpack --config webpack.prod.js --progress",
     "build:release": "npm run lint && cross-env NOLINT=1 npm run build:esm && cross-env NOLINT=1 npm run build:umd",
+    "release:create-packages": "node ./Utilities/ci/build-npm-package.js",
     "test": "karma start ./karma.conf.js",
     "test:headless": "karma start ./karma.conf.js --browsers ChromeHeadlessNoSandbox --single-run",
     "test:debug": "karma start ./karma.conf.js --no-single-run",
@@ -182,6 +177,26 @@
         "name": "beta",
         "prerelease": true
       }
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/npm",
+        {
+          "pkgRoot": "./pkg/umd"
+        }
+      ],
+      [
+        "@semantic-release/npm",
+        {
+          "pkgRoot": "./pkg/esm"
+        }
+      ],
+      "@semantic-release/github"
     ]
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This will result in two packages: `vtk.js`, and `@kitware/vtk.js`.

- `vtk.js` will still provide `vtk.js/Sources/*` as well as the UMD build. `vtk.js@beta` no longer contains the ESM build.
- `@kitware/vtk.js` will only provide the ESM build. `@kitware/vtk.js/Sources/*` no longer exists.

A few things to note:
- `build-npm-package.js` generates two packages: the ESM and UMD packages.
- Both packages have customized package.json entries.