### PR TITLE
chore(WebGPU): better render encoder checks

### DIFF
--- a/Sources/Rendering/WebGPU/Pipeline/index.js
+++ b/Sources/Rendering/WebGPU/Pipeline/index.js
@@ -11,11 +11,11 @@ function vtkWebGPUPipeline(publicAPI, model) {
 
   publicAPI.initialize = (device) => {
     // start with the renderencoder settings
-    const pipelineDesc = model.renderEncoder.getPipelineSettings();
+    model.pipelineDescription = model.renderEncoder.getPipelineSettings();
 
-    pipelineDesc.primitive.topology = model.topology;
+    model.pipelineDescription.primitive.topology = model.topology;
 
-    pipelineDesc.vertex = model.vertexState;
+    model.pipelineDescription.vertex = model.vertexState;
 
     // add in bind group layouts
     const bindGroupLayouts = [];
@@ -25,22 +25,24 @@ function vtkWebGPUPipeline(publicAPI, model) {
     model.pipelineLayout = device
       .getHandle()
       .createPipelineLayout({ bindGroupLayouts });
-    pipelineDesc.layout = model.pipelineLayout;
+    model.pipelineDescription.layout = model.pipelineLayout;
 
     for (let i = 0; i < model.shaderDescriptions.length; i++) {
       const sd = model.shaderDescriptions[i];
       const sm = device.getShaderModule(sd);
       if (sd.getType() === 'vertex') {
-        pipelineDesc.vertex.module = sm.getHandle();
-        pipelineDesc.vertex.entryPoint = 'main';
+        model.pipelineDescription.vertex.module = sm.getHandle();
+        model.pipelineDescription.vertex.entryPoint = 'main';
       }
       if (sd.getType() === 'fragment') {
-        pipelineDesc.fragment.module = sm.getHandle();
-        pipelineDesc.fragment.entryPoint = 'main';
+        model.pipelineDescription.fragment.module = sm.getHandle();
+        model.pipelineDescription.fragment.entryPoint = 'main';
       }
     }
 
-    model.handle = device.getHandle().createRenderPipeline(pipelineDesc);
+    model.handle = device
+      .getHandle()
+      .createRenderPipeline(model.pipelineDescription);
   };
 
   publicAPI.getShaderDescription = (stype) => {
@@ -87,6 +89,7 @@ const DEFAULT_VALUES = {
   shaderDescriptions: null,
   vertexState: null,
   topology: null,
+  pipelineDescription: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -99,7 +102,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.layouts = [];
   model.shaderDescriptions = [];
 
-  macro.get(publicAPI, model, ['handle']);
+  macro.get(publicAPI, model, ['handle', 'pipelineDescription']);
   macro.setGet(publicAPI, model, [
     'device',
     'renderEncoder',

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -21,11 +21,39 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
 
   publicAPI.setPipeline = (pl) => {
     model.handle.setPipeline(pl.getHandle());
-    // todo check attachment state?
-    // console.log(
-    //   `bound pipeline for ${model.pipelineHash} ${JSON.stringify(pl.get())}`
-    // );
-    // console.log(model.description);
+    const pd = pl.getPipelineDescription();
+
+    // check attachment state
+    if (model.colorTextureViews.length !== pd.fragment.targets.length) {
+      console.log(
+        `mismatched attachment counts on pipeline ${pd.fragment.targets.length} while encoder has ${model.colorTextureViews.length}`
+      );
+      console.trace();
+    } else {
+      for (let i = 0; i < model.colorTextureViews.length; i++) {
+        const fmt = model.colorTextureViews[i].getTexture().getFormat();
+        if (fmt !== pd.fragment.targets[i].format) {
+          console.log(
+            `mismatched attachments for attachment ${i} on pipeline ${pd.fragment.targets[i].format} while encoder has ${fmt}`
+          );
+          console.trace();
+        }
+      }
+    }
+
+    // check depth buffer
+    if (!model.depthTextureView !== !('depthStencil' in pd)) {
+      console.log('mismatched depth attachments');
+      console.trace();
+    } else if (model.depthTextureView) {
+      const dfmt = model.depthTextureView.getTexture().getFormat();
+      if (dfmt !== pd.depthStencil.format) {
+        console.log(
+          `mismatched depth attachments on pipeline ${pd.depthStencil.format} while encoder has ${dfmt}`
+        );
+        console.trace();
+      }
+    }
     model.boundPipeline = pl;
   };
 


### PR DESCRIPTION
Catch encore/pipeline attachment mismatches earlier
in the code to make them easier to debug.

