### PR TITLE
fix(renderwindowinteractor): fix interaction event name

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -531,7 +531,7 @@ export interface vtkRenderWindowInteractor extends VtkObject {
      *
      * @param args
      */
-    endInteractionEventEvent(args: any): any;
+    endInteractionEvent(args: any): any;
 
     /**
      *
@@ -573,7 +573,7 @@ export interface vtkRenderWindowInteractor extends VtkObject {
      *
      * @param args
      */
-    interactionEventEvent(args: any): any;
+    interactionEvent(args: any): any;
 
     /**
      *
@@ -725,7 +725,7 @@ export interface vtkRenderWindowInteractor extends VtkObject {
      *
      * @param args
      */
-    startInteractionEventEvent(args: any): any;
+    startInteractionEvent(args: any): any;
 
 
     /**

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -58,9 +58,9 @@ const handledEvents = [
   'Move3D',
   'StartPointerLock',
   'EndPointerLock',
-  'StartInteractionEvent',
-  'InteractionEvent',
-  'EndInteractionEvent',
+  'StartInteraction',
+  'Interaction',
+  'EndInteraction',
 ];
 
 function preventDefault(event) {


### PR DESCRIPTION
This commit fixes the Interaction event name

fix #1780