### PR TITLE
feat(ScalarBarActor): make layout function settable / gettable

### DIFF
--- a/Sources/Rendering/Core/ScalarBarActor/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/index.js
@@ -34,22 +34,23 @@ function applyTextStyle(ctx, style) {
   ctx.font = `${style.fontStyle} ${style.fontSize}px ${style.fontFamily}`;
 }
 
-function vtkScalarBarActor(publicAPI, model) {
-  // Set our className
-  model.classHierarchy.push('vtkScalarBarActor');
+// ----------------------------------------------------------------------------
+// Default autoLayout function
+// ----------------------------------------------------------------------------
 
-  // compute good values to use based on window size etc
-  // a bunch of heuristics here with hand tuned constants
-  // These values worked for me but really this method
-  // could be redically changed. The basic gist is
-  // 1) compute a resonable font size
-  // 2) render the text atlas using those font sizes
-  // 3) pick horizontal or vertical bsed on window size
-  // 4) based on the size of the title and tick labels rendered
-  //    compute the box size and position such that
-  //    the text will all fit nicely and the bar will be a resonable size
-  // 5) compute the bar segments based on the above settings
-  publicAPI.computeAndApplyAutomatedSettings = () => {
+// compute good values to use based on window size etc
+// a bunch of heuristics here with hand tuned constants
+// These values worked for me but really this method
+// could be redically changed. The basic gist is
+// 1) compute a resonable font size
+// 2) render the text atlas using those font sizes
+// 3) pick horizontal or vertical bsed on window size
+// 4) based on the size of the title and tick labels rendered
+//    compute the box size and position such that
+//    the text will all fit nicely and the bar will be a resonable size
+// 5) compute the bar segments based on the above settings
+function defaultAutoLayout(publicAPI, model) {
+  return () => {
     // we don't do a linear scale, the proportions for
     // a 700 pixel window differ from a 1400
     const xAxisAdjust = (model.lastSize[0] / 700) ** 0.8;
@@ -119,6 +120,11 @@ function vtkScalarBarActor(publicAPI, model) {
     // recomute bar segments based on positioning
     publicAPI.recomputeBarSegments(textSizes);
   };
+}
+
+function vtkScalarBarActor(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkScalarBarActor');
 
   // main method to rebuild the scalarBar when something has changed
   // tracks modified times
@@ -149,7 +155,7 @@ function vtkScalarBarActor(publicAPI, model) {
       model.tickStrings = model.ticks.map(format);
 
       if (model.automated) {
-        publicAPI.computeAndApplyAutomatedSettings();
+        model.autoLayout();
       } else {
         // rebuild the texture only when force or changed bounds, face
         // visibility changes do to change the atlas
@@ -757,6 +763,10 @@ function vtkScalarBarActor(publicAPI, model) {
     model.barActor.setVisibility,
     model.tmActor.setVisibility
   );
+
+  publicAPI.resetAutoLayoutToDefault = () => {
+    model.autoLayout = defaultAutoLayout(publicAPI, model);
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -766,6 +776,7 @@ function vtkScalarBarActor(publicAPI, model) {
 function defaultValues(initialValues) {
   return {
     automated: true,
+    autoLayout: null,
     axisLabel: 'Scalar Value',
     barPosition: [0, 0],
     barSize: [0, 0],
@@ -794,6 +805,8 @@ function defaultValues(initialValues) {
 
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, defaultValues(initialValues));
+
+  if (!model.autoLayout) model.autoLayout = defaultAutoLayout(publicAPI, model);
 
   // Inheritance
   vtkActor.extend(publicAPI, model, initialValues);
@@ -857,6 +870,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   macro.setGet(publicAPI, model, [
     'automated',
+    'autoLayout',
     'axisTitlePixelOffset',
     'axisLabel',
     'scalarsToColors',


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->
fix #2020

Allow user to get / set autoLayout function, previously called computeAndApplyAutomatedSettings

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

ScalarBarActor doesn't seem to have documentation or TypeScript definitions yet.
https://kitware.github.io/vtk-js/api/Rendering_Core_ScalarBarActor.html

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

I've successfully been able to customize the autoLayout function! 

<img src="https://user-images.githubusercontent.com/34066664/128057459-65469bf4-8360-49eb-9662-9d1a2e3728af.png" width="128" height="350" />

Not sure the best way to develop test changes to vtk.js module:
https://discourse.vtk.org/t/npm-link-for-vtk-js/6283

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - latest master: <!-- ex: 14.0.0 (favor latest master) -->
  - macOS 12.2.1: <!-- ex: Windows 10, iOS 13.6 -->
  - Firefox <!-- ex: Chrome 89.0.4389.128 -->

<!-- Remove the line below if it is not relevant -->
_This contribution is funded by [Pollination](https://www.pollination.cloud/)._
