### PR TITLE
fix(macro): Apply macro.js shim at pkg build time

### DIFF
--- a/Utilities/ci/build-npm-package.js
+++ b/Utilities/ci/build-npm-package.js
@@ -12,6 +12,18 @@ function copyDirSync(src, dst) {
   return fs.copySync(src, path.join(dst, dirname));
 }
 
+function applyBabelPluginMacroWorkaround(srcRoot, pkgName) {
+  fs.moveSync(path.join(srcRoot, 'macro.js'), path.join(srcRoot, 'macros.js'));
+
+  const shim = fs.readFileSync(path.join('Utilities', 'ci', 'macro-shim.js'), {
+    encoding: 'utf8',
+    flag: 'r',
+  });
+  const preparedShim = shim.replace('{{ packageName }}', pkgName);
+
+  fs.writeFileSync(path.join(srcRoot, 'macro.js'), preparedShim);
+}
+
 function prepareESM() {
   const pkgdir = path.join(rootdir, 'esm');
   fs.ensureDirSync(pkgdir);
@@ -73,6 +85,8 @@ function prepareESM() {
   pkgInfo.module = './index.js';
 
   fs.writeFileSync(packageJson, JSON.stringify(pkgInfo, null, 2));
+
+  applyBabelPluginMacroWorkaround(pkgdir, '@kitware/vtk.js');
 }
 
 function prepareUMD() {
@@ -127,6 +141,8 @@ function prepareUMD() {
   delete pkgInfo.module;
 
   fs.writeFileSync(packageJson, JSON.stringify(pkgInfo, null, 2));
+
+  applyBabelPluginMacroWorkaround(path.join(pkgdir, 'Sources'), 'vtk.js');
 }
 
 fs.removeSync(rootdir);

--- a/Utilities/ci/macro-shim.js
+++ b/Utilities/ci/macro-shim.js
@@ -1,0 +1,20 @@
+// unfortunate hacks necessary to sneak past babel-plugin-macros.
+const fakeBabelMacro = () => {
+  return { keepImports: true };
+};
+fakeBabelMacro.isBabelMacro = true;
+fakeBabelMacro.options = {};
+fakeBabelMacro.toString = () =>
+  "This is a fake babel macro whose properties match that of the vtk.js macro.js exports";
+
+
+try {
+  const macro = require('{{ packageName }}/macros.js');
+  const keys = Object.keys(macro);
+  for (let i = 0; i < keys.length; i++) {
+    // assign the macro.js exports to the shim's exports
+    fakeBabelMacro[prop] = macro[prop];
+  }
+} catch (e) {}
+
+module.exports = fakeBabelMacro;


### PR DESCRIPTION
babel-plugin-macros interferes with our macro.js file. As it is not
ideal to rename it, nor is it feasible to convince babel-plugin-macros
to change its "ownership" of any files ending in "macro.js", this is an
attempt at shimming macro.js to effectively sneak past
babel-plugin-macros while still maintaining compatibility with existing
macro.js consumers.

### Context

- Fixes #1990 
- [VTK discourse on the same issue](https://discourse.vtk.org/t/how-to-tune-babel-loader-to-properly-import-a-module-named-macro-js-when-using-cra/5808/4)

### Changes

- Add a package build-time step to apply a macro.js shim.

### Results

- CRA, Jest, and other users of babel-plugin-macro should no longer have cryptic errors when trying to use vtk.js.

### Testing

- [ ] verify Typescript experience is still the same
- [ ] verify both ESM and UMD packages operate correctly