### PR TITLE
chore(WebGPU): more volume support, add bind group

### DIFF
--- a/Sources/Rendering/WebGPU/BindGroup/index.js
+++ b/Sources/Rendering/WebGPU/BindGroup/index.js
@@ -1,0 +1,114 @@
+import macro from 'vtk.js/Sources/macro';
+
+// ----------------------------------------------------------------------------
+// vtkWebGPUBindGroup methods
+// ----------------------------------------------------------------------------
+
+function vtkWebGPUBindGroup(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkWebGPUBindGroup');
+
+  publicAPI.addBindable = (bindable) => {
+    // only add new bindables
+    for (let i = 0; i < model.bindables.length; i++) {
+      if (model.bindables[i] === bindable) {
+        return;
+      }
+    }
+    model.bindables.push(bindable);
+    publicAPI.modified();
+  };
+
+  publicAPI.getBindGroupLayout = (device) => {
+    const entries = [];
+    for (let i = 0; i < model.bindables.length; i++) {
+      const entry = model.bindables[i].getBindGroupLayoutEntry();
+      entry.binding = i;
+      entries.push(entry);
+    }
+    return device.getBindGroupLayout({ entries });
+  };
+
+  publicAPI.getBindGroup = (device) => {
+    // check mtime
+    let mtime = publicAPI.getMTime();
+    for (let i = 0; i < model.bindables.length; i++) {
+      const tm = model.bindables[i].getBindGroupTime();
+      mtime = tm > mtime ? tm : mtime;
+    }
+    if (mtime < model.bindGroupTime.getMTime()) {
+      return model.bindGroup;
+    }
+
+    const entries = [];
+    for (let i = 0; i < model.bindables.length; i++) {
+      const entry = model.bindables[i].getBindGroupEntry();
+      entry.binding = i;
+      entries.push(entry);
+    }
+
+    model.bindGroup = device.getHandle().createBindGroup({
+      layout: publicAPI.getBindGroupLayout(device),
+      entries,
+    });
+    model.bindGroupTime.modified();
+
+    return model.bindGroup;
+  };
+
+  publicAPI.getShaderCode = (pipeline) => {
+    const lines = [];
+    const bgroup = pipeline.getBindGroupLayoutCount(model.name);
+    for (let i = 0; i < model.bindables.length; i++) {
+      lines.push(model.bindables[i].getShaderCode(i, bgroup));
+    }
+    return lines.join('\n');
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  device: null,
+  handle: null,
+  name: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Object methods
+  macro.obj(publicAPI, model);
+
+  model.bindables = [];
+
+  model.bindGroupTime = {};
+  macro.obj(model.bindGroupTime, { mtime: 0 });
+
+  macro.get(publicAPI, model, [
+    'bindGroupTime',
+    'handle',
+    'sizeInBytes',
+    'usage',
+  ]);
+  macro.setGet(publicAPI, model, [
+    'name',
+    'device',
+    'arrayInformation',
+    'sourceTime',
+  ]);
+
+  vtkWebGPUBindGroup(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Rendering/WebGPU/Camera/api.md
+++ b/Sources/Rendering/WebGPU/Camera/api.md
@@ -1,7 +1,0 @@
-## Introduction
-
-This class is not intended for general use.  Please use the
-similarly named class under Rendering/Core. This class is
-a WebGPU implementation of that generic renderable class in
-Rendering Core.  This class will automatically get instantiated
-and rendered as needed by WebGPU

--- a/Sources/Rendering/WebGPU/Camera/index.js
+++ b/Sources/Rendering/WebGPU/Camera/index.js
@@ -59,6 +59,8 @@ function vtkWebGPUCamera(publicAPI, model) {
         model.keyMatrices.scvc
       );
 
+      mat4.invert(model.keyMatrices.pcsc, model.keyMatrices.scpc);
+
       model.keyMatrixTime.modified();
     }
     return model.keyMatrices;
@@ -89,6 +91,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.keyMatrices = {
     normalMatrix: new Float64Array(16),
     vcpc: new Float64Array(16),
+    pcsc: new Float64Array(16),
     wcvc: new Float64Array(16),
     scpc: new Float64Array(16),
     scvc: new Float64Array(16),

--- a/Sources/Rendering/WebGPU/Device/index.js
+++ b/Sources/Rendering/WebGPU/Device/index.js
@@ -47,7 +47,7 @@ function vtkWebGPUDevice(publicAPI, model) {
     // create one and store it
     const layout = model.handle.createBindGroupLayout(val);
 
-    // we actuall yonly store the stringified version
+    // we actually only store the stringified version
     // as that is what we always compare against
     model.bindGroupLayouts.push({ sval, layout });
     return layout;

--- a/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
@@ -8,6 +8,8 @@ import vtkWebGPUFullScreenQuad from 'vtk.js/Sources/Rendering/WebGPU/FullScreenQ
 // ----------------------------------------------------------------------------
 
 const oitpFragTemplate = `
+//VTK::Mapper::Dec
+
 //VTK::TCoord::Dec
 
 //VTK::RenderEncoder::Dec

--- a/Sources/Rendering/WebGPU/Pipeline/index.js
+++ b/Sources/Rendering/WebGPU/Pipeline/index.js
@@ -51,18 +51,14 @@ function vtkWebGPUPipeline(publicAPI, model) {
     return null;
   };
 
-  publicAPI.addBindGroupLayout2 = (buffObj) => {
-    if (!buffObj) {
+  publicAPI.addBindGroupLayout = (bindGroup) => {
+    if (!bindGroup) {
       return;
     }
     model.layouts.push({
-      layout: buffObj.getBindGroupLayout(model.device),
-      name: buffObj.getName(),
+      layout: bindGroup.getBindGroupLayout(model.device),
+      name: bindGroup.getName(),
     });
-  };
-
-  publicAPI.addBindGroupLayout = (layout, lname) => {
-    model.layouts.push({ layout, name: lname });
   };
 
   publicAPI.getBindGroupLayoutCount = (lname) => {

--- a/Sources/Rendering/WebGPU/PolyDataMapper/index.js
+++ b/Sources/Rendering/WebGPU/PolyDataMapper/index.js
@@ -290,24 +290,11 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
 
     const fDesc = pipeline.getShaderDescription('fragment');
     code = fDesc.getCode();
-    const tcinput = [];
 
-    for (let t = 0; t < model.textures.length; t++) {
-      const tcount = pipeline.getBindGroupLayoutCount(`Texture${t}`);
-      tcinput.push(
-        `[[binding(0), group(${tcount})]] var Texture${t}: texture_2d<f32>;`
-      );
-      tcinput.push(
-        `[[binding(1), group(${tcount})]] var Sampler${t}: sampler;`
-      );
-    }
-
-    code = vtkWebGPUShaderCache.substitute(code, '//VTK::TCoord::Dec', tcinput)
-      .result;
-
+    // todo handle multiple textures? Blend multiply ?
     if (model.textures.length) {
       code = vtkWebGPUShaderCache.substitute(code, '//VTK::TCoord::Impl', [
-        'var tcolor: vec4<f32> = textureSample(Texture0, Sampler0, input.tcoordVS);',
+        'var tcolor: vec4<f32> = textureSample(Texture0, Texture0Sampler, input.tcoordVS);',
         'computedColor = computedColor*tcolor;',
       ]).result;
     }
@@ -585,6 +572,7 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
     for (let i = model.textures.length - 1; i >= 0; i--) {
       if (!usedTextures[i]) {
         model.textures.splice(i, 1);
+        model.textureViews.splice(i, 1);
       }
     }
   };

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -35,6 +35,14 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
     model.colorTextureViews[idx] = view;
   };
 
+  publicAPI.activateBindGroup = (bg) => {
+    const midx = model.boundPipeline.getBindGroupLayoutCount(bg.getName());
+    model.handle.setBindGroup(
+      midx,
+      bg.getBindGroup(model.boundPipeline.getDevice())
+    );
+  };
+
   publicAPI.attachTextureViews = () => {
     // for each texture create a view if we do not already have one
     for (let i = 0; i < model.colorTextureViews.length; i++) {

--- a/Sources/Rendering/WebGPU/Sampler/index.js
+++ b/Sources/Rendering/WebGPU/Sampler/index.js
@@ -1,10 +1,6 @@
 import macro from 'vtk.js/Sources/macro';
 
-// const { ObjectType } = Constants;
-
-// ----------------------------------------------------------------------------
-// Global methods
-// ----------------------------------------------------------------------------
+/* eslint-disable no-bitwise */
 
 // ----------------------------------------------------------------------------
 // vtkWebGPUSampler methods
@@ -20,6 +16,19 @@ function vtkWebGPUSampler(publicAPI, model) {
       magFilter: options.magFilter ? options.magFilter : 'nearest',
       minFilter: options.minFilter ? options.minFilter : 'nearest',
     });
+    model.bindGroupTime.modified();
+  };
+
+  publicAPI.getShaderCode = (binding, group) => {
+    const result = `[[binding(${binding}), group(${group})]] var ${model.name}: sampler;`;
+    return result;
+  };
+
+  publicAPI.getBindGroupEntry = () => {
+    const foo = {
+      resource: model.handle,
+    };
+    return foo;
   };
 }
 
@@ -30,6 +39,7 @@ function vtkWebGPUSampler(publicAPI, model) {
 const DEFAULT_VALUES = {
   device: null,
   handle: null,
+  name: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -40,8 +50,20 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Object methods
   macro.obj(publicAPI, model);
 
-  macro.get(publicAPI, model, ['handle']);
-  macro.setGet(publicAPI, model, ['device']);
+  model.bindGroupLayoutEntry = {
+    /* eslint-disable no-undef */
+    visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+    /* eslint-enable no-undef */
+    sampler: {
+      // type: 'filtering',
+    },
+  };
+
+  model.bindGroupTime = {};
+  macro.obj(model.bindGroupTime, { mtime: 0 });
+
+  macro.get(publicAPI, model, ['bindGroupTime', 'handle']);
+  macro.setGet(publicAPI, model, ['bindGroupLayoutEntry', 'device', 'name']);
 
   vtkWebGPUSampler(publicAPI, model);
 }

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -1,12 +1,37 @@
 import macro from 'vtk.js/Sources/macro';
+import { mat4 } from 'gl-matrix';
 import vtkWebGPUFullScreenQuad from 'vtk.js/Sources/Rendering/WebGPU/FullScreenQuad';
+import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
+import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
+import vtkWebGPUStorageBuffer from 'vtk.js/Sources/Rendering/WebGPU/StorageBuffer';
 
 const volFragTemplate = `
+//VTK::Renderer::Dec
+
+//VTK::Mapper::Dec
+
 //VTK::TCoord::Dec
 
 //VTK::RenderEncoder::Dec
 
 //VTK::IOStructs::Dec
+
+fn processVolume(vNum: i32, posSC: vec4<f32>) -> vec4<f32>
+{
+  var outColor: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+
+  // convert to tcoords and reject if outside the volume
+  var tpos: vec4<f32> = volumeSSBO.values[vNum].SCTCMatrix*posSC;
+  // var tpos: vec4<f32> = posSC*0.003;
+  if (tpos.x < 0.0 || tpos.y < 0.0 || tpos.z < 0.0 ||
+      tpos.x > 1.0 || tpos.y > 1.0 || tpos.z > 1.0) { return outColor; }
+
+  outColor = vec4<f32>(f32(vNum), 0.0, 1.0 - f32(vNum), 0.01);
+
+  //VTK::Volume::Process
+
+  return outColor;
+}
 
 [[stage(fragment)]]
 fn main(
@@ -18,13 +43,57 @@ fn main(
 
   var rayMax: f32 = textureSample(maxTexture, maxTextureSampler, input.tcoordVS).r;
   var rayMin: f32 = textureSample(minTexture, minTextureSampler, input.tcoordVS).r;
+
+  // discard empty rays
   if (rayMax <= rayMin) { discard; }
-  var computedColor: vec4<f32> = vec4<f32>(rayMin, rayMax, 0.0, min(100.0*(rayMax - rayMin), 1.0));
+  else
+  {
+    var winDimsI32: vec2<i32> = textureDimensions(minTexture);
+    var winDims: vec2<f32> = vec2<f32>(f32(winDimsI32.x), f32(winDimsI32.y));
+
+    // compute start and end ray positions in view coordinates
+    var minPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMin, 1.0);
+    minPosSC = minPosSC * (1.0 / minPosSC.w);
+    var maxPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMax, 1.0);
+    maxPosSC = maxPosSC * (1.0 / maxPosSC.w);
+
+    // initial ray position is at the beginning
+    var rayPosSC: vec4<f32> = minPosSC;
+    var rayLengthSC: f32 = distance(minPosSC.xyz, maxPosSC.xyz);
+    var rayStepSC: vec4<f32> = (maxPosSC - minPosSC)*(mapperUBO.SampleDistance/rayLengthSC);
+    rayStepSC.w = 0.0;
+
+    var curDist: f32 = 0.0;
+    var computedColor: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    var sampleColor: vec4<f32>;
+    loop
+    {
+      // for each volume, sample and accumulate color
+
+//VTK::Volume::Calls
+
+      // increment position
+      curDist = curDist + mapperUBO.SampleDistance;
+      rayPosSC = rayPosSC + rayStepSC;
+
+      // check if we have reached a terminating condition
+      if (curDist > rayLengthSC) { break; }
+      if (computedColor.a > 0.98) { break; }
+    }
+
+  // var computedColor: vec4<f32> = vec4<f32>(rayMin, rayMax, 0.0, min(100.0*(rayMax - rayMin), 1.0));
+  // computedColor = vec4<f32>(rayLengthSC / 500.0, 1.0, 0.0, 1.0);
+  // computedColor = vec4<f32>(maxPosSC.xyz*0.01, 1.0);
 
   //VTK::RenderEncoder::Impl
+  }
+
   return output;
 }
 `;
+
+const tmpMat4 = new Float64Array(16);
+const tmp2Mat4 = new Float64Array(16);
 
 // ----------------------------------------------------------------------------
 // vtkWebGPUVolumePassFSQ methods
@@ -33,13 +102,131 @@ fn main(
 function vtkWebGPUVolumePassFSQ(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkWebGPUVolumePassFSQ');
+
+  publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
+    const vDesc = pipeline.getShaderDescription('vertex');
+    vDesc.addBuiltinOutput('vec4<f32>', '[[builtin(position)]] Position');
+    let code = vDesc.getCode();
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+      'output.tcoordVS = vec2<f32>(vertexBC.x * 0.5 + 0.5, 1.0 - vertexBC.y * 0.5 - 0.5);',
+      'output.Position = vec4<f32>(vertexBC, 1.0);',
+    ]).result;
+    vDesc.setCode(code);
+    const fDesc = pipeline.getShaderDescription('fragment');
+    fDesc.addBuiltinInput('vec4<f32>', '[[builtin(position)]] fragPos');
+  };
+  model.shaderReplacements.set(
+    'replaceShaderPosition',
+    publicAPI.replaceShaderPosition
+  );
+
+  publicAPI.replaceShaderVolume = (hash, pipeline, vertexInput) => {
+    const fDesc = pipeline.getShaderDescription('fragment');
+    let code = fDesc.getCode();
+    const calls = [];
+    for (let i = 0; i < model.volumes.length; i++) {
+      calls.push(`      sampleColor = processVolume(${i}, rayPosSC);`);
+      calls.push(`      computedColor = vec4<f32>(
+        sampleColor.a * sampleColor.rgb * (1.0 - computedColor.a) + computedColor.rgb,
+        (1.0 - computedColor.a)*sampleColor.a + computedColor.a);`);
+    }
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Volume::Calls', calls)
+      .result;
+    fDesc.setCode(code);
+  };
+  model.shaderReplacements.set(
+    'replaceShaderVolume',
+    publicAPI.replaceShaderVolume
+  );
+
+  publicAPI.updateUBO = (device) => {
+    const utime = model.UBO.getSendTime();
+    if (publicAPI.getMTime() > utime) {
+      const center = model.WebGPURenderer.getStabilizedCenterByReference();
+
+      // compute the min step size
+      let sampleDist = model.volumes[0]
+        .getRenderable()
+        .getMapper()
+        .getSampleDistance();
+      for (let i = 0; i < model.volumes.length; i++) {
+        const vol = model.volumes[i];
+        const volMapr = vol.getRenderable().getMapper();
+        const sd = volMapr.getSampleDistance();
+        if (sd < sampleDist) {
+          sampleDist = sd;
+        }
+      }
+      model.UBO.setValue('SampleDistance', sampleDist);
+      model.UBO.sendIfNeeded(device);
+
+      model.SSBO.clearData();
+      model.SSBO.setNumberOfInstances(model.volumes.length);
+
+      // create SCTC matrices
+      //
+      // SC -> world -> model -> index -> tcoord
+      // when doing coord conversions from A to C
+      // the order is mat4.mult(AtoC, BtoC, AtoB);
+      //
+      const marray = new Float64Array(model.volumes.length * 16);
+      for (let i = 0; i < model.volumes.length; i++) {
+        mat4.identity(tmpMat4);
+        mat4.translate(tmpMat4, tmpMat4, center);
+        // tmpMat4 is now SC->World
+
+        const vol = model.volumes[i];
+        const mcwcmat = vol.getRenderable().getMatrix();
+        mat4.transpose(tmp2Mat4, mcwcmat);
+        mat4.invert(tmp2Mat4, tmp2Mat4);
+        // tmp2Mat4 is now world to model
+
+        mat4.multiply(tmpMat4, tmp2Mat4, tmpMat4);
+        // tmp4Mat is now SC->Model
+
+        const volMapr = vol.getRenderable().getMapper();
+        const image = volMapr.getInputData();
+        // the method on the data is world to index but the volume is in
+        // model coordinates so really in this context it is model to index
+        const modelToIndex = image.getWorldToIndex();
+        mat4.transpose(tmp2Mat4, modelToIndex);
+        mat4.multiply(tmpMat4, tmp2Mat4, tmpMat4);
+        // tmpMat4 is now SC -> Index
+
+        const dims = image.getDimensions();
+        mat4.identity(tmp2Mat4);
+        mat4.scale(tmp2Mat4, tmp2Mat4, [
+          1.0 / dims[0],
+          1.0 / dims[1],
+          1.0 / dims[2],
+        ]);
+        mat4.multiply(tmpMat4, tmp2Mat4, tmpMat4);
+        // tmpMat4 is now SC -> Tcoord
+
+        for (let j = 0; j < 16; j++) {
+          marray[i * 16 + j] = tmpMat4[j];
+        }
+      }
+      model.SSBO.addEntry('SCTCMatrix', 'mat4x4<f32>');
+      model.SSBO.setAllInstancesFromArray('SCTCMatrix', marray);
+      model.SSBO.send(device);
+    }
+  };
+
+  const superclassBuild = publicAPI.build;
+  publicAPI.build = (renderEncoder, device) => {
+    publicAPI.updateUBO(device);
+    superclassBuild(renderEncoder, device);
+  };
 }
 
 // ----------------------------------------------------------------------------
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {};
+const DEFAULT_VALUES = {
+  volumes: null,
+};
 
 // ----------------------------------------------------------------------------
 
@@ -51,7 +238,18 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.fragmentShaderTemplate = volFragTemplate;
 
+  // todo need to compute a hash in this class as
+  // the pipeline will change due to num volumes etc
   publicAPI.setPipelineHash('volfsq');
+
+  model.UBO = vtkWebGPUUniformBuffer.newInstance();
+  model.UBO.setName('mapperUBO');
+  model.UBO.addEntry('SampleDistance', 'f32');
+
+  model.SSBO = vtkWebGPUStorageBuffer.newInstance();
+  model.SSBO.setName('volumeSSBO');
+
+  macro.setGet(publicAPI, model, ['volumes']);
 
   // Object methods
   vtkWebGPUVolumePassFSQ(publicAPI, model);


### PR DESCRIPTION
Flesh out the multivolume renderer a bit more

Add a bind group class as WebGPU only requires support for 4 bind group
layouts and the old approach could easily go past 4. With the bind group
class we typically only have two bind groups active, one for the
renderer and one for the mapper. Tons of changes to support this.

