### PR TITLE
ESM: avoid critical dependency webpack error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3927,6 +3927,17 @@
         }
       }
     },
+    "@rollup/plugin-inject": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz",
+      "integrity": "sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.4",
+        "estree-walker": "^1.0.1",
+        "magic-string": "^0.25.5"
+      }
+    },
     "@rollup/plugin-json": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -19364,6 +19375,15 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-ignore/-/rollup-plugin-ignore-1.0.9.tgz",
       "integrity": "sha512-+Q2jmD4gbO3ByFuljkDEfpEcYvll7J5+ZadUuk/Pu35x2KGrbHxKtt3+s+dPIgXX1mG7zCxG4s/NdRqztR5Ruw==",
       "dev": true
+    },
+    "rollup-plugin-polyfill-node": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.6.2.tgz",
+      "integrity": "sha512-gMCVuR0zsKq0jdBn8pSXN1Ejsc458k2QsFFvQdbHoM0Pot5hEnck+pBP/FDwFS6uAi77pD3rDTytsaUStsOMlA==",
+      "dev": true,
+      "requires": {
+        "@rollup/plugin-inject": "^4.0.0"
+      }
     },
     "rollup-plugin-postcss": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "resemblejs": "3.2.5",
     "rollup": "2.45.0",
     "rollup-plugin-ignore": "1.0.9",
+    "rollup-plugin-polyfill-node": "^0.6.2",
     "rollup-plugin-postcss": "4.0.0",
     "rollup-plugin-re": "1.0.7",
     "rollup-plugin-string": "3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import eslint from '@rollup/plugin-eslint';
 import ignore from 'rollup-plugin-ignore';
 import json from '@rollup/plugin-json';
+import nodePolyfills from 'rollup-plugin-polyfill-node';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import postcss from 'rollup-plugin-postcss';
 import replace from 'rollup-plugin-re';
@@ -125,7 +126,6 @@ export default {
     alias({
       entries: [
         { find: 'vtk.js', replacement: path.resolve(__dirname) },
-        { find: 'stream', replacement: require.resolve('stream-browserify') },
       ],
     }),
     // ignore crypto module
@@ -151,17 +151,12 @@ export default {
       }),
     // commonjs should be before babel
     commonjs({
-      dynamicRequireTargets: [
-        // handle a dynamic require circular dependencies
-        'node_modules/readable-stream/lib/_stream_duplex.js',
-        // Do not handle these circular dependencies, as downstream will get
-        // runtime errors related to commonjs require.
-        // 'node_modules/jszip/lib/base64.js',
-      ],
       // dynamicRequireTargets implies transformMixedEsModules because
       // dynamicRequireTargets generates mixed modules
       transformMixedEsModules: true,
     }),
+    // should be after commonjs
+    nodePolyfills(),
     babel({
       include: 'Sources/**',
       exclude: 'node_modules/**',


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context

When using the `@kitware/vtk.js` package, webpack users would run into a `Critical dependency` error, like the one below.

```
WARNING in ./node_modules/@kitware/vtk.js/_virtual/commonjsHelpers.js 154:8-29
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/@kitware/vtk.js/_vendor/readable-stream/lib/_stream_duplex.js_commonjs-dynamic-register 4:0-77 6:0-16
 @ ./node_modules/@kitware/vtk.js/Rendering/Core/Actor.js 2:0-87
 @ ./src/index.js 10:0-60 50:14-34

```

### Changes

We switch to using the polyfill rollup plugin in order to polyfill out stream (and readable-stream).

### Results

Initial testing indicates that the polyfill works and the error does not occur in webpack builds that consume `@kitware/vtk.js`.
