### PR TITLE
feat(Interaction): Add world up vector option to trackball rotate man…

### DIFF
--- a/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
@@ -126,7 +126,7 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  useWorldUpVec: true,
+  useWorldUpVec: false,
   // set WorldUpVector to be y-axis by default
   worldUpVec: [0, 1, 0],
 };

--- a/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
@@ -47,11 +47,14 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
     if (model.useWorldUpVec) {
       const centerOfRotation = new Float64Array(3);
       vec3.copy(centerOfRotation, model.worldUpVec);
+
+      // Compute projection of cameraPos onto worldUpVec
       vtkMath.multiplyScalar(
         centerOfRotation,
         vtkMath.dot(cameraPos, model.worldUpVec) /
           vtkMath.dot(model.worldUpVec, model.worldUpVec)
       );
+
       mat4.translate(trans, trans, centerOfRotation);
       mat4.rotate(
         trans,
@@ -60,11 +63,12 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
         model.worldUpVec
       );
 
-      centerNeg[0] = -centerOfRotation[0];
-      centerNeg[1] = -centerOfRotation[1];
-      centerNeg[2] = -centerOfRotation[2];
-      mat4.translate(trans, trans, centerNeg);
-      mat4.translate(trans, trans, center);
+      // Translate back
+      mat4.translate(
+        trans,
+        trans,
+        vtkMath.subtract(center, centerOfRotation, centerOfRotation)
+      );
     } else {
       mat4.translate(trans, trans, center);
       mat4.rotate(
@@ -122,7 +126,7 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  useWorldUpVec: false,
+  useWorldUpVec: true,
   // set WorldUpVector to be y-axis by default
   worldUpVec: [0, 1, 0],
 };


### PR DESCRIPTION
…ipulator

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
This brings over the world up vector feature of the unicam interactor into the manipulator interactor. It works in exactly the same way in that it forces the camera to rotate about the specified vector for the azimuth component of the total rotation, The API is the same as well, except it has to be set on the rotate manipulator instead.

### Testing
Call setUseWorldUpVec on the rotate manipulator with a parameter of true to enable the feature. By default the world up vector is [0, 1, 0], which can be changed by calling setWorldUpVec.