### PR TITLE
fix(reslicecursor): fix reslice cursor when aspect ratio is != 1

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -197,7 +197,6 @@ function vtkResliceCursorWidget(publicAPI, model) {
 
       const worldFocal = renderer.normalizedDisplayToWorld(
         ...displayFocal,
-        1,
         aspect
       );
 


### PR DESCRIPTION
displayFocal has 3 elements and not 2