### PR TITLE
fix(DracoReader): Compatible with Draco 1.4.0

### DIFF
--- a/Sources/IO/Geometry/DracoReader/index.js
+++ b/Sources/IO/Geometry/DracoReader/index.js
@@ -36,8 +36,14 @@ function setWasmBinary(url, binaryName) {
     xhr.onload = () => {
       if (xhr.status === 200) {
         dracoDecoderType.wasmBinary = xhr.response;
-        decoderModule = window.DracoDecoderModule(dracoDecoderType);
-        resolve(true);
+        // Use Promise.resolve to be compatible with versions before Draco 1.4.0
+        Promise.resolve(window.DracoDecoderModule(dracoDecoderType)).then(
+          (module) => {
+            decoderModule = module;
+            resolve(true);
+          },
+          reject
+        );
       } else {
         reject(Error(`WASM binary could not be loaded: ${xhr.statusText}`));
       }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->
Since Draco 1.4.0, Emscripten has been updated to V2, this causes the Draco codec modules to return a promise instead of the module directly.
[Draco Release https://github.com/google/draco/releases/tag/1.4.0](https://github.com/google/draco/releases/tag/1.4.0)

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Use `Promise.resolve` to be compatible with both new and old versions.

