### PR TITLE
docs(ts): move primitive vtk interfaces to interfaces.d.ts

### DIFF
--- a/Sources/Common/Core/DataArray/index.d.ts
+++ b/Sources/Common/Core/DataArray/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../types.ts' />
 
-import { VtkObject, vtkRange } from "vtk.js/Sources/macro";
+import { vtkObject, vtkRange } from "vtk.js/Sources/interfaces";
 
 /**
  * Output of the rangeHelper instance
@@ -22,7 +22,7 @@ interface vtkRangeHelper {
 	getRange(): vtkRange;
 }
 
-export interface vtkDataArray extends VtkObject {
+export interface vtkDataArray extends vtkObject {
 
 	/**
 	 * Get the size, in bytes, of the lowest-level element of an array.

--- a/Sources/Common/Core/PriorityQueue/index.d.ts
+++ b/Sources/Common/Core/PriorityQueue/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -7,7 +7,7 @@ interface IPriorityQueueInitialValues {
 	elements?: Array<any>;
 }
 
-export interface vtkPriorityQueue extends VtkObject {
+export interface vtkPriorityQueue extends vtkObject {
 
 	/**
 	 * Push an element to the queue while defining a priority.

--- a/Sources/Common/Core/ProgressHandler/index.d.ts
+++ b/Sources/Common/Core/ProgressHandler/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
 
 
 /**
@@ -8,7 +8,7 @@ interface IProgressHandlerInitialValues {
 	workCount?: number;
 }
 
-export interface vtkProgressHandler extends VtkObject {
+export interface vtkProgressHandler extends vtkObject {
 	
 	/**
 	 * 

--- a/Sources/Common/DataModel/Cell/index.d.ts
+++ b/Sources/Common/DataModel/Cell/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 import vtkPoints from 'vtk.js/Sources/Core/Points';
 
 interface ICellInitialValues {
@@ -6,7 +6,7 @@ interface ICellInitialValues {
 	pointsIds?: number[];
 }
 
-export interface vtkCell extends VtkObject {
+export interface vtkCell extends vtkObject {
 
 	/**
 	 * Copy this cell by completely copying internal data structures.

--- a/Sources/Common/DataModel/Cone/index.d.ts
+++ b/Sources/Common/DataModel/Cone/index.d.ts
@@ -1,11 +1,11 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 
 interface IConeInitialValues {
 	angle?: number;
 }
 
-export interface vtkCone extends VtkObject {
+export interface vtkCone extends vtkObject {
 
 	/**
 	 * Given the point x evaluate the cone equation.

--- a/Sources/Common/DataModel/Cylinder/index.d.ts
+++ b/Sources/Common/DataModel/Cylinder/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 
 interface ICylinderInitialValues {
@@ -7,7 +7,7 @@ interface ICylinderInitialValues {
 	axis?: number[];
 }
 
-export interface vtkCylinder extends VtkObject {
+export interface vtkCylinder extends vtkObject {
 
 	/**
 	 * Given the point xyz (three floating value) evaluate the cylinder

--- a/Sources/Common/DataModel/DataSet/index.d.ts
+++ b/Sources/Common/DataModel/DataSet/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 import vtkDataSetAttributes from 'vtk.js/Sources/Common/DataModel/DataSetAttributes';
 
 export enum FieldDataTypes {
@@ -34,7 +34,7 @@ export enum FieldAssociations {
  */
 interface IDataSetInitialValues {}
 
-export interface vtkDataSet extends VtkObject {
+export interface vtkDataSet extends vtkObject {
 
 	/**
 	 * Get dataset's cell data

--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 
 /**
@@ -19,7 +19,7 @@ interface IArrayWithIndex {
 	index: number;
 }
 
-export interface vtkFieldData extends VtkObject {
+export interface vtkFieldData extends vtkObject {
 
 	/**
 	 * 

--- a/Sources/Common/DataModel/DataSetAttributes/index.d.ts
+++ b/Sources/Common/DataModel/DataSetAttributes/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 import {
 	vtkFieldData
 } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/FieldData';

--- a/Sources/Common/DataModel/Plane/index.d.ts
+++ b/Sources/Common/DataModel/Plane/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 /**
  *
@@ -16,7 +16,7 @@ interface IIntersectWithLine {
 }
 
 
-export interface vtkPlane extends VtkObject {
+export interface vtkPlane extends vtkObject {
 
 	/**
 	 * Return the distance of a point x to a plane defined by n (x-p0) = 0.

--- a/Sources/Common/DataModel/Sphere/index.d.ts
+++ b/Sources/Common/DataModel/Sphere/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 
 interface ISphereInitialValues {
@@ -6,7 +6,7 @@ interface ISphereInitialValues {
 	center?: number[];
 }
 
-export interface vtkSphere extends VtkObject {
+export interface vtkSphere extends vtkObject {
 
 	/**
 	 * Given the point xyz (three floating value) evaluate the sphere

--- a/Sources/Common/DataModel/Spline1D/index.d.ts
+++ b/Sources/Common/DataModel/Spline1D/index.d.ts
@@ -1,9 +1,9 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 
 interface ISpline1DInitialValues {}
 
-export interface vtkSpline1D extends VtkObject {
+export interface vtkSpline1D extends vtkObject {
 
 	/**
 	 * 

--- a/Sources/Common/DataModel/Spline3D/index.d.ts
+++ b/Sources/Common/DataModel/Spline3D/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 export enum splineKind {
 	CARDINAL_SPLINE,
@@ -15,7 +15,7 @@ interface ISpline3DInitialValues {
 	bias?: number;
 }
 
-export interface vtkSpline3D extends VtkObject {
+export interface vtkSpline3D extends vtkObject {
 	/**
 	 * 
 	 * @param points 

--- a/Sources/Filters/General/AppendPolyData/index.d.ts
+++ b/Sources/Filters/General/AppendPolyData/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum DesiredOutputPrecision {
 	/**
@@ -24,7 +24,7 @@ interface IAppendPolyDataInitialValues {
 	outputPointsPrecision?: DesiredOutputPrecision;
 }
 
-type vtkAppendPolyDataBase = VtkObject & VtkAlgorithm;
+type vtkAppendPolyDataBase = vtkObject & vtkAlgorithm;
 
 export interface vtkAppendPolyData extends vtkAppendPolyDataBase {
 

--- a/Sources/Filters/General/ImageCropFilter/index.d.ts
+++ b/Sources/Filters/General/ImageCropFilter/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -7,7 +7,7 @@ interface IImageCropFilterInitialValues {
 	croppingPlanes?: any;
 }
 
-type vtkImageCropFilterBase = VtkObject & VtkAlgorithm;
+type vtkImageCropFilterBase = vtkObject & vtkAlgorithm;
 
 export interface vtkImageCropFilter extends vtkImageCropFilterBase {
 

--- a/Sources/Filters/General/ImageOutlineFilter/index.d.ts
+++ b/Sources/Filters/General/ImageOutlineFilter/index.d.ts
@@ -1,22 +1,14 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
-/*
+/**
  * 
  */
 interface IImageOutlineFilterInitialValues {
-    
-    /**
-     * 
-     */
     slicingMode?: number;
-
-    /**
-     * 
-     */
     background?: number;
 }
 
-type vtkImageOutlineFilterBase = VtkObject & VtkAlgorithm;
+type vtkImageOutlineFilterBase = vtkObject & vtkAlgorithm;
 
 export interface vtkImageOutlineFilter extends vtkImageOutlineFilterBase {
 

--- a/Sources/Filters/General/ImageSliceFilter/index.d.ts
+++ b/Sources/Filters/General/ImageSliceFilter/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /*
  * 
@@ -8,7 +8,7 @@ interface IImageSliceFilterInitialValues {
     sliceIndex?: number
 }
 
-type vtkImageSliceFilterBase = VtkObject & VtkAlgorithm;
+type vtkImageSliceFilterBase = vtkObject & vtkAlgorithm;
 
 export interface vtkImageSliceFilter extends vtkImageSliceFilterBase {
 

--- a/Sources/Filters/General/LineFilter/index.d.ts
+++ b/Sources/Filters/General/LineFilter/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -6,7 +6,7 @@ import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
 interface ILineFilterInitialValues {
 }
 
-type vtkLineFilterBase = VtkObject & VtkAlgorithm;
+type vtkLineFilterBase = vtkObject & vtkAlgorithm;
 
 export interface vtkLineFilter extends vtkLineFilterBase {
 

--- a/Sources/Filters/General/OutlineFilter/index.d.ts
+++ b/Sources/Filters/General/OutlineFilter/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export const BOUNDS_MAP: number[];
 
@@ -10,7 +10,7 @@ export const LINE_ARRAY: number[];
 interface IOutlineFilterInitialValues {
 }
 
-type vtkOutlineFilterBase = VtkObject & VtkAlgorithm;
+type vtkOutlineFilterBase = vtkObject & vtkAlgorithm;
 
 export interface vtkOutlineFilter extends vtkOutlineFilterBase {
 

--- a/Sources/Filters/General/TriangleFilter/index.d.ts
+++ b/Sources/Filters/General/TriangleFilter/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -7,7 +7,7 @@ interface ITriangleFilterInitialValues {
 	errorCount?: number;
 }
 
-type vtkTriangleFilterBase = VtkObject & VtkAlgorithm;
+type vtkTriangleFilterBase = vtkObject & vtkAlgorithm;
 
 export interface vtkTriangleFilter extends vtkTriangleFilterBase {
 

--- a/Sources/Filters/General/TubeFilter/index.d.ts
+++ b/Sources/Filters/General/TubeFilter/index.d.ts
@@ -1,6 +1,5 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 import { DesiredOutputPrecision } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
-import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 
 export enum VaryRadius {
 	VARY_RADIUS_OFF,
@@ -20,86 +19,22 @@ export enum GenerateTCoords {
  *
  */
 interface ITubeFilterInitialValues {
-	/**
-	 *
-	 * @default DesiredOutputPrecision.DEFAULT
-	 */
 	outputPointsPrecision?: DesiredOutputPrecision,
-
-	/**
-	 *
-	 * @default 0.5
-	 */
 	radius?: number;
-
-	/**
-	 *
-	 * @default VaryRadius.VARY_RADIUS_OFF
-	 */
 	varyRadius?: VaryRadius,
-
-	/**
-	 *
-	 * @default 3
-	 */
 	numberOfSides?: number;
-
-	/**
-	 *
-	 * @default 10
-	 */
 	radiusFactor?: number;
-
-	/**
-	 *
-	 * @default [0, 0, 1]
-	 */
 	defaultNormal?: number[];
-
-	/**
-	 *
-	 * @default false
-	 */
 	useDefaultNormal?: boolean;
-
-	/**
-	 *
-	 * @default true
-	 */
 	sidesShareVertices?: boolean;
-
-	/**
-	 *
-	 * @default false
-	 */
 	capping?: boolean;
-
-	/**
-	 *
-	 * @default 1
-	 */
 	onRatio?: number;
-
-	/**
-	 *
-	 * @default 0
-	 */
 	offset?: number;
-
-	/**
-	 *
-	 * @default GenerateTCoords.TCOORDS_OFF
-	 */
 	generateTCoords?: GenerateTCoords,
-
-	/**
-	 *
-	 * @default 1.0
-	 */
 	textureLength?: number;
 }
 
-type vtkTubeFilterBase = VtkObject & VtkAlgorithm;
+type vtkTubeFilterBase = vtkObject & vtkAlgorithm;
 
 export interface vtkTubeFilter extends vtkTubeFilterBase {
 

--- a/Sources/Filters/Sources/Arrow2DSource/index.d.ts
+++ b/Sources/Filters/Sources/Arrow2DSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum ShapeType {
 	TRIANGLE,
@@ -21,7 +21,7 @@ interface IArrow2DSourceInitialValues {
 	direction?: number[];
 }
 
-type vtkArrow2DSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkArrow2DSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/ArrowSource/index.d.ts
+++ b/Sources/Filters/Sources/ArrowSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum ShapeType {
 	TRIANGLE,
@@ -21,7 +21,7 @@ interface IArrowSourceInitialValues {
 	pointType?: string;
 }
 
-type vtkArrowSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkArrowSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/CircleSource/index.d.ts
+++ b/Sources/Filters/Sources/CircleSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -12,7 +12,7 @@ interface ICircleSourceInitialValues {
 	face?: boolean;
 }
 
-type vtkCircleSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkCircleSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/ConeSource/index.d.ts
+++ b/Sources/Filters/Sources/ConeSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -13,7 +13,7 @@ interface IConeSourceInitialValues {
 	pointType?: string;
 }
 
-type vtkConeSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkConeSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/CubeSource/index.d.ts
+++ b/Sources/Filters/Sources/CubeSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -13,7 +13,7 @@ interface ICircleSourceInitialValues {
 	generate3DTextureCoordinates?: boolean;
 }
 
-type vtkCubeSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkCubeSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/Cursor3D/index.d.ts
+++ b/Sources/Filters/Sources/Cursor3D/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 
@@ -18,7 +18,7 @@ interface ICursor3DInitialValues {
 	translationMode?: boolean;
 }
 
-type vtkCursor3DBase = VtkObject & Omit<VtkAlgorithm,
+type vtkCursor3DBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/CylinderSource/index.d.ts
+++ b/Sources/Filters/Sources/CylinderSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -13,7 +13,7 @@ interface ICylinderSourceInitialValues {
 	pointType?: string;
 }
 
-type vtkCylinderSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkCylinderSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/LineSource/index.d.ts
+++ b/Sources/Filters/Sources/LineSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -10,7 +10,7 @@ interface ILineSourceInitialValues {
 	pointType?: string;
 }
 
-type vtkLineSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkLineSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/PlaneSource/index.d.ts
+++ b/Sources/Filters/Sources/PlaneSource/index.d.ts
@@ -1,5 +1,5 @@
 import { vec3 } from 'gl-matrix';
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  * 
@@ -13,7 +13,7 @@ interface IPlaneSourceInitialValues {
 	pointType?: string;
 }
 
-type vtkPlaneSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkPlaneSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/PointSource/index.d.ts
+++ b/Sources/Filters/Sources/PointSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  * 
@@ -10,7 +10,7 @@ interface IPointSourceInitialValues {
 	pointType?: string;
 }
 
-type vtkPointSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkPointSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Sources/SphereSource/index.d.ts
+++ b/Sources/Filters/Sources/SphereSource/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  * 
@@ -16,7 +16,7 @@ interface ISphereSourceInitialValues {
 	pointType?: string;
 }
 
-type vtkSphereSourceBase = VtkObject & Omit<VtkAlgorithm,
+type vtkSphereSourceBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Filters/Texture/TextureMapToPlane/index.d.ts
+++ b/Sources/Filters/Texture/TextureMapToPlane/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -13,7 +13,7 @@ interface ITextureMapToPlane {
 	automaticPlaneGeneration?: number;
 }
 
-type vtkTextureMapToPlaneBase = VtkObject & VtkAlgorithm;
+type vtkTextureMapToPlaneBase = vtkObject & vtkAlgorithm;
 
 export interface vtkTextureMapToPlane extends vtkTextureMapToPlaneBase {
 

--- a/Sources/Filters/Texture/TextureMapToSphere/index.d.ts
+++ b/Sources/Filters/Texture/TextureMapToSphere/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  *
@@ -9,7 +9,7 @@ interface ITextureMapToSphere {
 	preventSeam?: number;
 }
 
-type vtkTextureMapToSphereBase = VtkObject & VtkAlgorithm;
+type vtkTextureMapToSphereBase = vtkObject & vtkAlgorithm;
 
 export interface vtkTextureMapToSphere extends vtkTextureMapToSphereBase {
 

--- a/Sources/IO/Geometry/DracoReader/index.d.ts
+++ b/Sources/IO/Geometry/DracoReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 
 interface IDracoReaderOptions {
@@ -12,7 +12,7 @@ interface IDracoReaderOptions {
  */
 interface IDracoReaderInitialValues { }
 
-type vtkDracoReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkDracoReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/IO/Geometry/PLYReader/index.d.ts
+++ b/Sources/IO/Geometry/PLYReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 interface IPLYReaderOptions {
 	binary?: boolean;
@@ -11,7 +11,7 @@ interface IPLYReaderOptions {
  */
 interface IPLYReaderInitialValues {}
 
-type vtkPLYReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkPLYReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/IO/Geometry/STLReader/index.d.ts
+++ b/Sources/IO/Geometry/STLReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 
 interface ISTLReaderOptions {
@@ -12,7 +12,7 @@ interface ISTLReaderOptions {
  */
 interface ISTLReaderInitialValues {}
 
-type vtkSTLReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkSTLReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/IO/Geometry/STLWriter/index.d.ts
+++ b/Sources/IO/Geometry/STLWriter/index.d.ts
@@ -1,6 +1,6 @@
 import { mat4 } from "gl-matrix";
 import vtkPolyData from "vtk.js/Sources/Common/DataModel/PolyData";
-import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum FormatTypes {
 	ASCII,

--- a/Sources/IO/Misc/ElevationReader/index.d.ts
+++ b/Sources/IO/Misc/ElevationReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject, VtkSubscription } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject, vtkSubscription } from "vtk.js/Sources/interfaces";
 
 
 interface IElevationReaderOptions {
@@ -20,7 +20,7 @@ interface IElevationReaderInitialValues {
 	requestCount?: number;
 }
 
-type vtkElevationReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkElevationReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'
@@ -86,7 +86,7 @@ export interface vtkElevationReader extends vtkElevationReaderBase {
 	 * 
 	 * @param busy 
 	 */
-	onBusy(busy: boolean): VtkSubscription;
+	onBusy(busy: boolean): vtkSubscription;
 
 	/**
 	 * Parse data as text.

--- a/Sources/IO/Misc/ITKImageReader/index.d.ts
+++ b/Sources/IO/Misc/ITKImageReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  * 
@@ -8,7 +8,7 @@ interface IITKImageReaderInitialValues {
 	arrayName?: string;
 }
 
-type vtkITKImageReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkITKImageReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/IO/Misc/ITKPolyDataReader/index.d.ts
+++ b/Sources/IO/Misc/ITKPolyDataReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 /**
  * 
@@ -8,7 +8,7 @@ interface IITKPolyDataReaderInitialValues {
 	arrayName?: string;
 }
 
-type vtkITKPolyDataReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkITKPolyDataReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/IO/Misc/JSONNucleoReader/index.d.ts
+++ b/Sources/IO/Misc/JSONNucleoReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 interface IJSONNucleoReaderOptions {
 	binary?: boolean;
@@ -11,7 +11,7 @@ interface IJSONNucleoReaderOptions {
  */
 interface IJSONNucleoReaderInitialValues {}
 
-type vtkJSONNucleoReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkJSONNucleoReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/IO/Misc/JSONReader/index.d.ts
+++ b/Sources/IO/Misc/JSONReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject, VtkSubscription } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject, vtkSubscription } from "vtk.js/Sources/interfaces";
 
 
 interface IJSONReaderOptions {
@@ -12,7 +12,7 @@ interface IJSONReaderOptions {
  */
 interface IJSONReaderInitialValues { }
 
-type vtkJSONReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkJSONReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'
@@ -53,7 +53,7 @@ export interface vtkJSONReader extends vtkJSONReaderBase {
 	 * 
 	 * @param busy 
 	 */
-	onBusy(busy: boolean): VtkSubscription;
+	onBusy(busy: boolean): vtkSubscription;
 
 	/**
 	 * Parse data as text.

--- a/Sources/IO/Misc/MTLReader/index.d.ts
+++ b/Sources/IO/Misc/MTLReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject, VtkSubscription } from "vtk.js/Sources/macro";
+import { vtkObject, vtkSubscription } from "vtk.js/Sources/interfaces";
 import vtkActor from "vtk.js/Sources/Rendering/Core/Actor";
 
 
@@ -18,7 +18,7 @@ interface IMTLReaderInitialValues {
 	interpolateTextures?: boolean;
 }
 
-export interface vtkMTLReader extends VtkObject {
+export interface vtkMTLReader extends vtkObject {
 
 	applyMaterialToActor(name: string, actor: vtkActor): void;
 	/**
@@ -82,7 +82,7 @@ export interface vtkMTLReader extends VtkObject {
 	 * 
 	 * @param busy 
 	 */
-	onBusy(busy: boolean): VtkSubscription;
+	onBusy(busy: boolean): vtkSubscription;
 
 	/**
 	 * Parse data as text.

--- a/Sources/IO/Misc/OBJReader/index.d.ts
+++ b/Sources/IO/Misc/OBJReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject, VtkSubscription } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject, vtkSubscription } from "vtk.js/Sources/interfaces";
 
 
 interface IOBJReaderOptions {
@@ -16,7 +16,7 @@ interface IElevationReaderInitialValues {
 	splitMode?: null | string;
 }
 
-type vtkOBJReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkOBJReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'
@@ -67,7 +67,7 @@ export interface vtkOBJReader extends vtkOBJReaderBase {
 	 * 
 	 * @param busy 
 	 */
-	onBusy(busy: boolean): VtkSubscription;
+	onBusy(busy: boolean): vtkSubscription;
 
 	/**
 	 * Parse data as text.

--- a/Sources/IO/Misc/PDBReader/index.d.ts
+++ b/Sources/IO/Misc/PDBReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject, VtkSubscription } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject, vtkSubscription } from "vtk.js/Sources/interfaces";
 
 
 interface IPDBReaderOptions {
@@ -15,7 +15,7 @@ interface IPDBReaderInitialValues {
 	requestCount?: number;
 }
 
-type vtkPDBReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkPDBReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'
@@ -71,7 +71,7 @@ export interface vtkPDBReader extends vtkPDBReaderBase {
 	 * 
 	 * @param busy 
 	 */
-	onBusy(busy: boolean): VtkSubscription;
+	onBusy(busy: boolean): vtkSubscription;
 
 	/**
 	 * Parse data as text.

--- a/Sources/IO/XML/XMLReader/index.d.ts
+++ b/Sources/IO/XML/XMLReader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 
 interface IXMLReaderOptions {
@@ -18,7 +18,7 @@ interface IRet {
  */
 interface IXMLReaderInitialValues { }
 
-type vtkXMLReaderBase = VtkObject & Omit<VtkAlgorithm,
+type vtkXMLReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
 	| 'setInputConnection'

--- a/Sources/Rendering/Core/AbstractMapper/index.d.ts
+++ b/Sources/Rendering/Core/AbstractMapper/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkAlgorithm, VtkObject } from 'vtk.js/Sources/macro';
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
 
 /**
@@ -8,7 +8,7 @@ interface IAbstractMapperInitialValues {
 	clippingPlanes?: vtkPlane[];
 }
 
-type vtkAbstractMapperBase = VtkObject & Omit<VtkAlgorithm,
+type vtkAbstractMapperBase = vtkObject & Omit<vtkAlgorithm,
     | 'getOutputData'
     | 'getOutputPort'> ;
 

--- a/Sources/Rendering/Core/AbstractPicker/index.d.ts
+++ b/Sources/Rendering/Core/AbstractPicker/index.d.ts
@@ -1,11 +1,11 @@
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer'
 
 /**
  * 
  */
-export interface vtkAbstractPicker extends VtkObject {
+export interface vtkAbstractPicker extends vtkObject {
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/Camera/index.d.ts
+++ b/Sources/Rendering/Core/Camera/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../types.ts' />
 
 import { mat4 } from 'gl-matrix';
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 
 /**
  * 
@@ -29,7 +29,7 @@ interface ICameraInitialValues {
 	physicalViewNorth?: number[];
 }
 
-export interface vtkCamera extends VtkObject {
+export interface vtkCamera extends vtkObject {
 
 	/**
 	 * Apply a transform to the camera.

--- a/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum ColorSpace {
 	RGB,
@@ -13,7 +13,7 @@ export enum Scale {
 }
 
 /* TODO: use VtkScalarsToColors instead of VtkObject */
-export interface vtkColorTransferFunction extends VtkObject {
+export interface vtkColorTransferFunction extends vtkObject {
 
 	/**
 	 * Add a point defined in RGB

--- a/Sources/Rendering/Core/Coordinate/index.d.ts
+++ b/Sources/Rendering/Core/Coordinate/index.d.ts
@@ -1,4 +1,6 @@
-import { VtkObject, VtkProperty } from "vtk.js/Sources/macro";
+import { VtkProperty } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
+
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 
 export enum Coordinate {
@@ -24,7 +26,7 @@ interface ICoordinateInitialValues {
 	computedDoubleDisplayValue?: number[],
 }
 
-export interface vtkCoordinate extends VtkObject {
+export interface vtkCoordinate extends vtkObject {
 
 
 	/**

--- a/Sources/Rendering/Core/ImageProperty/index.d.ts
+++ b/Sources/Rendering/Core/ImageProperty/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum InterpolationType {
 	NEAREST,
@@ -21,7 +21,7 @@ interface IImageMapperInitialValues {
 	componentData: IComponentData[];
 }
 
-export interface vtkImageProperty extends VtkObject {
+export interface vtkImageProperty extends vtkObject {
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/Light/index.d.ts
+++ b/Sources/Rendering/Core/Light/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 interface ILightInitialValues {
     switch?: boolean;
@@ -16,7 +16,7 @@ interface ILightInitialValues {
     directionMTime?: number;
 }
 
-export interface vtkLight extends VtkObject {
+export interface vtkLight extends vtkObject {
 
     /**
      * 

--- a/Sources/Rendering/Core/Prop/index.d.ts
+++ b/Sources/Rendering/Core/Prop/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 import vtkActor from "vtk.js/Sources/Rendering/Core/Actor";
 import vtkActor2D from "vtk.js/Sources/Rendering/Core/Actor2D";
 import vtkTexture from "vtk.js/Sources/Rendering/Core/Texture";
@@ -62,7 +62,7 @@ interface IPropInitialValues {
     textures?: Array<any>;
 }
 
-export interface vtkProp extends VtkObject {
+export interface vtkProp extends vtkObject {
 
     /**
      * 

--- a/Sources/Rendering/Core/Property/index.d.ts
+++ b/Sources/Rendering/Core/Property/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum Shading {
     FLAT,
@@ -38,7 +38,7 @@ interface IPropertyValues {
     shading?: boolean;
 }
 
-export interface vtkProperty extends VtkObject {
+export interface vtkProperty extends vtkObject {
 
 
     /**

--- a/Sources/Rendering/Core/Property2D/index.d.ts
+++ b/Sources/Rendering/Core/Property2D/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
 
 interface IProperty2DInitialValues{
 	color?: number[];
@@ -8,7 +8,7 @@ interface IProperty2DInitialValues{
 	displayLocation?: string;
 }
 
-export interface vtkProperty2D extends VtkObject {
+export interface vtkProperty2D extends vtkObject {
 
 	/**
      * Get the color of the object.

--- a/Sources/Rendering/Core/RenderWindow/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindow/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject, VtkSubscription } from "vtk.js/Sources/macro";
+import { vtkObject, vtkSubscription } from "vtk.js/Sources/interfaces";
 import vtkRenderer from "vtk.js/Sources/Rendering/Core/Renderer";
 import vtkRenderWindowInteractor from "vtk.js/Sources/Rendering/Core/RenderWindowInteractor";
 // import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
@@ -34,7 +34,7 @@ export const enum DEFAULT_VIEW_API {
 	'WebGPU'
 }
 
-export interface vtkRenderWindow extends VtkObject {
+export interface vtkRenderWindow extends vtkObject {
 
 	/**
 	 * Add renderer
@@ -115,7 +115,7 @@ export interface vtkRenderWindow extends VtkObject {
 	 * 
 	 * @param callback 
 	 */
-	onCompletion(callback: (instance: VtkObject) => any): VtkSubscription;
+	onCompletion(callback: (instance: vtkObject) => any): vtkSubscription;
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
 import vtkRenderer from "vtk.js/Sources/Rendering/Core/Renderer";
 
 export enum Device {
@@ -40,7 +40,7 @@ interface IPosition {
     type: string;
 }
 
-export interface vtkRenderWindowInteractor extends VtkObject {
+export interface vtkRenderWindowInteractor extends vtkObject {
 
     /**
      * 

--- a/Sources/Rendering/Core/Texture/index.d.ts
+++ b/Sources/Rendering/Core/Texture/index.d.ts
@@ -1,25 +1,13 @@
-import { VtkAlgorithm } from "vtk.js/Sources/macro";
+import { vtkAlgorithm } from "vtk.js/Sources/interfaces";
 
 interface ITextureInitialValues {
-	/**
-	 * 
-	 */
-	repeat: boolean;
-	/**
-	 * 
-	 */
-	interpolate: boolean;
-	/**
-	 * 
-	 */
-	edgeClamp: boolean;
-	/**
-	 * 
-	 */
-	imageLoaded: boolean;
+	repeat?: boolean;
+	interpolate?: boolean;
+	edgeClamp?: boolean;
+	imageLoaded?: boolean;
 }
 
-export interface vtkTexture extends VtkAlgorithm {
+export interface vtkTexture extends vtkAlgorithm {
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/Viewport/index.d.ts
+++ b/Sources/Rendering/Core/Viewport/index.d.ts
@@ -1,5 +1,5 @@
 
-import { VtkObject } from 'vtk.js/Sources/macro';
+import { vtkObject } from "vtk.js/Sources/interfaces" ;
 import vtkActor2D from 'vtk.js/Sources/Rendering/Core/Actor2D';
 import vtkProp from 'vtk.js/Sources/Rendering/Core/Prop';
 
@@ -14,7 +14,7 @@ interface IViewportInitialValues {
     actors2D?: vtkActor2D[];
 }
 
-export interface vtkViewport extends VtkObject {
+export interface vtkViewport extends vtkObject {
 
 
     /**

--- a/Sources/Rendering/Core/VolumeProperty/index.d.ts
+++ b/Sources/Rendering/Core/VolumeProperty/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
 
 export enum InterpolationType {
 	NEAREST,
@@ -22,7 +22,7 @@ interface IVolumePropertyInitialValues  {
 	labelOutlineThickness?: number;
 }
 
-export interface vtkVolumeProperty extends VtkObject {
+export interface vtkVolumeProperty extends vtkObject {
 
 	/**
 	 * Get the ambient lighting coefficient.

--- a/Sources/Rendering/Misc/CanvasView/index.d.ts
+++ b/Sources/Rendering/Misc/CanvasView/index.d.ts
@@ -1,6 +1,6 @@
 ///<reference path='../../../types.ts' />
 
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
 
 
 /**
@@ -16,7 +16,7 @@ interface ICanvasViewInitialValues {
 }
 
 
-export interface vtkCanvasView extends VtkObject {
+export interface vtkCanvasView extends vtkObject {
 
 	/**
 	 * Get the canvas element

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
 import vtkRenderer from "vtk.js/Sources/Rendering/Core/Renderer";
 import vtkRenderWindow from "vtk.js/Sources/Rendering/Core/RenderWindow";
 import vtkRenderWindowInteractor from "vtk.js/Sources/Rendering/Core/RenderWindowInteractor";
@@ -20,7 +20,7 @@ interface IFullScreenRenderWindowInitialValues {
 }
 
 
-export interface vtkFullScreenRenderWindow extends VtkObject {
+export interface vtkFullScreenRenderWindow extends vtkObject {
 
 	/**
 	 * 

--- a/Sources/Rendering/Misc/GenericRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/GenericRenderWindow/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject, VtkSubscription } from "vtk.js/Sources/macro";
+import { vtkObject, vtkSubscription } from "vtk.js/Sources/interfaces";
 import vtkRenderer from "vtk.js/Sources/Rendering/Core/Renderer";
 import vtkRenderWindow from "vtk.js/Sources/Rendering/Core/RenderWindow";
 import vtkRenderWindowInteractor from "vtk.js/Sources/Rendering/Core/RenderWindowInteractor";
@@ -15,7 +15,7 @@ interface IGenericRenderWindowInitialValues {
 	container?: HTMLElement,
 }
 
-export interface vtkGenericRenderWindow extends VtkObject {
+export interface vtkGenericRenderWindow extends vtkObject {
 
 	/**
 	 * Release GL context
@@ -53,7 +53,7 @@ export interface vtkGenericRenderWindow extends VtkObject {
 	 * @param callback function
 	 * @returns subscription object so you can easily unsubscribe later on
 	 */
-	onResize(callback: (instance: VtkObject) => any): VtkSubscription;
+	onResize(callback: (instance: vtkObject) => any): vtkSubscription;
 
 	/**
 	 * Handle window resize

--- a/Sources/Rendering/Misc/TextureLODsDownloader/index.d.ts
+++ b/Sources/Rendering/Misc/TextureLODsDownloader/index.d.ts
@@ -1,4 +1,4 @@
-import { VtkObject } from "vtk.js/Sources/macro";
+import { vtkObject } from "vtk.js/Sources/interfaces";
 import vtkTexture from "vtk.js/Sources/Rendering/Core/Texture";
 
 declare type CrossOrigin = '' | 'anonymous' | 'use-credentials';
@@ -8,7 +8,7 @@ declare type CrossOrigin = '' | 'anonymous' | 'use-credentials';
  */
 interface ITextureLODsDownloaderInitialValues {
 	baseUrl?: string;
-	crossOrigin?: CrossOrigin | null;
+	crossOrigin?: CrossOrigin;
 	files?: string[];
 	maxTextureLODSize?: number;
 	texture?: vtkTexture;
@@ -18,7 +18,7 @@ interface ITextureLODsDownloaderInitialValues {
 }
 
 
-export interface vtkTextureLODsDownloader extends VtkObject {
+export interface vtkTextureLODsDownloader extends vtkObject {
 
 	/**
 	 * Get the base of the url

--- a/Sources/Widgets/Manipulators/LineManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/LineManipulator/index.d.ts
@@ -1,0 +1,115 @@
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
+
+/**
+ *
+ */
+interface ILineManipulatorInitialValues {
+	origin?: number[];
+	normal?: number[];
+}
+
+export interface vtkLineManipulator extends vtkObject {
+
+	/**
+	 * Set the normal of the line
+	 */
+	getNormal(): number[];
+
+	/**
+	 * Set the normal of the line
+	 */
+	getNormalByReference(): number[];
+
+	/**
+	 * Set the origin of the line
+	 */
+	getOrigin(): number[];
+
+	/**
+	 * Set the origin of the line
+	 */
+	getOriginByReference(): number[];
+
+	/**
+	 * 
+	 * @param callData 
+	 * @param glRenderWindow 
+	 */
+	handleEvent(callData: any, glRenderWindow: any): number[];
+
+	/**
+	 * Set the normal of the line
+	 * @param {Number[]} normal The normal coordinate.
+	 */
+	setNormal(normal: number[]): boolean;
+
+	/**
+	 * Set the normal of the line
+	 * @param {Number} x The x coordinate.
+	 * @param {Number} y The y coordinate.
+	 * @param {Number} z The z coordinate.
+	 */
+	setNormal(x: number, y: number, z: number): boolean;
+
+	/**
+	 * Set the normal of the line
+	 * @param {Number[]} normal The normal coordinate.
+	 */
+	setNormalFrom(normal: number[]): boolean;
+
+	/**
+	 * Set the origin of the line.
+	 * @param {Number[]} origin The coordinate of the origin point.
+	 */
+	setOrigin(origin: number[]): boolean;
+
+	/**
+	 * Set the origin of the line
+	 * @param {Number} x The x coordinate of the origin point.
+	 * @param {Number} y The y coordinate of the origin point.
+	 * @param {Number} z The z coordinate of the origin point.
+	 */
+	setOrigin(x: number, y: number, z: number): boolean;
+
+	/**
+	 * Set the origin of the line
+	 * @param {Number[]} origin The coordinate of the origin point.
+	 */
+	setOriginFrom(origin: number[]): boolean;
+}
+
+
+/**
+ * Method use to decorate a given object (publicAPI+model) with vtkLineManipulator characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {ILineManipulatorInitialValues} [initialValues] (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ILineManipulatorInitialValues): void;
+
+/**
+ * Method use to create a new instance of vtkLineManipulator
+ */
+export function newInstance(initialValues?: ILineManipulatorInitialValues): vtkLineManipulator;
+
+/**
+ * 
+ * @param {Number} x 
+ * @param {Number} y 
+ * @param {Number[]} lineOrigin 
+ * @param {Number[]} lineDirection 
+ * @param renderer 
+ * @param glRenderWindow 
+ */
+export function projectDisplayToLine(x: number, y: number, lineOrigin: number[], lineDirection: number[], renderer: any, glRenderWindow: any): number[];
+
+/**
+ * vtkLineManipulator.
+ */
+export declare const vtkLineManipulator: {
+	newInstance: typeof newInstance,
+	extend: typeof extend,
+	projectDisplayToLine: typeof projectDisplayToLine;
+};
+export default vtkLineManipulator;

--- a/Sources/Widgets/Manipulators/PlaneManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/PlaneManipulator/index.d.ts
@@ -1,0 +1,116 @@
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
+
+/**
+ *
+ */
+interface IPlaneManipulatorInitialValues {
+	origin?: number[];
+	normal?: number[];
+}
+
+export interface vtkPlaneManipulator extends vtkObject {
+
+	/**
+	 * Get the normal of the plane
+	 */
+	getNormal(): number[];
+
+	/**
+	 * Get the normal of the plane
+	 */
+	getNormalByReference(): number[];
+
+	/**
+	 * Get the origin of the plane
+	 */
+	getOrigin(): number[];
+
+	/**
+	 * Get the origin of the plane
+	 */
+	getOriginByReference(): number[];
+
+	/**
+	 * 
+	 * @param callData 
+	 * @param glRenderWindow 
+	 */
+	handleEvent(callData: any, glRenderWindow: any): number[];
+
+	/**
+	 * Set the normal of the plane
+	 * @param {Number[]} normal The normal coordinate.
+	 */
+	setNormal(normal: number[]): boolean;
+
+	/**
+	 * Set the normal of the plane
+	 * @param {Number} x The x coordinate.
+	 * @param {Number} y The y coordinate.
+	 * @param {Number} z The z coordinate.
+	 */
+	setNormal(x: number, y: number, z: number): boolean;
+
+	/**
+	 * Set the normal of the plane
+	 * @param {Number[]} normal The normal coordinate.
+	 */
+	setNormalFrom(normal: number[]): boolean;
+
+	/**
+	 * Set the origin of the plane.
+	 * @param {Number[]} origin The coordinate of the origin point.
+	 */
+	setOrigin(origin: number[]): boolean;
+
+	/**
+	 * Set the origin of the plane.
+	 * @param {Number} x The x coordinate of the origin point.
+	 * @param {Number} y The y coordinate of the origin point.
+	 * @param {Number} z The z coordinate of the origin point.
+	 */
+	setOrigin(x: number, y: number, z: number): boolean;
+
+	/**
+	 * Set the origin of the plane.
+	 * @param {Number[]} origin The coordinate of the origin point.
+	 */
+	setOriginFrom(origin: number[]): boolean;
+}
+
+
+/**
+ * Method use to decorate a given object (publicAPI+model) with vtkPlaneManipulator characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {IPlaneManipulatorInitialValues} [initialValues] (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IPlaneManipulatorInitialValues): void;
+
+/**
+ * Method use to create a new instance of vtkPlaneManipulator
+ */
+export function newInstance(initialValues?: IPlaneManipulatorInitialValues): vtkPlaneManipulator;
+
+/**
+ * 
+ * @param {Number} x 
+ * @param {Number} y 
+ * @param {Number[]} planeOrigin 
+ * @param {Number[]} planeNormal 
+ * @param renderer 
+ * @param glRenderWindow 
+ */
+export function intersectDisplayWithPlane(x: number, y: number, planeOrigin: number[], planeNormal: number[], renderer: any, glRenderWindow: any): number[];
+
+
+/**
+ * vtkPlaneManipulator.
+ */
+export declare const vtkPlaneManipulator: {
+	newInstance: typeof newInstance,
+	extend: typeof extend,
+	intersectDisplayWithPlane: typeof intersectDisplayWithPlane;
+};
+export default vtkPlaneManipulator;

--- a/Sources/Widgets/Manipulators/TrackballManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/TrackballManipulator/index.d.ts
@@ -1,0 +1,92 @@
+import { vtkAlgorithm, vtkObject } from "vtk.js/Sources/interfaces";
+
+/**
+ *
+ */
+interface ITrackballManipulatorInitialValues {
+	normal?: number[];
+}
+
+export interface vtkTrackballManipulator extends vtkObject {
+
+	/**
+	 * Get normal
+	 */
+	getNormal(): number[];
+
+	/**
+	 * Get normal
+	 */
+	getNormalByReference(): number[];
+
+	/**
+	 * 
+	 * @param callData 
+	 * @param glRenderWindow 
+	 */
+	handleEvent(callData: any, glRenderWindow: any): void;
+
+	/**
+	 * Set the normal of the line.
+	 * @param {Number[]} normal The normal coordinate.
+	 */
+	setNormal(normal: number[]): boolean;
+
+	/**
+	 * Set the normal of the line.
+	 * @param {Number} x The x coordinate.
+	 * @param {Number} y The y coordinate.
+	 * @param {Number} z The z coordinate.
+	 */
+	setNormal(x: number, y: number, z: number): boolean;
+
+	/**
+	 * Set the normal of the line.
+	 * @param {Number[]} normal The normal coordinate.
+	 */
+	setNormalFrom(normal: number[]): boolean;
+
+	/**
+	 * 
+	 */
+	reset(callData: any): void;
+}
+
+
+/**
+ * Method use to decorate a given object (publicAPI+model) with vtkTrackballManipulator characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {ITrackballManipulatorInitialValues} [initialValues] (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: ITrackballManipulatorInitialValues): void;
+
+/**
+ * Method use to create a new instance of vtkTrackballManipulator
+ */
+export function newInstance(initialValues?: ITrackballManipulatorInitialValues): vtkTrackballManipulator;
+
+/**
+ * 
+ * @param {Number} prevX 
+ * @param {Number} prevY 
+ * @param {Number} curX 
+ * @param {Number} curY 
+ * @param {Number[]} origin 
+ * @param {Number[]} direction 
+ * @param renderer 
+ * @param glRenderWindow 
+ */
+export function trackballRotate(prevX: number, prevY: number, curX: number, curY: number, origin: number[], direction: number[], renderer: any, glRenderWindow: any): void;
+
+
+/**
+ * vtkTrackballManipulator.
+ */
+export declare const vtkTrackballManipulator: {
+	newInstance: typeof newInstance,
+	extend: typeof extend,
+	trackballRotate: typeof trackballRotate;
+};
+export default vtkTrackballManipulator;

--- a/Sources/interfaces.d.ts
+++ b/Sources/interfaces.d.ts
@@ -1,0 +1,213 @@
+import vtkDataArray from "vtk.js/Sources/Common/Core/DataArray";
+
+/**
+ * Object returned on any subscription call
+ */
+export interface vtkSubscription {
+	unsubscribe(): void;
+}
+
+/**
+ * Basic object representing a data range
+ */
+export interface vtkRange {
+	min: number;
+	max: number;
+}
+
+export interface vtkOutputPort {
+	filter: vtkAlgorithm;
+}
+
+/**
+ * vtkAlgorithm API
+ */
+export interface vtkAlgorithm {
+	/**
+	 * @param dataset
+	 * @param port (default 0)
+	 */
+	setInputData(dataset: any, port?: number): void;
+	/**
+	 * @param port (default 0)
+	 */
+	getInputData(port?: number): any;
+	/**
+	 * @param outputPort
+	 * @param port (default 0)
+	 */
+	setInputConnection(outputPort: vtkPipelineConnection, port?: number): void;
+	/**
+	 * @param port (default 0)
+	 */
+	getInputConnection(port?: number): vtkPipelineConnection;
+	addInputConnection(outputPort: vtkPipelineConnection): void;
+	addInputData(dataset: any): void;
+	/**
+	 * @param port (default 0)
+	 */
+	getOutputData(port?: number): any;
+	shouldUpdate(): boolean;
+	/**
+	 * @param port (default 0)
+	 */
+	getOutputPort(port?: number): vtkPipelineConnection;
+	update(): void;
+	getNumberOfInputPorts(): number;
+	getNumberOfOutputPorts(): number;
+	/**
+	 * @param port (default 0)
+	 */
+	getInputArrayToProcess(inputPort?: number): vtkDataArray;
+	/**
+	 *
+	 * @param inputPort
+	 * @param arrayName
+	 * @param fieldAssociation
+	 * @param attributeType (default 'Scalars')
+	 */
+	setInputArrayToProcess(
+		inputPort: number,
+		arrayName: string,
+		fieldAssociation: string,
+		attributeType?: string
+	): void;
+}
+
+/**
+* Base vtkClass which provides MTime tracking and class infrastructure
+*/
+export interface vtkObject {
+	/**
+	 * Allow to check if that object was deleted (.delete() was called before).
+	 *
+	 * @returns true if delete() was previously called
+	 */
+	isDeleted(): boolean;
+
+	/**
+	 * Mark the object dirty by increasing its MTime.
+	 * Such action also trigger the onModified() callbacks if any was registered.
+	 * This naturally happens when you call any setXXX(value) with a different value.
+	 */
+	modified(): void;
+
+	/**
+	 * Method to register callback when the object is modified().
+	 *
+	 * @param callback function
+	 * @returns subscription object so you can easily unsubscribe later on
+	 */
+	onModified(callback: (instance: vtkObject) => any): vtkSubscription;
+
+	/**
+	 * Return the `Modified Time` which is a monotonic increasing integer
+	 * global for all vtkObjects.
+	 *
+	 * This allow to solve a question such as:
+	 *  - Is that object created/modified after another one?
+	 *  - Do I need to re-execute this filter, or not? ...
+	 *
+	 * @return {Number} the global modified time.
+	 */
+	getMTime(): number;
+
+	/**
+	 * Method to check if an instance is of a given class name.
+	 * For example such method for a vtkCellArray will return true
+	 * for any of the following string: ['vtkObject', 'vtkDataArray', 'vtkCellArray']
+	 */
+	isA(className: string): boolean;
+
+	/**
+	 * Return the instance class name.
+	 */
+	getClassName(): string;
+
+	/**
+	 * Generic method to set many fields at one.
+	 *
+	 * For example calling the following function
+	 * ```
+	 * changeDetected = sphereSourceInstance.set({
+	 *    phiResolution: 10,
+	 *    thetaResolution: 20,
+	 * });
+	 * ```
+	 * will be equivalent of calling
+	 * ```
+	 * changeDetected += sphereSourceInstance.setPhiResolution(10);
+	 * changeDetected += sphereSourceInstance.setThetaResolution(20);
+	 * changeDetected = !!changeDetected;
+	 * ```
+	 *
+	 * In case you provide other field names that do not belong to the instance,
+	 * vtkWarningMacro will be used to warn you. To disable those warning,
+	 * you can set `noWarning` to true.
+	 *
+	 * If `noFunction` is set to true, the field will be set directly on the model
+	 * without calling the `set${FieldName}()` method.
+	 *
+	 * @param map (default: {}) Object capturing the set of fieldNames and associated values to set.
+	 * @param noWarning (default: false) Boolean to disable any warning.
+	 * @param noFunctions (default: false) Boolean to skip any function execution and rely on only setting the fields on the model.
+	 * @return true if a change was actually performed. False otherwise when the value provided were equal to the ones already set inside the instance.
+	 */
+	set(map?: object, noWarning?: boolean, noFunction?: boolean): boolean;
+
+	/**
+	 * Extract a set of properties at once from a vtkObject.
+	 *
+	 * This can be convenient to pass a partial state of
+	 * one object to another.
+	 *
+	 * ```
+	 * cameraB.set(cameraA.get('position', 'viewUp', 'focalPoint'));
+	 * ```
+	 *
+	 * @param listOfKeys set of field names that you want to retrieve. If not provided, the full model get returned as a new object.
+	 * @returns a new object containing only the values of requested fields
+	 */
+	get(...listOfKeys: Array<string>): object;
+
+	/**
+	 * Allow to get a direct reference of a model element
+	 *
+	 * @param name of the field to extract from the instance model
+	 * @returns model[name]
+	 */
+	getReferenceByName(name: string): any;
+
+	/**
+	 * Dereference any internal object and remove any subscription.
+	 * It gives custom class to properly detach themselves from the DOM
+	 * or any external dependency that could prevent their deletion
+	 * when the GC runs.
+	 */
+	delete(): void;
+
+	/**
+	 * Try to extract a serializable (JSON) object of the given
+	 * instance tree.
+	 *
+	 * Such state can then be reused to clone or rebuild a full
+	 * vtkObject tree using the root vtk() function.
+	 *
+	 * The following example will grab mapper and dataset that are
+	 * beneath the vtkActor instance as well.
+	 *
+	 * ```
+	 * const actorStr = JSON.stringify(actor.getState());
+	 * const newActor = vtk(JSON.parse(actorStr));
+	 * ```
+	 */
+	getState(): object;
+
+	/**
+	 * Try to copy the state of the other to ourselves by just using references.
+	 *
+	 * @param other instance to copy the reference from
+	 * @param debug (default: false) if true feedback will be provided when mismatch happen
+	 */
+	shallowCopy(other: vtkObject, debug?: boolean): void;
+}

--- a/Sources/macro.d.ts
+++ b/Sources/macro.d.ts
@@ -1,4 +1,4 @@
-import vtkDataArray from "vtk.js/Sources/Common/Core/DataArray";
+import { vtkSubscription } from "vtk.js/Sources/interfaces";
 
 /**
  * Allow user to redefine vtkXXXMacro method call.
@@ -127,151 +127,6 @@ declare function getStateArrayMapFunc(item: any): any;
 export function setImmediateVTK(fn: () => void ): void;
 
 /**
- * Object returned on any subscription call
- */
-export interface VtkSubscription {
-  unsubscribe(): void;
-}
-
-/**
- * Base vtkClass which provides MTime tracking and class infrastructure
- */
-export interface VtkObject {
-  /**
-   * Allow to check if that object was deleted (.delete() was called before).
-   *
-   * @returns true if delete() was previously called
-   */
-  isDeleted(): boolean;
-
-  /**
-   * Mark the object dirty by increasing its MTime.
-   * Such action also trigger the onModified() callbacks if any was registered.
-   * This naturally happens when you call any setXXX(value) with a different value.
-   */
-  modified(): void;
-
-  /**
-   * Method to register callback when the object is modified().
-   *
-   * @param callback function
-   * @returns subscription object so you can easily unsubscribe later on
-   */
-  onModified(callback: (instance: VtkObject) => any): VtkSubscription;
-
-  /**
-   * Return the `Modified Time` which is a monotonic increasing integer
-   * global for all vtkObjects.
-   *
-   * This allow to solve a question such as:
-   *  - Is that object created/modified after another one?
-   *  - Do I need to re-execute this filter, or not? ...
-   *
-   * @return {Number} the global modified time.
-   */
-  getMTime(): number;
-
-  /**
-   * Method to check if an instance is of a given class name.
-   * For example such method for a vtkCellArray will return true
-   * for any of the following string: ['vtkObject', 'vtkDataArray', 'vtkCellArray']
-   */
-  isA(className: string): boolean;
-
-  /**
-   * Return the instance class name.
-   */
-  getClassName(): string;
-
-  /**
-   * Generic method to set many fields at one.
-   *
-   * For example calling the following function
-   * ```
-   * changeDetected = sphereSourceInstance.set({
-   *    phiResolution: 10,
-   *    thetaResolution: 20,
-   * });
-   * ```
-   * will be equivalent of calling
-   * ```
-   * changeDetected += sphereSourceInstance.setPhiResolution(10);
-   * changeDetected += sphereSourceInstance.setThetaResolution(20);
-   * changeDetected = !!changeDetected;
-   * ```
-   *
-   * In case you provide other field names that do not belong to the instance,
-   * vtkWarningMacro will be used to warn you. To disable those warning,
-   * you can set `noWarning` to true.
-   *
-   * If `noFunction` is set to true, the field will be set directly on the model
-   * without calling the `set${FieldName}()` method.
-   *
-   * @param map (default: {}) Object capturing the set of fieldNames and associated values to set.
-   * @param noWarning (default: false) Boolean to disable any warning.
-   * @param noFunctions (default: false) Boolean to skip any function execution and rely on only setting the fields on the model.
-   * @return true if a change was actually performed. False otherwise when the value provided were equal to the ones already set inside the instance.
-   */
-  set(map?: object, noWarning?: boolean, noFunction?: boolean): boolean;
-
-  /**
-   * Extract a set of properties at once from a vtkObject.
-   *
-   * This can be convenient to pass a partial state of
-   * one object to another.
-   *
-   * ```
-   * cameraB.set(cameraA.get('position', 'viewUp', 'focalPoint'));
-   * ```
-   *
-   * @param listOfKeys set of field names that you want to retrieve. If not provided, the full model get returned as a new object.
-   * @returns a new object containing only the values of requested fields
-   */
-  get(...listOfKeys: Array<string>): object;
-
-  /**
-   * Allow to get a direct reference of a model element
-   *
-   * @param name of the field to extract from the instance model
-   * @returns model[name]
-   */
-  getReferenceByName(name: string): any;
-
-  /**
-   * Dereference any internal object and remove any subscription.
-   * It gives custom class to properly detach themselves from the DOM
-   * or any external dependency that could prevent their deletion
-   * when the GC runs.
-   */
-  delete(): void;
-
-  /**
-   * Try to extract a serializable (JSON) object of the given
-   * instance tree.
-   *
-   * Such state can then be reused to clone or rebuild a full
-   * vtkObject tree using the root vtk() function.
-   *
-   * The following example will grab mapper and dataset that are
-   * beneath the vtkActor instance as well.
-   *
-   * ```
-   * const actorStr = JSON.stringify(actor.getState());
-   * const newActor = vtk(JSON.parse(actorStr));
-   * ```
-   */
-  getState(): object;
-
-  /**
-   * Try to copy the state of the other to ourselves by just using references.
-   *
-   * @param other instance to copy the reference from
-   * @param debug (default: false) if true feedback will be provided when mismatch happen
-   */
-  shallowCopy(other: VtkObject, debug?: boolean): void;
-}
-
-/**
  * Turns the provided publicAPI into a VtkObject
  *
  * @param publicAPI (default: {}) object on which public methods get attached to
@@ -353,76 +208,6 @@ export function setArray(publicAPI: object, model: object, fieldNames: Array<str
  */
 export function setGetArray(publicAPI: object, model: object, fieldNames: Array<string>, size: Number, defaultVal?: any): void;
 
-/**
- * Basic object representing a data range
- */
-export interface vtkRange {
-  min: number;
-  max: number;
-}
-
-
-
-export interface VtkOutputPort {
-  filter: VtkAlgorithm;
-}
-
-export type VtkPipelineConnection = () => any | VtkOutputPort;
-
-/**
- * vtkAlgorithm API
- */
-export interface VtkAlgorithm {
-  /**
-   * @param dataset
-   * @param port (default 0)
-   */
-  setInputData(dataset: any, port?: number): void;
-  /**
-   * @param port (default 0)
-   */
-  getInputData(port?: number): any;
-  /**
-   * @param outputPort
-   * @param port (default 0)
-   */
-  setInputConnection(outputPort: VtkPipelineConnection, port?: number): void;
-  /**
-   * @param port (default 0)
-   */
-  getInputConnection(port?: number): VtkPipelineConnection;
-  addInputConnection(outputPort: VtkPipelineConnection): void;
-  addInputData(dataset: any): void;
-  /**
-   * @param port (default 0)
-   */
-  getOutputData(port?: number): any;
-  shouldUpdate(): boolean;
-  /**
-   * @param port (default 0)
-   */
-  getOutputPort(port?: number): VtkPipelineConnection;
-  update(): void;
-  getNumberOfInputPorts(): number;
-  getNumberOfOutputPorts(): number;
-  /**
-   * @param port (default 0)
-   */
-  getInputArrayToProcess(inputPort?: number): vtkDataArray;
-  /**
-   *
-   * @param inputPort
-   * @param arrayName
-   * @param fieldAssociation
-   * @param attributeType (default 'Scalars')
-   */
-  setInputArrayToProcess(
-    inputPort: number,
-    arrayName: string,
-    fieldAssociation: string,
-    attributeType?: string
-  ): void;
-}
 
 /**
  * Add algorithm methods onto the provided publicAPI
@@ -468,7 +253,7 @@ export interface VtkChangeEvent {
    * @param VtkCallback
    * @param priority (default 0.0)
    */
-  onChange(VtkCallback, priority?: number): VtkSubscription;
+  onChange(VtkCallback, priority?: number): vtkSubscription;
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/types.ts
+++ b/Sources/types.ts
@@ -21,3 +21,5 @@ declare type HSVColor = [number, number, number];
 declare type RGBColor = [number, number, number];
 declare type RGBAColor = [number, number, number, number];
 declare type Color = HSLColor | HSVColor | RGBColor | RGBAColor;
+
+declare type vtkPipelineConnection = () => any | vtkOutputPort;


### PR DESCRIPTION
### Context
Refactor Typescript definitions

### Changes
- Move `VtkObject`, `VtkAlgorithm`, `vtkRange` to interfaces.d.ts
- Rename `VtkObject` to `vtkObject`
- Rename `VtkAlgorithm` to `vtkAlgorithm`

### Results
No changes in behavior but `vtkObject` type/interface can be imported from interfaces.d.ts rather than macro.d.ts

### Testing
Other vtk classes which extend `vtkObject` are still working
![image](https://user-images.githubusercontent.com/878518/117555012-cb0be900-b05b-11eb-8c68-c8bf8e07f410.png)

`vtkObject` used as a type
![image](https://user-images.githubusercontent.com/878518/117555024-f098f280-b05b-11eb-9a9c-b67b4f892a24.png)

