### PR TITLE
fix(Coordinate): Incorrect coordinate calculation for multiple view p…

### DIFF
--- a/Sources/Rendering/Core/Coordinate/index.js
+++ b/Sources/Rendering/Core/Coordinate/index.js
@@ -428,7 +428,12 @@ function vtkCoordinate(publicAPI, model) {
         val = renderer.viewToProjection(val[0], val[1], val[2], aspect);
 
         val = renderer.projectionToNormalizedViewport(val[0], val[1], val[2]);
-        val = view.normalizedViewportToViewport(val[0], val[1], val[2]);
+        val = view.normalizedViewportToViewport(
+          val[0],
+          val[1],
+          val[2],
+          renderer
+        );
         val = view.viewportToNormalizedDisplay(
           val[0],
           val[1],
@@ -441,7 +446,12 @@ function vtkCoordinate(publicAPI, model) {
       case Coordinate.VIEW: {
         val = renderer.viewToProjection(val[0], val[1], val[2], aspect);
         val = renderer.projectionToNormalizedViewport(val[0], val[1], val[2]);
-        val = view.normalizedViewportToViewport(val[0], val[1], val[2]);
+        val = view.normalizedViewportToViewport(
+          val[0],
+          val[1],
+          val[2],
+          renderer
+        );
         val = view.viewportToNormalizedDisplay(
           val[0],
           val[1],
@@ -453,7 +463,12 @@ function vtkCoordinate(publicAPI, model) {
       }
       case Coordinate.PROJECTION: {
         val = renderer.projectionToNormalizedViewport(val[0], val[1], val[2]);
-        val = view.normalizedViewportToViewport(val[0], val[1], val[2]);
+        val = view.normalizedViewportToViewport(
+          val[0],
+          val[1],
+          val[2],
+          renderer
+        );
         val = view.viewportToNormalizedDisplay(
           val[0],
           val[1],
@@ -464,7 +479,12 @@ function vtkCoordinate(publicAPI, model) {
         break;
       }
       case Coordinate.NORMALIZED_VIEWPORT: {
-        val = view.normalizedViewportToViewport(val[0], val[1], val[2]);
+        val = view.normalizedViewportToViewport(
+          val[0],
+          val[1],
+          val[2],
+          renderer
+        );
 
         if (model.referenceCoordinate) {
           const refValue = model.referenceCoordinate.getComputedDoubleViewportValue(

--- a/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
+++ b/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
@@ -113,6 +113,169 @@ test('Test vtkCoordinate publicAPI', (t) => {
   viewPort = [50.0, 50.0];
   testGetters(coord, renderer, testVal, world, display, localDisplay, viewPort);
 
+  // --------------------- Multi Renderers
+  // In my previous test, some view ports were normal and some not. so create a 2x2 grid view to test.
+  const renderers = new Array(4);
+  for (let i = 0; i < renderers.length; i++) {
+    const ren = gc.registerResource(vtkRenderer.newInstance());
+    /* index order
+    0 1
+    2 3
+    */
+    const x = (i % 2) * 0.5;
+    const y = 1 - Math.floor(i / 2) * 0.5;
+    ren.setViewport(x, y - 0.5, x + 0.5, y);
+    ren.setActiveCamera(vtkCamera.newInstance());
+    renderWindow.addRenderer(ren);
+    renderers[i] = ren;
+  }
+
+  coord.setCoordinateSystemToWorld();
+  testVal = [0.0, 0.0, 0.0];
+  world = [0.0, 0.0, 0.0];
+  let displays = [
+    [25.0, 75.0],
+    [75.0, 75.0],
+    [25.0, 25.0],
+    [75.0, 25.0],
+  ];
+  let localDisplays = [
+    [25.0, 24.0],
+    [75.0, 24.0],
+    [25.0, 74.0],
+    [75.0, 74.0],
+  ];
+  viewPort = [25.0, 25.0];
+
+  for (let i = 0; i < renderers.length; i++) {
+    testGetters(
+      coord,
+      renderers[i],
+      testVal,
+      world,
+      displays[i],
+      localDisplays[i],
+      viewPort
+    );
+  }
+
+  coord.setCoordinateSystemToDisplay();
+  testVal = [
+    [25.0, 75.0],
+    [75.0, 75.0],
+    [25.0, 25.0],
+    [75.0, 25.0],
+  ];
+  world = [0.0, 0.0, 0.99];
+  displays = [
+    [25.0, 75.0],
+    [75.0, 75.0],
+    [25.0, 25.0],
+    [75.0, 25.0],
+  ];
+  localDisplays = [
+    [25.0, 24.0],
+    [75.0, 24.0],
+    [25.0, 74.0],
+    [75.0, 74.0],
+  ];
+  viewPort = [25.0, 25.0];
+  for (let i = 0; i < renderers.length; i++) {
+    testGetters(
+      coord,
+      renderers[i],
+      testVal[i],
+      world,
+      displays[i],
+      localDisplays[i],
+      viewPort
+    );
+  }
+
+  coord.setCoordinateSystemToViewport();
+  testVal = [25.0, 25.0, 0.0];
+  world = [0.0, 0.0, 0.99];
+  displays = [
+    [25.0, 75.0],
+    [75.0, 75.0],
+    [25.0, 25.0],
+    [75.0, 25.0],
+  ];
+  localDisplays = [
+    [25.0, 24.0],
+    [75.0, 24.0],
+    [25.0, 74.0],
+    [75.0, 74.0],
+  ];
+  viewPort = [25.0, 25.0];
+  for (let i = 0; i < renderers.length; i++) {
+    testGetters(
+      coord,
+      renderers[i],
+      testVal,
+      world,
+      displays[i],
+      localDisplays[i],
+      viewPort
+    );
+  }
+
+  coord.setCoordinateSystemToNormalizedViewport();
+  testVal = [0.5, 0.5, 0.0];
+  world = [0.0, 0.0, 0.99];
+  displays = [
+    [25.0, 75.0],
+    [75.0, 75.0],
+    [25.0, 25.0],
+    [75.0, 25.0],
+  ];
+  localDisplays = [
+    [25.0, 24.0],
+    [75.0, 24.0],
+    [25.0, 74.0],
+    [75.0, 74.0],
+  ];
+  viewPort = [25.0, 25.0];
+  for (let i = 0; i < renderers.length; i++) {
+    testGetters(
+      coord,
+      renderers[i],
+      testVal,
+      world,
+      displays[i],
+      localDisplays[i],
+      viewPort
+    );
+  }
+
+  coord.setCoordinateSystemToView();
+  testVal = [0.0, 0.0, 0.0];
+  world = [0.0, 0.0, 1.0];
+  displays = [
+    [25.0, 75.0],
+    [75.0, 75.0],
+    [25.0, 25.0],
+    [75.0, 25.0],
+  ];
+  localDisplays = [
+    [25.0, 24.0],
+    [75.0, 24.0],
+    [25.0, 74.0],
+    [75.0, 74.0],
+  ];
+  viewPort = [25.0, 25.0];
+  for (let i = 0; i < renderers.length; i++) {
+    testGetters(
+      coord,
+      renderers[i],
+      testVal,
+      world,
+      displays[i],
+      localDisplays[i],
+      viewPort
+    );
+  }
+
   // --------------------- Add a specific renderer
   coord.setRenderer(renderer);
 

--- a/Sources/Rendering/SceneGraph/RenderWindowViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/RenderWindowViewNode/index.js
@@ -117,8 +117,8 @@ function vtkRenderWindowViewNode(publicAPI, model) {
     return [x, y, z];
   };
 
-  publicAPI.normalizedViewportToViewport = (x, y, z) => {
-    const size = publicAPI.getFramebufferSize();
+  publicAPI.normalizedViewportToViewport = (x, y, z, renderer) => {
+    const size = publicAPI.getViewportSize(renderer);
     return [x * (size[0] - 1.0), y * (size[1] - 1.0), z];
   };
 


### PR DESCRIPTION
### Context
The `normalizedViewportToViewport` is not calculated according to the size of the Viewport, but is calculated using the size of the Display, which leads to incorrect coordinates when I use `getComputedViewportValue`.

### Testing
I tested it on a single ViewPort and multiple ViewPorts and it works fine.
