### PR TITLE
feat(View): Replace useFocalPointAsCenterOfRotation with more generic…

### DIFF
--- a/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
@@ -36,7 +36,7 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
     mat4.identity(trans);
 
     const { center, rotationFactor } = model;
-    const useCenterOfRotation = vec3.length(model.centerOfRotation) !== 0.0;
+    const useCenterOfRotation = vtkMath.areEquals(model.centerOfRotation, [0, 0, 0]);
 
     if (useCenterOfRotation) {
       center[0] = model.centerOfRotation[0];

--- a/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
@@ -36,11 +36,12 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
     mat4.identity(trans);
 
     const { center, rotationFactor } = model;
+    const useCenterOfRotation = vec3.length(model.centerOfRotation) !== 0.0;
 
-    if (model.useFocalPointAsCenterOfRotation) {
-      center[0] = cameraFp[0];
-      center[1] = cameraFp[1];
-      center[2] = cameraFp[2];
+    if (useCenterOfRotation) {
+      center[0] = model.centerOfRotation[0];
+      center[1] = model.centerOfRotation[1];
+      center[2] = model.centerOfRotation[2];
     }
 
     const dx = model.previousPosition.x - position.x;
@@ -61,7 +62,7 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
           vtkMath.dot(model.worldUpVec, model.worldUpVec)
       );
 
-      if (model.useFocalPointAsCenterOfRotation) {
+      if (useCenterOfRotation) {
         vtkMath.add(center, centerOfRotation, centerOfRotation);
       }
 
@@ -74,7 +75,7 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
       );
 
       // Translate back
-      if (model.useFocalPointAsCenterOfRotation) {
+      if (useCenterOfRotation) {
         centerOfRotation[0] = -centerOfRotation[0];
         centerOfRotation[1] = -centerOfRotation[1];
         centerOfRotation[2] = -centerOfRotation[2];
@@ -147,7 +148,7 @@ const DEFAULT_VALUES = {
   useWorldUpVec: false,
   // set WorldUpVector to be y-axis by default
   worldUpVec: [0, 1, 0],
-  useFocalPointAsCenterOfRotation: false,
+  centerOfRotation: [0, 0, 0],
 };
 
 // ----------------------------------------------------------------------------
@@ -163,7 +164,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Create get-set macro
   macro.setGet(publicAPI, model, ['useWorldUpVec']);
   macro.setGetArray(publicAPI, model, ['worldUpVec'], 3);
-  macro.setGet(publicAPI, model, ['useFocalPointAsCenterOfRotation']);
+  macro.setGetArray(publicAPI, model, ['centerOfRotation'], 3);
 
   // Object specific methods
   vtkMouseCameraTrackballRotateManipulator(publicAPI, model);

--- a/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
@@ -36,7 +36,11 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
     mat4.identity(trans);
 
     const { center, rotationFactor } = model;
-    const useCenterOfRotation = vtkMath.areEquals(model.centerOfRotation, [0, 0, 0]);
+    const useCenterOfRotation = vtkMath.areEquals(model.centerOfRotation, [
+      0,
+      0,
+      0,
+    ]);
 
     if (useCenterOfRotation) {
       center[0] = model.centerOfRotation[0];


### PR DESCRIPTION
… centerOfRotation setting

### Context
This replaces the "useFocalPointAsCenterOfRotation" setting with a more generic "centerOfRotation" setting. To keep the previous behavior, simply pass the camera focal point to the new setting.

### Testing
Call setCenterOfRotation on the rotate manipulator with a non-zero vector parameter.