### PR TITLE
Add typescript definitions for filters

### DIFF
--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
@@ -1,0 +1,257 @@
+import {
+	VtkObject
+} from 'vtk.js/Sources/macro';
+
+
+/**
+ * 
+ */
+interface IFieldDataInitialValues {
+	/**
+	 * 
+	 * @default []
+	 */
+	arrays: Array<any>;
+
+	/**
+	 * 
+	 * @default []
+	 */
+	copyFieldFlags: Array<any>;
+
+	/**
+	 * 
+	 * @default true
+	 */
+	doCopyAllOn: boolean;
+
+	/**
+	 * 
+	 * @default false
+	 */
+	doCopyAllOff: boolean;
+}
+
+/**
+ * 
+ */
+interface IArrayWithIndex {
+	/**
+	 * 
+	 */
+	array: any[],
+	/**
+	 * 
+	 */
+	index: number;
+}
+
+export interface vtkFieldData extends VtkObject {
+
+	/**
+	 * 
+	 */
+	initialize(): void;
+
+	/**
+	 * 
+	 */
+	initializeFields(): void;
+
+	/**
+	 * 
+	 * @param other 
+	 */
+	copyStructure(other: any): void;
+
+	/**
+	 * 
+	 * @return  
+	 */
+	getNumberOfArrays(): number;
+
+	/**
+	 * 
+	 * @return  
+	 */
+	getNumberOfActiveArrays(): number;
+
+	/**
+	 * 
+	 * @param arr 
+	 * @return  
+	 */
+	addArray(arr: any): number;
+
+	/**
+	 * 
+	 */
+	removeAllArrays(): void;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	removeArray(arrayName: string): void;
+
+	/**
+	 * 
+	 * @param arrayIdx 
+	 */
+	removeArrayByIndex(arrayIdx: any): void;
+
+	/**
+	 * 
+	 * @return  
+	 */
+	getArrays(): any[];
+
+	/**
+	 * 
+	 * @param arraySpec 
+	 */
+	getArray(arraySpec: any): void;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	getArrayByName(arrayName: string): any[] | null;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 * @return  
+	 */
+	getArrayWithIndex(arrayName: string): IArrayWithIndex;
+
+	/**
+	 * 
+	 * @param idx 
+	 */
+	getArrayByIndex(idx: any): any[] | null;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 * @return  
+	 */
+	hasArray(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param idx 
+	 * @return  
+	 */
+	getArrayName(idx: any): string;
+
+	/**
+	 * 
+	 * @return  
+	 */
+	getCopyFieldFlags(): object;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 * @return  
+	 */
+	getFlag(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param other 
+	 * @param fromId 
+	 * @param toId 
+	 */
+	passData(other: any, fromId?: number, toId?: number): void;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	copyFieldOn(arrayName: string): void;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	copyFieldOff(arrayName: string): void;
+
+	/**
+	 * 
+	 */
+	copyAllOn(): void;
+
+	/**
+	 * 
+	 */
+	copyAllOff(): void;
+
+	/**
+	 * 
+	 */
+	clearFieldFlags(): void;
+
+	/**
+	 * 
+	 * @param other 
+	 */
+	deepCopy(other: any): void;
+
+	/**
+	 * 
+	 * @param other 
+	 */
+	copyFlags(other: any): void;
+
+	/**
+	 * TODO: publicAPI.squeeze = () => model.arrays.forEach(entry => entry.data.squeeze());
+	 */
+	reset(): void;
+
+	/**
+	 * TODO: getActualMemorySize
+	 */
+	getMTime(): number;
+
+	/**
+	 * TODO: publicAPI.getField = (ids, other) => { copy ids from other into this model's arrays }
+	 * TODO: publicAPI.getArrayContainingComponent = (component) => ...
+	 */
+	getNumberOfComponents(): number;
+
+	/**
+	 * 
+	 */
+	getNumberOfTuples(): number;
+
+	/**
+	 *   
+	 */
+	getState(): object;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkFieldData characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IFieldDataInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkFieldData.
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IFieldDataInitialValues): vtkFieldData;
+
+/**
+ * 
+ */
+export declare const vtkFieldData: {
+	newInstance: typeof newInstance,
+	extend: typeof extend,
+};
+export default vtkFieldData;

--- a/Sources/Common/DataModel/DataSetAttributes/index.d.ts
+++ b/Sources/Common/DataModel/DataSetAttributes/index.d.ts
@@ -1,0 +1,475 @@
+import {
+	vtkFieldData
+} from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/FieldData';
+
+export enum AttributeTypes {
+	SCALARS,
+	VECTORS,
+	NORMALS,
+	TCOORDS,
+	TENSORS,
+	GLOBALIDS,
+	PEDIGREEIDS,
+	EDGEFLAG,
+	NUM_ATTRIBUTES,
+}
+
+export enum AttributeLimitTypes {
+	MAX,
+	EXACT,
+	NOLIMIT,
+}
+
+export enum CellGhostTypes {
+	/**
+	 * The cell is present on multiple processors
+	 */
+	DUPLICATECELL,
+	/**	
+	 * The cell has more neighbors than in a regular mesh
+	 */
+	HIGHCONNECTIVITYCELL,
+	/**	
+	 * The cell has less neighbors than in a regular mesh
+	 */
+	LOWCONNECTIVITYCELL,
+	/**	
+	 * Tther cells are present that refines it.
+	 */
+	REFINEDCELL,
+	/**	
+	 * The cell is on the exterior of the data set
+	 */
+	EXTERIORCELL,
+	/**	
+	 * The cell is needed to maintain connectivity, but the data values should be ignored.
+	 */
+	HIDDENCELL,
+}
+
+export enum PointGhostTypes {
+	/**
+	 * The cell is present on multiple processors
+	 */
+	DUPLICATEPOINT,
+	/**
+	 * The point is needed to maintain connectivity, but the data values should be ignored.
+	 */
+	HIDDENPOINT
+};
+
+export enum AttributeCopyOperations {
+	COPYTUPLE,
+	INTERPOLATE,
+	PASSDATA,
+	/**
+	 * All of the above
+	 */
+	ALLCOPY,
+};
+
+export const ghostArrayName: string;
+
+export enum DesiredOutputPrecision {
+	/**
+	 * Use the point type that does not truncate any data
+	 */
+	DEFAULT,
+	/**
+	 * Use Float32Array
+	 */
+	SINGLE,
+	/**
+	 * Use Float64Array
+	 */
+	DOUBLE,
+};
+/**
+ * 
+ */
+interface IDataSetAttributesInitialValues {
+
+	/**
+	 * 
+	 */
+	activeScalars?: number;
+
+	/**
+	 * 
+	 */
+	activeVectors?: number;
+
+	/**
+	 * 
+	 */
+	activeTensors?: number;
+
+	/**
+	 * 
+	 */
+	activeNormals?: number;
+
+	/**
+	 * 
+	 */
+	activeTCoords?: number;
+
+	/**
+	 * 
+	 */
+	activeGlobalIds?: number;
+
+	/**
+	 * 
+	 */
+	activePedigreeIds?: number;
+}
+
+export interface vtkDataSetAttributes extends vtkFieldData {
+
+	/**
+	 * 
+	 * @param x 
+	 * @return  
+	 */
+	checkNumberOfComponents(x: any): boolean;
+
+	/**
+	 * 
+	 * @param attType 
+	 * @return  
+	 */
+	getActiveAttribute(attType: any): number;
+
+	/**
+	 * 
+	 */
+	getActiveScalars(): number;
+
+	/**
+	 * 
+	 */
+	getActiveVectors(): number;
+
+	/**
+	 * 
+	 */
+	getActiveTensors(): number;
+
+	/**
+	 * 
+	 */
+	getActiveNormals(): number;
+
+	/**
+	 * 
+	 */
+	getActiveTCoords(): number;
+
+	/**
+	 * 
+	 */
+	getActiveGlobalIds(): number;
+
+	/**
+	 * 
+	 */
+	getActivePedigreeIds(): number;
+
+	/**
+	 * 
+	 * @param arr 
+	 * @param uncleanAttType 
+	 * @return  
+	 */
+	setAttribute(arr: any, uncleanAttType: string): number;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 * @param attType 
+	 * @return  
+	 */
+	setActiveAttributeByName(arrayName: string, attType: any): number;
+
+	/**
+	 * 
+	 * @param arrayIdx 
+	 * @param uncleanAttType 
+	 * @return  
+	 */
+	setActiveAttributeByIndex(arrayIdx: any, uncleanAttType: string): number;
+
+	/**
+	 * Override to allow proper handling of active attributes
+	 */
+	removeAllArrays(): void;
+
+	/**
+	 * Override to allow proper handling of active attributes
+	 * @param arrayName 
+	 */
+	removeArray(arrayName: string): void;
+
+	/**
+	 * Override to allow proper handling of active attributes
+	 * @param arrayIdx 
+	 */
+	removeArrayByIndex(arrayIdx: number): void;
+
+	/**
+	 * 
+	 */
+	initializeAttributeCopyFlags(): void;
+
+	/**
+	 * 
+	 * @param activeScalars 
+	 */
+	setActiveScalars(activeScalars: number): boolean;
+
+	/**
+	 * 
+	 * @param activeVectors 
+	 */
+	setActiveVectors(activeVectors: number): boolean;
+
+	/**
+	 * 
+	 * @param activeTensors 
+	 */
+	setActiveTensors(activeTensors: number): boolean;
+
+	/**
+	 * 
+	 * @param activeNormals 
+	 */
+	setActiveNormals(activeNormals: number): boolean;
+
+	/**
+	 * 
+	 * @param activeTCoords 
+	 */
+	setActiveTCoords(activeTCoords: number): boolean;
+
+	/**
+	 * 
+	 * @param activeGlobalIds 
+	 */
+	setActiveGlobalIds(activeGlobalIds: number): boolean;
+
+	/**
+	 * 
+	 * @param activePedigreeIds 
+	 */
+	setActivePedigreeIds(activePedigreeIds: number): boolean;
+
+	/**
+	 * 
+	 * @param other 
+	 * @param debug 
+	 */
+	shallowCopy(other: any, debug: any): void;
+
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	setActiveScalars(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	setActiveVectors(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	setActiveNormals(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	setActiveTCoords(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	setActiveTensors(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	setActiveGlobalIds(arrayName: string): boolean;
+
+	/**
+	 * 
+	 * @param arrayName 
+	 */
+	setActivePedigreeIds(arrayName: string): boolean;
+
+	/**
+	 * 
+	 */
+	getScalars(): any[];
+
+	/**
+	 * 
+	 */
+	getVectors(): any[];
+
+	/**
+	 * 
+	 */
+	getNormals(): any[];
+
+	/**
+	 * 
+	 */
+	getTCoords(): any[];
+
+	/**
+	 * 
+	 */
+	getTensors(): any[];
+
+	/**
+	 * 
+	 */
+	getGlobalIds(): any[];
+
+	/**
+	 * 
+	 */
+	getPedigreeIds(): any[];
+
+
+	/**
+	 * 
+	 * @param scalars 
+	 */
+	setScalars(scalars: any[]): boolean;
+
+	/**
+	 * 
+	 * @param vectors 
+	 */
+	setVectors(vectors: any[]): boolean;
+
+	/**
+	 * 
+	 * @param normals 
+	 */
+	setNormals(normals: any[]): boolean;
+
+	/**
+	 * 
+	 * @param tcoords 
+	 */
+	setTCoords(tcoords: any[]): boolean;
+
+	/**
+	 * 
+	 * @param tensors 
+	 */
+	setTensors(tensors: any[]): boolean;
+
+	/**
+	 * 
+	 * @param globalids 
+	 */
+	setGlobalIds(globalids: any[]): boolean;
+
+	/**
+	 * 
+	 * @param pedigreeids 
+	 */
+	setPedigreeIds(pedigreeids: any[]): boolean;
+
+	/**
+	 * 
+	 */
+	copyScalarsOff(): void;
+
+	/**
+	 * 
+	 */
+	copyVectorsOff(): void;
+
+	/**
+	 * 
+	 */
+	copyNormalsOff(): void;
+
+	/**
+	 * 
+	 */
+	copyTCoordsOff(): void;
+
+	/**
+	 * 
+	 */
+	copyTensorsOff(): void;
+
+	/**
+	 * 
+	 */
+	copyGlobalIdsOff(): void;
+
+	/**
+	 * 
+	 */
+	copyPedigreeIdsOff(): void;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkDataSetAttributes characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IDataSetAttributesInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkDataSetAttributes.
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IDataSetAttributesInitialValues): vtkDataSetAttributes;
+
+/**
+ * vtkDataSetAttributes is a class that is used to represent and manipulate
+ * attribute data (e.g., scalars, vectors, normals, texture coordinates,
+ * tensors, global ids, pedigree ids, and field data).
+ *
+ * This adds to vtkFieldData the ability to pick one of the arrays from the
+ * field as the currently active array for each attribute type. In other words,
+ * you pick one array to be called "THE" Scalars, and then filters down the
+ * pipeline will treat that array specially. For example vtkContourFilter will
+ * contour "THE" Scalar array unless a different array is asked for.
+ *
+ * Additionally vtkDataSetAttributes provides methods that filters call to pass
+ * data through, copy data into, and interpolate from Fields. PassData passes
+ * entire arrays from the source to the destination. Copy passes through some
+ * subset of the tuples from the source to the destination. Interpolate
+ * interpolates from the chosen tuple(s) in the source data, using the provided
+ * weights, to produce new tuples in the destination. Each attribute type has
+ * pass, copy and interpolate "copy" flags that can be set in the destination to
+ * choose which attribute arrays will be transferred from the source to the
+ * destination.
+ *
+ * Finally this class provides a mechanism to determine which attributes a group
+ * of sources have in common, and to copy tuples from a source into the
+ * destination, for only those attributes that are held by all.
+ */
+export declare const vtkDataSetAttributes: {
+	newInstance: typeof newInstance,
+	extend: typeof extend,
+};
+export default vtkDataSetAttributes;

--- a/Sources/Filters/General/AppendPolyData/index.d.ts
+++ b/Sources/Filters/General/AppendPolyData/index.d.ts
@@ -1,0 +1,99 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+export enum DesiredOutputPrecision {
+    /**
+     * Output precision should match the input precision
+     */
+    DEFAULT,
+
+    /**
+     * Output single-precision floating-point (i.e. float32)
+     */
+    SINGLE,
+
+    /**
+     * Output double-precision floating point (i.e. float64)
+     */
+    DOUBLE
+}
+
+/**
+ * 
+ */
+interface IAppendPolyDataInitialValues {
+
+    /**
+     * 
+     */
+    outputPointsPrecision?: DesiredOutputPrecision;
+}
+
+type vtkAppendPolyDataBase = VtkObject & VtkAlgorithm;
+
+export interface vtkAppendPolyData extends vtkAppendPolyDataBase {
+
+    /**
+     * Get the desired precision for the output types.
+     */
+    getOutputPointsPrecision(): DesiredOutputPrecision;
+
+    /**
+     * Set the desired precision for the output types.
+     * @param outputPointsPrecision 
+     */
+    setOutputPointsPrecision(outputPointsPrecision: DesiredOutputPrecision): boolean;
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkAppendPolyData characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IAppendPolyDataInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkAppendPolyData
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IAppendPolyDataInitialValues): vtkAppendPolyData;
+
+
+/**
+ * vtkAppendPolyData - append one or more polygonal datasets together
+ * 
+ * vtkAppendPolyData is a filter that appends one of more polygonal datasets into a
+ * single polygonal dataset. All geometry is extracted and appended, but point and
+ * cell attributes (i.e., scalars, vectors, normals) are extracted and appended
+ * only if all datasets have the point and/or cell attributes available.  (For
+ * example, if one dataset has point scalars but another does not, point scalars
+ * will not be appended.)
+ * ## Usage
+ * Provide the first input to the filter via the standard
+ * `setInput(Data/Connection)` methods. Any additional inputs can be provided via
+ * the `addInput(Data/Connection)` methods. When only a single input is provided,
+ * it is passed through as is to the output.
+ * ```js
+ * const cone = vtkConeSource.newInstance();
+ * const cylinder = vtkCylinderSource.newInstance();
+ * 
+ * const appendPolyData = vtkAppendPolyData.newInstance();
+ * appendPolyData.setInputConnection(cone.getOutputPort());
+ * appendPolyData.addInputConnection(cylinder.getOutputPort());
+ * 
+ * const appendedData = appendPolyData.getOutputData();
+ * ```
+ */
+export declare const vtkAppendPolyData: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkAppendPolyData;

--- a/Sources/Filters/General/ImageCropFilter/index.d.ts
+++ b/Sources/Filters/General/ImageCropFilter/index.d.ts
@@ -1,0 +1,84 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+/**
+ * 
+ */
+interface IImageCropFilterInitialValues {
+
+    /**
+     * 
+     */
+    croppingPlanes?: any;
+}
+
+type vtkImageCropFilterBase = VtkObject & VtkAlgorithm;
+
+export interface vtkImageCropFilter extends vtkImageCropFilterBase {
+
+    /**
+     * Get The cropping planes, in IJK space. 
+     * @default [0, 0, 0, 0, 0, 0].
+     */
+    getCroppingPlanes(): number[];
+
+    /**
+     * Get The cropping planes, in IJK space. 
+     * @default [0, 0, 0, 0, 0, 0].
+     */
+    getCroppingPlanesByReference(): number[];
+
+    /**
+     * 
+     */
+    isResetAvailable(): boolean;
+    /**
+     * 
+     */
+    reset(): void;
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+
+    /**
+     * 
+     * @param croppingPlanes 
+     */
+    setCroppingPlanes(croppingPlanes: number[]): boolean;
+
+    /**
+     * 
+     * @param croppingPlanes 
+     */
+    setCroppingPlanesFrom(croppingPlanes: number[]): boolean;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkImageCropFilter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IImageCropFilterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkImageCropFilter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IImageCropFilterInitialValues): vtkImageCropFilter;
+
+
+/**
+ * The vtkImageCropFilter will crop a vtkImageData. This will only crop against
+ * IJK-aligned planes. Note this is slow on large datasets due to CPU-bound
+ * cropping.
+ */
+export declare const vtkImageCropFilter: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkImageCropFilter;

--- a/Sources/Filters/General/ImageOutlineFilter/index.d.ts
+++ b/Sources/Filters/General/ImageOutlineFilter/index.d.ts
@@ -1,0 +1,82 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+/*
+ * 
+ */
+interface IImageOutlineFilterInitialValues {
+    
+    /**
+     * 
+     */
+    slicingMode?: number;
+
+    /**
+     * 
+     */
+    background?: number;
+}
+
+type vtkImageOutlineFilterBase = VtkObject & VtkAlgorithm;
+
+export interface vtkImageOutlineFilter extends vtkImageOutlineFilterBase {
+
+    /**
+     * 
+     * @default 0
+     */
+    getBackground(): number;
+
+    /**
+     * 
+     * @default 2
+     */
+    getSlicingMode(): number;
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+
+     /**
+      * 
+      * @param background 
+      */
+    setBackground(background: number): boolean; 
+
+    /**
+     * 
+     * @param slicingMode 
+     */
+    setSlicingMode(slicingMode: number): boolean;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkImageOutlineFilter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IImageOutlineFilterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkImageOutlineFilter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IImageOutlineFilterInitialValues): vtkImageOutlineFilter;
+
+
+/**
+ * vtkImageOutlineFilter - generates outline of labelmap from an vtkImageData
+ * input in a given direction (slicing mode).   
+ *
+ * vtkImageOutlineFilter creates a region (labelmap) outline based on input data
+ * given . The output is a vtkImageData object containing only boundary voxels.
+ */
+export declare const vtkImageOutlineFilter: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkImageOutlineFilter;

--- a/Sources/Filters/General/ImageSliceFilter/index.d.ts
+++ b/Sources/Filters/General/ImageSliceFilter/index.d.ts
@@ -1,0 +1,69 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+/*
+ * 
+ */
+interface IImageSliceFilterInitialValues {
+
+    sliceIndex?: number
+}
+
+type vtkImageSliceFilterBase = VtkObject & VtkAlgorithm;
+
+export interface vtkImageSliceFilter extends vtkImageSliceFilterBase {
+
+    /**
+     * 
+     */
+    getOrientation(): any;
+
+    /**
+     * 
+     * @default 0
+     */
+    getSliceIndex(): number;
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+
+     /**
+      * 
+      * @param orientation 
+      */
+    setOrientation(orientation: any): boolean; 
+
+    /**
+     * 
+     * @param sliceIndex 
+     */
+    setSliceIndex(sliceIndex: number): boolean;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkImageSliceFilter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IImageSliceFilterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkImageSliceFilter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IImageSliceFilterInitialValues): vtkImageSliceFilter;
+
+
+/**
+ *
+ */
+export declare const vtkImageSliceFilter: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkImageSliceFilter;

--- a/Sources/Filters/General/LineFilter/index.d.ts
+++ b/Sources/Filters/General/LineFilter/index.d.ts
@@ -1,0 +1,46 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+/**
+ * 
+ */
+interface ILineFilterInitialValues {
+}
+
+type vtkLineFilterBase = VtkObject & VtkAlgorithm;
+
+export interface vtkLineFilter extends vtkLineFilterBase {
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkLineFilter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ILineFilterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkLineFilter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: ILineFilterInitialValues): vtkLineFilter;
+
+
+/**
+ * vtkLineFilter - filters lines in polydata
+ * 
+ * vtkLineFilter is a filter that only let's through lines of a vtkPolydata.
+ */
+export declare const vtkLineFilter: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkLineFilter;

--- a/Sources/Filters/General/OutlineFilter/index.d.ts
+++ b/Sources/Filters/General/OutlineFilter/index.d.ts
@@ -1,0 +1,51 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+export const BOUNDS_MAP: number[];
+
+export const LINE_ARRAY: number[];
+
+/*
+ * 
+ */
+interface IOutlineFilterInitialValues {
+}
+
+type vtkOutlineFilterBase = VtkObject & VtkAlgorithm;
+
+export interface vtkOutlineFilter extends vtkOutlineFilterBase {
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkOutlineFilter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IOutlineFilterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkOutlineFilter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IOutlineFilterInitialValues): vtkOutlineFilter;
+
+
+/**
+ * vtkOutlineFilter - A filter that generates triangles for larger cells
+ *
+ * vtkOutlineFilter is a filter that converts cells wih more than 3 points into
+ * triangles.
+ */
+export declare const vtkOutlineFilter: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkOutlineFilter;

--- a/Sources/Filters/General/TriangleFilter/index.d.ts
+++ b/Sources/Filters/General/TriangleFilter/index.d.ts
@@ -1,0 +1,57 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+/**
+ * 
+ */
+interface ITriangleFilterInitialValues {
+
+    /**
+     * 
+     */
+    errorCount?: number;
+}
+
+type vtkTriangleFilterBase = VtkObject & VtkAlgorithm;
+
+export interface vtkTriangleFilter extends vtkTriangleFilterBase {
+
+    /**
+     * Get the desired precision for the output types.
+     */
+    getErrorCount(): number;
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkTriangleFilter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ITriangleFilterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkTriangleFilter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: ITriangleFilterInitialValues): vtkTriangleFilter;
+
+
+/**
+ * vtkTriangleFilter - A filter that generates triangles for larger cells
+ *
+ * vtkTriangleFilter is a filter that converts cells wih more than 3 points into
+ * triangles.
+ */
+export declare const vtkTriangleFilter: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkTriangleFilter;

--- a/Sources/Filters/General/TubeFilter/index.d.ts
+++ b/Sources/Filters/General/TubeFilter/index.d.ts
@@ -1,0 +1,318 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { DesiredOutputPrecision } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
+import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
+
+export enum VaryRadius {
+    VARY_RADIUS_OFF,
+    VARY_RADIUS_BY_SCALAR,
+    VARY_RADIUS_BY_VECTOR,
+    VARY_RADIUS_BY_ABSOLUTE_SCALAR
+}
+
+export enum GenerateTCoords {
+    TCOORDS_OFF,
+    TCOORDS_FROM_NORMALIZED_LENGTH,
+    TCOORDS_FROM_LENGTH,
+    TCOORDS_FROM_SCALARS
+}
+
+/**
+ * 
+ */
+interface ITubeFilterInitialValues {
+    /**
+     * 
+     * @default DesiredOutputPrecision.DEFAULT
+     */
+    outputPointsPrecision?: DesiredOutputPrecision,
+
+    /**
+     * 
+     * @default 0.5
+     */
+    radius?: number;
+
+    /**
+     * 
+     * @default VaryRadius.VARY_RADIUS_OFF
+     */
+    varyRadius?: VaryRadius,
+
+    /**
+     * 
+     * @default 3
+     */
+    numberOfSides?: number;
+
+    /**
+     * 
+     * @default 10
+     */
+    radiusFactor?: number;
+
+    /**
+     * 
+     * @default [0, 0, 1]
+     */
+    defaultNormal?: number[];
+
+    /**
+     * 
+     * @default false
+     */
+    useDefaultNormal?: boolean;
+
+    /**
+     * 
+     * @default true
+     */
+    sidesShareVertices?: boolean;
+
+    /**
+     * 
+     * @default false
+     */
+    capping?: boolean;
+
+    /**
+     * 
+     * @default 1
+     */
+    onRatio?: number;
+
+    /**
+     * 
+     * @default 0
+     */
+    offset?: number;
+
+    /**
+     * 
+     * @default GenerateTCoords.TCOORDS_OFF
+     */
+    generateTCoords?: GenerateTCoords,
+
+    /**
+     * 
+     * @default 1.0
+     */
+    textureLength?: number;
+}
+
+type vtkTubeFilterBase = VtkObject & VtkAlgorithm;
+
+export interface vtkTubeFilter extends vtkTubeFilterBase {
+
+    /**
+     * Get the desired precision for the output types.
+     */
+    getOutputPointsPrecision(): DesiredOutputPrecision;
+
+    /**
+     * Get the minimum tube radius.
+     */
+    getRadius(): number;
+
+    /**
+     * Get variation of tube radius with scalar or vector values.
+     */
+    getVaryRadius(): VaryRadius;
+
+    /**
+     * Get the number of sides for the tube.
+     */
+    getNumberOfSides(): number;
+
+    /**
+     * Get the maximum tube radius in terms of a multiple of the minimum radius.
+     */
+    getRadiusFactor(): number;
+
+    /**
+     * Get the default normal value.
+     */
+    getDefaultNormal(): number[];
+
+    /**
+     * Get useDefaultNormal value.
+     */
+    getUseDefaultNormal(): boolean;
+
+    /**
+     * Get sidesShareVertices value.
+     */
+    getSidesShareVertices(): boolean;
+
+    /**
+     * Get whether the capping is enabled or not.
+     */
+    getCapping(): boolean;
+
+    /**
+     * Get onRatio value.
+     */
+    getOnRatio(): number;
+
+    /**
+     * Get offset value.
+     */
+    getOffset(): number;
+
+    /**
+     * Get generateTCoords value.
+     */
+    getGenerateTCoords(): GenerateTCoords;
+
+    /**
+     * Get textureLength value.
+     */
+    getTextureLength(): number;
+
+    /**
+     *
+     * @param inData 
+     * @param outData 
+     */
+    requestData(inData: any, outData: any): void;
+
+    /**
+     * Set the desired precision for the output types.
+     * @param outputPointsPrecision 
+     */
+    setOutputPointsPrecision(outputPointsPrecision: DesiredOutputPrecision): boolean;
+
+    /**
+     * Set the minimum tube radius (minimum because the tube radius may vary).
+     * @param radius 
+     */
+    setRadius(radius: number): boolean;
+
+    /**
+     * Enable or disable variation of tube radius with scalar or vector values.
+     * @param varyRadius 
+     */
+    setVaryRadius(varyRadius: VaryRadius): boolean;
+
+    /**
+     * Set the number of sides for the tube. At a minimum, number of sides is 3.
+     * @param numberOfSides 
+     */
+    setNumberOfSides(numberOfSides: number): boolean;
+
+    /**
+     * Set the maximum tube radius in terms of a multiple of the minimum radius.
+     * @param radiusFactor 
+     */
+    setRadiusFactor(radiusFactor: number): boolean;
+
+    /**
+     * Set the default normal to use if no normals are supplied. Requires that
+     * useDefaultNormal is set.
+     * @param defaultNormal 
+     */
+    setDefaultNormal(defaultNormal: number[]): boolean;
+
+    /**
+     * Control whether to use the defaultNormal.
+     * @param useDefaultNormal 
+     */
+    setUseDefaultNormal(useDefaultNormal: boolean): boolean;
+
+    /**
+     * Control whether the tube sides should share vertices. This creates
+     * independent strips, with constant normals so the tube is always faceted
+     * in appearance.
+     * @param sidesShareVertices 
+     */
+    setSidesShareVertices(sidesShareVertices: boolean): boolean;
+
+    /**
+     * Enable / disable capping the ends of the tube with polygons.
+     * @param capping 
+     */
+    setCapping(capping: boolean): boolean;
+
+    /**
+     * Control the stripping of tubes. If OnRatio is greater than 1, then every
+     * nth tube side is turned on, beginning with the offset side.
+     * @param onRatio 
+     */
+    setOnRatio(onRatio: number): boolean;
+
+    /**
+     * Control the stripping of tubes. The offset sets the first tube side that
+     * is visible. Offset is generally used with onRatio to create nifty
+     * stripping effects.
+     * @param offset 
+     */
+    setOffset(offset: number): boolean;
+
+    /**
+     * Control whether and how texture coordinates are produced. This is useful
+     * for stripping the tube with length textures, etc. If you use scalars to
+     * create the texture, the scalars are assumed to be monotonically
+     * increasing (or decreasing).
+     * @param generateTCoords 
+     */
+    setGenerateTCoords(generateTCoords: GenerateTCoords): boolean;
+
+    /**
+     * Control the conversion of units during texture coordinates calculation.
+     * The texture length indicates what length (whether calculated from scalars
+     * or length) is mapped to [0, 1) texture space.
+     * @param textureLength 
+     */
+    setTextureLength(textureLength: number): boolean;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkTubeFilter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ITubeFilterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkTubeFilter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: ITubeFilterInitialValues): vtkTubeFilter;
+
+
+/**
+ * vtkTubeFilter - A filter that generates tubes around lines 
+ *
+ * vtkTubeFilter is a filter that generates a tube around each input line.  The
+ * tubes are made up of triangle strips and rotate around the tube with the
+ * rotation of the line normals. (If no normals are present, they are computed
+ * automatically.) The radius of the tube can be set to vary with scalar or
+ * vector value. If the radius varies with scalar value the radius is linearly
+ * adjusted. If the radius varies with vector value, a mass flux preserving
+ * variation is used. The number of sides for the tube also can be specified.
+ * You can also specify which of the sides are visible. This is useful for
+ * generating interesting striping effects. Other options include the ability to
+ * cap the tube and generate texture coordinates.  Texture coordinates can be
+ * used with an associated texture map to create interesting effects such as
+ * marking the tube with stripes corresponding to length or time.
+ *
+ * This filter is typically used to create thick or dramatic lines. Another
+ * common use is to combine this filter with vtkStreamTracer to generate
+ * streamtubes.
+ *
+ * **Warning** 
+ * 
+ * The number of tube sides must be greater than 3.
+ *
+ * **Warning**
+ *
+ * The input line must not have duplicate points, or normals at points that are
+ * parallel to the incoming/outgoing line segments. If a line does not meet this
+ * criteria, then that line is not tubed.
+ */
+export declare const vtkTubeFilter: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+}
+export default vtkTubeFilter;

--- a/Sources/IO/Geometry/DracoReader/index.d.ts
+++ b/Sources/IO/Geometry/DracoReader/index.d.ts
@@ -1,0 +1,143 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+
+interface IDracoReaderOptions {
+
+	/**
+	 * 
+	 */
+	binary?: boolean;
+
+	/**
+	 * 
+	 */
+	compression?: string;
+
+	/**
+	 * 
+	 */
+	progressCallback?: any;
+}
+
+/**
+ * 
+ */
+interface IDracoReaderInitialValues { }
+
+type vtkDracoReaderBase = VtkObject & Omit<VtkAlgorithm,
+	'getInputData' |
+	'setInputData' |
+	'setInputConnection' |
+	'getInputConnection' |
+	'addInputConnection' |
+	'addInputData'>;
+
+export interface vtkDracoReader extends vtkDracoReaderBase {
+
+	/**
+	 * 
+	 */
+	getBaseURL(): string;
+
+	/**
+	 * 
+	 */
+	getDataAccessHelper(): any;
+
+	/**
+	 * 
+	 */
+	getUrl(): string;
+
+	/**
+	 * 
+	 * @param options 
+	 */
+	loadData(options?: IDracoReaderOptions): Promise<any>;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parse(content: string | ArrayBuffer): void;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parseAsArrayBuffer(content: ArrayBuffer): void;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parseAsText(content: string): void;
+	/**
+	 *
+	 * @param inData 
+	 * @param outData 
+	 */
+	requestData(inData: any, outData: any): void;
+
+	/**
+	 * 
+	 * @param url 
+	 * @param option 
+	 */
+	setUrl(url: string, option?: IDracoReaderOptions): boolean;
+
+	/**
+	 * 
+	 * @param dataAccessHelper 
+	 */
+	setDataAccessHelper(dataAccessHelper: any): boolean;
+
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkDracoReader characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IDracoReaderInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkDracoReader
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IDracoReaderInitialValues): vtkDracoReader;
+
+
+/**
+ * 
+ */
+export function getDracoDecoder(): any;
+
+/**
+ * 
+ * @param createDracoModule 
+ */
+export function setDracoDecoder(createDracoModule: any): void;
+
+/**
+ * Load the WASM decoder from url and set the decoderModule
+ * @param url 
+ * @param binaryName 
+ */
+export function setWasmBinary(url: string, binaryName: string): Promise<boolean>;
+
+
+/**
+ * vtkDracoReader is a source object that reads a geometry compressed with the
+ * Draco library.
+ */
+export declare const vtkDracoReader: {
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+	getDracoDecoder: typeof getDracoDecoder;
+	setDracoDecoder: typeof setDracoDecoder;
+	setWasmBinary: typeof setWasmBinary;
+}
+export default vtkDracoReader;

--- a/Sources/IO/Geometry/PLYReader/index.d.ts
+++ b/Sources/IO/Geometry/PLYReader/index.d.ts
@@ -1,0 +1,129 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+
+interface IPLYReaderOptions {
+
+	/**
+	 * 
+	 */
+	binary?: boolean;
+
+	/**
+	 * 
+	 */
+	compression?: string;
+
+	/**
+	 * 
+	 */
+	progressCallback?: any;
+}
+
+/**
+ * 
+ */
+interface IPLYReaderInitialValues {}
+
+type vtkPLYReaderBase = VtkObject & Omit<VtkAlgorithm,
+	'getInputData' |
+	'setInputData' |
+	'setInputConnection' |
+	'getInputConnection' | 
+	'addInputConnection' | 
+	'addInputData' > ;
+
+export interface vtkPLYReader extends vtkPLYReaderBase {
+
+	/**
+	 * 
+	 */
+	getBaseURL(): string;
+
+	/**
+	 * 
+	 */
+	getDataAccessHelper(): any;
+
+	/**
+	 * 
+	 */
+	getUrl(): string;
+
+	/**
+	 * 
+	 * @param options 
+	 */
+	loadData(options?: IPLYReaderOptions): Promise<any>;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parse(content: string | ArrayBuffer): void;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parseAsArrayBuffer(content: ArrayBuffer): void;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parseAsText(content: string): void;
+	/**
+	 *
+	 * @param inData 
+	 * @param outData 
+	 */
+	requestData(inData: any, outData: any): void;
+
+	/**
+	 * 
+	 * @param url 
+	 * @param option 
+	 */
+	setUrl(url: string, option?: IPLYReaderOptions): boolean;
+
+	/**
+	 * 
+	 * @param dataAccessHelper 
+	 */
+	setDataAccessHelper(dataAccessHelper: any): boolean;
+	
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkPLYReader characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IPLYReaderInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkPLYReader
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IPLYReaderInitialValues): vtkPLYReader;
+
+
+/**
+ * vtkPLYReader is a source object that reads polygonal data in Stanford
+ * University PLY file format (see http://graphics.stanford.edu/data/3Dscanrep).
+ * It requires that the elements "vertex" and "face" are defined. The "vertex"
+ * element must have the properties "x", "y", and "z". The "face" element must
+ * have the property "vertex_indices" defined. Optionally, if the "face" element
+ * has the properties "intensity" and/or the triplet "red", "green", "blue", and
+ * optionally "alpha"; these are read and added as scalars to the output data.
+ * If the "face" element has the property "texcoord" a new TCoords point array
+ * is created and points are duplicated if they have 2 or more different texture
+ * coordinates.
+ */
+export declare const vtkPLYReader: {
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+}
+export default vtkPLYReader;

--- a/Sources/IO/Geometry/STLReader/index.d.ts
+++ b/Sources/IO/Geometry/STLReader/index.d.ts
@@ -1,0 +1,123 @@
+import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+
+
+interface ISTLReaderOptions {
+
+	/**
+	 * 
+	 */
+	binary?: boolean;
+
+	/**
+	 * 
+	 */
+	compression?: string;
+
+	/**
+	 * 
+	 */
+	progressCallback?: any;
+}
+
+/**
+ * 
+ */
+interface ISTLReaderInitialValues {}
+
+type vtkSTLReaderBase = VtkObject & Omit<VtkAlgorithm,
+	'getInputData' |
+	'setInputData' |
+	'setInputConnection' |
+	'getInputConnection' | 
+	'addInputConnection' | 
+	'addInputData' > ;
+
+export interface vtkSTLReader extends vtkSTLReaderBase {
+
+	/**
+	 * 
+	 */
+	getBaseURL(): string;
+
+	/**
+	 * 
+	 */
+	getDataAccessHelper(): any;
+
+	/**
+	 * 
+	 */
+	getUrl(): string;
+
+	/**
+	 * 
+	 * @param options 
+	 */
+	loadData(options?: ISTLReaderOptions): Promise<any>;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parse(content: string | ArrayBuffer): void;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parseAsArrayBuffer(content: ArrayBuffer): void;
+
+	/**
+	 * 
+	 * @param content 
+	 */
+	parseAsText(content: string): void;
+	/**
+	 *
+	 * @param inData 
+	 * @param outData 
+	 */
+	requestData(inData: any, outData: any): void;
+
+	/**
+	 * 
+	 * @param url 
+	 * @param option 
+	 */
+	setUrl(url: string, option?: ISTLReaderOptions): boolean;
+
+	/**
+	 * 
+	 * @param dataAccessHelper 
+	 */
+	setDataAccessHelper(dataAccessHelper: any): boolean;
+	
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkSTLReader characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ISTLReaderInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkSTLReader
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: ISTLReaderInitialValues): vtkSTLReader;
+
+
+/**
+ * vtkSTLReader is a source object that reads ASCII or binary stereo lithography
+ * files (.stl files). The object automatically detects whether the file is
+ * ASCII or binary. .stl files are quite inefficient since they duplicate vertex
+ * definitions.
+ */
+export declare const vtkSTLReader: {
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+}
+export default vtkSTLReader;

--- a/Sources/IO/Geometry/STLWriter/index.d.ts
+++ b/Sources/IO/Geometry/STLWriter/index.d.ts
@@ -1,0 +1,82 @@
+import { mat4 } from "gl-matrix";
+import vtkPolyData from "vtk.js/Sources/Common/DataModel/PolyData";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/macro";
+
+export enum FormatTypes {
+	ASCII,
+	BINARY
+}
+
+/**
+ * 
+ */
+interface ISTLWriterInitialValues { }
+
+type vtkSTLWriterBase = vtkObject & vtkAlgorithm;
+
+export interface vtkSTLWriter extends vtkSTLWriterBase {
+
+	/**
+	 * 
+	 */
+	getFormat(): FormatTypes;
+
+	/**
+	 * 
+	 */
+	getTransform(): mat4;
+
+	/**
+	 *
+	 * @param inData 
+	 * @param outData 
+	 */
+	requestData(inData: any, outData: any): void;
+
+	/**
+	 * 
+	 * @param format 
+	 */
+	setFormat(format: FormatTypes): boolean;
+
+	/**
+	 * 
+	 * @param format 
+	 */
+	setTransform(transform: mat4): boolean;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkSTLWriter characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param initialValues (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ISTLWriterInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkSTLWriter
+ * @param initialValues for pre-setting some of its content
+ */
+export function newInstance(initialValues?: ISTLWriterInitialValues): vtkSTLWriter;
+
+/**
+ * 
+ */
+export function writeSTL(polyData: vtkPolyData, format?: FormatTypes, transform?: mat4): any;
+
+
+/**
+ * vtkSTLWriter writes stereo lithography (.stl) files in either ASCII or binary
+ * form. Stereo lithography files contain only triangles. Since VTK 8.1, this
+ * writer converts non-triangle polygons into triangles, so there is no longer a
+ * need to use vtkTriangleFilter prior to using this writer if the input
+ * contains polygons with more than three vertices.
+ */
+export declare const vtkSTLWriter: {
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+	writeSTL: typeof writeSTL;
+}
+export default vtkSTLWriter;


### PR DESCRIPTION
Add typescript definitions for the following classes:

* AppendPolyData
* DataSetAttributes
* ImageCropFilter
* ImageOutlineFilter
* ImageSliceFilter
* LineFilter
* OutlineFilter
* TriangleFilter
* TubeFilter

Readers:
* STLReader
* PLYReader
* DracoReader

Writers:
* STLWriter

fix #466