### PR TITLE
fix(RenderWindowInteractor): add/remove event listeners on same object

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -264,15 +264,9 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     );
     model.container.removeEventListener('mousemove', publicAPI.handleMouseMove);
     model.container.removeEventListener('mousedown', publicAPI.handleMouseDown);
-    document
-      .querySelector('body')
-      .removeEventListener('keypress', publicAPI.handleKeyPress);
-    document
-      .querySelector('body')
-      .removeEventListener('keydown', publicAPI.handleKeyDown);
-    document
-      .querySelector('body')
-      .removeEventListener('keyup', publicAPI.handleKeyUp);
+    document.removeEventListener('keypress', publicAPI.handleKeyPress);
+    document.removeEventListener('keydown', publicAPI.handleKeyDown);
+    document.removeEventListener('keyup', publicAPI.handleKeyUp);
     document.removeEventListener(
       'pointerlockchange',
       publicAPI.handlePointerLockChange


### PR DESCRIPTION
### Context

Fix console errors coming from `vtkRenderWindowInteractor` after unbinding and rebinding events.

### Changes

#1858 Changed the `bindEvents` method in the RWI to add key event listeners on the `document` rather than the `body`.  This change fixes the `unbindEvents` methods to match, i.e. it uses the `document` rather than the `body` to `removeEventListener`.
