### PR TITLE
fix(httpdatasetreader): when caching array data, differentiate by class

### DIFF
--- a/Sources/IO/Core/HttpDataSetReader/index.js
+++ b/Sources/IO/Core/HttpDataSetReader/index.js
@@ -144,7 +144,7 @@ function vtkHttpDataSetReader(publicAPI, model) {
 
   // Internal method to fetch Array
   function fetchArray(array, options = {}) {
-    const arrayId = array.ref.id;
+    const arrayId = `${array.ref.id}|${array.vtkClass}`;
     if (!cachedArrays[arrayId]) {
       // Cache the promise while fetching
       cachedArrays[arrayId] = model.dataAccessHelper


### PR DESCRIPTION
A clear and concise description of what the problem was and how this pull request solves it.

The reader caches array instances to avoid having to load and instanciate the same array multiple times. Arrays are
cached using a hash of the binary data they contain.

This means a vtkPoints and vtkDataArray sharing the same data could be cached under the same index.

This case can happen quite often with empty meshes, as all arrays will share the same hash.

This fix appends the class type to the caching key to avoid these conflicts.
