### PR TITLE
Addtive Blending Mode

### DIFF
--- a/Examples/Volume/VolumeMapperBlendModes/controller.html
+++ b/Examples/Volume/VolumeMapperBlendModes/controller.html
@@ -7,15 +7,16 @@
         <option value="1">Maximum Intensity</option>
         <option value="2">Minimum Intensity</option>
         <option value="3">Average Intensity</option>
+        <option value="3">Additive Intensity</option>
       </select>
     </td>
   </tr>
-  <tr class="averageIPScalar" style="display:none;">
-    <td>Average IP Scalar Min</td>
+  <tr class="ipScalar" style="display:none;">
+    <td>IP Scalar Min</td>
     <td><input class="scalarMin" type="range" min="0" max="1" value="0" step="0.01"></td>
   </tr>
-  <tr class="averageIPScalar" style="display:none;">
-    <td><p>Average IP Scalar Max</p></td>
+  <tr class="ipScalar" style="display:none;">
+    <td><p>IP Scalar Max</p></td>
     <td><input class="scalarMax" type="range" min="0" max="1" value="1" step="0.01"></td>
   </tr>
 </table>

--- a/Examples/Volume/VolumeMapperBlendModes/controller.html
+++ b/Examples/Volume/VolumeMapperBlendModes/controller.html
@@ -7,7 +7,7 @@
         <option value="1">Maximum Intensity</option>
         <option value="2">Minimum Intensity</option>
         <option value="3">Average Intensity</option>
-        <option value="3">Additive Intensity</option>
+        <option value="4">Additive Intensity</option>
       </select>
     </td>
   </tr>

--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -69,22 +69,22 @@ mapper.setInputConnection(reader.getOutputPort());
 
 function updateBlendMode(event) {
   const blendMode = parseInt(event.target.value, 10);
-  const averageIPScalarEls = document.querySelectorAll('.averageIPScalar');
+  const ipScalarEls = document.querySelectorAll('.ipScalar');
 
   mapper.setBlendMode(blendMode);
-  mapper.setAverageIPScalarRange(0.0, 1.0);
+  mapper.setIpScalarRange(0.0, 1.0);
 
-  // if average blend mode
-  if (blendMode === 3) {
-    // Show average scalar ui
-    for (let i = 0; i < averageIPScalarEls.length; i += 1) {
-      const el = averageIPScalarEls[i];
+  // if average or additive blend mode
+  if (blendMode === 3 || blendMode === 4) {
+    // Show scalar ui
+    for (let i = 0; i < ipScalarEls.length; i += 1) {
+      const el = ipScalarEls[i];
       el.style.display = 'table-row';
     }
   } else {
-    // Hide average scalar ui
-    for (let i = 0; i < averageIPScalarEls.length; i += 1) {
-      const el = averageIPScalarEls[i];
+    // Hide scalar ui
+    for (let i = 0; i < ipScalarEls.length; i += 1) {
+      const el = ipScalarEls[i];
       el.style.display = 'none';
     }
   }
@@ -93,16 +93,16 @@ function updateBlendMode(event) {
 }
 
 function updateScalarMin(event) {
-  mapper.setAverageIPScalarRange(
+  mapper.setIpScalarRange(
     event.target.value,
-    parseFloat(mapper.getAverageIPScalarRange()[1])
+    parseFloat(mapper.getIpScalarRange()[1])
   );
   renderWindow.render();
 }
 
 function updateScalarMax(event) {
-  mapper.setAverageIPScalarRange(
-    mapper.getAverageIPScalarRange()[0],
+  mapper.setIpScalarRange(
+    mapper.getIpScalarRange()[0],
     parseFloat(event.target.value)
   );
   renderWindow.render();

--- a/Sources/Rendering/Core/VolumeMapper/Constants.js
+++ b/Sources/Rendering/Core/VolumeMapper/Constants.js
@@ -3,6 +3,7 @@ export const BlendMode = {
   MAXIMUM_INTENSITY_BLEND: 1,
   MINIMUM_INTENSITY_BLEND: 2,
   AVERAGE_INTENSITY_BLEND: 3,
+  ADDITIVE_INTENSITY_BLEND: 4,
 };
 
 export default {

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -50,9 +50,9 @@ function vtkVolumeMapper(publicAPI, model) {
     publicAPI.setBlendMode(BlendMode.ADDITIVE_INTENSITY_BLEND);
   };
 
-  publicAPI.setAverageIPScalarRange = (range) => {
+  publicAPI.setAverageIPScalarRange = (min, max) => {
     console.warn('setAverageIPScalarRange is deprecated use setIpScalarRange');
-    publicAPI.setIpScalarRange(range);
+    publicAPI.setIpScalarRange(min, max);
   };
 
   publicAPI.getBlendModeAsString = () =>

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -50,6 +50,11 @@ function vtkVolumeMapper(publicAPI, model) {
     publicAPI.setBlendMode(BlendMode.ADDITIVE_INTENSITY_BLEND);
   };
 
+  publicAPI.setAverageIPScalarRange = (range) => {
+    console.warn('setAverageIPScalarRange is deprecated use setIpScalarRange');
+    publicAPI.setIpScalarRange(range);
+  };
+
   publicAPI.getBlendModeAsString = () =>
     macro.enumToString(BlendMode, model.blendMode);
 }
@@ -66,7 +71,7 @@ const DEFAULT_VALUES = {
   maximumSamplesPerRay: 1000,
   autoAdjustSampleDistances: true,
   blendMode: BlendMode.COMPOSITE_BLEND,
-  averageIPScalarRange: [-1000000.0, 1000000.0],
+  ipScalarRange: [-1000000.0, 1000000.0],
 };
 
 // ----------------------------------------------------------------------------
@@ -88,7 +93,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'blendMode',
   ]);
 
-  macro.setGetArray(publicAPI, model, ['averageIPScalarRange'], 2);
+  macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);
 
   macro.event(publicAPI, model, 'lightingActivated');
 

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -46,6 +46,10 @@ function vtkVolumeMapper(publicAPI, model) {
     publicAPI.setBlendMode(BlendMode.AVERAGE_INTENSITY_BLEND);
   };
 
+  publicAPI.setBlendModeToAdditiveIntensity = () => {
+    publicAPI.setBlendMode(BlendMode.ADDITIVE_INTENSITY_BLEND);
+  };
+
   publicAPI.getBlendModeAsString = () =>
     macro.enumToString(BlendMode, model.blendMode);
 }

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -231,9 +231,9 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       `${model.renderable.getBlendMode()}`
     ).result;
 
-    const averageIPScalarRange = model.renderable.getAverageIPScalarRange();
-    let min = averageIPScalarRange[0];
-    let max = averageIPScalarRange[1];
+    const ipScalarRange = model.renderable.getIpScalarRange();
+    let min = ipScalarRange[0];
+    let max = ipScalarRange[1];
 
     // If min or max is not already a float.
     // make them into floats for glsl
@@ -242,13 +242,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
     FSSource = vtkShaderProgram.substitute(
       FSSource,
-      '//VTK::AverageIPScalarRangeMin',
+      '//VTK::IPScalarRangeMin',
       min
     ).result;
 
     FSSource = vtkShaderProgram.substitute(
       FSSource,
-      '//VTK::AverageIPScalarRangeMax',
+      '//VTK::IPScalarRangeMax',
       max
     ).result;
 
@@ -434,7 +434,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       maxSamples,
       useGradientOpacity: actor.getProperty().getUseGradientOpacity(0),
       blendMode: model.renderable.getBlendMode(),
-      averageIPScalarMode: model.renderable.getAverageIPScalarRange(),
+      ipScalarMode: model.renderable.getIpScalarRange(),
       proportionalComponents,
     };
 
@@ -451,10 +451,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       model.previousState.maxSamples !== state.maxSamples ||
       model.previousState.useGradientOpacity !== state.useGradientOpacity ||
       model.previousState.blendMode !== state.blendMode ||
-      !arrayEquals(
-        model.previousState.averageIPScalarMode,
-        state.averageIPScalarMode
-      ) ||
+      !arrayEquals(model.previousState.ipScalarMode, state.ipScalarMode) ||
       !arrayEquals(
         model.previousState.proportionalComponents,
         state.proportionalComponents

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -794,7 +794,7 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
     // Now map through opacity and color
     gl_FragData[0] = getColorForValue(value, posIS, tstep);
   #endif
-  #if vtkBlendMode == 3 //AVERAGE_INTENSITY_BLEND
+  #if vtkBlendMode == 3 || vtkBlendMode == 4 //AVERAGE_INTENSITY_BLEND || ADDITIVE_BLEND
     vec4 averageIPScalarRangeMin = vec4 (
       //VTK::AverageIPScalarRangeMin,
       //VTK::AverageIPScalarRangeMin,
@@ -856,7 +856,9 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
       stepsTraveled++;
     }
 
-    sum /= vec4(stepsTraveled, stepsTraveled, stepsTraveled, 1.0);
+    #if vtkBlendMode == 3 // Average
+      sum /= vec4(stepsTraveled, stepsTraveled, stepsTraveled, 1.0);
+    #endif
 
     gl_FragData[0] = getColorForValue(sum, posIS, tstep);
   #endif

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -650,8 +650,8 @@ bool valueWithinScalarRange(vec4 val, vec4 min, vec4 max) {
     }
   #endif
   #if defined(vtkIndependentComponentsOn) && vtkNumComponents >= 3
-    if (all(greaterThanEqual(val, averageIPScalarRangeMin)) &&
-        all(lessThanEqual(val, averageIPScalarRangeMax))) {
+    if (all(greaterThanEqual(val, ipScalarRangeMin)) &&
+        all(lessThanEqual(val, ipScalarRangeMax))) {
       withinRange = true;
     }
   #endif
@@ -795,20 +795,20 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
     gl_FragData[0] = getColorForValue(value, posIS, tstep);
   #endif
   #if vtkBlendMode == 3 || vtkBlendMode == 4 //AVERAGE_INTENSITY_BLEND || ADDITIVE_BLEND
-    vec4 averageIPScalarRangeMin = vec4 (
-      //VTK::AverageIPScalarRangeMin,
-      //VTK::AverageIPScalarRangeMin,
-      //VTK::AverageIPScalarRangeMin,
-      //VTK::AverageIPScalarRangeMax);
-    vec4 averageIPScalarRangeMax = vec4(
-      //VTK::AverageIPScalarRangeMax,
-      //VTK::AverageIPScalarRangeMax,
-      //VTK::AverageIPScalarRangeMax,
-      //VTK::AverageIPScalarRangeMax);
+    vec4 ipScalarRangeMin = vec4 (
+      //VTK::IPScalarRangeMin,
+      //VTK::IPScalarRangeMin,
+      //VTK::IPScalarRangeMin,
+      //VTK::IPScalarRangeMax);
+    vec4 ipScalarRangeMax = vec4(
+      //VTK::IPScalarRangeMax,
+      //VTK::IPScalarRangeMax,
+      //VTK::IPScalarRangeMax,
+      //VTK::IPScalarRangeMax);
 
     vec4 sum = vec4(0.);
 
-    if (valueWithinScalarRange(tValue, averageIPScalarRangeMin, averageIPScalarRangeMax)) {
+    if (valueWithinScalarRange(tValue, ipScalarRangeMin, ipScalarRangeMax)) {
       sum += tValue;
     }
 
@@ -834,7 +834,7 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
       // - We are comparing all values in the texture to see if any of them
       //   are outside of the scalar range. In the future we might want to allow
       //   scalar ranges for each component.
-      if (valueWithinScalarRange(tValue, averageIPScalarRangeMin, averageIPScalarRangeMax)) {
+      if (valueWithinScalarRange(tValue, ipScalarRangeMin, ipScalarRangeMax)) {
         // Sum the values across each step in the path
         sum += tValue;
       }
@@ -849,8 +849,8 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
     // compute the scalar
     tValue = getTextureValue(posIS);
 
-    // One can control the scalar range by setting the AverageIPScalarRange to disregard scalar values, not in the range of interest, from the average computation
-    if (valueWithinScalarRange(tValue, averageIPScalarRangeMin, averageIPScalarRangeMax)) {
+    // One can control the scalar range by setting the IPScalarRange to disregard scalar values, not in the range of interest, from the average computation
+    if (valueWithinScalarRange(tValue, ipScalarRangeMin, ipScalarRangeMax)) {
       sum += tValue;
 
       stepsTraveled++;


### PR DESCRIPTION
### Context
We had a need for an additive blend mode. Here's a simple implementation using the existing average blend mode.

### Changes
Added in an additive blend mode
Renamed AverageIPScalar to ipScalar, since it is now used for average and additive.
Added in a depreciation warning for AverageIPScalar and a handler to pass it through to ipScalar

### Results
![additive](https://user-images.githubusercontent.com/7668858/120786068-b705bb00-c525-11eb-9b7c-f6e64674c121.gif)

### Testing
`npm run example -- VolumeMapperBlendModes`
Then select additive from the dropdown.



