### PR TITLE
fix(esm): Output all files with js extension

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -76,13 +76,13 @@ export default {
         return name.replace('node_modules', 'vendor');
       }
 
+      if (!name.endsWith('.js')) {
+        name += '.js';
+      }
+
       // throw all subscript prefixed chunks into a virtual folder
       if (name.startsWith('_')) {
         return name.replace(/^_/, `_virtual${path.sep}`);
-      }
-
-      if (!name.endsWith('.js')) {
-        name += '.js';
       }
 
       // rewrite Sources/ chunks


### PR DESCRIPTION
This fixes an issue where the js extension is missing for rollup-generated intermediate files. Webpack rules might not pick these files up correctly depending on the loader rules.