### PR TITLE
docs(ts): fix typescript definitions

### DIFF
--- a/Sources/Common/Core/MatrixBuilder/index.d.ts
+++ b/Sources/Common/Core/MatrixBuilder/index.d.ts
@@ -1,13 +1,18 @@
+import { mat4 } from 'gl-matrix';
+import { TypedArray } from 'vtk.js/Sources/macro';
+
 declare interface Transform {
 
 	/**
 	 * 
 	 * @param useDegree 
 	 */
-	new (useDegree: boolean);
+	new (useDegree?: boolean);
 
 	/**
-	 * 
+	 * Multiplies the current matrix with a transformation matrix created by
+	 * normalizing both direction vectors and rotating around the axis of the
+	 * crossProduct by the angle from the dotProduct of the two directions.
 	 * @param originDirection 
 	 * @param targetDirection 
 	 * @return  
@@ -15,7 +20,8 @@ declare interface Transform {
 	rotateFromDirections(originDirection: number[], targetDirection: number[]): Transform
 
 	/**
-	 * 
+	 * Normalizes the axis of rotation then rotates the current matrix `angle`
+	 * degrees/radians around the provided axis.
 	 * @param angle 
 	 * @param axis 
 	 * @return  
@@ -23,28 +29,28 @@ declare interface Transform {
 	rotate(angle: number, axis: number): Transform
 
 	/**
-	 * 
+	 * Rotates `angle` degrees/radians around the X axis.
 	 * @param angle 
 	 * @return  
 	 */
 	rotateX(angle: number): Transform
 
 	/**
-	 * 
+	 * Rotates `angle` degrees/radians around the Y axis.
 	 * @param angle 
 	 * @return  
 	 */
 	rotateY(angle: number): Transform
 
 	/**
-	 * 
+	 * Rotates `angle` degrees/radians around the Z axis.
 	 * @param angle 
 	 * @return  
 	 */
 	rotateZ(angle: number): Transform
 
 	/**
-	 * 
+	 * Translates the matrix by x, y, z.
 	 * @param x 
 	 * @param y 
 	 * @param z 
@@ -53,7 +59,7 @@ declare interface Transform {
 	translate(x: number, y: number, z: number): Transform
 
 	/**
-	 * 
+	 * Scales the matrix by sx, sy, sz.
 	 * @param sx 
 	 * @param sy 
 	 * @param sz 
@@ -62,42 +68,80 @@ declare interface Transform {
 	scale(sx: number, sy: number, sz: number): Transform
 
 	/**
-	 * 
+	 * Resets the MatrixBuilder to the Identity matrix.
+	 * @param mat4x4 
 	 * @return  
 	 */
+	multiply(mat4x4: mat4): Transform
+
+	/**
+	 * Resets the MatrixBuilder to the Identity matrix.
+	 * @return
+	 */	
 	identity(): Transform
 
 	/**
-	 * -----------
+	 * Multiplies the array by the MatrixBuilder's internal matrix, in sets of
+	 * 3. Updates the array in place. If specified, `offset` starts at a given
+	 * position in the array, and `nbIterations` will determine the number of
+	 * iterations (sets of 3) to loop through. Assumes the `typedArray` is an
+	 * array of multiples of 3, unless specifically handling with offset and
+	 * iterations. Returns the instance for chaining.
 	 * @param typedArray 
 	 * @param offset 
 	 * @param nbIterations 
 	 * @return  
 	 */
-	apply(typedArray: number[], offset: number, nbIterations: number): Transform
+	apply(typedArray: TypedArray, offset?: number, nbIterations?: number): Transform
 
 	/**
-	 * 
+	 * Returns the internal `mat4` matrix.
 	 * @return  
 	 */
-	getMatrix(): Float64Array;
+	getMatrix(): mat4;
 
 	/**
-	 * 
+	 * Copies the given `mat4` into the builder. Useful if you already have a
+	 * transformation matrix and want to transform it further. Returns the
+	 * instance for chaining.
 	 * @param mat4x4 
 	 * @return  
 	 */
-	setMatrix(mat4x4: Float64Array): Transform
+	setMatrix(mat4x4: mat4): Transform
 }
 
 /**
  * 
  * @return {Transform}
  */
-export declare function buildFromDegree(): Transform;
+declare function buildFromDegree(): Transform;
 
 /**
  * 
  * @return {Transform}
  */
-export declare function buildFromRadian(): Transform;
+declare function buildFromRadian(): Transform;
+
+
+/**
+ * The `vtkMatrixBuilder` class provides a system to create a mat4
+ * transformation matrix. All functions return the MatrixBuilder Object
+ * instance, allowing transformations to be chained. Example:
+ * ```js
+ * let point = [2,5,12];
+ * vtkMatrixBuilder.buildfromDegree().translate(1,0,2).rotateZ(45).apply(point);
+ * ```
+ * ## Usage
+ * The vtkMatrixBuilder class has two functions,
+ * `vtkMatrixBuilder.buildFromDegree()` and
+ * `vtkMatrixbuilder.buildFromRadian()`, predefining the angle format used for
+ * transformations and returning a MatrixBuilder instance. The matrix is
+ * initialized with the Identity Matrix.
+ *
+ */
+declare const vtkMatrixBuilder: {
+  buildFromDegree: typeof buildFromDegree,
+  buildFromRadian: typeof buildFromRadian,
+};
+
+export default vtkMatrixBuilder;

--- a/Sources/macro.d.ts
+++ b/Sources/macro.d.ts
@@ -56,6 +56,18 @@ export enum TYPED_ARRAYS {
   Int32Array,
 }
 
+export type TypedArray =
+    | number[]
+    | Uint32Array
+    | Uint16Array
+    | Uint8Array
+    | Uint8ClampedArray
+    | Int32Array
+    | Int16Array
+    | Int8Array
+    | Float64Array
+    | Float32Array;
+
 /**
  * Capitalize provided string.
  * This is typically used to convert the name of a field into its method name.
@@ -368,7 +380,7 @@ export interface VtkDataArray extends VtkObject {
    */
   getComponent(tupleIdx: number, componentIndex: number): number;
   setComponent(tupleIdx: number, componentIndex: number, value: number): void;
-  getData: () => Array<number>;
+  getData: () => TypedArray;
   /**
    * Return the range of the given component.
    *
@@ -394,7 +406,7 @@ export interface VtkDataArray extends VtkObject {
   getDataType: () => string;
   newClone: () => VtkDataArray;
   getName: () => string;
-  setData: (typedArray: Array<number>, numberOfComponents: number) => void;
+  setData: (typedArray: TypedArray, numberOfComponents?: number) => void;
   getState: () => object;
   // --- via macro --
   setName: (name: string) => boolean;


### PR DESCRIPTION
This should fix the `vtkMatrixBuilder` and `setData` definitions

fix #466