### PR TITLE
chore(WebGPU): add a UBO class and use it

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'jsx-a11y/label-has-for': 0,
     'no-console': 0,
     'no-plusplus': 0,
+    'no-underscore-dangle': 0,
     'import/no-named-as-default': 0,
     'import/no-named-as-default-member': 0,
 

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -307,9 +307,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   }
 
   if (!model.values) {
-    model.values = new window[model.dataType](model.size);
+    model.values = macro.newTypedArray(model.dataType, model.size);
   } else if (Array.isArray(model.values)) {
-    model.values = window[model.dataType].from(model.values);
+    model.values = macro.newTypedArrayFrom(model.dataType, model.values);
   }
 
   if (model.values) {

--- a/Sources/Common/Core/Points/index.js
+++ b/Sources/Common/Core/Points/index.js
@@ -20,7 +20,7 @@ function vtkPoints(publicAPI, model) {
   publicAPI.setNumberOfPoints = (nbPoints, dimension = 3) => {
     if (publicAPI.getNumberOfPoints() !== nbPoints) {
       model.size = nbPoints * dimension;
-      model.values = new window[model.dataType](model.size);
+      model.values = macro.newTypedArray(model.dataType, model.size);
       publicAPI.setNumberOfComponents(dimension);
       publicAPI.modified();
     }

--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -222,7 +222,8 @@ function vtkScalarsToColors(publicAPI, model) {
         dataType: VtkDataTypes.UNSIGNED_CHAR,
       };
 
-      const s = new window[newscalars.dataType](
+      const s = macro.newTypedArray(
+        newscalars.dataType,
         4 * scalars.getNumberOfTuples()
       );
       newscalars.values = s;

--- a/Sources/Common/DataModel/Cell/index.js
+++ b/Sources/Common/DataModel/Cell/index.js
@@ -21,7 +21,8 @@ function vtkCell(publicAPI, model) {
       model.pointsIds = pointIdsList;
       let triangleData = model.points.getData();
       if (triangleData.length !== 3 * model.pointsIds.length) {
-        triangleData = new window[points.getDataType()](
+        triangleData = macro.newTypedArray(
+          points.getDataType(),
           3 * model.pointsIds.length
         );
       }

--- a/Sources/Common/DataModel/Cell/test/testCell.js
+++ b/Sources/Common/DataModel/Cell/test/testCell.js
@@ -27,7 +27,7 @@ test('Test vtkCell initialize without pointsIds', (t) => {
 
 test('Test vtkCell initialize with pointsIds', (t) => {
   const points = vtkPoints.newInstance();
-  points.setData([0, 0, 0, 2, 0, 0, 2, 2, 0]);
+  points.setData(Float64Array.from([0, 0, 0, 2, 0, 0, 2, 2, 0]));
 
   const cell = vtkCell.newInstance();
 

--- a/Sources/Filters/Core/Cutter/index.js
+++ b/Sources/Filters/Core/Cutter/index.js
@@ -1,7 +1,7 @@
 import * as macro from 'vtk.js/Sources/macro';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 
-const { vtkErrorMacro, TYPED_ARRAYS } = macro;
+const { vtkErrorMacro } = macro;
 
 function initPolyIterator(pd) {
   const polys = pd.getPolys().getData();
@@ -235,7 +235,7 @@ function vtkCutter(publicAPI, model) {
     // Set points
     const outputPoints = output.getPoints();
     outputPoints.setData(
-      TYPED_ARRAYS[points.getDataType()].from(newPointsData),
+      macro.newTypedArrayFrom(points.getDataType(), newPointsData),
       3
     );
 

--- a/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
+++ b/Sources/Filters/Cornerstone/ImageDataToCornerstoneImage/index.js
@@ -41,7 +41,8 @@ function vtkImageDataToCornerstoneImage(publicAPI, model) {
     } else {
       const offset =
         model.sliceIndex * dims[0] * dims[1] * rawData.BYTES_PER_ELEMENT;
-      pixelData = new macro.TYPED_ARRAYS[scalars.getDataType()](
+      pixelData = macro.newTypedArray(
+        scalars.getDataType(),
         rawData.buffer,
         offset,
         dims[0] * dims[1]

--- a/Sources/Filters/General/TriangleFilter/index.js
+++ b/Sources/Filters/General/TriangleFilter/index.js
@@ -73,10 +73,10 @@ function vtkTriangleFilter(publicAPI, model) {
     const dataset = vtkPolyData.newInstance();
     dataset
       .getPoints()
-      .setData(macro.TYPED_ARRAYS[pointsDataType].from(newPoints));
+      .setData(macro.newTypedArrayFrom(pointsDataType, newPoints));
     dataset
       .getPolys()
-      .setData(macro.TYPED_ARRAYS[cellsDataType].from(newCells));
+      .setData(macro.newTypedArrayFrom(cellsDataType, newCells));
 
     outData[0] = dataset;
   };

--- a/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
+++ b/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
@@ -334,7 +334,7 @@ function vtkWindowedSincPolyDataFilter(publicAPI, model) {
       // for (let i = 0; i < numPts; ++i) {
       //   newPts[zero].setPoint(i, inPts.subarray(i));
       // }
-      const copy = new window[newPts[zero].getDataType()](inPtsData);
+      const copy = macro.newTypedArray(newPts[zero].getDataType(), inPtsData);
       newPts[zero].setData(copy, 3);
     } else {
       // center the data and scale to be within unit cube [-1, 1]

--- a/Sources/Filters/Sources/Arrow2DSource/index.js
+++ b/Sources/Filters/Sources/Arrow2DSource/index.js
@@ -12,7 +12,7 @@ const { ShapeType } = Constants;
 function vtkStarSource(publicAPI, model) {
   const dataset = vtkPolyData.newInstance();
 
-  const points = new macro.TYPED_ARRAYS[model.pointType](10 * 3);
+  const points = macro.newTypedArray(model.pointType, 10 * 3);
   const edges = new Uint32Array(11);
   edges[0] = 10;
   for (let i = 0; i < 10; i++) {
@@ -33,7 +33,7 @@ function vtkStarSource(publicAPI, model) {
 function vtk6PointsArrow(publicAPI, model) {
   const dataset = vtkPolyData.newInstance();
 
-  const points = new macro.TYPED_ARRAYS[model.pointType](6 * 3);
+  const points = macro.newTypedArray(model.pointType, 6 * 3);
 
   const thickOp = model.height * 0.5 * model.thickness;
 
@@ -87,7 +87,7 @@ function vtk6PointsArrow(publicAPI, model) {
 function vtk4PointsArrow(publicAPI, model) {
   const dataset = vtkPolyData.newInstance();
 
-  const points = new macro.TYPED_ARRAYS[model.pointType](4 * 3);
+  const points = macro.newTypedArray(model.pointType, 4 * 3);
 
   const thickOp = (model.height / 3) * model.thickness;
 
@@ -124,7 +124,7 @@ function vtk4PointsArrow(publicAPI, model) {
 function vtkTriangleSource(publicAPI, model) {
   const dataset = vtkPolyData.newInstance();
 
-  const points = new macro.TYPED_ARRAYS[model.pointType](3 * 3);
+  const points = macro.newTypedArray(model.pointType, 3 * 3);
 
   const baseOffsetOp = model.height * (1 - model.base);
 
@@ -174,10 +174,10 @@ function vtkArrow2DSource(publicAPI, model) {
 /**
  * height modifies the size of the source along x axis
  * width modifies the size of the source along y axis
- 
+
  * thickness modifies the shape of the source, which becomes wider on
- * y axis 
- 
+ * y axis
+
  * base modifies the position which lowers the source on x axis for 0 and moves
  * the source up on x axis for 1
  */

--- a/Sources/Filters/Sources/CircleSource/index.js
+++ b/Sources/Filters/Sources/CircleSource/index.js
@@ -19,7 +19,7 @@ function vtkCircleSource(publicAPI, model) {
     let dataset = outData[0];
 
     // Points
-    const points = new window[model.pointType](model.resolution * 3);
+    const points = macro.newTypedArray(model.pointType, model.resolution * 3);
 
     // Lines/cells
     // [# of points in line, vert_index_0, vert_index_1, ..., vert_index_0]

--- a/Sources/Filters/Sources/ConcentricCylinderSource/index.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/index.js
@@ -188,7 +188,7 @@ function vtkConcentricCylinderSource(publicAPI, model) {
 
     // Points
     let pointIdx = 0;
-    const points = new window[model.pointType](numberOfPoints * 3);
+    const points = macro.newTypedArray(model.pointType, numberOfPoints * 3);
 
     // Cells
     let cellLocation = 0;

--- a/Sources/Filters/Sources/ConeSource/index.js
+++ b/Sources/Filters/Sources/ConeSource/index.js
@@ -24,7 +24,7 @@ function vtkConeSource(publicAPI, model) {
 
     // Points
     let pointIdx = 0;
-    const points = new window[model.pointType](numberOfPoints * 3);
+    const points = macro.newTypedArray(model.pointType, numberOfPoints * 3);
 
     // Cells
     let cellLocation = 0;

--- a/Sources/Filters/Sources/CubeSource/index.js
+++ b/Sources/Filters/Sources/CubeSource/index.js
@@ -23,10 +23,10 @@ function vtkCubeSource(publicAPI, model) {
     const numberOfPoints = 24;
 
     // Define points
-    const points = new window[model.pointType](numberOfPoints * 3);
+    const points = macro.newTypedArray(model.pointType, numberOfPoints * 3);
     polyData.getPoints().setData(points, 3);
 
-    const normals = new window[model.pointType](numberOfPoints * 3);
+    const normals = macro.newTypedArray(model.pointType, numberOfPoints * 3);
     const normalArray = vtkDataArray.newInstance({
       name: 'Normals',
       values: normals,
@@ -39,7 +39,10 @@ function vtkCubeSource(publicAPI, model) {
       tcdim = 3;
     }
 
-    const textureCoords = new window[model.pointType](numberOfPoints * tcdim);
+    const textureCoords = macro.newTypedArray(
+      model.pointType,
+      numberOfPoints * tcdim
+    );
     const tcoords = vtkDataArray.newInstance({
       name: 'TextureCoordinates',
       values: textureCoords,
@@ -189,7 +192,7 @@ function vtkCubeSource(publicAPI, model) {
       .apply(points);
 
     // Define quads
-    const polys = new window[model.pointType](numberOfPolys * 5);
+    const polys = macro.newTypedArray(model.pointType, numberOfPolys * 5);
     polyData.getPolys().setData(polys, 1);
 
     let polyIndex = 0;

--- a/Sources/Filters/Sources/CylinderSource/index.js
+++ b/Sources/Filters/Sources/CylinderSource/index.js
@@ -28,7 +28,7 @@ function vtkCylinderSource(publicAPI, model) {
     }
 
     // Points
-    const points = new window[model.pointType](numberOfPoints * 3);
+    const points = macro.newTypedArray(model.pointType, numberOfPoints * 3);
 
     // Cells
     let cellLocation = 0;

--- a/Sources/Filters/Sources/LineSource/index.js
+++ b/Sources/Filters/Sources/LineSource/index.js
@@ -36,7 +36,7 @@ function vtkLineSource(publicAPI, model) {
     const numPts = xres + 1;
 
     // Points
-    const points = new window[pointDataType](numPts * 3);
+    const points = macro.newTypedArray(pointDataType, numPts * 3);
     pd.getPoints().setData(points, 3);
 
     // Cells

--- a/Sources/Filters/Sources/PlaneSource/index.js
+++ b/Sources/Filters/Sources/PlaneSource/index.js
@@ -47,7 +47,7 @@ function vtkPlaneSource(publicAPI, model) {
     const numPolys = xres * yres;
 
     // Points
-    const points = new window[pointDataType](numPts * 3);
+    const points = macro.newTypedArray(pointDataType, numPts * 3);
     pd.getPoints().setData(points, 3);
 
     // Cells

--- a/Sources/Filters/Sources/PointSource/index.js
+++ b/Sources/Filters/Sources/PointSource/index.js
@@ -27,7 +27,7 @@ function vtkPointSource(publicAPI, model) {
     const numPts = model.numberOfPoints;
 
     // Points
-    const points = new window[pointDataType](numPts * 3);
+    const points = macro.newTypedArray(pointDataType, numPts * 3);
     pd.getPoints().setData(points, 3);
 
     // Cells

--- a/Sources/Filters/Sources/SLICSource/index.js
+++ b/Sources/Filters/Sources/SLICSource/index.js
@@ -125,7 +125,10 @@ function vtkSLICSource(publicAPI, model) {
     const nbBytes =
       (model.clusters.length < 256 ? 8 : 0) ||
       (model.clusters.length < 65536 ? 16 : 32);
-    const clusterIdxValues = new window[`Uint${nbBytes}Array`](dataSize);
+    const clusterIdxValues = macro.newTypedArray(
+      `Uint${nbBytes}Array`,
+      dataSize
+    );
     for (let i = 0; i < dataSize; i++) {
       let clusterDistance = Number.MAX_VALUE;
       model.clusters.forEach((cluster, idx) => {

--- a/Sources/Filters/Sources/SphereSource/index.js
+++ b/Sources/Filters/Sources/SphereSource/index.js
@@ -52,7 +52,7 @@ function vtkSphereSource(publicAPI, model) {
 
     // Points
     let pointIdx = 0;
-    let points = new window[pointDataType](numPts * 3);
+    let points = macro.newTypedArray(pointDataType, numPts * 3);
 
     // Normals
     let normals = new Float32Array(numPts * 3);

--- a/Sources/Filters/Sources/ViewFinderSource/index.js
+++ b/Sources/Filters/Sources/ViewFinderSource/index.js
@@ -6,7 +6,7 @@ function vtkViewFinderSource(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     const dataset = vtkPolyData.newInstance();
 
-    const points = new macro.TYPED_ARRAYS[model.pointType](3 * 16);
+    const points = macro.newTypedArray(model.pointType, 3 * 16);
 
     points[0] = model.radius;
     points[1] = model.radius / model.width;
@@ -71,7 +71,7 @@ function vtkViewFinderSource(publicAPI, model) {
     3, 4, 6, 5,
     3, 6, 5, 7,
     3, 8, 11, 9,
-    3, 8, 10, 11,    
+    3, 8, 10, 11,
     3, 12, 13, 15,
     3, 12, 15, 14,
   ]);

--- a/Sources/IO/Core/DataAccessHelper/HtmlDataAccessHelper.js
+++ b/Sources/IO/Core/DataAccessHelper/HtmlDataAccessHelper.js
@@ -93,7 +93,7 @@ function fetchArray(instance = {}, baseURL, array, options = {}) {
             Endian.swapBytes(array.buffer, DataTypeByteSize[array.dataType]);
           }
 
-          array.values = new window[array.dataType](array.buffer);
+          array.values = macro.newTypedArray(array.dataType, array.buffer);
         }
 
         if (array.values.length !== array.size) {

--- a/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
+++ b/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
@@ -94,7 +94,7 @@ function fetchArray(instance = {}, baseURL, array, options = {}) {
                 );
               }
 
-              array.values = new window[array.dataType](array.buffer);
+              array.values = macro.newTypedArray(array.dataType, array.buffer);
             }
 
             if (array.values.length !== array.size) {

--- a/Sources/IO/Core/DataAccessHelper/JSZipDataAccessHelper.js
+++ b/Sources/IO/Core/DataAccessHelper/JSZipDataAccessHelper.js
@@ -43,7 +43,7 @@ function handleUint8Array(array, compression, done) {
         Endian.swapBytes(array.buffer, DataTypeByteSize[array.dataType]);
       }
 
-      array.values = new window[array.dataType](array.buffer);
+      array.values = macro.newTypedArray(array.dataType, array.buffer);
     }
 
     if (array.values.length !== array.size) {

--- a/Sources/IO/Core/DataAccessHelper/LiteHttpDataAccessHelper.js
+++ b/Sources/IO/Core/DataAccessHelper/LiteHttpDataAccessHelper.js
@@ -90,7 +90,7 @@ function fetchArray(instance = {}, baseURL, array, options = {}) {
                 );
               }
 
-              array.values = new window[array.dataType](array.buffer);
+              array.values = macro.newTypedArray(array.dataType, array.buffer);
             }
 
             if (array.values.length !== array.size) {

--- a/Sources/IO/Core/ZipMultiDataSetReader/index.js
+++ b/Sources/IO/Core/ZipMultiDataSetReader/index.js
@@ -75,7 +75,7 @@ function vtkZipMultiDataSetReader(publicAPI, model) {
               zipEntry.async('arraybuffer').then((arraybuffer) => {
                 processing--;
                 const [type, id] = relativePath.split('_').slice(-2);
-                model.arrays[id] = new macro.TYPED_ARRAYS[type](arraybuffer);
+                model.arrays[id] = macro.newTypedArray(type, arraybuffer);
                 if (!processing) {
                   resolve();
                 }

--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -20,7 +20,7 @@ import Constants from 'vtk.js/Sources/Imaging/Core/ImageReslice/Constants';
 
 const { SlabMode } = Constants;
 
-const { TYPED_ARRAYS, capitalize, vtkErrorMacro } = macro;
+const { capitalize, vtkErrorMacro } = macro;
 
 // ----------------------------------------------------------------------------
 // vtkImageReslice methods
@@ -235,7 +235,8 @@ function vtkImageReslice(publicAPI, model) {
       .getScalars()
       .getNumberOfComponents(); // or s.numberOfComponents;
 
-    const outScalarsData = new TYPED_ARRAYS[dataType](
+    const outScalarsData = macro.newTypedArray(
+      dataType,
       outDims[0] * outDims[1] * outDims[2] * numComponents
     );
     const outScalars = vtkDataArray.newInstance({
@@ -387,7 +388,10 @@ function vtkImageReslice(publicAPI, model) {
       floatPtr = new Float64Array(inComponents * (outExt[1] - outExt[0]));
     }
 
-    const background = new TYPED_ARRAYS[inputScalarType](model.backgroundColor);
+    const background = macro.newTypedArray(
+      inputScalarType,
+      model.backgroundColor
+    );
 
     // set color for area outside of input volume extent
     // void *background;
@@ -427,7 +431,8 @@ function vtkImageReslice(publicAPI, model) {
     iter.initialize(output, outExt, model.stencil, null);
     const outPtr0 = iter.getScalars(output, 0);
     let outPtrIndex = 0;
-    const outTmp = new TYPED_ARRAYS[scalarType](
+    const outTmp = macro.newTypedArray(
+      scalarType,
       vtkBoundingBox.getDiagonalLength(outExt) * outComponents * 2
     );
 

--- a/Sources/Imaging/Hybrid/SampleFunction/index.js
+++ b/Sources/Imaging/Hybrid/SampleFunction/index.js
@@ -58,7 +58,7 @@ function vtkSampleFunction(publicAPI, model) {
     volume.setSpacing(spacing);
 
     // Create scalars array
-    const s = new window[model.pointType](numScalars);
+    const s = macro.newTypedArray(model.pointType, numScalars);
     const scalars = vtkDataArray.newInstance({
       name: 'Scalars',
       values: s,

--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/index.js
@@ -44,7 +44,7 @@ function createArrayHandler() {
           if (buffer instanceof Blob) {
             const fileReader = new FileReader();
             fileReader.onload = () => {
-              const array = new window[dataType](fileReader.result);
+              const array = macro.newTypedArray(dataType, fileReader.result);
               const mtimes = {
                 [context.getActiveViewId()]: context.getMTime(),
               };
@@ -53,7 +53,7 @@ function createArrayHandler() {
             };
             fileReader.readAsArrayBuffer(buffer);
           } else {
-            const array = new window[dataType](buffer);
+            const array = macro.newTypedArray(dataType, buffer);
             const mtimes = { [context.getActiveViewId()]: context.getMTime() };
             dataArrayCache[sha] = { mtimes, array };
             resolve(array);

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -486,7 +486,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.activateTexture = (texture) => {
     // Only add if it isn't already there
-    const result = model.textureResourceIds.get(texture);
+    const result = model._textureResourceIds.get(texture);
     if (result !== undefined) {
       model.context.activeTexture(model.context.TEXTURE0 + result);
       return;
@@ -500,21 +500,21 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       return;
     }
 
-    model.textureResourceIds.set(texture, activeUnit);
+    model._textureResourceIds.set(texture, activeUnit);
     model.context.activeTexture(model.context.TEXTURE0 + activeUnit);
   };
 
   publicAPI.deactivateTexture = (texture) => {
     // Only deactivate if it isn't already there
-    const result = model.textureResourceIds.get(texture);
+    const result = model._textureResourceIds.get(texture);
     if (result !== undefined) {
       publicAPI.getTextureUnitManager().free(result);
-      delete model.textureResourceIds.delete(texture);
+      delete model._textureResourceIds.delete(texture);
     }
   };
 
   publicAPI.getTextureUnitForTexture = (texture) => {
-    const result = model.textureResourceIds.get(texture);
+    const result = model._textureResourceIds.get(texture);
     if (result !== undefined) {
       return result;
     }
@@ -1173,7 +1173,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.bgImage.style.height = '100%';
   model.bgImage.style.zIndex = '-1';
 
-  model.textureResourceIds = new Map();
+  model._textureResourceIds = new Map();
 
   // Inheritance
   vtkViewNode.extend(publicAPI, model, initialValues);

--- a/Sources/Rendering/OpenGL/ShaderCache/index.js
+++ b/Sources/Rendering/OpenGL/ShaderCache/index.js
@@ -239,8 +239,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   vtkShaderCache(publicAPI, model);
-
-  return Object.freeze(publicAPI);
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -753,7 +753,8 @@ function vtkOpenGLTexture(publicAPI, model) {
         widthLevel /= 2;
         heightLevel /= 2;
       }
-      invertedData[i] = new window[dataType](
+      invertedData[i] = macro.newTypedArray(
+        dataType,
         heightLevel * widthLevel * model.components
       );
       for (let y = 0; y < heightLevel; ++y) {

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -74,7 +74,7 @@ function vtkViewNode(publicAPI, model) {
     if (!dobj) {
       return;
     }
-    const result = model.renderableChildMap.get(dobj);
+    const result = model._renderableChildMap.get(dobj);
     // if found just mark as visited
     if (result !== undefined) {
       result.setVisited(true);
@@ -84,7 +84,7 @@ function vtkViewNode(publicAPI, model) {
       if (newNode) {
         newNode.setParent(publicAPI);
         newNode.setVisited(true);
-        model.renderableChildMap.set(dobj, newNode);
+        model._renderableChildMap.set(dobj, newNode);
         model.children.push(newNode);
       }
     }
@@ -97,7 +97,7 @@ function vtkViewNode(publicAPI, model) {
 
     for (let index = 0; index < dataObjs.length; ++index) {
       const dobj = dataObjs[index];
-      const result = model.renderableChildMap.get(dobj);
+      const result = model._renderableChildMap.get(dobj);
       // if found just mark as visited
       if (result !== undefined) {
         result.setVisited(true);
@@ -107,7 +107,7 @@ function vtkViewNode(publicAPI, model) {
         if (newNode) {
           newNode.setParent(publicAPI);
           newNode.setVisited(true);
-          model.renderableChildMap.set(dobj, newNode);
+          model._renderableChildMap.set(dobj, newNode);
           model.children.push(newNode);
         }
       }
@@ -132,7 +132,7 @@ function vtkViewNode(publicAPI, model) {
       if (!visited) {
         const renderable = child.getRenderable();
         if (renderable) {
-          model.renderableChildMap.delete(renderable);
+          model._renderableChildMap.delete(renderable);
         }
         if (!deleted) {
           deleted = [];
@@ -183,7 +183,7 @@ function extend(publicAPI, model, initialValues = {}) {
   macro.obj(publicAPI, model);
   macro.event(publicAPI, model, 'event');
 
-  model.renderableChildMap = new Map();
+  model._renderableChildMap = new Map();
 
   macro.get(publicAPI, model, ['visited']);
   macro.setGet(publicAPI, model, ['parent', 'renderable', 'myFactory']);

--- a/Sources/Rendering/WebGPU/BufferManager/index.js
+++ b/Sources/Rendering/WebGPU/BufferManager/index.js
@@ -13,12 +13,6 @@ const { vtkDebugMacro } = macro;
 // the webgpu constants all show up as undefined
 /* eslint-disable no-undef */
 
-// const { ObjectType } = Constants;
-
-// ----------------------------------------------------------------------------
-// Global methods
-// ----------------------------------------------------------------------------
-
 // ----------------------------------------------------------------------------
 // Static API
 // ----------------------------------------------------------------------------
@@ -205,7 +199,8 @@ function packArray(
   let vboidx = 0;
 
   const numComp = inArray.getNumberOfComponents();
-  const packedVBO = new window[outputType](
+  const packedVBO = macro.newTypedArray(
+    outputType,
     caboCount * (numComp + (packExtra ? 1 : 0))
   );
 

--- a/Sources/Rendering/WebGPU/BufferManager/index.js
+++ b/Sources/Rendering/WebGPU/BufferManager/index.js
@@ -1,6 +1,7 @@
 import * as macro from 'vtk.js/Sources/macro';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkWebGPUBuffer from 'vtk.js/Sources/Rendering/WebGPU/Buffer';
+import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
 import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
 import Constants from './Constants';
 
@@ -362,36 +363,6 @@ function generateNormals(cellArray, primType, representation, inArray) {
   return packedVBO;
 }
 
-function getStrideFromFormat(format) {
-  if (!format) return 0;
-  let numComp = 1;
-  if (format.substring(format.length - 2) === 'x4') numComp = 4;
-  if (format.substring(format.length - 2) === 'x3') numComp = 3;
-  if (format.substring(format.length - 2) === 'x2') numComp = 2;
-
-  let typeSize = 4;
-  if (numComp > 1) {
-    if (format.substring(format.length - 3, format.length - 1) === '8x') {
-      typeSize = 1;
-    }
-    if (format.substring(format.length - 4, format.length - 1) === '16x') {
-      typeSize = 2;
-    }
-  } else {
-    if (format.substring(format.length - 1) === '8') typeSize = 1;
-    if (format.substring(format.length - 2) === '16') typeSize = 2;
-  }
-  return numComp * typeSize;
-}
-
-function getArrayTypeFromFormat(format) {
-  if (!format) return null;
-  if (format.substring(0, 7) === 'float32') return 'Float32Array';
-  if (format.substring(0, 6) === 'snorm8') return 'Int8Array';
-  if (format.substring(0, 6) === 'unorm8') return 'Uint8Array';
-  return '';
-}
-
 // ----------------------------------------------------------------------------
 // vtkWebGPUBufferManager methods
 // ----------------------------------------------------------------------------
@@ -426,8 +397,8 @@ function vtkWebGPUBufferManager(publicAPI, model) {
     const buffer = vtkWebGPUBuffer.newInstance();
     buffer.setDevice(model.device);
 
-    const stride = getStrideFromFormat(req.format);
-    const arrayType = getArrayTypeFromFormat(req.format);
+    const stride = vtkWebGPUTypes.getByteStrideFromBufferFormat(req.format);
+    const arrayType = vtkWebGPUTypes.getNativeTypeFromBufferFormat(req.format);
     let gpuUsage = null;
 
     // handle uniform buffers

--- a/Sources/Rendering/WebGPU/Device/index.js
+++ b/Sources/Rendering/WebGPU/Device/index.js
@@ -187,4 +187,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 export const newInstance = macro.newInstance(extend, 'vtkWebGPUDevice');
 
 // ----------------------------------------------------------------------------
-export default { newInstance, extend };
+export default {
+  newInstance,
+  extend,
+};

--- a/Sources/Rendering/WebGPU/README.md
+++ b/Sources/Rendering/WebGPU/README.md
@@ -29,11 +29,11 @@ ToDo
 - PBR lighting to replace the simple model currently coded
 - image display
 - volume rendering
-- transparency
-- actor matrix support
+- actor matrix support with auto shift
 - sphere/stick mappers
-- post render operations/framebuffers
 - hardware selector
+- eventually switch to using IBOs and flat interpolation
+- cropping planes for polydata mapper
 
 Developer Notes
 ============

--- a/Sources/Rendering/WebGPU/ShaderCache/index.js
+++ b/Sources/Rendering/WebGPU/ShaderCache/index.js
@@ -72,8 +72,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   vtkWebGPUShaderCache(publicAPI, model);
-
-  return Object.freeze(publicAPI);
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/WebGPU/ShaderCache/index.js
+++ b/Sources/Rendering/WebGPU/ShaderCache/index.js
@@ -31,11 +31,11 @@ function vtkWebGPUShaderCache(publicAPI, model) {
     // has it already been created?
     const sType = shaderDesc.getType();
     const sHash = shaderDesc.getHash();
-    const keys = model.shaderModules.keys();
+    const keys = model._shaderModules.keys();
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       if (key.getHash() === sHash && key.getType() === sType) {
-        return model.shaderModules.get(key);
+        return model._shaderModules.get(key);
       }
     }
 
@@ -43,7 +43,7 @@ function vtkWebGPUShaderCache(publicAPI, model) {
 
     const sm = vtkWebGPUShaderModule.newInstance();
     sm.initialize(model.device, shaderDesc);
-    model.shaderModules.set(shaderDesc, sm);
+    model._shaderModules.set(shaderDesc, sm);
     return sm;
   };
 }
@@ -64,7 +64,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Internal objects
-  model.shaderModules = new Map();
+  model._shaderModules = new Map();
 
   // Build VTK API
   macro.obj(publicAPI, model);

--- a/Sources/Rendering/WebGPU/ShaderDescription/index.js
+++ b/Sources/Rendering/WebGPU/ShaderDescription/index.js
@@ -56,8 +56,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   vtkWebGPUShaderDescription(publicAPI, model);
-
-  return Object.freeze(publicAPI);
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/WebGPU/Types/index.js
+++ b/Sources/Rendering/WebGPU/Types/index.js
@@ -1,0 +1,74 @@
+// ----------------------------------------------------------------------------
+// vtkWebGPUDevice static functions
+//
+// WebGPU uses types in a many places and calls, and often those types
+// need to be associated with byte sizes, alignments, native arrays etc.
+// The folowing methods are designed to help vtk.js introspect those types.
+// WebGPU currently tends to use multiple type formats:
+//  - buffer types such as float32x4
+//  - shader types suchs as vec4<f32>
+//  - texture types such as rgba32float
+// ----------------------------------------------------------------------------
+
+function getByteStrideFromBufferFormat(format) {
+  if (!format) return 0;
+  let numComp = 1;
+  if (format.substring(format.length - 2) === 'x4') numComp = 4;
+  if (format.substring(format.length - 2) === 'x3') numComp = 3;
+  if (format.substring(format.length - 2) === 'x2') numComp = 2;
+
+  let typeSize = 4;
+  if (numComp > 1) {
+    if (format.substring(format.length - 3, format.length - 1) === '8x') {
+      typeSize = 1;
+    }
+    if (format.substring(format.length - 4, format.length - 1) === '16x') {
+      typeSize = 2;
+    }
+  } else {
+    if (format.substring(format.length - 1) === '8') typeSize = 1;
+    if (format.substring(format.length - 2) === '16') typeSize = 2;
+  }
+  return numComp * typeSize;
+}
+
+function getNativeTypeFromBufferFormat(format) {
+  if (!format) return null;
+  if (format.substring(0, 7) === 'float32') return 'Float32Array';
+  if (format.substring(0, 6) === 'snorm8') return 'Int8Array';
+  if (format.substring(0, 6) === 'unorm8') return 'Uint8Array';
+  return '';
+}
+
+function getByteStrideFromShaderFormat(format) {
+  if (!format) return 0;
+  let numComp = 1;
+
+  if (format.substring(0, 3) === 'vec') {
+    numComp = format[3];
+  } else if (format.substring(0, 3) === 'mat') {
+    numComp = format[3] * format[5];
+  }
+
+  const typeSize = 4;
+  return numComp * typeSize;
+}
+
+function getNativeTypeFromShaderFormat(format) {
+  if (!format) return null;
+  let type = format.substring(format.length - 3, format.length);
+  if (format[format.length - 1] === '>') {
+    type = format.substring(format.length - 4, format.length - 1);
+  }
+  if (type === 'f32') return 'Float32Array';
+  if (type === 'i32') return 'Int32Array';
+  if (type === 'u32') return 'Uint32Array';
+  return '';
+}
+
+export default {
+  getByteStrideFromBufferFormat,
+  getNativeTypeFromBufferFormat,
+  getByteStrideFromShaderFormat,
+  getNativeTypeFromShaderFormat,
+};

--- a/Sources/Rendering/WebGPU/UniformBuffer/index.js
+++ b/Sources/Rendering/WebGPU/UniformBuffer/index.js
@@ -1,0 +1,338 @@
+import macro from 'vtk.js/Sources/macro';
+import vtkWebGPUBufferManager from 'vtk.js/Sources/Rendering/WebGPU/BufferManager';
+import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
+
+const { BufferUsage } = vtkWebGPUBufferManager;
+
+const { vtkErrorMacro } = macro;
+
+// ----------------------------------------------------------------------------
+// vtkWebGPUUniformBuffer methods
+// ----------------------------------------------------------------------------
+
+function vtkWebGPUUniformBuffer(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkWebGPUUniformBuffer');
+
+  publicAPI.addEntry = (name, type) => {
+    if (model.bufferEntryNames.has(name)) {
+      vtkErrorMacro(`entry named ${name} already exists`);
+      return;
+    }
+    model.sortDirty = true;
+    model.bufferEntryNames.set(name, model.bufferEntries.length);
+    model.bufferEntries.push({
+      name,
+      type,
+      sizeInBytes: vtkWebGPUTypes.getByteStrideFromShaderFormat(type),
+      offset: -1,
+      nativeType: vtkWebGPUTypes.getNativeTypeFromShaderFormat(type),
+      packed: false,
+    });
+  };
+
+  // UBOs have layout rules in terms of how memory is aligned so we
+  // have to be careful how we order the entries. For example a vec4<f32>
+  // must be aligned on a 16 byte offset, etc. See
+  // https://gpuweb.github.io/gpuweb/wgsl/#memory-layouts
+  // for more details.
+  publicAPI.sortBufferEntries = () => {
+    if (!model.sortDirty) {
+      return;
+    }
+
+    let currOffset = 0;
+    const newEntries = [];
+
+    // pack anything whose size is a multiple of 16 bytes first
+    // this includes a couple types that don't require 16 byte alignment
+    // such as mat2x2<f32> but that is OK
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      const entry = model.bufferEntries[i];
+      if (entry.packed === false && entry.sizeInBytes % 16 === 0) {
+        entry.packed = true;
+        entry.offset = currOffset;
+        newEntries.push(entry);
+        currOffset += entry.sizeInBytes;
+      }
+    }
+
+    // now it gets tough, we have the following common types (f32, i32, u32)
+    // - vec2<f32> 8 byte size, 8 byte alignment
+    // - vec3<f32> 12 byte size, 16 byte alignment
+    // - f32 4 byte size, 4 byte alignment
+
+    // try adding 12 byte, 4 byte pairs
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      const entry = model.bufferEntries[i];
+      if (entry.packed === false && entry.sizeInBytes === 12) {
+        for (let i2 = 0; i2 < model.bufferEntries.length; i2++) {
+          const entry2 = model.bufferEntries[i2];
+          if (entry2.packed === false && entry2.sizeInBytes === 4) {
+            entry.packed = true;
+            entry.offset = currOffset;
+            newEntries.push(entry);
+            currOffset += entry.sizeInBytes;
+            entry2.packed = true;
+            entry2.offset = currOffset;
+            newEntries.push(entry2);
+            currOffset += entry2.sizeInBytes;
+            break;
+          }
+        }
+      }
+    }
+
+    // try adding 8 byte, 8 byte pairs
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      const entry = model.bufferEntries[i];
+      if (!entry.packed && entry.sizeInBytes % 8 === 0) {
+        for (let i2 = i + 1; i2 < model.bufferEntries.length; i2++) {
+          const entry2 = model.bufferEntries[i2];
+          if (!entry2.packed && entry2.sizeInBytes % 8 === 0) {
+            entry.packed = true;
+            entry.offset = currOffset;
+            newEntries.push(entry);
+            currOffset += entry.sizeInBytes;
+            entry2.packed = true;
+            entry2.offset = currOffset;
+            newEntries.push(entry2);
+            currOffset += entry2.sizeInBytes;
+            break;
+          }
+        }
+      }
+    }
+
+    // try adding 8 byte, 4 byte 4 byte triplets
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      const entry = model.bufferEntries[i];
+      if (!entry.packed && entry.sizeInBytes % 8 === 0) {
+        let found = false;
+        for (let i2 = 0; !found && i2 < model.bufferEntries.length; i2++) {
+          const entry2 = model.bufferEntries[i2];
+          if (!entry2.packed && entry2.sizeInBytes === 4) {
+            for (let i3 = i2 + 1; i3 < model.bufferEntries.length; i3++) {
+              const entry3 = model.bufferEntries[i3];
+              if (!entry3.packed && entry3.sizeInBytes === 4) {
+                entry.packed = true;
+                entry.offset = currOffset;
+                newEntries.push(entry);
+                currOffset += entry.sizeInBytes;
+                entry2.packed = true;
+                entry2.offset = currOffset;
+                newEntries.push(entry2);
+                currOffset += entry2.sizeInBytes;
+                entry3.packed = true;
+                entry3.offset = currOffset;
+                newEntries.push(entry3);
+                currOffset += entry3.sizeInBytes;
+                found = true;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Add anything remaining that is larger than 4 bytes and hope we get lucky.
+    // Likely if there is more than one item added here it will result
+    // in a failed UBO
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      const entry = model.bufferEntries[i];
+      if (!entry.packed && entry.sizeInBytes > 4) {
+        entry.packed = true;
+        entry.offset = currOffset;
+        newEntries.push(entry);
+        currOffset += entry.sizeInBytes;
+      }
+    }
+
+    // finally add remaining 4 byte items
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      const entry = model.bufferEntries[i];
+      if (!entry.packed) {
+        entry.packed = true;
+        entry.offset = currOffset;
+        newEntries.push(entry);
+        currOffset += entry.sizeInBytes;
+      }
+    }
+
+    // update entries and entryNames
+    model.bufferEntries = newEntries;
+    model.bufferEntryNames.clear();
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      model.bufferEntryNames.set(model.bufferEntries[i].name, i);
+    }
+    model.sizeInBytes = currOffset;
+    model.sortDirty = false;
+  };
+
+  publicAPI.sendIfNeeded = (device, layout) => {
+    if (!model.UBO) {
+      const req = {
+        address: model.Float32Array,
+        time: 0,
+        usage: BufferUsage.UniformArray,
+      };
+      model.UBO = device.getBufferManager().getBuffer(req);
+      model.bindGroup = device.getHandle().createBindGroup({
+        layout,
+        entries: [
+          {
+            binding: model.binding,
+            resource: {
+              buffer: model.UBO.getHandle(),
+            },
+          },
+        ],
+      });
+      model.sendTime.modified();
+      model.sendDirty = false;
+    }
+
+    // send data down if needed
+    if (model.sendDirty) {
+      device
+        .getHandle()
+        .queue.writeBuffer(
+          model.UBO.getHandle(),
+          0,
+          model.arrayBuffer,
+          0,
+          model.sizeInBytes
+        );
+      model.sendTime.modified();
+      model.sendDirty = false;
+    }
+  };
+
+  publicAPI.createView = (type) => {
+    if (type in model === false) {
+      if (!model.arrayBuffer) {
+        model.arrayBuffer = new ArrayBuffer(model.sizeInBytes);
+      }
+      model[type] = new window[type](model.arrayBuffer);
+    }
+  };
+
+  publicAPI.setValue = (name, val) => {
+    publicAPI.sortBufferEntries();
+    const idx = model.bufferEntryNames.get(name);
+    if (idx === undefined) {
+      vtkErrorMacro(`entry named ${name} not found in UBO`);
+      return;
+    }
+    const entry = model.bufferEntries[idx];
+    publicAPI.createView(entry.nativeType);
+    const view = model[entry.nativeType];
+    if (view[entry.offset / view.BYTES_PER_ELEMENT] !== val) {
+      view[entry.offset / view.BYTES_PER_ELEMENT] = val;
+      model.sendDirty = true;
+    }
+  };
+
+  publicAPI.setArray = (name, arr) => {
+    publicAPI.sortBufferEntries();
+    const idx = model.bufferEntryNames.get(name);
+    if (idx === undefined) {
+      vtkErrorMacro(`entry named ${name} not found in UBO`);
+      return;
+    }
+    const entry = model.bufferEntries[idx];
+    publicAPI.createView(entry.nativeType);
+    const view = model[entry.nativeType];
+    for (let i = 0; i < arr.length; i++) {
+      if (view[entry.offset / view.BYTES_PER_ELEMENT + i] !== arr[i]) {
+        view[entry.offset / view.BYTES_PER_ELEMENT + i] = arr[i];
+        model.sendDirty = true;
+      }
+    }
+  };
+
+  publicAPI.getNativeView = (name) => {
+    publicAPI.sortBufferEntries();
+    const idx = model.bufferEntryNames.get(name);
+    if (idx === undefined) {
+      vtkErrorMacro(`entry named ${name} not found in UBO`);
+      return undefined;
+    }
+    const entry = model.bufferEntries[idx];
+    publicAPI.createView(entry.nativeType);
+    const bpe = model[entry.nativeType].BYTES_PER_ELEMENT;
+    model.sendDirty = true;
+    return new window[entry.nativeType](
+      model.arrayBuffer,
+      entry.offset,
+      entry.sizeInBytes / bpe
+    );
+  };
+
+  publicAPI.getSendTime = () => model.sendTime.getMTime();
+  publicAPI.getShaderCode = () => {
+    // sort the entries
+    publicAPI.sortBufferEntries();
+
+    let result = `[[block]] struct ${model.name}Struct\n{\n`;
+    for (let i = 0; i < model.bufferEntries.length; i++) {
+      const entry = model.bufferEntries[i];
+      result += `[[offset(${entry.offset})]] ${entry.name}: ${entry.type};\n`;
+    }
+    result += `};\n[[binding(${model.binding}), group(${model.group})]] var<uniform> ${model.name}: ${model.name}Struct;`;
+    return result;
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  bufferEntries: null,
+  bufferEntryNames: null,
+  sizeInBytes: 0,
+  name: null,
+  binding: 0,
+  group: 0,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Build VTK API
+  macro.obj(publicAPI, model);
+
+  // Internal objects
+  model.bufferEntryNames = new Map();
+  model.bufferEntries = [];
+
+  model.sendTime = {};
+  macro.obj(model.sendTime, { mtime: 0 });
+
+  model.sendDirty = true;
+  model.sortDirty = true;
+
+  macro.get(publicAPI, model, ['bindGroup']);
+  macro.setGet(publicAPI, model, [
+    'binding',
+    'device',
+    'group',
+    'name',
+    'sizeInBytes',
+  ]);
+
+  // Object methods
+  vtkWebGPUUniformBuffer(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkWebGPUUniformBuffer');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -80,16 +80,26 @@ export function vtkOnceErrorMacro(str) {
 // TypedArray
 // ----------------------------------------------------------------------------
 
-export const TYPED_ARRAYS = {
-  Float32Array,
-  Float64Array,
-  Uint8Array,
-  Int8Array,
-  Uint16Array,
-  Int16Array,
-  Uint32Array,
-  Int32Array,
-};
+export const TYPED_ARRAYS = Object.create(null);
+TYPED_ARRAYS.Float32Array = Float32Array;
+TYPED_ARRAYS.Float64Array = Float64Array;
+TYPED_ARRAYS.Uint8Array = Uint8Array;
+TYPED_ARRAYS.Int8Array = Int8Array;
+TYPED_ARRAYS.Uint16Array = Uint16Array;
+TYPED_ARRAYS.Int16Array = Int16Array;
+TYPED_ARRAYS.Uint32Array = Uint32Array;
+TYPED_ARRAYS.Int32Array = Int32Array;
+TYPED_ARRAYS.Uint8ClampedArray = Uint8ClampedArray;
+// TYPED_ARRAYS.BigInt64Array = BigInt64Array;
+// TYPED_ARRAYS.BigUint64Array = BigUint64Array;
+
+export function newTypedArray(type, ...args) {
+  return new (TYPED_ARRAYS[type] || Float64Array)(...args);
+}
+
+export function newTypedArrayFrom(type, ...args) {
+  return (TYPED_ARRAYS[type] || Float64Array).from(...args);
+}
 
 // ----------------------------------------------------------------------------
 // capitilze provided string
@@ -312,7 +322,11 @@ export function obj(publicAPI = {}, model = {}) {
 
     // Convert every vtkObject to its serializable form
     Object.keys(jsonArchive).forEach((keyName) => {
-      if (jsonArchive[keyName] === null || jsonArchive[keyName] === undefined) {
+      if (
+        jsonArchive[keyName] === null ||
+        jsonArchive[keyName] === undefined ||
+        keyName[0] === '_' // protected members start with _
+      ) {
         delete jsonArchive[keyName];
       } else if (jsonArchive[keyName].isA) {
         jsonArchive[keyName] = jsonArchive[keyName].getState();
@@ -1622,6 +1636,8 @@ export default {
   isVtkObject,
   keystore,
   newInstance,
+  newTypedArray,
+  newTypedArrayFrom,
   normalizeWheel,
   obj,
   proxy,
@@ -1636,7 +1652,7 @@ export default {
   setLoggerFunction,
   throttle,
   traverseInstanceTree,
-  TYPED_ARRAYS,
+  TYPED_ARRAYS, // deprecated todo remove on breaking API revision
   uncapitalize,
   VOID,
   vtkDebugMacro,


### PR DESCRIPTION
Add a Uniform Buffer Object class for WebGPU to manage UBOs
and make it easier for people to extend mappers etc by adding
additional fields to the UBOs used in a pipeline.

The UBO class handles memory alignment issues but currently
only supports basic types such as vec/mat not arrays or
structs as members.
