### PR TITLE
Ensure clicking on Sponsor button displays links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-custom: ["https://www.kitware.com/contact-us/": kitware.com]
+custom: ["https://www.kitware.com/contact-us/", kitware.com]


### PR DESCRIPTION
### Context

Commit https://github.com/Kitware/vtk-js/commit/df03201f388a981dcaae682bbcb11e8d89ebb266 introduce error preventing users from successfully clicking on the "sponsor" link.

![image](https://user-images.githubusercontent.com/219043/119875056-54446c00-bef4-11eb-8a8d-4577bc26a468.png)



### Changes

Implement change based on  format documented at https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/displaying-a-sponsor-button-in-your-repository


### Results

NA

### Testing

NA