### PR TITLE
test(testtubefilter): fix rng consistency

### DIFF
--- a/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
+++ b/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
@@ -29,10 +29,13 @@ test('Test vtkTubeFilter instance', (t) => {
   t.end();
 });
 
-vtkMath.randomSeed(15322);
 const numSegments = 3;
 
 function initializePolyData(dType) {
+  const seed = 15322;
+  if (vtkMath.getSeed() !== seed) {
+    vtkMath.randomSeed(seed);
+  }
   let pointType = VtkDataTypes.FLOAT;
   if (dType === DesiredOutputPrecision.SINGLE) {
     pointType = VtkDataTypes.FLOAT;


### PR DESCRIPTION
Seeding the rng in global scope meant that any call to Math.random() in previous tests would alter the random sequence produced in testTubeFilter, thus altering the results.

This MR makes sure that Math.random is properly seeded right before the
test is executed.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

The addition of testPaintEllipse caused this test to fail (because testPaintEllipse creates a worker, which causes a call to Math.random).

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
Make sure that vtkMath.random is initialized at the right time in testTubeFilter.

- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
testTubeFilter passes again.
### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: master
  - **OS**:  linux
  - **Browser**: chromium 91.0.4472.77

<!-- Remove the line below if it is not relevant -->
_This contribution is funded by [Example](https://example.com)._
