### PR TITLE
docs: Overhaul intro docs to use the ESM build

### DIFF
--- a/Documentation/content/api/index.md
+++ b/Documentation/content/api/index.md
@@ -3,6 +3,8 @@ title: API
 
 This documentation provides more detailed information about the API and will be particularly helpful for people who want to use VTK.js into their application.
 
+If you are looking for general information on VTK pipelines, data structures, and more, check out [the freely available VTK book](https://www.vtk.org/vtk-textbook/).
+
 <style>
   .categories {
     columns: 2 200px;

--- a/Documentation/content/docs/develop_requirement.md
+++ b/Documentation/content/docs/develop_requirement.md
@@ -1,17 +1,19 @@
 title: Requirements
 ---
 
-Installing and developing vtk.js is quite easy, there are just two dependencies: 
+Installing and developing vtk.js is quite easy, there are just two dependencies:
 
 - [Node.js](http://nodejs.org/)
 - [Git](http://git-scm.com/) - only necessary for developing and committing to the library.
 
-Instructions for installing these are located at the bottom of this page. If your computer already has these, congratulations! 
+Instructions for installing these are located at the bottom of this page. If your computer already has these, congratulations!
 
 To install vtk.js within your project:
 
 ```sh
 $ npm install vtk.js --save
+# or for the ESM build
+$ npm install @kitware/vtk.js --save
 ```
 
 If you're developing for vtk.js, then clone the repository using git:
@@ -22,7 +24,7 @@ $ cd vtk-js
 $ npm install
 ```
 
-Further instructions on vtk.js development can be found on the [contributing page](https://kitware.github.io/vtk-js/docs/misc_contributing.html). 
+Further instructions on vtk.js development can be found on the [contributing page](https://kitware.github.io/vtk-js/docs/misc_contributing.html).
 
 ### Git
 

--- a/Documentation/content/docs/old_intro_vtk_es6.md
+++ b/Documentation/content/docs/old_intro_vtk_es6.md
@@ -1,0 +1,70 @@
+title: (Old approach) Transpiling vtk.js manually
+---
+
+This guide illustrates how to consume vtk.js by way of transpiling. Please note that this method is *discouraged*, and it is recommended instead to follow [the modern approach outlined in the introduction](./intro_vtk_as_es6_dependency.html).
+
+## Which package to use
+
+In order to take the transpilation approach, you must use the `vtk.js` package instead of `@kitware/vtk.js`. This will also impact your imports; imports will now be prefixed with `vtk.js/Sources`, as shown below.
+
+```diff
+-import vtkRenderer from '@kitware/vtk.js/Rendering/Core/Renderer';
++import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+```
+
+## Transpiling vtk.js code
+
+We primarily support webpack for transpiling vtk.js. The generic structure of the webpack structure is listed below, with comments.
+
+``` js ./webpack.config.js
+// Required in order to build vtk.js alongside your project
+var vtkRules = require('vtk.js/Utilities/config/dependency.js').webpack.core.rules;
+
+// Optional if you want to load *.css and *.module.css files
+// var cssRules = require('vtk.js/Utilities/config/dependency.js').webpack.css.rules;
+
+module.exports = {
+  ...
+  module: {
+    rules: [
+      ...yourRules,
+    // This is needed to include vtk.js build rules
+    ].concat(vtkRules),
+  },
+  ...
+};
+```
+
+### With vue-cli
+
+If you are using `vue-cli`, then you will need to have the following `vue.config.js`:
+
+```js
+const vtkChainWebpack = require('vtk.js/Utilities/config/chainWebpack');
+
+module.exports = {
+  ...
+  chainWebpack: (config) => {
+    vtkChainWebpack(config);
+    // do not cache worker files
+    // https://github.com/webpack-contrib/worker-loader/issues/195
+    config.module.rule('js').exclude.add(/\.worker\.js$/);
+  },
+  ...
+};
+```
+
+### with create-react-app
+
+If you are using `create-react-app` or `react-app-rewired`, you will need to override the default build config. Specifically, there is a `file-loader` rule that outputs assets to `static/media/*`. In order for vtk.js glsl files to not be split out (since vtk.js does dynamic shader generation), you will need to add an exclude condition to that `file-loader`, like so:
+
+```js
+{
+  loader: 'file-loader',
+  exclude: [
+    ...,
+    /node_modules[\/\\]vtk\.js[\/\\]/,
+  ],
+  ...
+}
+```

--- a/Documentation/content/docs/vtk_react.md
+++ b/Documentation/content/docs/vtk_react.md
@@ -1,0 +1,161 @@
+title: Using vtk.js with React
+---
+
+This is a quickstart tutorial for using vtk.js with React.
+
+## Initialize your project
+
+Use `npx create-react-app my-vtkjs-app`, `yarn create react-app my-vtkjs-app`, or `npm init react-app` to initialize your project.
+For this tutorial, we will use `yarn`.
+
+```sh
+$ yarn create react-app my-vtkjs-app
+$ cd my-vtkjs-app
+$ ls
+node_modules/  package.json  public/  README.md  src/  yarn.lock
+```
+
+Now install vtk.js as a dependency.
+
+```sh
+$ yarn add @kitware/vtk.js
+```
+
+## Using vtk.js in your app
+
+To add a minimal vtk.js example to your app, replace `src/App.js` with the following contents.
+
+```js src/App.js
+import { useState, useRef, useEffect } from 'react';
+
+import '@kitware/vtk.js/Rendering/Profiles/Geometry';
+
+import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
+
+import vtkActor           from '@kitware/vtk.js/Rendering/Core/Actor';
+import vtkMapper          from '@kitware/vtk.js/Rendering/Core/Mapper';
+import vtkConeSource      from '@kitware/vtk.js/Filters/Sources/ConeSource';
+
+function App() {
+  const vtkContainerRef = useRef(null);
+  const context = useRef(null);
+  const [coneResolution, setConeResolution] = useState(6);
+  const [representation, setRepresentation] = useState(2);
+
+  useEffect(() => {
+    if (!context.current) {
+      const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
+        rootContainer: vtkContainerRef.current,
+      });
+      const coneSource = vtkConeSource.newInstance({ height: 1.0 });
+
+      const mapper = vtkMapper.newInstance();
+      mapper.setInputConnection(coneSource.getOutputPort());
+
+      const actor = vtkActor.newInstance();
+      actor.setMapper(mapper);
+
+      const renderer = fullScreenRenderer.getRenderer();
+      const renderWindow = fullScreenRenderer.getRenderWindow();
+
+      renderer.addActor(actor);
+      renderer.resetCamera();
+      renderWindow.render();
+
+      context.current = {
+        fullScreenRenderer,
+        renderWindow,
+        renderer,
+        coneSource,
+        actor,
+        mapper,
+      };
+    }
+
+    return () => {
+      if (context.current) {
+        const { fullScreenRenderer, coneSource, actor, mapper } = context.current;
+        actor.delete();
+        mapper.delete();
+        coneSource.delete();
+        fullScreenRenderer.delete();
+        context.current = null;
+      }
+    };
+  }, [vtkContainerRef]);
+
+  useEffect(() => {
+    if (context.current) {
+      const { coneSource, renderWindow } = context.current;
+      coneSource.setResolution(coneResolution);
+      renderWindow.render();
+    }
+  }, [coneResolution]);
+
+  useEffect(() => {
+    if (context.current) {
+      const { actor, renderWindow } = context.current;
+      actor.getProperty().setRepresentation(representation);
+      renderWindow.render();
+    }
+  }, [representation]);
+
+  return (
+    <div>
+      <div ref={vtkContainerRef} />
+      <table
+        style={{
+          position: 'absolute',
+          top: '25px',
+          left: '25px',
+          background: 'white',
+          padding: '12px',
+        }}
+      >
+        <tbody>
+          <tr>
+            <td>
+              <select
+                value={representation}
+                style={{ width: '100%' }}
+                onInput={(ev) => setRepresentation(Number(ev.target.value))}
+              >
+                <option value="0">Points</option>
+                <option value="1">Wireframe</option>
+                <option value="2">Surface</option>
+              </select>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <input
+                type="range"
+                min="4"
+                max="80"
+                value={coneResolution}
+                onChange={(ev) => setConeResolution(Number(ev.target.value))}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default App;
+```
+
+## Running the app
+
+You can run the app using the project's built-in dev server.
+
+```sh
+$ yarn start
+```
+
+Navigate to `http://localhost:3000`, and you should have an interactive 3D visualization of a cone, similar to the [SimpleCone](../examples/SimpleCone.html) example.
+
+## Where to go next
+
+Check out the [tutorials](./tutorial.html), or if you know what you want but need API docs, check out the [API](../api).

--- a/Documentation/content/docs/vtk_vanilla.md
+++ b/Documentation/content/docs/vtk_vanilla.md
@@ -1,0 +1,172 @@
+title: Starting a vtk.js project from scratch
+---
+
+This is a quickstart tutorial for using vanilla vtk.js.
+
+## Initialize your project
+
+Let's start by initializing a new project.
+
+```sh
+$ mkdir my-vtkjs-app
+$ cd my-vtkjs-app
+$ npm init
+...
+```
+
+Now install `@kitware/vtk.js` as a dependency.
+
+```sh
+$ npm install @kitware/vtk.js
+```
+
+For this example, we will be using webpack to build our application.
+If you are using other bundlers (e.g. parcel, rollup, etc.), please refer to the "Getting Started" tutorials there before skipping down to [how to use vtk.js](#Using-vtk-js-in-your-app).
+
+```sh
+$ npm install -D webpack-cli webpack webpack-dev-server
+```
+
+## Project scaffolding
+
+We need to take care of some project scaffolding first. Let's first create some directories.
+
+```sh
+$ mkdir dist/ src/
+```
+
+Inside `dist/`, we will create an `index.html`.
+
+```html ./dist/index.html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <script src="./main.js"></script>
+  </body>
+</html>
+```
+
+Additionally, we will add some scripts to make our lives easier for running build commands.
+Inside `package.json`, add the following lines in the scripts object.
+
+```diff
+   "scripts": {
++    "build": "webpack --progress --mode=development",
++    "start": "webpack serve --progress --mode=development --content-base=dist",
+     "test": "echo \"Error: no test specified\" && exit 1"
+   }
+```
+
+## Using vtk.js in your app
+
+Add the following code to `src/index.js`.
+
+```js
+import '@kitware/vtk.js/Rendering/Profiles/Geometry';
+
+import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
+
+import vtkActor           from '@kitware/vtk.js/Rendering/Core/Actor';
+import vtkMapper          from '@kitware/vtk.js/Rendering/Core/Mapper';
+import vtkCalculator      from '@kitware/vtk.js/Filters/General/Calculator';
+import vtkConeSource      from '@kitware/vtk.js/Filters/Sources/ConeSource';
+import { AttributeTypes } from '@kitware/vtk.js/Common/DataModel/DataSetAttributes/Constants';
+import { FieldDataTypes } from '@kitware/vtk.js/Common/DataModel/DataSet/Constants';
+
+const controlPanel = `
+<table>
+  <tr>
+    <td>
+      <select class="representations" style="width: 100%">
+        <option value="0">Points</option>
+        <option value="1">Wireframe</option>
+        <option value="2" selected>Surface</option>
+      </select>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <input class="resolution" type="range" min="4" max="80" value="6" />
+    </td>
+  </tr>
+</table>
+`;
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance();
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+
+// ----------------------------------------------------------------------------
+// Example code
+// ----------------------------------------------------------------------------
+
+const coneSource = vtkConeSource.newInstance({ height: 1.0 });
+const filter = vtkCalculator.newInstance();
+
+filter.setInputConnection(coneSource.getOutputPort());
+filter.setFormula({
+  getArrays: inputDataSets => ({
+    input: [],
+    output: [
+      { location: FieldDataTypes.CELL, name: 'Random', dataType: 'Float32Array', attribute: AttributeTypes.SCALARS },
+    ],
+  }),
+  evaluate: (arraysIn, arraysOut) => {
+    const [scalars] = arraysOut.map(d => d.getData());
+    for (let i = 0; i < scalars.length; i++) {
+      scalars[i] = Math.random();
+    }
+  },
+});
+
+const mapper = vtkMapper.newInstance();
+mapper.setInputConnection(filter.getOutputPort());
+
+const actor = vtkActor.newInstance();
+actor.setMapper(mapper);
+
+renderer.addActor(actor);
+renderer.resetCamera();
+renderWindow.render();
+
+// -----------------------------------------------------------
+// UI control handling
+// -----------------------------------------------------------
+
+fullScreenRenderer.addController(controlPanel);
+const representationSelector = document.querySelector('.representations');
+const resolutionChange = document.querySelector('.resolution');
+
+representationSelector.addEventListener('change', (e) => {
+  const newRepValue = Number(e.target.value);
+  actor.getProperty().setRepresentation(newRepValue);
+  renderWindow.render();
+});
+
+resolutionChange.addEventListener('input', (e) => {
+  const resolution = Number(e.target.value);
+  coneSource.setResolution(resolution);
+  renderWindow.render();
+});
+```
+
+## Running the app
+
+After adding the source file, run the app with the webpack dev server.
+
+```sh
+$ npm run start
+```
+
+Navigate to `http://localhost:8080`, and you should have an interactive 3D visualization of a cone, similar to the [SimpleCone](../examples/SimpleCone.html) example.
+
+## Where to go next
+
+Check out the [tutorials](./tutorial.html), or if you know what you want but need API docs, check out the [API](../api).

--- a/Documentation/content/docs/vtk_vue.md
+++ b/Documentation/content/docs/vtk_vue.md
@@ -1,0 +1,179 @@
+title: Using vtk.js with vue.js
+---
+
+This is a quickstart tutorial for using vtk.js with vue.js.
+
+## Initialize your project
+
+Install the vue-cli [as per the vue-cli docs](https://cli.vuejs.org/guide/installation.html).
+Then, create and initialize your project with `vue create`.
+For this example, we will be using Vue 3 and npm.
+
+```sh
+$ vue create my-vtkjs-app
+> Select Vue 3 defaults
+
+$ cd my-vtkjs-app
+```
+
+Now install vtk.js as a dependency.
+
+```sh
+$ npm install @kitware/vtk.js
+```
+
+## Using vtk.js in your app
+
+To add a minimal vtk.js example to your app, replace `src/components/HelloWorld.vue` with the following contents.
+
+```js src/components/HelloWorld.vue
+<template>
+  <div>
+    <div ref="vtkContainer" />
+    <table class="controls">
+      <tbody>
+        <tr>
+          <td>
+            <select
+              style="width: 100%"
+              :value="representation"
+              @change="setRepresentation($event.target.value)"
+            >
+              <option value="0">Points</option>
+              <option value="1">Wireframe</option>
+              <option value="2">Surface</option>
+            </select>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <input
+              type="range"
+              min="4"
+              max="80"
+              :value="coneResolution"
+              @input="setConeResolution($event.target.value)"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import { ref, unref, onMounted, onBeforeUnmount, watchEffect } from 'vue';
+
+import '@kitware/vtk.js/Rendering/Profiles/Geometry';
+
+import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
+
+import vtkActor           from '@kitware/vtk.js/Rendering/Core/Actor';
+import vtkMapper          from '@kitware/vtk.js/Rendering/Core/Mapper';
+import vtkConeSource      from '@kitware/vtk.js/Filters/Sources/ConeSource';
+
+export default {
+  name: 'HelloWorld',
+
+  setup() {
+    const vtkContainer = ref(null);
+    const context = ref(null);
+    const coneResolution = ref(6);
+    const representation = ref(2);
+
+    function setConeResolution(res) {
+      coneResolution.value = Number(res);
+    }
+
+    function setRepresentation(rep) {
+      representation.value = Number(rep);
+    }
+
+    watchEffect(() => {
+      const res = unref(coneResolution);
+      const rep = unref(representation);
+      if (context.value) {
+        const { actor, coneSource, renderWindow } = context.value;
+        coneSource.setResolution(res);
+        actor.getProperty().setRepresentation(rep);
+        renderWindow.render();
+      }
+    });
+
+    onMounted(() => {
+      if (!context.value) {
+        const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
+          rootContainer: vtkContainer.value,
+        });
+        const coneSource = vtkConeSource.newInstance({ height: 1.0 });
+
+        const mapper = vtkMapper.newInstance();
+        mapper.setInputConnection(coneSource.getOutputPort());
+
+        const actor = vtkActor.newInstance();
+        actor.setMapper(mapper);
+
+        const renderer = fullScreenRenderer.getRenderer();
+        const renderWindow = fullScreenRenderer.getRenderWindow();
+
+        renderer.addActor(actor);
+        renderer.resetCamera();
+        renderWindow.render();
+
+        context.value = {
+          fullScreenRenderer,
+          renderWindow,
+          renderer,
+          coneSource,
+          actor,
+          mapper,
+        };
+      }
+    });
+
+    onBeforeUnmount(() => {
+      if (context.value) {
+        const { fullScreenRenderer, coneSource, actor, mapper } = context.value;
+        actor.delete();
+        mapper.delete();
+        coneSource.delete();
+        fullScreenRenderer.delete();
+        context.value = null;
+      }
+    });
+
+    return {
+      vtkContainer,
+      setRepresentation,
+      setConeResolution,
+      coneResolution,
+      representation,
+    };
+  }
+}
+</script>
+
+<style scoped>
+.controls {
+  position: absolute;
+  top: 25px;
+  left: 25px;
+  background: white;
+  padding: 12px;
+}
+</style>
+```
+
+## Running the app
+
+You can run the app using the project's built-in dev server.
+
+```sh
+$ npm run start
+```
+
+Navigate to `http://localhost:8080`, and you should have an interactive 3D visualization of a cone, similar to the [SimpleCone](../examples/SimpleCone.html) example.
+
+## Where to go next
+
+Check out the [tutorials](./tutorial.html), or if you know what you want but need API docs, check out the [API](../api).

--- a/Documentation/tpl/__en__
+++ b/Documentation/tpl/__en__
@@ -50,3 +50,7 @@ sidebar:
     testing: Testing
     tests: Tests
     coverage: Coverage
+    react_usage: vtk.js + React
+    vue_usage: vtk.js + vue.js
+    vanilla_usage: Vanilla vtk.js
+    old_es6_docs: ES6 usage (Non-ESM build)

--- a/Documentation/tpl/__sidebar__
+++ b/Documentation/tpl/__sidebar__
@@ -3,7 +3,11 @@ docs:
     overview: index.html
     external: intro_vtk_as_external_script.html
     es6_dep: intro_vtk_as_es6_dependency.html
+    react_usage: vtk_react.html
+    vue_usage: vtk_vue.html
+    vanilla_usage: vtk_vanilla.html
     tutorial: tutorial.html
+    old_es6_docs: old_intro_vtk_es6.html
 
   develop:
     requirement: develop_requirement.html


### PR DESCRIPTION
### Context

This PR updates the documentation to use the new `@kitware/vtk.js` ESM build. The old webpack-dependent approach is still supported, but its use in new projects is discouraged.

Fixes issue #1867 

### Changes

This only introduces documentation changes.