### PR TITLE
fix(HttpDataAccessHelper): decompression pass for binary files

### DIFF
--- a/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
+++ b/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
@@ -29,13 +29,25 @@ function openAsyncXHR(method, url, options = {}) {
 }
 
 function fetchBinary(url, options = {}) {
+  if (options && options.compression && options.compression !== 'gz') {
+    vtkErrorMacro('Supported algorithms are: [gz]');
+    vtkErrorMacro(`Unkown compression algorithm: ${options.compression}`);
+  }
+
   return new Promise((resolve, reject) => {
     const xhr = openAsyncXHR('GET', url, options);
 
     xhr.onreadystatechange = (e) => {
       if (xhr.readyState === 4) {
         if (xhr.status === 200 || xhr.status === 0) {
-          resolve(xhr.response);
+          if (options.compression) {
+            resolve(
+              pako.inflate(new Uint8Array(xhr.response), { to: 'arraybuffer' })
+                .buffer
+            );
+          } else {
+            resolve(xhr.response);
+          }
         } else {
           reject({ xhr, e });
         }


### PR DESCRIPTION
### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
- Fixes #1994 
- Migrated changes from https://github.com/Kitware/vtk-js/pull/1995
- Thanks to @aerogt3!

### Changes
- No doc changes

### Results

Adds decompression pass for binary files.

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

Co-authored-by: aerogt3 <34963757+aerogt3@users.noreply.github.com>