### PR TITLE
fix(vtkVolumeFS): Relax tolerance for checking if ray is parallel to viewPlane

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -874,7 +874,7 @@ void getRayPointIntersectionBounds(
   float vSize1, float vSize2)
 {
   float result = dot(rayDir, planeDir);
-  if (result == 0.0)
+  if (abs(result) < 1e-6)
   {
     return;
   }


### PR DESCRIPTION
### Context
There is a section of the volume mapper shader (computeRayDistances) which uses the location (vPlaneDistance) and direction (vPlaneNormal) faces of the volume to optimize the distance that the raycasting needs to step. This check updates the the start / stop locations (stored in a vec2 named dists) for the ray by checking, for each face of the volume, where the intersection point between the ray and the face is, and verifying that it is inside the rectangular bounds of that face (getRayPointIntersectionBounds).

There is a condition at the beginning of this function which allows it to exit early if the ray direction is parallel to the plane (the face of the volume that is being checked). It checks this by performing a dot product between the ray direction and the normal to the view plane. If the dot product between these two vectors is zero, they are perpendicular, and the ray is parallel to the plane, so we can bail out.

The problem is that the result of this call is not always zero. Sometimes it's just extremely small (e.g. 1e-10).

### Changes
This PR relaxes the requirement for a strict check against zero, and instead uses an abs(value) < EPSILON check which fixes rendering issues we have noticed in our usage of the VTK.js volume mapper.

### Results
Occasionally, some volumes (or thin slices of volumes in our use case) were not rendering properly. This fixes that issue and should have no negative impact. We typically saw this when the camera was facing almost directly down the normal to the plane direction. Slightly rotating the volume would fix the display.

Before the change
![Screenshot 2021-07-21 at 09 52 17](https://user-images.githubusercontent.com/607793/126452151-4960ef45-181a-4492-adda-63f47d74a038.png)

After the change
![Screenshot 2021-07-21 at 09 51 56](https://user-images.githubusercontent.com/607793/126452159-29f145f4-43cf-4810-a74f-bab49fd3f855.png)

### Testing
As long as the existing volume mapper tests pass, I think there isn't much else to test.

### Notes
We should probably review everywhere in the shaders that have similar logic for exactly requiring equal when checking if things are parallel. One example of this may be the ClipPlane implementation:

https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/OpenGL/VolumeMapper/index.js#L336-L341

We haven't use clip planes at all yet though, so I didn't want to change that in this PR. I'm also not usre what a proper value of epsilon should be for the tolerance, so I went with 1e-6 for now.

(cc @sedghi and @mix3d because I'm pretty sure he's hit this issue before as well)