### PR TITLE
fix(STLReader): fix progressCallback

### DIFF
--- a/Sources/IO/Geometry/STLReader/index.js
+++ b/Sources/IO/Geometry/STLReader/index.js
@@ -126,6 +126,7 @@ function vtkSTLReader(publicAPI, model) {
     model.baseURL = path.join('/');
 
     model.compression = option.compression;
+    model.progressCallback = option.progressCallback;
 
     // Fetch metadata
     return publicAPI.loadData({

--- a/Sources/IO/Geometry/STLReader/index.js
+++ b/Sources/IO/Geometry/STLReader/index.js
@@ -103,8 +103,14 @@ function vtkSTLReader(publicAPI, model) {
 
   // Internal method to fetch Array
   function fetchData(url, option = {}) {
-    const compression = option.compression || model.compression;
-    const progressCallback = option.progressCallback || model.progressCallback;
+    const compression =
+      option.compression !== 'undefined'
+        ? option.compression
+        : model.compression;
+    const progressCallback =
+      option.progressCallback !== 'undefined'
+        ? option.progressCallback
+        : model.progressCallback;
 
     if (option.binary) {
       return model.dataAccessHelper.fetchBinary(url, {

--- a/Sources/IO/Geometry/STLReader/index.js
+++ b/Sources/IO/Geometry/STLReader/index.js
@@ -104,11 +104,9 @@ function vtkSTLReader(publicAPI, model) {
   // Internal method to fetch Array
   function fetchData(url, option = {}) {
     const compression =
-      option.compression !== 'undefined'
-        ? option.compression
-        : model.compression;
+      option.compression !== undefined ? option.compression : model.compression;
     const progressCallback =
-      option.progressCallback !== 'undefined'
+      option.progressCallback !== undefined
         ? option.progressCallback
         : model.progressCallback;
 

--- a/Sources/IO/Geometry/STLReader/index.js
+++ b/Sources/IO/Geometry/STLReader/index.js
@@ -103,7 +103,9 @@ function vtkSTLReader(publicAPI, model) {
 
   // Internal method to fetch Array
   function fetchData(url, option = {}) {
-    const { compression, progressCallback } = model;
+    const compression = option.compression || model.compression;
+    const progressCallback = option.progressCallback || model.progressCallback;
+
     if (option.binary) {
       return model.dataAccessHelper.fetchBinary(url, {
         compression,
@@ -125,14 +127,8 @@ function vtkSTLReader(publicAPI, model) {
     path.pop();
     model.baseURL = path.join('/');
 
-    model.compression = option.compression;
-    model.progressCallback = option.progressCallback;
-
     // Fetch metadata
-    return publicAPI.loadData({
-      progressCallback: option.progressCallback,
-      binary: !!option.binary,
-    });
+    return publicAPI.loadData(option);
   };
 
   // Fetch the actual data arrays


### PR DESCRIPTION
Assign progressCallback property to the model object, so it will be passed to dataAccessHelper upon
calling setUrl method.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Without this fix, when you use method [setUrl](https://kitware.github.io/vtk-js/api/IO_Geometry_STLReader.html#setUrl) and pass your function as [progressCallback option](https://github.com/Kitware/vtk-js/blob/master/Sources/IO/Geometry/STLReader/index.d.ts#L7) it will never be called.
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
The reason why it's never called is that it's not passed to `dataAccessHelper` as [compression option do](https://github.com/Kitware/vtk-js/blob/master/Sources/IO/Geometry/STLReader/index.js#L128). I updated the code to assign `progressCallback` property to the model object the same way as `compression`.
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: 18.7.2 <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: MacOS 11.4 <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: Chrome 91.0.4472.114 <!-- ex: Chrome 89.0.4389.128 -->


p.s. I found that progressCallback can be passed through the reader constructor, so this fix is not mandatory. However according to the documentation you should be able to pass progressCallback when using setURL method, so you may still want to merge it.
