### PR TITLE
 fix(setAverageIPScalarRange)

### DIFF
--- a/Examples/Volume/VolumeMapperBlendModes/controller.html
+++ b/Examples/Volume/VolumeMapperBlendModes/controller.html
@@ -10,4 +10,12 @@
       </select>
     </td>
   </tr>
+  <tr class="averageIPScalar" style="display:none;">
+    <td>Average IP Scalar Min</td>
+    <td><input class="scalarMin" type="range" min="0" max="1" value="0" step="0.01"></td>
+  </tr>
+  <tr class="averageIPScalar" style="display:none;">
+    <td><p>Average IP Scalar Max</p></td>
+    <td><input class="scalarMax" type="range" min="0" max="1" value="1" step="0.01"></td>
+  </tr>
 </table>

--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -79,7 +79,7 @@ function updateBlendMode(event) {
     // Show average scalar ui
     for (let i = 0; i < averageIPScalarEls.length; i += 1) {
       const el = averageIPScalarEls[i];
-      el.style.display = 'block';
+      el.style.display = 'table-row';
     }
   } else {
     // Hide average scalar ui

--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -69,11 +69,43 @@ mapper.setInputConnection(reader.getOutputPort());
 
 function updateBlendMode(event) {
   const blendMode = parseInt(event.target.value, 10);
+  const averageIPScalarEls = document.querySelectorAll('.averageIPScalar');
 
   mapper.setBlendMode(blendMode);
+  mapper.setAverageIPScalarRange(0.0, 1.0);
+
+  // if average blend mode
+  if (blendMode === 3) {
+    // Show average scalar ui
+    for (let i = 0; i < averageIPScalarEls.length; i += 1) {
+      const el = averageIPScalarEls[i];
+      el.style.display = 'block';
+    }
+  } else {
+    // Hide average scalar ui
+    for (let i = 0; i < averageIPScalarEls.length; i += 1) {
+      const el = averageIPScalarEls[i];
+      el.style.display = 'none';
+    }
+  }
 
   renderWindow.render();
 }
+
+function updateScalarMin(event) {
+  mapper.setAverageIPScalarRange(
+    event.target.value,
+    parseFloat(mapper.getAverageIPScalarRange()[1])
+  );
+}
+
+function updateScalarMax(event) {
+  mapper.setAverageIPScalarRange(
+    mapper.getAverageIPScalarRange()[0],
+    parseFloat(event.target.value)
+  );
+}
+
 reader.setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`).then(() => {
   reader.loadData().then(() => {
     renderer.addVolume(actor);
@@ -85,6 +117,10 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`).then(() => {
 
     const el = document.querySelector('.blendMode');
     el.addEventListener('change', updateBlendMode);
+    const scalarMinEl = document.querySelector('.scalarMin');
+    scalarMinEl.addEventListener('change', updateScalarMin);
+    const scalarMaxEl = document.querySelector('.scalarMax');
+    scalarMaxEl.addEventListener('change', updateScalarMax);
   });
 });
 

--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -97,6 +97,7 @@ function updateScalarMin(event) {
     event.target.value,
     parseFloat(mapper.getAverageIPScalarRange()[1])
   );
+  renderWindow.render();
 }
 
 function updateScalarMax(event) {
@@ -104,6 +105,7 @@ function updateScalarMax(event) {
     mapper.getAverageIPScalarRange()[0],
     parseFloat(event.target.value)
   );
+  renderWindow.render();
 }
 
 reader.setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`).then(() => {
@@ -118,9 +120,9 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`).then(() => {
     const el = document.querySelector('.blendMode');
     el.addEventListener('change', updateBlendMode);
     const scalarMinEl = document.querySelector('.scalarMin');
-    scalarMinEl.addEventListener('change', updateScalarMin);
+    scalarMinEl.addEventListener('input', updateScalarMin);
     const scalarMaxEl = document.querySelector('.scalarMax');
-    scalarMaxEl.addEventListener('change', updateScalarMax);
+    scalarMaxEl.addEventListener('input', updateScalarMax);
   });
 });
 

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -232,18 +232,31 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     ).result;
 
     const averageIPScalarRange = model.renderable.getAverageIPScalarRange();
+    let min;
+    let max;
 
-    // TODO: Adding the .0 at the end feels hacky
+    // If min or max is not already a float.
+    // make them into floats for glsl
+    if (Number.isInteger(averageIPScalarRange[0])) {
+      min = `${averageIPScalarRange[0]}.0`;
+    } else {
+      min = `${averageIPScalarRange[0]}`;
+    }
+    if (Number.isInteger(averageIPScalarRange[1])) {
+      max = `${averageIPScalarRange[1]}.0`;
+    } else {
+      max = `${averageIPScalarRange[1]}`;
+    }
     FSSource = vtkShaderProgram.substitute(
       FSSource,
       '//VTK::AverageIPScalarRangeMin',
-      `${averageIPScalarRange[0]}.0`
+      min
     ).result;
 
     FSSource = vtkShaderProgram.substitute(
       FSSource,
       '//VTK::AverageIPScalarRangeMax',
-      `${averageIPScalarRange[1]}.0`
+      max
     ).result;
 
     shaders.Fragment = FSSource;

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -232,21 +232,14 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     ).result;
 
     const averageIPScalarRange = model.renderable.getAverageIPScalarRange();
-    let min;
-    let max;
+    let min = averageIPScalarRange[0];
+    let max = averageIPScalarRange[1];
 
     // If min or max is not already a float.
     // make them into floats for glsl
-    if (Number.isInteger(averageIPScalarRange[0])) {
-      min = `${averageIPScalarRange[0]}.0`;
-    } else {
-      min = `${averageIPScalarRange[0]}`;
-    }
-    if (Number.isInteger(averageIPScalarRange[1])) {
-      max = `${averageIPScalarRange[1]}.0`;
-    } else {
-      max = `${averageIPScalarRange[1]}`;
-    }
+    min = Number.isInteger(min) ? min.toFixed(1).toString() : min.toString();
+    max = Number.isInteger(max) ? max.toFixed(1).toString() : max.toString();
+
     FSSource = vtkShaderProgram.substitute(
       FSSource,
       '//VTK::AverageIPScalarRangeMin',

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -638,14 +638,14 @@ return tColor;
 
 bool valueWithinScalarRange(vec4 val, vec4 min, vec4 max) {
   bool withinRange = false;
-  #if vtkNumComponents >= 1
-    if (val.r > min.r && val.r < max.r) {
+  #if vtkNumComponents == 1
+    if (val.r >= min.r && val.r <= max.r) {
       withinRange = true;
     }
   #endif
   #if defined(vtkIndependentComponentsOn) && vtkNumComponents == 2
-     if (val.r > min.r && val.r < max.r &&
-        val.g > min.g && val.g < max.g) {
+     if (val.r >= min.r && val.r <= max.r &&
+        val.g >= min.g && val.g <= max.g) {
       withinRange = true;
     }
   #endif

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -834,9 +834,6 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
       // - We are comparing all values in the texture to see if any of them
       //   are outside of the scalar range. In the future we might want to allow
       //   scalar ranges for each component.
-      // - There might be a better way to do this. I'm not sure if there is an
-      //   equivalent of 'any' which only operates on RGB, though I suppose
-      //   we could write an 'anyRGB' function and see if that is faster.
       if (valueWithinScalarRange(tValue, averageIPScalarRangeMin, averageIPScalarRangeMax)) {
         // Sum the values across each step in the path
         sum += tValue;

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -799,17 +799,14 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
       //VTK::AverageIPScalarRangeMin,
       //VTK::AverageIPScalarRangeMin,
       //VTK::AverageIPScalarRangeMin,
-      1.0);
+      //VTK::AverageIPScalarRangeMax);
     vec4 averageIPScalarRangeMax = vec4(
       //VTK::AverageIPScalarRangeMax,
       //VTK::AverageIPScalarRangeMax,
       //VTK::AverageIPScalarRangeMax,
-      1.0);
+      //VTK::AverageIPScalarRangeMax);
 
     vec4 sum = vec4(0.);
-
-    averageIPScalarRangeMin.a = tValue.a;
-    averageIPScalarRangeMax.a = tValue.a;
 
     if (valueWithinScalarRange(tValue, averageIPScalarRangeMin, averageIPScalarRangeMax)) {
       sum += tValue;
@@ -837,22 +834,13 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
       // - We are comparing all values in the texture to see if any of them
       //   are outside of the scalar range. In the future we might want to allow
       //   scalar ranges for each component.
-      // - We are setting the alpha channel for averageIPScalarRangeMin and
-      //   averageIPScalarRangeMax so that we do not trigger this 'continue'
-      //   based on the alpha channel comparison.
       // - There might be a better way to do this. I'm not sure if there is an
       //   equivalent of 'any' which only operates on RGB, though I suppose
       //   we could write an 'anyRGB' function and see if that is faster.
-      averageIPScalarRangeMin.a = tValue.a;
-      averageIPScalarRangeMax.a = tValue.a;
-      if (!valueWithinScalarRange(tValue, averageIPScalarRangeMin, averageIPScalarRangeMax)) {
-        continue;
+      if (valueWithinScalarRange(tValue, averageIPScalarRangeMin, averageIPScalarRangeMax)) {
+        // Sum the values across each step in the path
+        sum += tValue;
       }
-
-      // Sum the values across each step in the path
-      sum += tValue;
-
-      // Otherwise, continue along the ray
       stepsTraveled++;
       posIS += stepIS;
     }


### PR DESCRIPTION
### Context
fix #1924
https://discourse.vtk.org/t/averageipscalarrange/5544/4

### Changes
averageIPScalarRange working for single component volumes (from some angles).
averageIPScalarRange can now accept float values.

### Results
Previously setting the range to a float: 
`mapper.setAverageIPScalarRange(0.0, 0.9);`
would result in a blank canvas on a volume and shader errors.

Currently: Adjusting the max slider between 0.0 and 1.0 results in this: 
![averageIPScalarTest](https://user-images.githubusercontent.com/7668858/119002657-f8726400-b984-11eb-84b7-6b43f507f75b.gif)

### Testing
run 
`npm run example -- VolumeMapperBlendModes`
switch the drop down to Average Intensity.
