### PR TITLE
chore(Rendering): Remove some OpenGL Dependencies

### DIFF
--- a/Examples/Widgets/Box/BoxWidget.js
+++ b/Examples/Widgets/Box/BoxWidget.js
@@ -55,7 +55,7 @@ function widgetBehavior(publicAPI, model) {
       model.manipulator.setNormal(model.camera.getDirectionOfProjection());
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.openGLRenderWindow
+        model.apiSpecificRenderWindow
       );
 
       if (worldCoords.length) {

--- a/Sources/Common/Core/LookupTable/test/testCategoricalColors.js
+++ b/Sources/Common/Core/LookupTable/test/testCategoricalColors.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';
@@ -102,8 +102,8 @@ test.onlyIfWebGL('Test Categorical Colors', (t) => {
   mapper.setInputData(pd);
   mapper.setInterpolateScalarsBeforeMapping(true);
 
-  // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  // now create something to view it
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Common/Core/LookupTable/test/testSetTable.js
+++ b/Sources/Common/Core/LookupTable/test/testSetTable.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';
@@ -127,7 +127,7 @@ test.onlyIfWebGL('Test LookupTable setTable', (t) => {
   mapper.setInterpolateScalarsBeforeMapping(false);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Common/DataModel/Cone/test/testConeImplicitFunction.js
+++ b/Sources/Common/DataModel/Cone/test/testConeImplicitFunction.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkCone from 'vtk.js/Sources/Common/DataModel/Cone';
@@ -52,7 +52,7 @@ test.onlyIfWebGL('Test Cone Implicit Function', (t) => {
   renderer.addActor(actor);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
+++ b/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
@@ -9,7 +9,7 @@ import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 
@@ -126,7 +126,7 @@ test.onlyIfWebGL('Test vtkAppendPolyData rendering', (t) => {
   mapper.setInputConnection(filter.getOutputPort());
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/General/MoleculeToRepresentation/test/testMultipleBonds.js
+++ b/Sources/Filters/General/MoleculeToRepresentation/test/testMultipleBonds.js
@@ -8,7 +8,7 @@ import vtkSphereMapper from 'vtk.js/Sources/Rendering/Core/SphereMapper';
 import vtkStickMapper from 'vtk.js/Sources/Rendering/Core/StickMapper';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 
 import testMolecule from 'vtk.js/Data/molecule/test-multiple-bonds.cjson';
 import baseline from './testMolecule_multiple_bonds.png';
@@ -65,7 +65,7 @@ test.onlyIfWebGL('Test MultipleBonds', (t) => {
   // -----------------------------------------------------------
 
   // create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/General/TubeFilter/test/testTubeColors.js
+++ b/Sources/Filters/General/TubeFilter/test/testTubeColors.js
@@ -6,7 +6,7 @@ import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import vtkTubeFilter from 'vtk.js/Sources/Filters/General/TubeFilter';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import baseline from './testTubeColors.png';
@@ -145,7 +145,7 @@ test.onlyIfWebGL('Test vtkTubeFilter color map rendering', (t) => {
 
   // Create the renderer and display the colored tube
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
+++ b/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
@@ -5,7 +5,7 @@ import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
@@ -157,7 +157,7 @@ test.onlyIfWebGL('Test vtkTubeFilter rendering', (t) => {
   });
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/Sources/ConcentricCylinderSource/test/testConcentricCylinder.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/test/testConcentricCylinder.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkConcentricCylinderSource from 'vtk.js/Sources/Filters/Sources/ConcentricCylinderSource';
@@ -54,7 +54,7 @@ test.onlyIfWebGL('Test vtkConcentricCylinderSource Rendering', (t) => {
   activeCamera.setViewUp(0, 1, 0);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/Sources/ConeSource/test/testCone.js
+++ b/Sources/Filters/Sources/ConeSource/test/testCone.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
@@ -50,7 +50,7 @@ test.onlyIfWebGL('Test vtkConeSource Rendering', (t) => {
   mapper.setInputConnection(coneSource.getOutputPort());
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/Sources/CubeSource/test/testCube.js
+++ b/Sources/Filters/Sources/CubeSource/test/testCube.js
@@ -4,7 +4,7 @@ import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 
@@ -68,7 +68,7 @@ test.onlyIfWebGL('Test vtkCubeSource Rendering', (t) => {
   renderer.addActor(actorCube3);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/Sources/CylinderSource/test/testCylinder.js
+++ b/Sources/Filters/Sources/CylinderSource/test/testCylinder.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkCylinderSource from 'vtk.js/Sources/Filters/Sources/CylinderSource';
@@ -50,7 +50,7 @@ test.onlyIfWebGL('Test vtkCylinderSource Rendering', (t) => {
   mapper.setInputConnection(cylinderSource.getOutputPort());
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/Sources/LineSource/test/testLine.js
+++ b/Sources/Filters/Sources/LineSource/test/testLine.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkLineSource from 'vtk.js/Sources/Filters/Sources/LineSource';
@@ -39,7 +39,7 @@ test.onlyIfWebGL('Test vtkLineSource Rendering', (t) => {
   mapper.setInputConnection(lineSource.getOutputPort());
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/Sources/PlaneSource/test/testPlane.js
+++ b/Sources/Filters/Sources/PlaneSource/test/testPlane.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
@@ -54,7 +54,7 @@ test.onlyIfWebGL('Test vtkPlaneSource Rendering', (t) => {
   mapper.setInputConnection(PlaneSource.getOutputPort());
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Filters/Sources/PointSource/test/testPointSource.js
+++ b/Sources/Filters/Sources/PointSource/test/testPointSource.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkPointSource from 'vtk.js/Sources/Filters/Sources/PointSource';
@@ -43,7 +43,7 @@ test.onlyIfWebGL('Test vtkPointSource Rendering', (t) => {
   mapper.setInputConnection(PointSource.getOutputPort());
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/IO/Core/ImageStream/example/index.js
+++ b/Sources/IO/Core/ImageStream/example/index.js
@@ -33,7 +33,7 @@ smartConnect.onConnectionReady((connection) => {
   // Image
   imageStream.connect(session);
   const viewStream = imageStream.createViewStream('-1');
-  fullScreenRenderer.getOpenGLRenderWindow().setViewStream(viewStream);
+  fullScreenRenderer.getApiSpecificRenderWindow().setViewStream(viewStream);
 
   // Configure image quality
   viewStream.setInteractiveQuality(75);

--- a/Sources/IO/Misc/PDBReader/test/testMolecule.js
+++ b/Sources/IO/Misc/PDBReader/test/testMolecule.js
@@ -3,7 +3,7 @@ import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkMoleculeToRepresentation from 'vtk.js/Sources/Filters/General/MoleculeToRepresentation';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkPDBReader from 'vtk.js/Sources/IO/Misc/PDBReader';
 import vtkSphereMapper from 'vtk.js/Sources/Rendering/Core/SphereMapper';
 import vtkStickMapper from 'vtk.js/Sources/Rendering/Core/StickMapper';
@@ -65,7 +65,7 @@ test.onlyIfWebGL('Test MoleculeMapper', (t) => {
   // -----------------------------------------------------------
 
   // create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Imaging/Core/ImageReslice/test/testImageReslice.js
+++ b/Sources/Imaging/Core/ImageReslice/test/testImageReslice.js
@@ -7,7 +7,7 @@ import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
 import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
 import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
 import vtkImageReslice from 'vtk.js/Sources/Imaging/Core/ImageReslice';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 
@@ -89,7 +89,7 @@ test.onlyIfWebGL('Test vtkImageReslice Rendering', (t) => {
   renderer.addActor(resliceActor);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Interaction/Manipulators/MouseCameraUnicamRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraUnicamRotateManipulator/index.js
@@ -3,7 +3,6 @@ import vtkCompositeCameraManipulator from 'vtk.js/Sources/Interaction/Manipulato
 import vtkCompositeMouseManipulator from 'vtk.js/Sources/Interaction/Manipulators/CompositeMouseManipulator';
 import vtkInteractorStyleConstants from 'vtk.js/Sources/Rendering/Core/InteractorStyle/Constants';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOpenGLHardwareSelector from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector';
 import vtkPointPicker from 'vtk.js/Sources/Rendering/Core/PointPicker';
 import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
 
@@ -22,13 +21,7 @@ function vtkMouseCameraUnicamRotateManipulator(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkMouseCameraUnicamRotateManipulator');
 
-  // Setup HardwareSelector and Picker to pick points
-  model.selector = vtkOpenGLHardwareSelector.newInstance({
-    captureZValues: true,
-  });
-  model.selector.setFieldAssociation(
-    FieldAssociations.FIELD_ASSOCIATION_POINTS
-  );
+  // Setup Picker to pick points
   model.picker = vtkPointPicker.newInstance();
 
   model.downPoint = [0, 0, 0];
@@ -275,10 +268,13 @@ function vtkMouseCameraUnicamRotateManipulator(publicAPI, model) {
     // This seems like an arbitrary, but perhaps reasonable, default value.
     let selections = null;
     if (model.useHardwareSelector) {
-      model.selector.attach(interactor.getView(), renderer);
+      const selector = interactor.getView().getSelector();
+      selector.setCaptureZValues(true);
+      selector.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_POINTS);
+      selector.attach(interactor.getView(), renderer);
 
-      model.selector.setArea(position.x, position.y, position.x, position.y);
-      selections = model.selector.select();
+      selector.setArea(position.x, position.y, position.x, position.y);
+      selections = selector.select();
     }
 
     if (selections && selections.length !== 0) {

--- a/Sources/Interaction/Widgets/ResliceCursor/example/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/example/index.js
@@ -1,7 +1,7 @@
 import 'vtk.js/Sources/favicon';
 
 import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkResliceCursor from 'vtk.js/Sources/Interaction/Widgets/ResliceCursor/ResliceCursor';
 import vtkResliceCursorLineRepresentation from 'vtk.js/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorLineRepresentation';
 import vtkResliceCursorWidget from 'vtk.js/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorWidget';
@@ -57,7 +57,7 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
       renderers[j].getActiveCamera().setParallelProjection(true);
       renderWindows[j].addRenderer(renderers[j]);
 
-      GLWindows[j] = vtkOpenGLRenderWindow.newInstance();
+      GLWindows[j] = renderWindows[j].newAPISpecificView();
       GLWindows[j].setContainer(element);
       renderWindows[j].addView(GLWindows[j]);
 

--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -5,7 +5,7 @@ import vtkAxesActor from 'vtk.js/Sources/Rendering/Core/AxesActor';
 import vtkCornerAnnotation from 'vtk.js/Sources/Interaction/UI/CornerAnnotation';
 import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/InteractorStyleManipulator';
 import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkOrientationMarkerWidget from 'vtk.js/Sources/Interaction/Widgets/OrientationMarkerWidget';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
@@ -37,7 +37,7 @@ function vtkViewProxy(publicAPI, model) {
   model.renderer = vtkRenderer.newInstance({ background: [0, 0, 0] });
   model.renderWindow.addRenderer(model.renderer);
 
-  model.openglRenderWindow = vtkOpenGLRenderWindow.newInstance();
+  model.openglRenderWindow = model.renderWindow.newAPISpecificView();
   model.renderWindow.addView(model.openglRenderWindow);
 
   model.interactor = vtkRenderWindowInteractor.newInstance();
@@ -622,7 +622,7 @@ function extend(publicAPI, model, initialValues = {}) {
     'interactor',
     'interactorStyle2D',
     'interactorStyle3D',
-    'openglRenderWindow',
+    'openglRenderWindow', // todo breaking? convert to apiSpecificWindow
     'orientationAxesType',
     'presetToOrientationAxes',
     'renderer',

--- a/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
+++ b/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
@@ -44,7 +44,7 @@ test.onlyIfWebGL('Test vtkCellPicker image mapper', (t) => {
   renderer.addActor(actor);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';
@@ -103,7 +103,7 @@ test.onlyIfWebGL('Test Interpolate Scalars Before Colors', (t) => {
   mapper.setInterpolateScalarsBeforeMapping(true);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionInterpolation.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionInterpolation.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 
@@ -40,7 +40,7 @@ test.onlyIfWebGL('Test Interpolate Scalars Before Colors', (t) => {
   renderer.addActor(createScalarMap(0.5, 0, preset, gc));
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 500);

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionPresets.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionPresets.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 
@@ -44,7 +44,7 @@ test.onlyIfWebGL('Test Interpolate Scalars Before Colors', (t) => {
   });
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(

--- a/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
+++ b/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
@@ -219,5 +219,5 @@ test('Test vtkCoordinate publicAPI', (t) => {
   viewPort = [50.0, 50.0];
   testGetters(coord, renderer, testVal, world, display, localDisplay, viewPort);
 
-  t.end();
+  gc.releaseResources();
 });

--- a/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
+++ b/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
@@ -3,7 +3,7 @@ import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
 import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 
@@ -57,7 +57,7 @@ test('Test vtkCoordinate publicAPI', (t) => {
   const cam = vtkCamera.newInstance();
   renderer.setActiveCamera(cam);
 
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(100, 100);

--- a/Sources/Rendering/Core/Follower/test/testFollower.js
+++ b/Sources/Rendering/Core/Follower/test/testFollower.js
@@ -4,7 +4,7 @@ import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import vtkFollower from 'vtk.js/Sources/Rendering/Core/Follower';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkOBJReader from 'vtk.js/Sources/IO/Misc/OBJReader';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 
@@ -50,7 +50,7 @@ test.onlyIfWebGL('Test Follower class', (t) => {
       renderer.resetCamera();
       renderWindow.render();
 
-      const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+      const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
       glwindow.setContainer(renderWindowContainer);
       renderWindow.addView(glwindow);
       glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/Glyph3DMapper/test/testGlyph3DMapper.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/test/testGlyph3DMapper.js
@@ -2,7 +2,7 @@ import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
@@ -98,7 +98,7 @@ test.onlyIfWebGL('Test vtkGlyph3DMapper Rendering', (t) => {
   renderer.getActiveCamera().zoom(1.3);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/HardwareSelector/index.js
+++ b/Sources/Rendering/Core/HardwareSelector/index.js
@@ -1,0 +1,75 @@
+import macro from 'vtk.js/Sources/macro';
+import vtkDataSet from 'vtk.js/Sources/Common/DataModel/DataSet';
+
+const { FieldAssociations } = vtkDataSet;
+
+// ----------------------------------------------------------------------------
+// vtkHardwareSelector methods
+// ----------------------------------------------------------------------------
+
+function vtkHardwareSelector(publicAPI, model) {
+  model.classHierarchy.push('vtkHardwareSelector');
+
+  // update and source data that is used for generating a selection. This
+  // must be called at least once before calling generateSelection. In
+  // raster based backends this method will capture the buffers. You can
+  // call this once and then make multiple selections.
+  publicAPI.updateSelectionSourceData = (fx1, fy1, fx2, fy2) => {};
+
+  // generate a selection for the specified region
+  // Return am array of vtkSelectionNode
+  publicAPI.generateSelection = (fx1, fy1, fx2, fy2) => {
+    macro.vtkErrorMacro('not implemented');
+    return [];
+  };
+
+  // override
+  const superSetArea = publicAPI.setArea;
+  publicAPI.setArea = (...args) => {
+    if (superSetArea(...args)) {
+      model.area[0] = Math.floor(model.area[0]);
+      model.area[1] = Math.floor(model.area[1]);
+      model.area[2] = Math.floor(model.area[2]);
+      model.area[3] = Math.floor(model.area[3]);
+      return true;
+    }
+    return false;
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  area: undefined,
+  fieldAssociation: FieldAssociations.FIELD_ASSOCIATION_CELLS,
+  captureZValues: false,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  macro.obj(publicAPI, model);
+
+  if (!model.area) {
+    model.area = [0, 0, 0, 0];
+  }
+
+  macro.setGetArray(publicAPI, model, ['area'], 4);
+  macro.setGet(publicAPI, model, ['fieldAssociation', 'captureZValues']);
+
+  // Object methods
+  vtkHardwareSelector(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkHardwareSelector');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Rendering/Core/Mapper/test/testEdgeVisibility.js
+++ b/Sources/Rendering/Core/Mapper/test/testEdgeVisibility.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
@@ -39,7 +39,7 @@ test.onlyIfWebGL('Test Edge Visibility', (t) => {
   mapper.setInputConnection(sphereSource.getOutputPort());
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/Mapper/test/testVectorComponent.js
+++ b/Sources/Rendering/Core/Mapper/test/testVectorComponent.js
@@ -2,7 +2,7 @@ import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
@@ -52,7 +52,7 @@ test.onlyIfWebGL('Test VectorComponent', (t) => {
   mapper.setScalarRange(-1.0, 1.0);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
+++ b/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
@@ -43,7 +43,7 @@ test.onlyIfWebGL('Test vtkPointPicker image mapper', (t) => {
   renderer.addActor(actor);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/Prop3D/test/testUserMatrix.js
+++ b/Sources/Rendering/Core/Prop3D/test/testUserMatrix.js
@@ -4,7 +4,7 @@ import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkOBJReader from 'vtk.js/Sources/IO/Misc/OBJReader';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 
@@ -57,7 +57,7 @@ test.onlyIfWebGL('Test Set Actor User Matrix', (t) => {
       renderer.resetCamera();
       renderWindow.render();
 
-      const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+      const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
       glwindow.setContainer(renderWindowContainer);
       renderWindow.addView(glwindow);
       glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/RenderWindow/test/testMultipleRenderers.js
+++ b/Sources/Rendering/Core/RenderWindow/test/testMultipleRenderers.js
@@ -3,7 +3,7 @@ import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
@@ -72,7 +72,7 @@ test.onlyIfWebGL('Test multiple renderers', (t) => {
   const cubeSource = gc.registerResource(vtkCubeSource.newInstance());
   cubeMapper.setInputConnection(cubeSource.getOutputPort());
 
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/SphereMapper/test/testDisableScalarColoring.js
+++ b/Sources/Rendering/Core/SphereMapper/test/testDisableScalarColoring.js
@@ -2,7 +2,7 @@ import test from 'tape-catch';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
-import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
@@ -90,7 +90,7 @@ test.onlyIfWebGL('Test vtkSphereMapper Rendering', (t) => {
   mapper.setScalarVisibility(true);
 
   // now create something to view it, in this case webgl
-  const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);

--- a/Sources/Rendering/Core/index.js
+++ b/Sources/Rendering/Core/index.js
@@ -16,6 +16,7 @@ import vtkCoordinate from './Coordinate';
 import vtkCubeAxesActor from './CubeAxesActor';
 import vtkFollower from './Follower';
 import vtkGlyph3DMapper from './Glyph3DMapper';
+import vtkHardwareSelector from './HardwareSelector';
 import vtkImageMapper from './ImageMapper';
 import vtkImageProperty from './ImageProperty';
 import vtkImageSlice from './ImageSlice';
@@ -57,6 +58,7 @@ export default {
   vtkCubeAxesActor,
   vtkFollower,
   vtkGlyph3DMapper,
+  vtkHardwareSelector,
   vtkImageMapper,
   vtkImageProperty,
   vtkImageSlice,

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
@@ -11,8 +11,7 @@ import 'vtk.js/Sources/Common/Core/DataArray';
 import 'vtk.js/Sources/Common/DataModel/PolyData';
 import 'vtk.js/Sources/Rendering/Core/Actor';
 import 'vtk.js/Sources/Rendering/Core/Mapper';
-import 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
-import 'vtk.js/Sources/Rendering/WebGPU/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 
 // Process arguments from URL
 const userParams = vtkURLExtract.extractURLParameters();

--- a/Sources/Rendering/Misc/RenderingAPIs/index.js
+++ b/Sources/Rendering/Misc/RenderingAPIs/index.js
@@ -1,0 +1,9 @@
+// register default rendering backends. Currently
+// WebGL and WebGPU. To use this just import this
+// file and then call something like
+//   const apiview = myRenderWindow.newAPISpecificView();
+//   apiview.setContainer(renderWindowContainer);
+//   myRenderWindow.addView(apiview);
+//
+import 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import 'vtk.js/Sources/Rendering/WebGPU/RenderWindow';

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -1,5 +1,6 @@
 import macro from 'vtk.js/Sources/macro';
 import Constants from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector/Constants';
+import vtkHardwareSelector from 'vtk.js/Sources/Rendering/Core/HardwareSelector';
 import vtkOpenGLFramebuffer from 'vtk.js/Sources/Rendering/OpenGL/Framebuffer';
 import vtkSelectionNode from 'vtk.js/Sources/Common/DataModel/SelectionNode';
 import vtkDataSet from 'vtk.js/Sources/Common/DataModel/DataSet';
@@ -497,21 +498,6 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
     model.openGLRenderWindow = w;
     model.renderer = r;
   };
-
-  //----------------------------------------------------------------------------
-
-  // override
-  const superSetArea = publicAPI.setArea;
-  publicAPI.setArea = (...args) => {
-    if (superSetArea(...args)) {
-      model.area[0] = Math.floor(model.area[0]);
-      model.area[1] = Math.floor(model.area[1]);
-      model.area[2] = Math.floor(model.area[2]);
-      model.area[3] = Math.floor(model.area[3]);
-      return true;
-    }
-    return false;
-  };
 }
 
 // ----------------------------------------------------------------------------
@@ -519,16 +505,13 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  fieldAssociation: FieldAssociations.FIELD_ASSOCIATION_CELLS,
   renderer: null,
-  area: null,
   openGLRenderWindow: null,
   openGLRenderer: null,
   currentPass: -1,
   propColorValue: null,
   props: null,
   idOffset: 1,
-  captureZValues: false,
 };
 
 // ----------------------------------------------------------------------------
@@ -537,20 +520,13 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Build VTK API
-  macro.obj(publicAPI, model);
+  vtkHardwareSelector.extend(publicAPI, model, initialValues);
 
-  model.area = [0, 0, 0, 0];
   model.propColorValue = [0, 0, 0];
   model.props = [];
 
-  macro.setGet(publicAPI, model, [
-    'fieldAssociation',
-    'renderer',
-    'currentPass',
-    'captureZValues',
-  ]);
+  macro.setGet(publicAPI, model, ['renderer', 'currentPass', 'captureZValues']);
 
-  macro.setGetArray(publicAPI, model, ['area'], 4);
   macro.setGetArray(publicAPI, model, ['propColorValue'], 3);
   macro.event(publicAPI, model, 'event');
 

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -6,6 +6,7 @@ import vtkRenderPass from 'vtk.js/Sources/Rendering/SceneGraph/RenderPass';
 import vtkShaderCache from 'vtk.js/Sources/Rendering/OpenGL/ShaderCache';
 import vtkRenderWindowViewNode from 'vtk.js/Sources/Rendering/SceneGraph/RenderWindowViewNode';
 import vtkOpenGLTextureUnitManager from 'vtk.js/Sources/Rendering/OpenGL/TextureUnitManager';
+import vtkOpenGLHardwareSelector from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector';
 import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 
 const { vtkDebugMacro, vtkErrorMacro } = macro;
@@ -1052,10 +1053,18 @@ const DEFAULT_VALUES = {
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
+  // Inheritance
+  vtkRenderWindowViewNode.extend(publicAPI, model, initialValues);
+
   // Create internal instances
   model.canvas = document.createElement('canvas');
   model.canvas.style.width = '100%';
   createGLContext();
+
+  if (!model.selector) {
+    model.selector = vtkOpenGLHardwareSelector.newInstance();
+    model.selector.attach(publicAPI, undefined);
+  }
 
   // Create internal bgImage
   model.bgImage = new Image();
@@ -1067,9 +1076,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.bgImage.style.zIndex = '-1';
 
   model._textureResourceIds = new Map();
-
-  // Inheritance
-  vtkRenderWindowViewNode.extend(publicAPI, model, initialValues);
 
   model.myFactory = vtkOpenGLViewNodeFactory.newInstance();
   /* eslint-disable no-use-before-define */

--- a/Sources/Rendering/SceneGraph/RenderWindowViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/RenderWindowViewNode/index.js
@@ -145,6 +145,7 @@ function vtkRenderWindowViewNode(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   size: undefined,
+  selector: undefined,
 };
 
 // ----------------------------------------------------------------------------
@@ -157,6 +158,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   }
 
   macro.getArray(publicAPI, model, ['size'], 2);
+  macro.get(publicAPI, model, ['selector']);
 
   // Inheritance
   vtkViewNode.extend(publicAPI, model, initialValues);

--- a/Sources/Rendering/SceneGraph/index.js
+++ b/Sources/Rendering/SceneGraph/index.js
@@ -1,11 +1,13 @@
 import vtkGenericWidgetRepresentation from './GenericWidgetRepresentation';
 import vtkRenderPass from './RenderPass';
+import vtkRenderWindowViewNode from './RenderWindowViewNode';
 import vtkViewNode from './ViewNode';
 import vtkViewNodeFactory from './ViewNodeFactory';
 
 export default {
   vtkGenericWidgetRepresentation,
   vtkRenderPass,
+  vtkRenderWindowViewNode,
   vtkViewNode,
   vtkViewNodeFactory,
 };

--- a/Sources/Widgets/Core/AbstractWidgetFactory/index.js
+++ b/Sources/Widgets/Core/AbstractWidgetFactory/index.js
@@ -27,7 +27,7 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
 
       const {
         interactor,
-        openGLRenderWindow,
+        apiSpecificRenderWindow,
         camera,
       } = extractRenderingComponents(renderer);
       const widgetModel = {};
@@ -38,7 +38,7 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
         viewType,
         renderer,
         camera,
-        openGLRenderWindow,
+        apiSpecificRenderWindow,
         factory: publicAPI,
       });
       macro.safeArrays(widgetModel);

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -293,8 +293,6 @@ function vtkWidgetManager(publicAPI, model) {
       subscriptions.pop().unsubscribe();
     }
 
-    console.log(model);
-    console.log(model.apiSpecificRenderWindow);
     model.selector = model.apiSpecificRenderWindow.getSelector();
     model.selector.setFieldAssociation(
       FieldAssociations.FIELD_ASSOCIATION_POINTS

--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -54,7 +54,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setScale1(moveHandle.getScale1());
     } else {
       isDragging = true;
-      model.openGLRenderWindow.setCursor('grabbing');
+      model.apiSpecificRenderWindow.setCursor('grabbing');
       model.interactor.requestAnimation(publicAPI);
     }
 
@@ -79,7 +79,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.manipulator.setNormal(model.camera.getDirectionOfProjection());
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.openGLRenderWindow
+        model.apiSpecificRenderWindow
       );
 
       if (
@@ -103,7 +103,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
-      model.openGLRenderWindow.setCursor('pointer');
+      model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model.interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -47,7 +47,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setScale1(moveHandle.getScale1());
     } else {
       isDragging = true;
-      model.openGLRenderWindow.setCursor('grabbing');
+      model.apiSpecificRenderWindow.setCursor('grabbing');
       model.interactor.requestAnimation(publicAPI);
     }
 
@@ -78,7 +78,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.openGLRenderWindow
+        model.apiSpecificRenderWindow
       );
 
       if (
@@ -100,7 +100,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
-      model.openGLRenderWindow.setCursor('pointer');
+      model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model.interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
@@ -57,7 +57,7 @@ export default function widgetBehavior(publicAPI, model) {
           manipulator.setNormal(model.camera.getDirectionOfProjection());
           worldCoords = manipulator.handleEvent(
             callData,
-            model.openGLRenderWindow
+            model.apiSpecificRenderWindow
           );
         }
 
@@ -79,7 +79,7 @@ export default function widgetBehavior(publicAPI, model) {
           manipulator.setNormal(transformVec3(constraintAxis, indexToWorldT));
           worldCoords = manipulator.handleEvent(
             callData,
-            model.openGLRenderWindow
+            model.apiSpecificRenderWindow
           );
         }
 
@@ -90,7 +90,7 @@ export default function widgetBehavior(publicAPI, model) {
           manipulator.setNormal(transformVec3(edgeAxis, indexToWorldT));
           worldCoords = manipulator.handleEvent(
             callData,
-            model.openGLRenderWindow
+            model.apiSPecificRenderWindow
           );
         }
 

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
@@ -21,16 +21,16 @@ function widgetBehavior(publicAPI, model) {
   publicAPI.updateCursor = () => {
     switch (model.activeState.getUpdateMethodName()) {
       case 'updateFromOrigin':
-        model.openGLRenderWindow.setCursor('crosshair');
+        model.apiSpecificRenderWindow.setCursor('crosshair');
         break;
       case 'updateFromPlane':
-        model.openGLRenderWindow.setCursor('move');
+        model.apiSpecificRenderWindow.setCursor('move');
         break;
       case 'updateFromNormal':
-        model.openGLRenderWindow.setCursor('alias');
+        model.apiSpecificRenderWindow.setCursor('alias');
         break;
       default:
-        model.openGLRenderWindow.setCursor('grabbing');
+        model.apiSpecificRenderWindow.setCursor('grabbing');
         break;
     }
   };
@@ -86,7 +86,7 @@ function widgetBehavior(publicAPI, model) {
     model.planeManipulator.setNormal(model.widgetState.getNormal());
     const worldCoords = model.planeManipulator.handleEvent(
       callData,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
 
     if (model.widgetState.containsPoint(worldCoords)) {
@@ -101,7 +101,7 @@ function widgetBehavior(publicAPI, model) {
     model.lineManipulator.setNormal(model.activeState.getNormal());
     const worldCoords = model.lineManipulator.handleEvent(
       callData,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
 
     if (model.widgetState.containsPoint(...worldCoords)) {
@@ -116,7 +116,7 @@ function widgetBehavior(publicAPI, model) {
 
     const newNormal = model.trackballManipulator.handleEvent(
       callData,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
     model.activeState.setNormal(newNormal);
   };

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -39,9 +39,9 @@ export default function widgetBehavior(publicAPI, model) {
   function updateCursor(callData) {
     model.isDragging = true;
     model.previousPosition = [
-      ...model.manipulator.handleEvent(callData, model.openGLRenderWindow),
+      ...model.manipulator.handleEvent(callData, model.apiSpecificRenderWindow),
     ];
-    model.openGLRenderWindow.setCursor('grabbing');
+    model.apiSpecificRenderWindow.setCursor('grabbing');
     model.interactor.requestAnimation(publicAPI);
   }
 
@@ -260,7 +260,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.openGLRenderWindow
+        model.apiSpecificRenderWindow
       );
       const translation = model.previousPosition
         ? vtkMath.subtract(worldCoords, model.previousPosition, [])
@@ -317,7 +317,7 @@ export default function widgetBehavior(publicAPI, model) {
       if (!wasTextActive) {
         model.interactor.cancelAnimation(publicAPI);
       }
-      model.openGLRenderWindow.setCursor('pointer');
+      model.apiSpecificRenderWindow.setCursor('pointer');
 
       model.hasFocus = false;
 

--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -43,7 +43,9 @@ scene.fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
 
 scene.renderer = scene.fullScreenRenderer.getRenderer();
 scene.renderWindow = scene.fullScreenRenderer.getRenderWindow();
-scene.openGLRenderWindow = scene.fullScreenRenderer.getInteractor().getView();
+scene.apiSpecificRenderWindow = scene.fullScreenRenderer
+  .getInteractor()
+  .getView();
 scene.camera = scene.renderer.getActiveCamera();
 
 // setup 2D view

--- a/Sources/Widgets/Widgets3D/PaintWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/index.js
@@ -55,7 +55,7 @@ function widgetBehavior(publicAPI, model) {
 
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.openGLRenderWindow
+        model.apiSpecificRenderWindow
       );
 
       if (worldCoords.length) {
@@ -88,7 +88,7 @@ function widgetBehavior(publicAPI, model) {
       model.activeState.activate();
       model.interactor.requestAnimation(publicAPI);
 
-      const canvas = model.openGLRenderWindow.getCanvas();
+      const canvas = model.apiSpecificRenderWindow.getCanvas();
       canvas.onmouseenter = () => {
         if (
           model.hasFocus &&

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -70,7 +70,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setScale1(moveHandle.getScale1());
     } else {
       isDragging = true;
-      model.openGLRenderWindow.setCursor('grabbing');
+      model.apiSpecificRenderWindow.setCursor('grabbing');
       model.interactor.requestAnimation(publicAPI);
     }
 
@@ -95,7 +95,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.manipulator.setNormal(model.camera.getDirectionOfProjection());
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.openGLRenderWindow
+        model.apiSpecificRenderWindow
       );
 
       if (
@@ -119,7 +119,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
-      model.openGLRenderWindow.setCursor('pointer');
+      model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model.interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -46,16 +46,16 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.updateCursor = () => {
     switch (model.activeState.getUpdateMethodName()) {
       case InteractionMethodsName.TranslateCenter:
-        model.openGLRenderWindow.setCursor('move');
+        model.apiSpecificRenderWindow.setCursor('move');
         break;
       case InteractionMethodsName.RotateLine:
-        model.openGLRenderWindow.setCursor('alias');
+        model.apiSpecificRenderWindow.setCursor('alias');
         break;
       case InteractionMethodsName.TranslateAxis:
-        model.openGLRenderWindow.setCursor('pointer');
+        model.apiSpecificRenderWindow.setCursor('pointer');
         break;
       default:
-        model.openGLRenderWindow.setCursor('default');
+        model.apiSpecificRenderWindow.setCursor('default');
         break;
     }
   };
@@ -238,7 +238,7 @@ export default function widgetBehavior(publicAPI, model) {
     const stateLine = model.widgetState.getActiveLineState();
     const worldCoords = model.planeManipulator.handleEvent(
       calldata,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
 
     const point1 = stateLine.getPoint1();
@@ -300,7 +300,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI[InteractionMethodsName.TranslateCenter] = (calldata) => {
     let worldCoords = model.planeManipulator.handleEvent(
       calldata,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
     worldCoords = publicAPI.getBoundedCenter(worldCoords);
     model.activeState.setCenter(worldCoords);
@@ -312,7 +312,7 @@ export default function widgetBehavior(publicAPI, model) {
     const planeNormal = model.planeManipulator.getNormal();
     const worldCoords = model.planeManipulator.handleEvent(
       calldata,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
 
     const center = model.widgetState.getCenter();

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -163,8 +163,8 @@ export default function widgetBehavior(publicAPI, model) {
       const scale =
         model.pixelScale *
         vec3.distance(
-          model.openGLRenderWindow.displayToWorld(0, 0, 0, model.renderer),
-          model.openGLRenderWindow.displayToWorld(1, 0, 0, model.renderer)
+          model.apiSpecificRenderWindow.displayToWorld(0, 0, 0, model.renderer),
+          model.apiSpecificRenderWindow.displayToWorld(1, 0, 0, model.renderer)
         );
 
       model.point1Handle.setScale1(scale);
@@ -265,11 +265,11 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.setCorners = (point1, point2) => {
     if (model.label && model.labelTextCallback) {
       const bounds = makeBoundsFromPoints(point1, point2);
-      const screenPoint1 = model.openGLRenderWindow.worldToDisplay(
+      const screenPoint1 = model.apiSpecificRenderWindow.worldToDisplay(
         ...point1,
         model.renderer
       );
-      const screenPoint2 = model.openGLRenderWindow.worldToDisplay(
+      const screenPoint2 = model.apiSpecificRenderWindow.worldToDisplay(
         ...point2,
         model.renderer
       );
@@ -386,7 +386,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
     const worldCoords = model.manipulator.handleEvent(
       callData,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
     if (!worldCoords.length) {
       return macro.VOID;
@@ -447,7 +447,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.activeState === model.point2Handle)
     ) {
       model.isDragging = true;
-      model.openGLRenderWindow.setCursor('grabbing');
+      model.apiSpecificRenderWindow.setCursor('grabbing');
       model.interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
 
@@ -464,7 +464,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleLeftButtonRelease = (e) => {
     if (model.isDragging) {
       model.isDragging = false;
-      model.openGLRenderWindow.setCursor('pointer');
+      model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model.interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
@@ -476,7 +476,7 @@ export default function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
 
-    const viewSize = model.openGLRenderWindow.getSize();
+    const viewSize = model.apiSpecificRenderWindow.getSize();
     if (
       e.position.x < 0 ||
       e.position.x > viewSize[0] - 1 ||

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -43,7 +43,7 @@ scene.fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
 
 scene.renderer = scene.fullScreenRenderer.getRenderer();
 scene.renderWindow = scene.fullScreenRenderer.getRenderWindow();
-scene.openGLRenderWindow = scene.fullScreenRenderer.getOpenGLRenderWindow();
+scene.openGLRenderWindow = scene.fullScreenRenderer.getApiSpecificRenderWindow();
 scene.camera = scene.renderer.getActiveCamera();
 
 // setup 2D view

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -13,8 +13,8 @@ export default function widgetBehavior(publicAPI, model) {
       const scale =
         model.handleSizeInPixels *
         vec3.distance(
-          model.openGLRenderWindow.displayToWorld(0, 0, 0, model.renderer),
-          model.openGLRenderWindow.displayToWorld(1, 0, 0, model.renderer)
+          model.apiSpecificRenderWindow.displayToWorld(0, 0, 0, model.renderer),
+          model.apiSpecificRenderWindow.displayToWorld(1, 0, 0, model.renderer)
         );
 
       model.moveHandle.setScale1(scale);
@@ -47,7 +47,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.firstHandle = model.lastHandle;
       }
 
-      model.openGLRenderWindow.setCursor('grabbing');
+      model.apiSpecificRenderWindow.setCursor('grabbing');
     }
   };
 
@@ -203,7 +203,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.freeHand = model.allowFreehand && !model.isDragging;
     } else {
       model.isDragging = true;
-      model.openGLRenderWindow.setCursor('grabbing');
+      model.apiSpecificRenderWindow.setCursor('grabbing');
       model.interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
@@ -218,7 +218,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleLeftButtonRelease = (e) => {
     if (model.isDragging) {
       if (!model.hasFocus) {
-        model.openGLRenderWindow.setCursor(model.defaultCursor);
+        model.apiSpecificRenderWindow.setCursor(model.defaultCursor);
         model.widgetState.deactivate();
         model.interactor.cancelAnimation(publicAPI);
         publicAPI.invokeEndInteractionEvent();
@@ -276,18 +276,18 @@ export default function widgetBehavior(publicAPI, model) {
 
     const worldCoords = model.manipulator.handleEvent(
       callData,
-      model.openGLRenderWindow
+      model.apiSpecificRenderWindow
     );
 
     const hoveredHandle = getHoveredHandle();
     if (hoveredHandle) {
       model.moveHandle.setVisible(false);
       if (hoveredHandle !== model.firstHandle) {
-        model.openGLRenderWindow.setCursor('grabbing');
+        model.apiSpecificRenderWindow.setCursor('grabbing');
       }
     } else if (!model.isDragging && model.hasFocus) {
       model.moveHandle.setVisible(true);
-      model.openGLRenderWindow.setCursor(model.defaultCursor);
+      model.apiSpecificRenderWindow.setCursor(model.defaultCursor);
     }
 
     if (model.lastHandle) {


### PR DESCRIPTION
Start removing places where people explicitly used
OpenGL so that the code can be more rendering API
agnostic.

Also fix one test that was not releasing its resources.