### PR TITLE
Improve reslice cursor line rendering

### DIFF
--- a/Sources/Filters/Sources/CylinderSource/index.d.ts
+++ b/Sources/Filters/Sources/CylinderSource/index.d.ts
@@ -5,6 +5,8 @@ import { vtkAlgorithm, vtkObject } from "../../../interfaces";
  */
 interface ICylinderSourceInitialValues {
 	height?: number;
+	initAngle?: number;
+	otherRadius?: number;
 	radius?: number;
 	resolution?: number;
 	center?: number[];
@@ -58,8 +60,24 @@ export interface vtkCylinderSource extends vtkCylinderSourceBase {
 	getHeight(): number;
 
 	/**
+	 * Get the initial angle along direction
+	 * @default 0
+	 * @see getDirection
+	 */
+	getInitAngle(): number;
+
+	/**
+	 * Get the radius on Z axis. If not null and different from radius,
+	 * the cylinder base becomes an ellipse instead of a circle.
+	 * @default null
+	 * @see getRadius()
+	 */
+	getOtherRadius(): number;
+
+	/**
 	 * Get the base radius of the cylinder.
 	 * @default 0.5
+	 * @see getOtherRadius()
 	 */
 	getRadius(): number;
 
@@ -125,8 +143,22 @@ export interface vtkCylinderSource extends vtkCylinderSourceBase {
 	setHeight(height: number): boolean;
 
 	/**
+	 * Set the initial angle along direction.
+	 * @param {Number} initAngle The initial angle in radian.
+	 */
+	setInitAngle(radianAngle: number): boolean;
+
+	/**
+	 * Set the base Z radius of the cylinder.
+	 * @param {Number} radius The radius of the cylinder in Z.
+	 * @see setRadius()
+	 */
+	setOtherRadius(radius: number): boolean;
+
+	/**
 	 * Set the base radius of the cylinder.
 	 * @param {Number} radius The radius of the cylinder.
+	 * @see setOtherRadius()
 	 */
 	setRadius(radius: number): boolean;
 
@@ -135,6 +167,7 @@ export interface vtkCylinderSource extends vtkCylinderSourceBase {
 	 * @param {Number} resolution The number of facets used to represent the cylinder.
 	 */
 	setResolution(resolution: number): boolean;
+
 }
 
 /**

--- a/Sources/Filters/Sources/CylinderSource/index.js
+++ b/Sources/Filters/Sources/CylinderSource/index.js
@@ -57,9 +57,11 @@ function vtkCylinderSource(publicAPI, model) {
     const xtop = [0.0, 0.0, 0.0];
     const tcbot = [0.0, 0.0];
     const tctop = [0.0, 0.0];
+    const otherRadius =
+      model.otherRadius == null ? model.radius : model.otherRadius;
     for (let i = 0; i < model.resolution; i++) {
       // x coordinate
-      nbot[0] = Math.cos(i * angle);
+      nbot[0] = Math.cos(i * angle + model.initAngle);
       ntop[0] = nbot[0];
       xbot[0] = model.radius * nbot[0] + model.center[0];
       xtop[0] = xbot[0];
@@ -73,9 +75,9 @@ function vtkCylinderSource(publicAPI, model) {
       tctop[1] = 1.0;
 
       // z coordinate
-      nbot[2] = -Math.sin(i * angle);
+      nbot[2] = -Math.sin(i * angle + model.initAngle);
       ntop[2] = nbot[2];
-      xbot[2] = model.radius * nbot[2] + model.center[2];
+      xbot[2] = otherRadius * nbot[2] + model.center[2];
       xtop[2] = xbot[2];
 
       const pointIdx = 2 * i;
@@ -105,7 +107,7 @@ function vtkCylinderSource(publicAPI, model) {
       // Generate points for top/bottom polygons
       for (let i = 0; i < model.resolution; i++) {
         // x coordinate
-        xbot[0] = model.radius * Math.cos(i * angle);
+        xbot[0] = model.radius * Math.cos(i * angle + model.initAngle);
         xtop[0] = xbot[0];
         tcbot[0] = xbot[0];
         tctop[0] = xbot[0];
@@ -119,7 +121,7 @@ function vtkCylinderSource(publicAPI, model) {
         xtop[1] = -0.5 * model.height + model.center[1];
 
         // z coordinate
-        xbot[2] = -model.radius * Math.sin(i * angle);
+        xbot[2] = -otherRadius * Math.sin(i * angle + model.initAngle);
         xtop[2] = xbot[2];
         tcbot[1] = xbot[2];
         tctop[1] = xbot[2];
@@ -178,6 +180,7 @@ function vtkCylinderSource(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   height: 1.0,
+  initAngle: 0,
   radius: 1.0,
   resolution: 6,
   center: [0, 0, 0],
@@ -193,7 +196,14 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Build VTK API
   macro.obj(publicAPI, model);
-  macro.setGet(publicAPI, model, ['height', 'radius', 'resolution', 'capping']);
+  macro.setGet(publicAPI, model, [
+    'height',
+    'initAngle',
+    'otherRadius',
+    'radius',
+    'resolution',
+    'capping',
+  ]);
   macro.setGetArray(publicAPI, model, ['center', 'direction'], 3);
   macro.algo(publicAPI, model, 0, 1);
   vtkCylinderSource(publicAPI, model);

--- a/Sources/Widgets/Representations/ResliceCursorContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/ResliceCursorContextRepresentation/index.js
@@ -36,10 +36,17 @@ function vtkResliceCursorContextRepresentation(publicAPI, model) {
     actor: vtkActor.newInstance({ parentProp: publicAPI }),
   };
   model.pipelines.axes = [];
+
+  const squarishCylinderProperties = {
+    initAngle: Math.PI / 4,
+    otherRadius: 0,
+    resolution: 4,
+  };
+
   // Create axis 1
   const axis1 = {};
   axis1.line = {
-    source: vtkCylinderSource.newInstance(),
+    source: vtkCylinderSource.newInstance(squarishCylinderProperties),
     mapper: vtkMapper.newInstance(),
     actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
   };
@@ -56,7 +63,7 @@ function vtkResliceCursorContextRepresentation(publicAPI, model) {
   // Create axis 2
   const axis2 = {};
   axis2.line = {
-    source: vtkCylinderSource.newInstance(),
+    source: vtkCylinderSource.newInstance(squarishCylinderProperties),
     mapper: vtkMapper.newInstance(),
     actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
   };
@@ -77,10 +84,7 @@ function vtkResliceCursorContextRepresentation(publicAPI, model) {
   // Improve actors rendering
   model.pipelines.center.actor.getProperty().setAmbient(1, 1, 1);
   model.pipelines.center.actor.getProperty().setDiffuse(0, 0, 0);
-
-  // Render it squarish
-  model.pipelines.axes[0].line.source.setResolution(4);
-  model.pipelines.axes[1].line.source.setResolution(4);
+  model.pipelines.center.actor.getProperty().setBackfaceCulling(true);
 
   model.pipelines.axes.forEach((axis) => {
     Object.values(axis).forEach((lineOrRotationHandle) => {
@@ -88,6 +92,7 @@ function vtkResliceCursorContextRepresentation(publicAPI, model) {
       const actor = lineOrRotationHandle.actor;
       actor.getProperty().setAmbient(1, 1, 1);
       actor.getProperty().setDiffuse(0, 0, 0);
+      actor.getProperty().setBackfaceCulling(true);
       publicAPI.addActor(actor);
     });
   });
@@ -147,9 +152,13 @@ function vtkResliceCursorContextRepresentation(publicAPI, model) {
     const center = [0, 0, 0];
     vtkMath.multiplyAccumulate(state.getPoint1(), vector, 0.5, center);
     const length = vtkMath.normalize(vector);
-    axis.line.source.setCenter(center);
-    axis.line.source.setDirection(vector);
     axis.line.source.setHeight(20 * length); // make it an infinite line
+    // Rotate the cylinder to be along vector
+    const viewNormal = model.inputData[0].getPlanes()[state.getInViewType()]
+      .normal;
+    const x = vtkMath.cross(vector, viewNormal, []);
+    const mat = [...x, 0, ...vector, 0, ...viewNormal, 0, ...center, 1];
+    axis.line.actor.setUserMatrix(mat);
 
     // Rotation handles
     const handleDistanceToCenter = 0.5;
@@ -319,6 +328,11 @@ function defaultValues(initialValues) {
   return {
     axis1Name: '',
     axis2Name: '',
+    rotationEnabled: true,
+    rotationHandlePosition: 0.5,
+    scaleInPixels: true,
+    viewType: null,
+    ...initialValues,
     coincidentTopologyParameters: {
       Point: {
         factor: -1.0,
@@ -332,12 +346,8 @@ function defaultValues(initialValues) {
         factor: -2.0,
         offset: -2.0,
       },
+      ...initialValues.coincidentTopologyParameters,
     },
-    rotationEnabled: true,
-    rotationHandlePosition: 0.5,
-    scaleInPixels: true,
-    viewType: null,
-    ...initialValues,
   };
 }
 

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -48,6 +48,8 @@ const widget = vtkResliceCursorWidget.newInstance();
 const widgetState = widget.getWidgetState();
 widgetState.setKeepOrthogonality(true);
 widgetState.setOpacity(0.6);
+widgetState.setSphereRadius(10);
+widgetState.setLineThickness(5);
 
 const showDebugActors = true;
 
@@ -104,9 +106,6 @@ function createRGBStringFromRGBValues(rgb) {
     rgb[2] * 255
   ).toString()})`;
 }
-
-widgetState.setOpacity(0.6);
-widgetState.setSphereRadius(10);
 
 const initialPlanesState = { ...widgetState.getPlanes() };
 


### PR DESCRIPTION
### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
Reslice cursor widget lines were rendered with some odd look and feel.

### Changes
- [x] CylinderSource learned 2 new properties: initAngle and otherRadius
- [x] ResliceCursorWidget lines are now rendered as flat 2D rectangles
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
Before:
![image](https://user-images.githubusercontent.com/219044/128877624-e3775c26-ac5d-4f80-8cd4-9908c75b46ed.png)
After:
![image](https://user-images.githubusercontent.com/219044/128876512-f231a616-181e-49d5-aa3f-3c580848a070.png)

### Testing
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome 89
