### PR TITLE
fix(vtkTriangleFilter): ignore duplicated last points before triangulating cells

### DIFF
--- a/Sources/Filters/General/TriangleFilter/index.js
+++ b/Sources/Filters/General/TriangleFilter/index.js
@@ -27,8 +27,15 @@ function vtkTriangleFilter(publicAPI, model) {
 
     if (polys) {
       let npts = 0;
+      let isLastPointDuplicated = false;
       for (let c = 0; c < polys.length; c += npts + 1) {
         npts = polys[c];
+        // If the first point is duplicated at the end of the cell, ignore it
+        isLastPointDuplicated = polys[c + 1] === polys[c + npts];
+        if (isLastPointDuplicated) {
+          --npts;
+        }
+
         // We can't use cell.map here, it doesn't seems to work properly with Uint32Arrays ...
         const cellPoints = [];
         cellPoints.length = npts;
@@ -66,6 +73,9 @@ function vtkTriangleFilter(publicAPI, model) {
             newCells.push(3, newIdStart, newIdStart + 1, newIdStart + 2);
             newPoints.push(...triPts);
           }
+        }
+        if (isLastPointDuplicated) {
+          ++npts;
         }
       }
     }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

The SplineWidget example is currently broken (surface area missing a triangle).

This is due to a change that caused the vtkTriangleFilter to stop supporting cells that duplicate the last point when triangulating.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->

If a cell is found to have its last point duplicated, ignore this last point when triangulating the cell.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

The SplineWidget example is fixed
### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->