### PR TITLE
Unique class hierarchy

### DIFF
--- a/Sources/Common/Core/ClassHierarchy/index.js
+++ b/Sources/Common/Core/ClassHierarchy/index.js
@@ -1,0 +1,7 @@
+export default class ClassHierarchy extends Array {
+  push(...args) {
+    // no perf issue since args.length should be small
+    const newArgs = args.filter((arg) => !this.includes(arg));
+    return super.push(...newArgs);
+  }
+}

--- a/Sources/Widgets/Core/AbstractWidgetFactory/index.js
+++ b/Sources/Widgets/Core/AbstractWidgetFactory/index.js
@@ -31,10 +31,15 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
         camera,
       } = extractRenderingComponents(renderer);
       const widgetModel = {};
-      const widgetPublicAPI = {
+      const widgetPublicAPI = {};
+
+      macro.obj(widgetPublicAPI, widgetModel);
+      Object.assign(widgetPublicAPI, {
         onWidgetChange: publicAPI.onWidgetChange,
-      };
-      Object.assign(widgetModel, model, {
+      });
+      Object.assign(widgetModel, {
+        widgetState: model.widgetState,
+        manipulator: model.manipulator,
         viewType,
         renderer,
         camera,

--- a/Sources/macro.js
+++ b/Sources/macro.js
@@ -1,4 +1,5 @@
 import vtk from './vtk';
+import ClassHierarchy from './Common/Core/ClassHierarchy';
 
 let globalMTime = 0;
 
@@ -214,7 +215,12 @@ export function obj(publicAPI = {}, model = {}) {
   if (!Number.isInteger(model.mtime)) {
     model.mtime = ++globalMTime;
   }
-  model.classHierarchy = ['vtkObject'];
+
+  if (!('classHierarchy' in model)) {
+    model.classHierarchy = new ClassHierarchy('vtkObject');
+  } else if (!(model.classHierarchy instanceof ClassHierarchy)) {
+    model.classHierarchy = ClassHierarchy.from(model.classHierarchy);
+  }
 
   function off(index) {
     callbacks[index] = null;


### PR DESCRIPTION
### Context

Fixes #1910 

### Changes

- Introduces `ClassHierarchy`, which subclasses Array. This is used to remove duplicates only when items are added via `.push`.
- Fixes unnecessary class hierarchy additions to AbstractWidget

### Results

model.classHierarchy should now not have any duplicates. Any existing code using classHierarchy should continue to operate correctly.

### Testing

I tested this by modifying the `PolyLineWidget` example to output the class hierarchy of the widget via `viewWidget.get('classHierarchy').classHierarchy`. The result should be the following:

```
ClassHierarchy(5) ["vtkObject", "vtkProp", "vtkInteractorObserver", "vtkAbstractWidget", "vtkPolyLineWidgetProp"]
```
