### PR TITLE
chore(Rendering): Update gl-matrix code to use Float64Array

### DIFF
--- a/Sources/Common/Core/MatrixBuilder/index.js
+++ b/Sources/Common/Core/MatrixBuilder/index.js
@@ -5,15 +5,13 @@ import { areMatricesEqual } from 'vtk.js/Sources/Common/Core/Math';
 
 const NoOp = (v) => v;
 
-const IDENTITY = new Float64Array(16);
-mat4.identity(IDENTITY);
+const IDENTITY = mat4.identity(new Float64Array(16));
 
 const EPSILON = 1e-6;
 
 class Transform {
   constructor(useDegree = false) {
-    this.matrix = new Float64Array(16);
-    mat4.identity(this.matrix);
+    this.matrix = mat4.identity(new Float64Array(16));
     this.tmp = new Float64Array(3);
     this.angleConv = useDegree ? glMatrix.toRadian : NoOp;
   }

--- a/Sources/Common/DataModel/ImageData/api.md
+++ b/Sources/Common/DataModel/ImageData/api.md
@@ -46,13 +46,11 @@ Determine the number of points composing the dataset.
 ### getPoint(index)
 Returns the world position of a data point. Index is the point's index in the 1D data array.
 
-### indexToWorld(in, out), indexToWorldVec3(vin, vout)
+### indexToWorld(in, out)
 Converts the input index vector `[i,j,k]` to world values `[x,y,z]`. Modifies the out vector array in place, but also returns it.
-Can be sped up by providing `gl-matrix vec3` objects directly to `indexToWorldVec3`
 
-### worldToIndex(in, out), worldToIndexVec3(vin, vout)
+### worldToIndex(in, out)
 Converts the input world vector `[x,y,z]` to approximate index values `[i,j,k]`. Should be rounded to integers before attempting to access the index. Modifies the out vector array in place, but also returns it.
-Can be sped up by providing `gl-matrix vec3` objects directly to `worldToIndexVec3`
 
 ### getIndexToWorld(), getWorldToIndex()
 Returns the `mat4` matrices used to convert between world and index. `worldToIndex` is the inverse matrix of `indexToWorld`. Both are made with `Float64Array`.

--- a/Sources/Common/Transform/LandmarkTransform/index.js
+++ b/Sources/Common/Transform/LandmarkTransform/index.js
@@ -77,14 +77,8 @@ function vtkLandmarkTransform(publicAPI, model) {
 
     // -- build the 3x3 matrix M --
 
-    const M = mat3.create();
-    M[0] = 0;
-    M[4] = 0;
-    M[8] = 0;
-    const AAT = mat3.create();
-    AAT[0] = 0;
-    AAT[4] = 0;
-    AAT[8] = 0;
+    const M = new Float64Array(9);
+    const AAT = new Float64Array(9);
 
     const a = [0, 0, 0];
     const b = [0, 0, 0];
@@ -140,12 +134,7 @@ function vtkLandmarkTransform(publicAPI, model) {
 
       // -- build the 4x4 matrix N --
 
-      const N = mat4.create();
-      N[0] = 0;
-      N[5] = 0;
-      N[10] = 0;
-      N[15] = 0;
-
+      const N = new Float64Array(16);
       // on-diagonal elements
       N[0] = M[0] + M[4] + M[8];
       N[5] = M[0] - M[4] - M[8];
@@ -332,7 +321,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.obj(publicAPI, model);
 
   // Internal objects initialization
-  model.matrix = mat4.create(); // identity
+  model.matrix = mat4.identity(new Float64Array(16));
 
   macro.setGet(publicAPI, model, ['sourceLandmark', 'targetLandmark', 'mode']);
   macro.get(publicAPI, model, ['matrix']);

--- a/Sources/Filters/Sources/PlaneSource/index.js
+++ b/Sources/Filters/Sources/PlaneSource/index.js
@@ -151,7 +151,7 @@ function vtkPlaneSource(publicAPI, model) {
       return;
     }
     // Create rotation matrix
-    const transform = mat4.create();
+    const transform = mat4.identity(new Float64Array(16));
     const negCenter = [];
     vec3.negate(negCenter, model.center);
 

--- a/Sources/Imaging/Core/ImageReslice/api.md
+++ b/Sources/Imaging/Core/ImageReslice/api.md
@@ -27,7 +27,7 @@ Provide the input to the filter via the standard
 const imageReslice = vtkImageReslice.newInstance();
 imageReslice.setInputData(imageData);
 imageReslice.setOutputDimensionality(2);
-const axes = mat4.create();
+const axes = mat4.identity(new Float64Array(16));
 mat4.rotateX(axes, axes, 45 * Math.PI / 180);
 imageReslice.setResliceAxes(axes);
 imageReslice.setOutputScalarType('Uint16Array');

--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -99,8 +99,7 @@ function vtkImageReslice(publicAPI, model) {
 
   publicAPI.setResliceAxes = (resliceAxes) => {
     if (!model.resliceAxes) {
-      model.resliceAxes = new Float64Array(16);
-      mat4.identity(model.resliceAxes);
+      model.resliceAxes = mat4.identity(new Float64Array(16));
     }
 
     if (!mat4.exactEquals(model.resliceAxes, resliceAxes)) {
@@ -135,10 +134,11 @@ function vtkImageReslice(publicAPI, model) {
     const outWholeExt = [0, 0, 0, 0, 0, 0];
     const outDims = [0, 0, 0];
 
-    let matrix = new Float64Array(16);
-    mat4.identity(matrix);
+    let matrix = null;
     if (model.resliceAxes) {
       matrix = model.resliceAxes;
+    } else {
+      matrix = mat4.identity(new Float64Array(16));
     }
     const imatrix = new Float64Array(16);
     mat4.invert(imatrix, matrix);
@@ -708,8 +708,7 @@ function vtkImageReslice(publicAPI, model) {
   publicAPI.getIndexMatrix = (input, output) => {
     // first verify that we have to update the matrix
     if (indexMatrix === null) {
-      indexMatrix = new Float64Array(16);
-      mat4.identity(indexMatrix);
+      indexMatrix = mat4.identity(new Float64Array(16));
     }
 
     const inOrigin = input.getOrigin();
@@ -717,12 +716,9 @@ function vtkImageReslice(publicAPI, model) {
     const outOrigin = output.getOrigin();
     const outSpacing = output.getSpacing();
 
-    const transform = new Float64Array(16);
-    mat4.identity(transform);
-    const inMatrix = new Float64Array(16);
-    mat4.identity(inMatrix);
-    const outMatrix = new Float64Array(16);
-    mat4.identity(outMatrix);
+    const transform = mat4.identity(new Float64Array(16));
+    const inMatrix = mat4.identity(new Float64Array(16));
+    const outMatrix = mat4.identity(new Float64Array(16));
 
     if (optimizedTransform) {
       optimizedTransform = null;

--- a/Sources/Imaging/Core/ImageReslice/test/testImageReslice.js
+++ b/Sources/Imaging/Core/ImageReslice/test/testImageReslice.js
@@ -65,7 +65,7 @@ test.onlyIfWebGL('Test vtkImageReslice Rendering', (t) => {
   const imageReslice = gc.registerResource(vtkImageReslice.newInstance());
   imageReslice.setInputData(imageData);
   imageReslice.setOutputDimensionality(2);
-  const axes = mat4.create();
+  const axes = mat4.identity(new Float64Array(16));
   mat4.rotateZ(axes, axes, (45 * Math.PI) / 180);
   imageReslice.setResliceAxes(axes);
   imageReslice.setBorder(true);

--- a/Sources/Interaction/Manipulators/MouseCameraUnicamRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraUnicamRotateManipulator/index.js
@@ -86,18 +86,17 @@ function vtkMouseCameraUnicamRotateManipulator(publicAPI, model) {
     cameraFocalPoint[3] = 1.0;
     cameraViewUp[3] = 0.0;
 
-    const transform = mat4.create();
-    mat4.identity(transform);
-    mat4.translate(transform, transform, vec3.fromValues(cx, cy, cz));
-    mat4.rotate(transform, transform, angle, vec3.fromValues(ax, ay, az));
-    mat4.translate(transform, transform, vec3.fromValues(-cx, -cy, -cz));
+    const transform = mat4.identity(new Float64Array(16));
+    mat4.translate(transform, transform, [cx, cy, cz]);
+    mat4.rotate(transform, transform, angle, [ax, ay, az]);
+    mat4.translate(transform, transform, [-cx, -cy, -cz]);
     const newCameraPosition = [];
     const newCameraFocalPoint = [];
     vec3.transformMat4(newCameraPosition, cameraPosition, transform);
     vec3.transformMat4(newCameraFocalPoint, cameraFocalPoint, transform);
 
     mat4.identity(transform);
-    mat4.rotate(transform, transform, angle, vec3.fromValues(ax, ay, az));
+    mat4.rotate(transform, transform, angle, [ax, ay, az]);
     const newCameraViewUp = [];
     vec3.transformMat4(newCameraViewUp, cameraViewUp, transform);
 

--- a/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
+++ b/Sources/Interaction/Widgets/ImageCroppingRegionsWidget/index.js
@@ -40,8 +40,8 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
   // camera subscription
   let cameraSub = null;
 
-  model.indexToWorld = mat4.create();
-  model.worldToIndex = mat4.create();
+  model.indexToWorld = mat4.identity(new Float64Array(16));
+  model.worldToIndex = mat4.identity(new Float64Array(16));
 
   let handlesCache = null;
 
@@ -53,17 +53,15 @@ function vtkImageCroppingRegionsWidget(publicAPI, model) {
   };
 
   function worldToIndex(ain) {
-    const vin = vec3.fromValues(ain[0], ain[1], ain[2]);
-    const vout = vec3.create();
-    vec3.transformMat4(vout, vin, model.worldToIndex);
-    return [vout[0], vout[1], vout[2]];
+    const vout = [];
+    vec3.transformMat4(vout, ain, model.worldToIndex);
+    return vout;
   }
 
   function indexToWorld(ain) {
-    const vin = vec3.fromValues(ain[0], ain[1], ain[2]);
-    const vout = vec3.create();
-    vec3.transformMat4(vout, vin, model.indexToWorld);
-    return [vout[0], vout[1], vout[2]];
+    const vout = [];
+    vec3.transformMat4(vout, ain, model.indexToWorld);
+    return vout;
   }
 
   // Overridden method

--- a/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorRepresentation/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorRepresentation/index.js
@@ -458,8 +458,8 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.reslice = null;
   model.planeSource = vtkPlaneSource.newInstance();
-  model.resliceAxes = mat4.create();
-  model.newResliceAxes = mat4.create();
+  model.resliceAxes = mat4.identity(new Float64Array(16));
+  model.newResliceAxes = mat4.identity(new Float64Array(16));
   model.imageActor = vtkImageSlice.newInstance();
   model.imageMapper = vtkImageMapper.newInstance();
   model.imageMapper.setResolveCoincidentTopologyToPolygonOffset();

--- a/Sources/Rendering/Core/Actor/index.js
+++ b/Sources/Rendering/Core/Actor/index.js
@@ -1,5 +1,6 @@
 import { vec3, mat4 } from 'gl-matrix';
 import macro from 'vtk.js/Sources/macro';
+import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import vtkProp3D from 'vtk.js/Sources/Rendering/Core/Prop3D';
 import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
 
@@ -101,19 +102,11 @@ function vtkActor(publicAPI, model) {
     ) {
       vtkDebugMacro('Recomputing bounds...');
       model.mapperBounds = bds.concat(); // copy the mapper's bounds
-      const bbox = [
-        vec3.fromValues(bds[1], bds[3], bds[5]),
-        vec3.fromValues(bds[1], bds[2], bds[5]),
-        vec3.fromValues(bds[0], bds[2], bds[5]),
-        vec3.fromValues(bds[0], bds[3], bds[5]),
-        vec3.fromValues(bds[1], bds[3], bds[4]),
-        vec3.fromValues(bds[1], bds[2], bds[4]),
-        vec3.fromValues(bds[0], bds[2], bds[4]),
-        vec3.fromValues(bds[0], bds[3], bds[4]),
-      ];
+      const bbox = [];
+      vtkBoundingBox.getCorners(bds, bbox);
 
       publicAPI.computeMatrix();
-      const tmp4 = mat4.create();
+      const tmp4 = new Float64Array(16);
       mat4.transpose(tmp4, model.matrix);
       bbox.forEach((pt) => vec3.transformMat4(pt, pt, tmp4));
 

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -26,18 +26,18 @@ function vtkCamera(publicAPI, model) {
   model.classHierarchy.push('vtkCamera');
 
   // Set up private variables and methods
-  const origin = vec3.create();
-  const dopbasis = vec3.fromValues(0.0, 0.0, -1.0);
-  const upbasis = vec3.fromValues(0.0, 1.0, 0.0);
-  const tmpMatrix = mat4.create();
-  const tmpvec1 = vec3.create();
-  const tmpvec2 = vec3.create();
-  const tmpvec3 = vec3.create();
+  const origin = new Float64Array(3);
+  const dopbasis = new Float64Array([0.0, 0.0, -1.0]);
+  const upbasis = new Float64Array([0.0, 1.0, 0.0]);
+  const tmpMatrix = mat4.identity(new Float64Array(16));
+  const tmpvec1 = new Float64Array(3);
+  const tmpvec2 = new Float64Array(3);
+  const tmpvec3 = new Float64Array(3);
 
-  const rotateMatrix = mat4.create();
-  const trans = mat4.create();
-  const newPosition = vec3.create();
-  const newFocalPoint = vec3.create();
+  const rotateMatrix = mat4.identity(new Float64Array(16));
+  const trans = mat4.identity(new Float64Array(16));
+  const newPosition = new Float64Array(3);
+  const newFocalPoint = new Float64Array(3);
 
   // Internal Functions that don't need to be public
   function computeViewPlaneNormal() {
@@ -168,14 +168,14 @@ function vtkCamera(publicAPI, model) {
     const eye = model.position;
     const at = model.focalPoint;
     const up = model.viewUp;
-    const viewUpVec4 = vec4.fromValues(up[0], up[1], up[2], 0.0);
+    const viewUpVec4 = new Float64Array([up[0], up[1], up[2], 0.0]);
 
     mat4.identity(rotateMatrix);
-    const viewDir = vec3.fromValues(
+    const viewDir = new Float64Array([
       at[0] - eye[0],
       at[1] - eye[1],
-      at[2] - eye[2]
-    );
+      at[2] - eye[2],
+    ]);
     mat4.rotate(
       rotateMatrix,
       rotateMatrix,
@@ -199,21 +199,12 @@ function vtkCamera(publicAPI, model) {
     // translate the focal point to the origin,
     // rotate about view up,
     // translate back again
-    mat4.translate(trans, trans, vec3.fromValues(fp[0], fp[1], fp[2]));
-    mat4.rotate(
-      trans,
-      trans,
-      vtkMath.radiansFromDegrees(angle),
-      vec3.fromValues(model.viewUp[0], model.viewUp[1], model.viewUp[2])
-    );
-    mat4.translate(trans, trans, vec3.fromValues(-fp[0], -fp[1], -fp[2]));
+    mat4.translate(trans, trans, fp);
+    mat4.rotate(trans, trans, vtkMath.radiansFromDegrees(angle), model.viewUp);
+    mat4.translate(trans, trans, [-fp[0], -fp[1], -fp[2]]);
 
     // apply the transform to the position
-    vec3.transformMat4(
-      newPosition,
-      vec3.fromValues(model.position[0], model.position[1], model.position[2]),
-      trans
-    );
+    vec3.transformMat4(newPosition, model.position, trans);
     publicAPI.setPosition(newPosition[0], newPosition[1], newPosition[2]);
   };
 
@@ -225,33 +216,12 @@ function vtkCamera(publicAPI, model) {
     // translate the camera to the origin,
     // rotate about axis,
     // translate back again
-    mat4.translate(
-      trans,
-      trans,
-      vec3.fromValues(position[0], position[1], position[2])
-    );
-    mat4.rotate(
-      trans,
-      trans,
-      vtkMath.radiansFromDegrees(angle),
-      vec3.fromValues(model.viewUp[0], model.viewUp[1], model.viewUp[2])
-    );
-    mat4.translate(
-      trans,
-      trans,
-      vec3.fromValues(-position[0], -position[1], -position[2])
-    );
+    mat4.translate(trans, trans, position);
+    mat4.rotate(trans, trans, vtkMath.radiansFromDegrees(angle), model.viewUp);
+    mat4.translate(trans, trans, [-position[0], -position[1], -position[2]]);
 
     // apply the transform to the position
-    vec3.transformMat4(
-      newFocalPoint,
-      vec3.fromValues(
-        model.focalPoint[0],
-        model.focalPoint[1],
-        model.focalPoint[2]
-      ),
-      trans
-    );
+    vec3.transformMat4(newFocalPoint, model.focalPoint, trans);
     publicAPI.setFocalPoint(
       newFocalPoint[0],
       newFocalPoint[1],
@@ -271,21 +241,12 @@ function vtkCamera(publicAPI, model) {
     // translate the focal point to the origin,
     // rotate about view up,
     // translate back again
-    mat4.translate(trans, trans, vec3.fromValues(fp[0], fp[1], fp[2]));
-    mat4.rotate(
-      trans,
-      trans,
-      vtkMath.radiansFromDegrees(angle),
-      vec3.fromValues(axis[0], axis[1], axis[2])
-    );
-    mat4.translate(trans, trans, vec3.fromValues(-fp[0], -fp[1], -fp[2]));
+    mat4.translate(trans, trans, fp);
+    mat4.rotate(trans, trans, vtkMath.radiansFromDegrees(angle), axis);
+    mat4.translate(trans, trans, [-fp[0], -fp[1], -fp[2]]);
 
     // apply the transform to the position
-    vec3.transformMat4(
-      newPosition,
-      vec3.fromValues(model.position[0], model.position[1], model.position[2]),
-      trans
-    );
+    vec3.transformMat4(newPosition, model.position, trans);
     publicAPI.setPosition(newPosition[0], newPosition[1], newPosition[2]);
   };
 
@@ -300,29 +261,12 @@ function vtkCamera(publicAPI, model) {
     // translate the camera to the origin,
     // rotate about axis,
     // translate back again
-    mat4.translate(
-      trans,
-      trans,
-      vec3.fromValues(position[0], position[1], position[2])
-    );
-    mat4.rotate(
-      trans,
-      trans,
-      vtkMath.radiansFromDegrees(angle),
-      vec3.fromValues(axis[0], axis[1], axis[2])
-    );
-    mat4.translate(
-      trans,
-      trans,
-      vec3.fromValues(-position[0], -position[1], -position[2])
-    );
+    mat4.translate(trans, trans, position);
+    mat4.rotate(trans, trans, vtkMath.radiansFromDegrees(angle), axis);
+    mat4.translate(trans, trans, [-position[0], -position[1], -position[2]]);
 
     // apply the transform to the focal point
-    vec3.transformMat4(
-      newFocalPoint,
-      vec3.fromValues(...model.focalPoint),
-      trans
-    );
+    vec3.transformMat4(newFocalPoint, model.focalPoint, trans);
     publicAPI.setFocalPoint(...newFocalPoint);
   };
 
@@ -516,17 +460,16 @@ function vtkCamera(publicAPI, model) {
       return model.viewMatrix;
     }
 
-    const result = mat4.create();
-
     mat4.lookAt(
       tmpMatrix,
-      vec3.fromValues(...model.position), // eye
-      vec3.fromValues(...model.focalPoint), // at
-      vec3.fromValues(...model.viewUp) // up
+      model.position, // eye
+      model.focalPoint, // at
+      model.viewUp // up
     );
 
     mat4.transpose(tmpMatrix, tmpMatrix);
 
+    const result = new Float64Array(16);
     mat4.copy(result, tmpMatrix);
     return result;
   };
@@ -536,7 +479,8 @@ function vtkCamera(publicAPI, model) {
   };
 
   publicAPI.getProjectionMatrix = (aspect, nearz, farz) => {
-    const result = mat4.create();
+    const result = new Float64Array(16);
+    mat4.identity(result);
 
     if (model.projectionMatrix) {
       const scale = 1 / model.physicalScale;
@@ -610,10 +554,10 @@ function vtkCamera(publicAPI, model) {
   publicAPI.getCompositeProjectionMatrix = (aspect, nearz, farz) => {
     const vMat = publicAPI.getViewMatrix();
     const pMat = publicAPI.getProjectionMatrix(aspect, nearz, farz);
-    const result = mat4.create();
     // mats are transposed so the order is A then B
-    mat4.multiply(result, vMat, pMat);
-    return result;
+    // we reuse pMat as it is a copy so we can do what we want with it
+    mat4.multiply(pMat, vMat, pMat);
+    return pMat;
   };
 
   publicAPI.setDirectionOfProjection = (x, y, z) => {
@@ -658,7 +602,8 @@ function vtkCamera(publicAPI, model) {
     const physVRight = [3];
     vtkMath.cross(model.physicalViewNorth, model.physicalViewUp, physVRight);
 
-    const rotmat = mat4.create(); // phone to physical coordinates
+    // phone to physical coordinates
+    const rotmat = mat4.identity(new Float64Array(16));
     mat4.rotate(
       rotmat,
       rotmat,
@@ -680,16 +625,12 @@ function vtkCamera(publicAPI, model) {
       model.physicalViewUp
     );
 
-    const dop = vec3.fromValues(
+    const dop = new Float64Array([
       -model.physicalViewUp[0],
       -model.physicalViewUp[1],
-      -model.physicalViewUp[2]
-    );
-    const vup = vec3.fromValues(
-      model.physicalViewNorth[0],
-      model.physicalViewNorth[1],
-      model.physicalViewNorth[2]
-    );
+      -model.physicalViewUp[2],
+    ]);
+    const vup = new Float64Array(model.physicalViewNorth);
     vec3.transformMat4(dop, dop, rotmat);
     vec3.transformMat4(vup, vup, rotmat);
 
@@ -699,7 +640,7 @@ function vtkCamera(publicAPI, model) {
   };
 
   publicAPI.setOrientationWXYZ = (degrees, x, y, z) => {
-    const quatMat = mat4.create();
+    const quatMat = mat4.identity(new Float64Array(16));
 
     if (degrees !== 0.0 && (x !== 0.0 || y !== 0.0 || z !== 0.0)) {
       // convert to radians
@@ -709,13 +650,11 @@ function vtkCamera(publicAPI, model) {
       mat4.fromQuat(quatMat, q);
     }
 
-    const dop = vec3.fromValues(0.0, 0.0, -1.0);
-    const newdop = vec3.create();
-    vec3.transformMat4(newdop, dop, quatMat);
+    const newdop = new Float64Array(3);
+    vec3.transformMat4(newdop, [0.0, 0.0, -1.0], quatMat);
 
-    const vup = vec3.fromValues(0.0, 1.0, 0.0);
-    const newvup = vec3.create();
-    vec3.transformMat4(newvup, vup, quatMat);
+    const newvup = new Float64Array(3);
+    vec3.transformMat4(newvup, [0.0, 1.0, 0.0], quatMat);
 
     publicAPI.setDirectionOfProjection(...newdop);
     publicAPI.setViewUp(...newvup);

--- a/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
+++ b/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
@@ -64,9 +64,9 @@ test.onlyIfWebGL('Test vtkCellPicker image mapper', (t) => {
   const positions = picker.getPickedPositions();
   t.equal(positions.length, 1);
   const xyz = positions[0];
-  t.equal(xyz[0], 64.49344014125458);
-  t.equal(xyz[1], 75.65265009452136);
-  t.equal(xyz[2], 12.000000145434939);
+  t.equal(xyz[0], 64.49344091067883);
+  t.equal(xyz[1], 75.65264519589407);
+  t.equal(xyz[2], 12);
 
   const ijk = picker.getCellIJK();
   t.equal(ijk[0], 64);

--- a/Sources/Rendering/Core/CubeAxesActor/index.js
+++ b/Sources/Rendering/Core/CubeAxesActor/index.js
@@ -1,4 +1,4 @@
-import { glMatrix, vec3, mat4 } from 'gl-matrix';
+import { vec3, mat4 } from 'gl-matrix';
 import * as d3 from 'd3-scale';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import macro from 'vtk.js/Sources/macro';
@@ -56,16 +56,13 @@ const faceAxes = [
 ];
 
 // some shared temp variables to reduce heap allocs
-const previousMatrixType = glMatrix.ARRAY_TYPE;
-glMatrix.setMatrixArrayType(Float64Array);
-const ptv3 = vec3.create();
-const pt2v3 = vec3.create();
-const tmpv3 = vec3.create();
-const tmp2v3 = vec3.create();
-const xDir = vec3.create();
-const yDir = vec3.create();
-const invmat = mat4.create();
-glMatrix.setMatrixArrayType(previousMatrixType);
+const ptv3 = new Float64Array(3);
+const pt2v3 = new Float64Array(3);
+const tmpv3 = new Float64Array(3);
+const tmp2v3 = new Float64Array(3);
+const xDir = new Float64Array(3);
+const yDir = new Float64Array(3);
+const invmat = new Float64Array(16);
 
 function applyTextStyle(ctx, style) {
   ctx.strokeStyle = style.strokeColor;

--- a/Sources/Rendering/Core/Follower/index.js
+++ b/Sources/Rendering/Core/Follower/index.js
@@ -37,24 +37,23 @@ function vtkFollower(publicAPI, model) {
 
       if (model.camera) {
         // first compute our target viewUp
-        const vup = vec3.fromValues(model.viewUp);
+        const vup = new Float64Array(model.viewUp);
         if (!model.useViewUp) {
           vec3.set(vup, ...model.camera.getViewUp());
         }
 
         // compute a vpn
-        const vpn = vec3.create();
+        const vpn = new Float64Array(3);
         if (model.camera.getParallelProjection()) {
           vec3.set(vpn, model.camera.getViewPlaneNormal());
         } else {
           vec3.set(vpn, ...model.position);
-          const tmpv3 = vec3.fromValues(...model.camera.getPosition());
-          vec3.subtract(vpn, tmpv3, vpn);
+          vec3.subtract(vpn, model.camera.getPosition(), vpn);
           vec3.normalize(vpn, vpn);
         }
 
         // compute vright
-        const vright = vec3.create();
+        const vright = new Float64Array(3);
         vec3.cross(vright, vup, vpn);
         vec3.normalize(vright, vright);
 
@@ -109,8 +108,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkActor.extend(publicAPI, model, initialValues);
 
-  model.followerMatrix = mat4.create();
-  mat4.identity(model.followerMatrix);
+  model.followerMatrix = mat4.identity(new Float64Array(16));
 
   // Build VTK API
   macro.setGet(publicAPI, model, ['useViewUp', 'camera']);

--- a/Sources/Rendering/Core/Glyph3DMapper/index.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.js
@@ -121,11 +121,11 @@ function vtkGlyph3DMapper(publicAPI, model) {
       model.bounds[4] = vtkBoundingBox.INIT_BOUNDS[4];
       model.bounds[5] = vtkBoundingBox.INIT_BOUNDS[5];
 
-      const tcorner = vec3.create();
+      const tcorner = new Float64Array(3);
 
       const oArray = publicAPI.getOrientationArrayData();
 
-      const identity = mat4.create();
+      const identity = mat4.identity(new Float64Array(16));
       const trans = [];
       const scale = [];
       const numPts = pts.length / 3;

--- a/Sources/Rendering/Core/ImageSlice/index.js
+++ b/Sources/Rendering/Core/ImageSlice/index.js
@@ -1,5 +1,6 @@
 import { vec3, mat4 } from 'gl-matrix';
 import macro from 'vtk.js/Sources/macro';
+import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import vtkProp3D from 'vtk.js/Sources/Rendering/Core/Prop3D';
 import vtkImageProperty from 'vtk.js/Sources/Rendering/Core/ImageProperty';
 
@@ -88,19 +89,11 @@ function vtkImageSlice(publicAPI, model) {
     ) {
       vtkDebugMacro('Recomputing bounds...');
       model.mapperBounds = bds.map((x) => x);
-      const bbox = [
-        vec3.fromValues(bds[1], bds[3], bds[5]),
-        vec3.fromValues(bds[1], bds[2], bds[5]),
-        vec3.fromValues(bds[0], bds[2], bds[5]),
-        vec3.fromValues(bds[0], bds[3], bds[5]),
-        vec3.fromValues(bds[1], bds[3], bds[4]),
-        vec3.fromValues(bds[1], bds[2], bds[4]),
-        vec3.fromValues(bds[0], bds[2], bds[4]),
-        vec3.fromValues(bds[0], bds[3], bds[4]),
-      ];
+      const bbox = [];
+      vtkBoundingBox.getCorners(bds, bbox);
 
       publicAPI.computeMatrix();
-      const tmp4 = mat4.create();
+      const tmp4 = new Float64Array(16);
       mat4.transpose(tmp4, model.matrix);
       bbox.forEach((pt) => vec3.transformMat4(pt, pt, tmp4));
 
@@ -130,19 +123,10 @@ function vtkImageSlice(publicAPI, model) {
       return bds;
     }
 
-    const bbox = [
-      vec3.fromValues(bds[1], bds[3], bds[5]),
-      vec3.fromValues(bds[1], bds[2], bds[5]),
-      vec3.fromValues(bds[0], bds[2], bds[5]),
-      vec3.fromValues(bds[0], bds[3], bds[5]),
-      vec3.fromValues(bds[1], bds[3], bds[4]),
-      vec3.fromValues(bds[1], bds[2], bds[4]),
-      vec3.fromValues(bds[0], bds[2], bds[4]),
-      vec3.fromValues(bds[0], bds[3], bds[4]),
-    ];
-
+    const bbox = [];
+    vtkBoundingBox.getCorners(bds, bbox);
     publicAPI.computeMatrix();
-    const tmp4 = mat4.create();
+    const tmp4 = new Float64Array(16);
     mat4.transpose(tmp4, model.matrix);
     bbox.forEach((pt) => vec3.transformMat4(pt, pt, tmp4));
 

--- a/Sources/Rendering/Core/Picker/index.js
+++ b/Sources/Rendering/Core/Picker/index.js
@@ -89,8 +89,8 @@ function vtkPicker(publicAPI, model) {
     let tol = 0.0;
     let props = [];
     let pickable = false;
-    const p1Mapper = vec4.create();
-    const p2Mapper = vec4.create();
+    const p1Mapper = new Float64Array(4);
+    const p2Mapper = new Float64Array(4);
     const bbox = [...vtkBoundingBox.INIT_BOUNDS];
     const t = [];
     const hitPosition = [];

--- a/Sources/Rendering/Core/PixelSpaceCallbackMapper/index.js
+++ b/Sources/Rendering/Core/PixelSpaceCallbackMapper/index.js
@@ -29,7 +29,7 @@ function vtkPixelSpaceCallbackMapper(publicAPI, model) {
     mat4.transpose(matrix, matrix);
 
     const dataPoints = dataset.getPoints();
-    const result = vec3.fromValues(0, 0, 0);
+    const result = new Float64Array(3);
     const width = windowSize.usize;
     const height = windowSize.vsize;
     const hw = width / 2;
@@ -38,10 +38,7 @@ function vtkPixelSpaceCallbackMapper(publicAPI, model) {
 
     for (let pidx = 0; pidx < dataPoints.getNumberOfPoints(); pidx += 1) {
       const point = dataPoints.getPoint(pidx);
-      result[0] = point[0];
-      result[1] = point[1];
-      result[2] = point[2];
-      vec3.transformMat4(result, result, matrix);
+      vec3.transformMat4(result, point, matrix);
       const coord = [result[0] * hw + hw, result[1] * hh + hh, result[2], 0];
 
       if (depthValues) {

--- a/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
+++ b/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
@@ -63,9 +63,9 @@ test.onlyIfWebGL('Test vtkPointPicker image mapper', (t) => {
   const positions = picker.getPickedPositions();
   t.equal(positions.length, 1);
   const xyz = positions[0];
-  t.equal(xyz[0], 64.49344014125458);
-  t.equal(xyz[1], 75.65265009452136);
-  t.equal(xyz[2], 12.000000145434939);
+  t.equal(xyz[0], 64.49344091067883);
+  t.equal(xyz[1], 75.65264519589407);
+  t.equal(xyz[2], 12);
 
   const ijk = picker.getPointIJK();
   t.equal(ijk[0], 64);

--- a/Sources/Rendering/Core/Prop3D/index.js
+++ b/Sources/Rendering/Core/Prop3D/index.js
@@ -1,4 +1,4 @@
-import { vec3, quat, mat4 } from 'gl-matrix';
+import { quat, mat4 } from 'gl-matrix';
 
 import macro from 'vtk.js/Sources/macro';
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
@@ -23,7 +23,7 @@ function vtkProp3D(publicAPI, model) {
   publicAPI.getOrientationWXYZ = () => {
     const q = quat.create();
     mat4.getRotation(q, model.rotation);
-    const oaxis = vec3.create();
+    const oaxis = new Float64Array(3);
     const w = quat.getAxisAngle(oaxis, q);
     return [vtkMath.degreesFromRadians(w), oaxis[0], oaxis[1], oaxis[2]];
   };
@@ -75,7 +75,7 @@ function vtkProp3D(publicAPI, model) {
     const q = quat.create();
     quat.setAxisAngle(q, [x, y, z], angle);
 
-    const quatMat = mat4.create();
+    const quatMat = new Float64Array(16);
     mat4.fromQuat(quatMat, q);
     mat4.multiply(model.rotation, model.rotation, quatMat);
     publicAPI.modified();
@@ -191,9 +191,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGetArray(publicAPI, model, ['origin', 'position', 'scale'], 3);
 
   // Object internal instance
-  model.matrix = mat4.create();
-  model.rotation = mat4.create();
-  model.userMatrix = mat4.create();
+  model.matrix = mat4.identity(new Float64Array(16));
+  model.rotation = mat4.identity(new Float64Array(16));
+  model.userMatrix = mat4.identity(new Float64Array(16));
   model.transform = null; // FIXME
 
   // Object methods

--- a/Sources/Rendering/Core/Prop3D/test/testUserMatrix.js
+++ b/Sources/Rendering/Core/Prop3D/test/testUserMatrix.js
@@ -43,7 +43,7 @@ test.onlyIfWebGL('Test Set Actor User Matrix', (t) => {
   actor.setMapper(mapper);
   renderer.addActor(actor);
 
-  const userMatrix = mat4.create();
+  const userMatrix = mat4.identity(new Float64Array(16));
   mat4.rotateZ(userMatrix, userMatrix, Math.PI / 4);
   actor.setUserMatrix(userMatrix);
 

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -255,9 +255,9 @@ function vtkRenderer(publicAPI, model) {
     mat4.transpose(matrix, matrix);
 
     // Transform point to world coordinates
-    const result = vec3.fromValues(x, y, z);
+    const result = new Float64Array([x, y, z]);
     vec3.transformMat4(result, result, matrix);
-    return [result[0], result[1], result[2]];
+    return result;
   };
 
   publicAPI.projectionToView = (x, y, z, aspect) => {
@@ -275,9 +275,9 @@ function vtkRenderer(publicAPI, model) {
     mat4.transpose(matrix, matrix);
 
     // Transform point to world coordinates
-    const result = vec3.fromValues(x, y, z);
+    const result = new Float64Array([x, y, z]);
     vec3.transformMat4(result, result, matrix);
-    return [result[0], result[1], result[2]];
+    return result;
   };
 
   // Convert world point coordinates to view coordinates.
@@ -293,9 +293,9 @@ function vtkRenderer(publicAPI, model) {
     const matrix = model.activeCamera.getViewMatrix();
     mat4.transpose(matrix, matrix);
 
-    const result = vec3.fromValues(x, y, z);
+    const result = new Float64Array([x, y, z]);
     vec3.transformMat4(result, result, matrix);
-    return [result[0], result[1], result[2]];
+    return result;
   };
 
   // Convert world point coordinates to view coordinates.
@@ -312,9 +312,9 @@ function vtkRenderer(publicAPI, model) {
     const matrix = model.activeCamera.getProjectionMatrix(aspect, -1.0, 1.0);
     mat4.transpose(matrix, matrix);
 
-    const result = vec3.fromValues(x, y, z);
+    const result = new Float64Array([x, y, z]);
     vec3.transformMat4(result, result, matrix);
-    return [result[0], result[1], result[2]];
+    return result;
   };
 
   publicAPI.computeVisiblePropBounds = () => {

--- a/Sources/Rendering/Core/Volume/index.js
+++ b/Sources/Rendering/Core/Volume/index.js
@@ -1,5 +1,6 @@
 import { vec3, mat4 } from 'gl-matrix';
 import macro from 'vtk.js/Sources/macro';
+import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import vtkProp3D from 'vtk.js/Sources/Rendering/Core/Prop3D';
 import vtkVolumeProperty from 'vtk.js/Sources/Rendering/Core/VolumeProperty';
 
@@ -59,19 +60,10 @@ function vtkVolume(publicAPI, model) {
     ) {
       vtkDebugMacro('Recomputing bounds...');
       model.mapperBounds = bds.map((x) => x);
-      const bbox = [
-        vec3.fromValues(bds[1], bds[3], bds[5]),
-        vec3.fromValues(bds[1], bds[2], bds[5]),
-        vec3.fromValues(bds[0], bds[2], bds[5]),
-        vec3.fromValues(bds[0], bds[3], bds[5]),
-        vec3.fromValues(bds[1], bds[3], bds[4]),
-        vec3.fromValues(bds[1], bds[2], bds[4]),
-        vec3.fromValues(bds[0], bds[2], bds[4]),
-        vec3.fromValues(bds[0], bds[3], bds[4]),
-      ];
-
+      const bbox = [];
+      vtkBoundingBox.getCorners(bds, bbox);
       publicAPI.computeMatrix();
-      const tmp4 = mat4.create();
+      const tmp4 = new Float64Array(16);
       mat4.transpose(tmp4, model.matrix);
       bbox.forEach((pt) => vec3.transformMat4(pt, pt, tmp4));
 

--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -187,8 +187,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.keyMatrixTime = {};
   macro.obj(model.keyMatrixTime, { mtime: 0 });
   model.keyMatrices = {
-    normalMatrix: mat3.create(),
-    mcwc: mat4.create(),
+    normalMatrix: mat3.identity(new Float64Array(9)),
+    mcwc: mat4.identity(new Float64Array(16)),
   };
 
   // Build VTK API

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -105,11 +105,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.keyMatrixTime = {};
   macro.obj(model.keyMatrixTime);
 
+  // values always get set by the get method
   model.keyMatrices = {
-    normalMatrix: mat3.create(),
-    vcpc: mat4.create(),
-    wcvc: mat4.create(),
-    wcpc: mat4.create(),
+    normalMatrix: new Float64Array(9),
+    vcpc: new Float64Array(16),
+    wcvc: new Float64Array(16),
+    wcpc: new Float64Array(16),
   };
 
   // Build VTK API

--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -12,10 +12,10 @@ const { vtkErrorMacro } = macro;
 // ----------------------------------------------------------------------------
 
 function computeInverseShiftAndScaleMatrix(coordShift, coordScale) {
-  const inverseScale = vec3.create();
+  const inverseScale = new Float64Array(3);
   vec3.inverse(inverseScale, coordScale);
 
-  const matrix = mat4.create();
+  const matrix = new Float64Array(16);
   mat4.fromRotationTranslationScale(
     matrix,
     quat.create(),
@@ -265,8 +265,8 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
 
     if (useShiftAndScale) {
       // Compute shift and scale vectors
-      const coordShift = vec3.create();
-      const coordScale = vec3.create();
+      const coordShift = new Float64Array(3);
+      const coordScale = new Float64Array(3);
       for (let i = 0; i < 3; ++i) {
         const range = options.points.getRange(i);
         const delta = range[1] - range[0];
@@ -354,7 +354,7 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
   publicAPI.setCoordShiftAndScale = (coordShift, coordScale) => {
     if (
       coordShift !== null &&
-      (coordShift.constructor !== Float32Array || coordShift.length !== 3)
+      (coordShift.constructor !== Float64Array || coordShift.length !== 3)
     ) {
       vtkErrorMacro('Wrong type for coordShift, expected vec3 or null');
       return;
@@ -362,7 +362,7 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
 
     if (
       coordScale !== null &&
-      (coordScale.constructor !== Float32Array || coordScale.length !== 3)
+      (coordScale.constructor !== Float64Array || coordScale.length !== 3)
     ) {
       vtkErrorMacro('Wrong type for coordScale, expected vec3 or null');
       return;

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -682,10 +682,10 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkOpenGLPolyDataMapper.extend(publicAPI, model, initialValues);
 
-  model.tmpMat3 = mat3.create();
-  model.normalMatrix = mat3.create();
-  model.mcpcMatrix = mat4.create();
-  model.mcvcMatrix = mat4.create();
+  model.tmpMat3 = mat3.identity(new Float64Array(9));
+  model.normalMatrix = mat3.identity(new Float64Array(9));
+  model.mcpcMatrix = mat4.identity(new Float64Array(16));
+  model.mcvcMatrix = mat4.identity(new Float64Array(16));
   model.tmpColor = [];
 
   model.glyphBOBuildTime = {};

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -986,7 +986,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.colorTexture = vtkOpenGLTexture.newInstance();
   model.pwfTexture = vtkOpenGLTexture.newInstance();
 
-  model.imagemat = mat4.create();
+  model.imagemat = mat4.identity(new Float64Array(16));
 
   // Build VTK API
   macro.setGet(publicAPI, model, []);

--- a/Sources/Rendering/OpenGL/ImageSlice/index.js
+++ b/Sources/Rendering/OpenGL/ImageSlice/index.js
@@ -141,7 +141,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.keyMatrixTime = {};
   macro.obj(model.keyMatrixTime, { mtime: 0 });
   model.keyMatrices = {
-    mcwc: mat4.create(),
+    mcwc: mat4.identity(new Float64Array(16)),
   };
 
   // Build VTK API

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1430,8 +1430,8 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       const status = light.getSwitch();
       if (status > 0.0) {
         const lp = light.getTransformedPosition();
-        const np = vec3.fromValues(lp[0], lp[1], lp[2]);
-        vec3.transformMat4(np, np, viewTF);
+        const np = new Float64Array(3);
+        vec3.transformMat4(np, lp, viewTF);
         program.setUniform3fArray(
           `lightAttenuation${numberOfLights}`,
           light.getAttenuationValuesByReference()
@@ -1953,8 +1953,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.primitives = [];
   model.primTypes = primTypes;
 
-  model.tmpMat3 = mat3.create();
-  model.tmpMat4 = mat4.create();
+  model.tmpMat3 = mat3.identity(new Float64Array(9));
+  model.tmpMat4 = mat4.identity(new Float64Array(16));
 
   for (let i = primTypes.Start; i < primTypes.End; i++) {
     model.primitives[i] = vtkHelper.newInstance();

--- a/Sources/Rendering/OpenGL/ShaderProgram/index.js
+++ b/Sources/Rendering/OpenGL/ShaderProgram/index.js
@@ -140,7 +140,8 @@ function vtkShaderProgram(publicAPI, model) {
       model.error = `Could not set uniform ${name} . No such uniform.`;
       return false;
     }
-    model.context.uniformMatrix4fv(location, false, v);
+    const f32 = new Float32Array(v);
+    model.context.uniformMatrix4fv(location, false, f32);
     return true;
   };
 
@@ -150,7 +151,8 @@ function vtkShaderProgram(publicAPI, model) {
       model.error = `Could not set uniform ${name} . No such uniform.`;
       return false;
     }
-    model.context.uniformMatrix3fv(location, false, v);
+    const f32 = new Float32Array(v);
+    model.context.uniformMatrix3fv(location, false, f32);
     return true;
   };
 

--- a/Sources/Rendering/OpenGL/Skybox/index.js
+++ b/Sources/Rendering/OpenGL/Skybox/index.js
@@ -62,7 +62,7 @@ function vtkOpenGLSkybox(publicAPI, model) {
       const ren = model.openGLRenderer.getRenderable();
 
       const keyMats = model.openGLCamera.getKeyMatrices(ren);
-      const imat = mat4.create();
+      const imat = new Float64Array(16);
       mat4.invert(imat, keyMats.wcpc);
       model.tris.getProgram().setUniformMatrix('IMCPCMatrix', imat);
 
@@ -256,8 +256,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.keyMatrixTime = {};
   macro.obj(model.keyMatrixTime, { mtime: 0 });
   model.keyMatrices = {
-    normalMatrix: mat3.create(),
-    mcwc: mat4.create(),
+    normalMatrix: mat3.identity(new Float64Array(9)),
+    mcwc: mat4.identity(new Float64Array(16)),
   };
 
   // Build VTK API

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -185,7 +185,7 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
     if (program.isUniformUsed('MCVCMatrix')) {
       if (!actor.getIsIdentity()) {
         const actMats = model.openGLActor.getKeyMatrices();
-        const tmp4 = mat4.create();
+        const tmp4 = new Float64Array(16);
         mat4.multiply(tmp4, keyMats.wcvc, actMats.mcwc);
         program.setUniformMatrix('MCVCMatrix', tmp4);
       } else {

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -244,14 +244,13 @@ function vtkOpenGLStickMapper(publicAPI, model) {
 
     if (!actor.getIsIdentity()) {
       const actMats = model.openGLActor.getKeyMatrices();
-      const tmp4 = mat4.create();
-
       if (program.isUniformUsed('MCVCMatrix')) {
+        const tmp4 = new Float64Array(16);
         mat4.multiply(tmp4, keyMats.wcvc, actMats.mcwc);
         program.setUniformMatrix('MCVCMatrix', tmp4);
       }
       if (program.isUniformUsed('normalMatrix')) {
-        const anorms = mat3.create();
+        const anorms = new Float64Array(9);
         mat3.multiply(anorms, keyMats.normalMatrix, actMats.normalMatrix);
         program.setUniformMatrix3x3('normalMatrix', anorms);
       }

--- a/Sources/Rendering/OpenGL/Volume/index.js
+++ b/Sources/Rendering/OpenGL/Volume/index.js
@@ -107,8 +107,9 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.keyMatrixTime = {};
   macro.obj(model.keyMatrixTime, { mtime: 0 });
-  model.normalMatrix = mat3.create();
-  model.MCWCMatrix = mat4.create();
+  // always set by getter
+  model.normalMatrix = new Float64Array(9);
+  model.MCWCMatrix = new Float64Array(16);
 
   // Build VTK API
   macro.setGet(publicAPI, model, ['context']);

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -166,7 +166,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     // a system will execute every step regardless
     const ext = model.currentInput.getExtent();
     const spc = model.currentInput.getSpacing();
-    const vsize = vec3.create();
+    const vsize = new Float64Array(3);
     vec3.set(
       vsize,
       (ext[1] - ext[0]) * spc[0],
@@ -406,7 +406,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
     const ext = model.currentInput.getExtent();
     const spc = model.currentInput.getSpacing();
-    const vsize = vec3.create();
+    const vsize = new Float64Array(3);
     vec3.set(
       vsize,
       (ext[1] - ext[0]) * spc[0],
@@ -580,8 +580,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
     // compute the viewport bounds of the volume
     // we will only render those fragments.
-    const pos = vec3.create();
-    const dir = vec3.create();
+    const pos = new Float64Array(3);
+    const dir = new Float64Array(3);
     let dcxmin = 1.0;
     let dcxmax = -1.0;
     let dcymin = 1.0;
@@ -626,7 +626,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
     const ext = model.currentInput.getExtent();
     const spc = model.currentInput.getSpacing();
-    const vsize = vec3.create();
+    const vsize = new Float64Array(3);
     vec3.set(
       vsize,
       (ext[1] - ext[0] + 1) * spc[0],
@@ -667,7 +667,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         volumeMapper sampleDistance or its maximum number of samples.`);
     }
 
-    const vctoijk = vec3.create();
+    const vctoijk = new Float64Array(3);
 
     vec3.set(vctoijk, 1.0, 1.0, 1.0);
     vec3.divide(vctoijk, vctoijk, vsize);
@@ -685,8 +685,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
     // map normals through normal matrix
     // then use a point on the plane to compute the distance
-    const normal = vec3.create();
-    const pos2 = vec3.create();
+    const normal = new Float64Array(3);
+    const pos2 = new Float64Array(3);
     for (let i = 0; i < 6; ++i) {
       switch (i) {
         default:
@@ -1495,11 +1495,11 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.jitterTexture.setWrapT(Wrap.REPEAT);
   model.framebuffer = vtkOpenGLFramebuffer.newInstance();
 
-  model.idxToView = mat4.create();
-  model.idxNormalMatrix = mat3.create();
-  model.modelToView = mat4.create();
-  model.projectionToView = mat4.create();
-  model.projectionToWorld = mat4.create();
+  model.idxToView = mat4.identity(new Float64Array(16));
+  model.idxNormalMatrix = mat3.identity(new Float64Array(9));
+  model.modelToView = mat4.identity(new Float64Array(16));
+  model.projectionToView = mat4.identity(new Float64Array(16));
+  model.projectionToWorld = mat4.identity(new Float64Array(16));
 
   // Build VTK API
   macro.setGet(publicAPI, model, ['context']);

--- a/Sources/Rendering/WebGPU/Actor/index.js
+++ b/Sources/Rendering/WebGPU/Actor/index.js
@@ -183,8 +183,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.keyMatrixTime = {};
   macro.obj(model.keyMatrixTime, { mtime: 0 });
   model.keyMatrices = {
-    normalMatrix: mat3.create(),
-    mcwc: mat4.create(),
+    normalMatrix: new Float64Array(9),
+    mcwc: new Float64Array(16),
   };
 
   // Build VTK API

--- a/Sources/Rendering/WebGPU/PolyDataMapper/index.js
+++ b/Sources/Rendering/WebGPU/PolyDataMapper/index.js
@@ -785,8 +785,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkViewNode.extend(publicAPI, model, initialValues);
 
-  model.tmpMat3 = mat3.create();
-  model.tmpMat4 = mat4.create();
+  model.tmpMat3 = mat3.identity(new Float64Array(9));
+  model.tmpMat4 = mat4.identity(new Float64Array(16));
   model.UBOData = new Float32Array(vtkWebGPUPolyDataMapperUBOSize);
   model.UBOUpdateTime = {};
   macro.obj(model.UBOUpdateTime);

--- a/Sources/Rendering/WebGPU/Renderer/index.js
+++ b/Sources/Rendering/WebGPU/Renderer/index.js
@@ -328,7 +328,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.UBOUpdateTime = {};
   macro.obj(model.UBOUpdateTime);
 
-  model.tmpMat4 = mat4.create();
+  model.tmpMat4 = mat4.identity(new Float64Array(16));
 
   // Build VTK API
   macro.get(publicAPI, model, ['renderPass']);

--- a/Sources/Widgets/Manipulators/TrackballManipulator/index.js
+++ b/Sources/Widgets/Manipulators/TrackballManipulator/index.js
@@ -23,22 +23,22 @@ export function trackballRotate(
   const xdeg = (360.0 * dx) / size[0];
   const ydeg = (360.0 * dy) / size[1];
 
-  const newDirection = vec3.fromValues(
+  const newDirection = new Float64Array([
     direction[0],
     direction[1],
-    direction[2]
-  );
+    direction[2],
+  ]);
 
   const xDisplayAxis = viewUp;
   const yDisplayAxis = [0, 0, 0];
   vtkMath.cross(dop, viewUp, yDisplayAxis);
 
-  const rot = mat4.create();
+  const rot = mat4.identity(new Float64Array(16));
   mat4.rotate(rot, rot, vtkMath.radiansFromDegrees(xdeg), xDisplayAxis);
   mat4.rotate(rot, rot, vtkMath.radiansFromDegrees(-ydeg), yDisplayAxis);
 
   vec3.transformMat4(newDirection, newDirection, rot);
-  return [newDirection[0], newDirection[1], newDirection[2]];
+  return newDirection;
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
@@ -195,7 +195,7 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
    * Returns the orientation matrix to align glyph on model.orientation.
    * */
   function getOrientationRotation(viewMatrixInv) {
-    const displayOrientation = vec3.create();
+    const displayOrientation = new Float64Array(3);
     const baseDir = [0, 1, 0];
 
     vec3.transformMat3(displayOrientation, model.orientation, viewMatrixInv);
@@ -205,13 +205,13 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
       .buildFromDegree()
       .rotateFromDirections(baseDir, displayOrientation)
       .getMatrix();
-    const displayRotation = mat3.create();
+    const displayRotation = new Float64Array(9);
     mat3.fromMat4(displayRotation, displayMatrix);
     return displayRotation;
   }
 
   function getCameraFacingRotation(scale3, displayRotation, viewMatrix) {
-    const rotation = mat3.create();
+    const rotation = new Float64Array(9);
     mat3.multiply(rotation, viewMatrix, displayRotation);
     vec3.transformMat3(scale3, scale3, rotation);
     return rotation;
@@ -228,16 +228,18 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
       model.faceCamera === true ||
       (model.faceCamera == null && publicAPI.is2DShape());
 
-    const viewMatrix = mat3.create();
+    const viewMatrix = new Float64Array(9);
     mat3.fromMat4(viewMatrix, model.viewMatrix);
-    const viewMatrixInv = mat3.create();
+    const viewMatrixInv = mat3.identity(new Float64Array(9));
     if (shouldFaceCamera) {
       mat3.invert(viewMatrixInv, viewMatrix);
     }
 
-    let orientationRotation = mat3.create();
+    let orientationRotation = null;
     if (publicAPI.isOrientableShape()) {
       orientationRotation = getOrientationRotation(viewMatrixInv);
+    } else {
+      orientationRotation = mat3.identity(new Float64Array(9));
     }
     if (shouldFaceCamera) {
       orientationRotation = getCameraFacingRotation(
@@ -344,14 +346,12 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
  *    - false to not face camera
  */
 function defaultValues(initialValues) {
-  const viewMatrix = new Float64Array(16);
-  mat4.identity(viewMatrix);
   return {
     defaultScale: 1,
     faceCamera: null,
     orientation: [1, 0, 0],
     shape: ShapeType.SPHERE,
-    viewMatrix,
+    viewMatrix: mat4.identity(new Float64Array(16)),
     ...initialValues,
   };
 }

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers.js
@@ -6,10 +6,9 @@ export const AXES = ['-', '=', '+'];
 // ----------------------------------------------------------------------------
 
 export function transformVec3(ain, transform) {
-  const vin = vec3.fromValues(ain[0], ain[1], ain[2]);
-  const vout = vec3.create();
-  vec3.transformMat4(vout, vin, transform);
-  return [vout[0], vout[1], vout[2]];
+  const vout = new Float64Array(3);
+  vec3.transformMat4(vout, ain, transform);
+  return vout;
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -57,9 +57,9 @@ function setCamera(sliceMode, renderer, data) {
   const ijk = [0, 0, 0];
   const position = [0, 0, 0];
   const focalPoint = [0, 0, 0];
-  data.indexToWorldVec3(ijk, focalPoint);
+  data.indexToWorld(ijk, focalPoint);
   ijk[sliceMode] = 1;
-  data.indexToWorldVec3(ijk, position);
+  data.indexToWorld(ijk, position);
   renderer.getActiveCamera().set({ focalPoint, position });
   renderer.resetCamera();
 }
@@ -270,7 +270,7 @@ reader
 
         // position
         ijk[slicingMode] = image.imageMapper.getSlice();
-        data.indexToWorldVec3(ijk, position);
+        data.indexToWorld(ijk, position);
 
         widgets.paintWidget.getManipulator().setOrigin(position);
         widgets.rectangleWidget.getManipulator().setOrigin(position);

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -429,8 +429,7 @@ function vtkResliceCursorWidget(publicAPI, model) {
     const planeSizeX = vtkMath.normalize(planeAxis1);
     const planeSizeY = vtkMath.normalize(planeAxis2);
 
-    const newResliceAxes = mat4.create();
-    mat4.identity(newResliceAxes);
+    const newResliceAxes = mat4.identity(new Float64Array(16));
 
     for (let i = 0; i < 3; i++) {
       newResliceAxes[4 * i + 0] = planeAxis1[i];
@@ -561,7 +560,7 @@ function vtkResliceCursorWidget(publicAPI, model) {
    * Return the reslice cursor matrix built as such: [YZ, XZ, XY, center]
    */
   publicAPI.getResliceMatrix = () => {
-    const resliceMatrix = mat4.create();
+    const resliceMatrix = mat4.identity(new Float64Array(16));
 
     for (let i = 0; i < 3; i++) {
       resliceMatrix[4 * i + 0] = publicAPI.getPlaneNormalFromViewType(

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -57,9 +57,9 @@ function setCamera(sliceMode, renderer, data) {
   const ijk = [0, 0, 0];
   const position = [0, 0, 0];
   const focalPoint = [0, 0, 0];
-  data.indexToWorldVec3(ijk, focalPoint);
+  data.indexToWorld(ijk, focalPoint);
   ijk[sliceMode] = 1;
-  data.indexToWorldVec3(ijk, position);
+  data.indexToWorld(ijk, position);
   renderer.getActiveCamera().set({ focalPoint, position });
   renderer.resetCamera();
 }
@@ -301,7 +301,7 @@ reader
 
         // position
         ijk[slicingMode] = image.imageMapper.getSlice();
-        data.indexToWorldVec3(ijk, position);
+        data.indexToWorld(ijk, position);
 
         widgets.rectangleWidget.getManipulator().setOrigin(position);
         widgets.ellipseWidget.getManipulator().setOrigin(position);


### PR DESCRIPTION
The default for gl-matrix is Float32Array but we want Float64Array for
our calculations and a consistent approach.

Removed all .create() methods and replaced with new Float64Array

Added identity calls as needed for matrices.

Cleaned up some cases where more work was being done than we needed.
Still more that could be cleaned up.

Update a couple tests where the improved accuracy resulted in different
test results.