### PR TITLE
fix(paintfilter): avoid NaNs while painting vtkPaintFilter ellipses

### DIFF
--- a/Sources/Filters/General/PaintFilter/PaintFilter.worker.js
+++ b/Sources/Filters/General/PaintFilter/PaintFilter.worker.js
@@ -43,39 +43,60 @@ function handlePaintEllipse({ center, scale3 }) {
   const radius3 = [...scale3];
   const indexCenter = center.map((val) => Math.round(val));
 
+  let sliceAxis = -1;
   if (globals.slicingMode != null && globals.slicingMode !== SlicingMode.NONE) {
-    const sliceAxis = globals.slicingMode % 3;
-    radius3[sliceAxis] = 0;
+    sliceAxis = globals.slicingMode % 3;
   }
 
   const yStride = globals.dimensions[0];
   const zStride = globals.dimensions[0] * globals.dimensions[1];
 
-  const zmin = Math.round(Math.max(indexCenter[2] - radius3[2], 0));
-  const zmax = Math.round(
-    Math.min(indexCenter[2] + radius3[2], globals.dimensions[2] - 1)
-  );
+  let [xmin, ymin, zmin] = indexCenter;
+  let [xmax, ymax, zmax] = indexCenter;
+
+  if (sliceAxis !== 2) {
+    zmin = Math.round(Math.max(indexCenter[2] - radius3[2], 0));
+    zmax = Math.round(
+      Math.min(indexCenter[2] + radius3[2], globals.dimensions[2] - 1)
+    );
+  }
 
   for (let z = zmin; z <= zmax; z++) {
-    const dz = (indexCenter[2] - z) / radius3[2];
-    const ay = radius3[1] * Math.sqrt(1 - dz * dz);
+    let dz = 0;
+    if (sliceAxis !== 2) {
+      dz = (indexCenter[2] - z) / radius3[2];
+    }
 
-    const ymin = Math.round(Math.max(indexCenter[1] - ay, 0));
-    const ymax = Math.round(
-      Math.min(indexCenter[1] + ay, globals.dimensions[1] - 1)
-    );
+    const dzSquared = dz * dz;
 
-    for (let y = ymin; y <= ymax; y++) {
-      const dy = (indexCenter[1] - y) / radius3[1];
-      const ax = radius3[0] * Math.sqrt(1 - dy * dy - dz * dz);
+    if (dzSquared <= 1) {
+      const ay = radius3[1] * Math.sqrt(1 - dzSquared);
+      if (sliceAxis !== 1) {
+        ymin = Math.round(Math.max(indexCenter[1] - ay, 0));
+        ymax = Math.round(
+          Math.min(indexCenter[1] + ay, globals.dimensions[1] - 1)
+        );
+      }
 
-      const xmin = Math.round(Math.max(indexCenter[0] - ax, 0));
-      const xmax = Math.round(
-        Math.min(indexCenter[0] + ax, globals.dimensions[0] - 1)
-      );
-      if (xmin <= xmax) {
-        const index = y * yStride + z * zStride;
-        globals.buffer.fill(1, index + xmin, index + xmax + 1);
+      for (let y = ymin; y <= ymax; y++) {
+        let dy = 0;
+        if (sliceAxis !== 1) {
+          dy = (indexCenter[1] - y) / radius3[1];
+        }
+        const dySquared = dy * dy;
+        if (dySquared + dzSquared <= 1) {
+          if (sliceAxis !== 0) {
+            const ax = radius3[0] * Math.sqrt(1 - dySquared - dzSquared);
+            xmin = Math.round(Math.max(indexCenter[0] - ax, 0));
+            xmax = Math.round(
+              Math.min(indexCenter[0] + ax, globals.dimensions[0] - 1)
+            );
+          }
+          if (xmin <= xmax) {
+            const index = y * yStride + z * zStride;
+            globals.buffer.fill(1, index + xmin, index + xmax + 1);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

Ellipse painting would fail under some conditions

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

* Instead of setting the slice axis to zero, directly set min and max values to the center for this axis.
* Make sure sqrt parameters are >= 0

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Ellipse painting is more consistent

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->
