### PR TITLE
docs(vr): fix VR example

### DIFF
--- a/Examples/Geometry/VR/index.js
+++ b/Examples/Geometry/VR/index.js
@@ -96,10 +96,10 @@ resolutionChange.addEventListener('input', (e) => {
 
 vrbutton.addEventListener('click', (e) => {
   if (vrbutton.textContent === 'Send To VR') {
-    fullScreenRenderer.getOpenGLRenderWindow().startVR();
+    fullScreenRenderer.getApiSpecificRenderWindow().startVR();
     vrbutton.textContent = 'Return From VR';
   } else {
-    fullScreenRenderer.getOpenGLRenderWindow().stopVR();
+    fullScreenRenderer.getApiSpecificRenderWindow().stopVR();
     vrbutton.textContent = 'Send To VR';
   }
 });

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -253,8 +253,12 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
           model.vrDisplay.depthNear = 0.01; // meters
           model.vrDisplay.depthFar = 100.0; // meters
           publicAPI.invokeHaveVRDisplay();
+        } else {
+          vtkErrorMacro('No WebVR display found');
         }
       });
+    } else {
+      vtkErrorMacro('WebVR is not available');
     }
 
     // prevent default context lost handler


### PR DESCRIPTION
Due to WebGPU support, the method name to access the WebGL view has changed.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
I tried to run the example with no luck

### Changes
The name of the method to access the WebGL view has been changed.
Added more explicit error messages.
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
Example is still failing on my machine without VR display, but at least I do not have any other error.

### Testing
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome 89.0.4389.128