### PR TITLE
docs: fix type definition for getRGBTransferFunction in vtkImageProperty

### DIFF
--- a/Sources/Rendering/Core/ImageProperty/index.d.ts
+++ b/Sources/Rendering/Core/ImageProperty/index.d.ts
@@ -83,9 +83,9 @@ export interface vtkImageProperty extends VtkObject {
 
 	/**
 	 * Get the currently set RGB transfer function.
-	 * @param idx 
+	 * @param {Number} idx
 	 */
-	getRGBTransferFunction(idx: any): void;
+	getRGBTransferFunction(idx: number): any;
 
 	/**
 	 * Alias to get the piecewise function (backwards compatibility)


### PR DESCRIPTION
fix type definition for getRGBTransferFunction in vtkImageProperty