### PR TITLE
Should be able to convert non-squared image into `vtkimagedata`

### DIFF
--- a/Sources/Common/Core/ImageHelper/index.js
+++ b/Sources/Common/Core/ImageHelper/index.js
@@ -58,7 +58,7 @@ function imageToImageData(
   ctx.translate(canvas.width / 2, canvas.height / 2);
   ctx.scale(flipX ? -1 : 1, flipY ? -1 : 1);
   ctx.rotate((rotate * Math.PI) / 180);
-  ctx.drawImage(image, -image.width / 2, -image.width / 2);
+  ctx.drawImage(image, -image.width / 2, -image.height / 2);
 
   return canvasToImageData(canvas);
 }


### PR DESCRIPTION


### Context
`vtkImageHelper.ImageToImageData` only properly works with `Image` in squared size (width == height = true)

### Changes
in `ImageToImageData` changed ctx.drawImage parameter to use image.height
- [ x ] Documentation and TypeScript definitions were updated to match those changes

### Results

Rectangle-sized image can be converted into vtk.js imagedata

![image](https://user-images.githubusercontent.com/8189976/124547722-86d47380-de67-11eb-9e7e-ca0429cdfc7c.png)
![image](https://user-images.githubusercontent.com/8189976/124547731-8b992780-de67-11eb-9a6b-bf37a87b2a0b.png)


### Testing
Try convert (512,128) sized image into vtkImageData using `vtkImageHelper.ImageToImageData`, render usign `vtkImageSlice`.
Originally, it displays nothing, and this change resolves the problem.


- [ x] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: latest master
  - **OS**: all
  - **Browser**: Chrome 89.0.4389.128 

