### PR TITLE
feat(Rendering): Add support for halfFloat 3D textures

### DIFF
--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -40,6 +40,7 @@ const reader = vtkHttpDataSetReader.newInstance({ fetchGzip: true });
 const actor = vtkVolume.newInstance();
 const mapper = vtkVolumeMapper.newInstance();
 mapper.setSampleDistance(1.3);
+mapper.setPreferSizeOverAccuracy(true);
 actor.setMapper(mapper);
 
 // create color and opacity transfer functions
@@ -93,18 +94,12 @@ function updateBlendMode(event) {
 }
 
 function updateScalarMin(event) {
-  mapper.setIpScalarRange(
-    event.target.value,
-    parseFloat(mapper.getIpScalarRange()[1])
-  );
+  mapper.setIpScalarRange(event.target.value, mapper.getIpScalarRange()[1]);
   renderWindow.render();
 }
 
 function updateScalarMax(event) {
-  mapper.setIpScalarRange(
-    mapper.getIpScalarRange()[0],
-    parseFloat(event.target.value)
-  );
+  mapper.setIpScalarRange(mapper.getIpScalarRange()[0], event.target.value);
   renderWindow.render();
 }
 

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -88,6 +88,7 @@ const DEFAULT_VALUES = {
   blendMode: BlendMode.COMPOSITE_BLEND,
   ipScalarRange: [-1000000.0, 1000000.0],
   filterMode: FilterMode.OFF, // ignored by WebGL so no behavior change
+  preferSizeOverAccuracy: false, // Whether to use halfFloat representation of float, when it is inaccurate
 };
 
 // ----------------------------------------------------------------------------
@@ -108,6 +109,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'autoAdjustSampleDistances',
     'blendMode',
     'filterMode',
+    'preferSizeOverAccuracy',
   ]);
 
   macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1215,6 +1215,8 @@ function vtkOpenGLTexture(publicAPI, model) {
     // compute min and max values
     const { offset: computedOffset, scale: computedScale } =
       computeScaleOffsets(numComps, numPixelsIn, data);
+    model.volumeInfo.dataComputedScale = computedScale;
+    model.volumeInfo.dataComputedOffset = computedOffset;
 
     const useHalfFloat = checkUseHalfFloat(
       dataType,

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -474,7 +474,7 @@ function vtkOpenGLTexture(publicAPI, model) {
   };
 
   //----------------------------------------------------------------------------
-  publicAPI.getDefaultDataType = (vtkScalarType) => {
+  publicAPI.getDefaultDataType = (vtkScalarType, useHalfFloatType = false) => {
     // DON'T DEAL with VTK_CHAR as this is platform dependent.
     if (model.openGLRenderWindow.getWebgl2()) {
       switch (vtkScalarType) {
@@ -482,10 +482,10 @@ function vtkOpenGLTexture(publicAPI, model) {
         //   return model.context.BYTE;
         case VtkDataTypes.UNSIGNED_CHAR:
           return model.context.UNSIGNED_BYTE;
-        // case VtkDataTypes.SHORT:
-        //   return model.context.SHORT;
-        // case VtkDataTypes.UNSIGNED_SHORT:
-        //   return model.context.UNSIGNED_SHORT;
+        case useHalfFloatType && VtkDataTypes.SHORT:
+          return model.context.HALF_FLOAT;
+        case useHalfFloatType && VtkDataTypes.UNSIGNED_SHORT:
+          return model.context.HALF_FLOAT;
         // case VtkDataTypes.INT:
         //   return model.context.INT;
         // case VtkDataTypes.UNSIGNED_INT:
@@ -535,8 +535,11 @@ function vtkOpenGLTexture(publicAPI, model) {
   };
 
   //----------------------------------------------------------------------------
-  publicAPI.getOpenGLDataType = (vtkScalarType) => {
-    model.openGLDataType = publicAPI.getDefaultDataType(vtkScalarType);
+  publicAPI.getOpenGLDataType = (vtkScalarType, useHalfFloatType = false) => {
+    model.openGLDataType = publicAPI.getDefaultDataType(
+      vtkScalarType,
+      useHalfFloatType
+    );
     return model.openGLDataType;
   };
 
@@ -612,15 +615,20 @@ function vtkOpenGLTexture(publicAPI, model) {
   };
 
   //----------------------------------------------------------------------------
-  function updateArrayDataType(dataType, data) {
+  function updateArrayDataType(dataType, data, depth = false) {
     const pixData = [];
+
+    let pixCount = model.width * model.height * model.components;
+    if (depth) {
+      pixCount *= model.depth;
+    }
+
     // if the opengl data type is float
     // then the data array must be float
     if (
       dataType !== VtkDataTypes.FLOAT &&
       model.openGLDataType === model.context.FLOAT
     ) {
-      const pixCount = model.width * model.height * model.components;
       for (let idx = 0; idx < data.length; idx++) {
         const newArray = new Float32Array(pixCount);
         for (let i = 0; i < pixCount; i++) {
@@ -636,7 +644,6 @@ function vtkOpenGLTexture(publicAPI, model) {
       dataType !== VtkDataTypes.UNSIGNED_CHAR &&
       model.openGLDataType === model.context.UNSIGNED_BYTE
     ) {
-      const pixCount = model.width * model.height * model.components;
       for (let idx = 0; idx < data.length; idx++) {
         const newArray = new Uint8Array(pixCount);
         for (let i = 0; i < pixCount; i++) {
@@ -648,9 +655,12 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     // if the opengl data type is half float
     // then the data array must be u16
-    const halfFloat = model.context.getExtension('OES_texture_half_float');
-    if (halfFloat && model.openGLDataType === halfFloat.HALF_FLOAT_OES) {
-      const pixCount = model.width * model.height * model.components;
+    const halfFloatExt = model.context.getExtension('OES_texture_half_float');
+    const halfFloat = model.openGLRenderWindow.getWebgl2()
+      ? model.openGLDataType === model.context.HALF_FLOAT
+      : halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
+
+    if (halfFloat) {
       for (let idx = 0; idx < data.length; idx++) {
         const newArray = new Uint16Array(pixCount);
         for (let i = 0; i < pixCount; i++) {
@@ -1043,60 +1053,6 @@ function vtkOpenGLTexture(publicAPI, model) {
     return true;
   };
 
-  //----------------------------------------------------------------------------
-  publicAPI.create3DFromRaw = (
-    width,
-    height,
-    depth,
-    numComps,
-    dataType,
-    data
-  ) => {
-    // Now determine the texture parameters using the arguments.
-    publicAPI.getOpenGLDataType(dataType);
-    publicAPI.getInternalFormat(dataType, numComps);
-    publicAPI.getFormat(dataType, numComps);
-
-    if (!model.internalFormat || !model.format || !model.openGLDataType) {
-      vtkErrorMacro('Failed to determine texture parameters.');
-      return false;
-    }
-
-    model.target = model.context.TEXTURE_3D;
-    model.components = numComps;
-    model.width = width;
-    model.height = height;
-    model.depth = depth;
-    model.numberOfDimensions = 3;
-    model.openGLRenderWindow.activateTexture(publicAPI);
-    publicAPI.createTexture();
-    publicAPI.bind();
-
-    // Source texture data from the PBO.
-    // model.context.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-    // model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
-
-    model.context.texImage3D(
-      model.target,
-      0,
-      model.internalFormat,
-      model.width,
-      model.height,
-      model.depth,
-      0,
-      model.format,
-      model.openGLDataType,
-      data
-    );
-
-    if (model.generateMipmap) {
-      model.context.generateMipmap(model.target);
-    }
-
-    publicAPI.deactivate();
-    return true;
-  };
-
   function computeScaleOffsets(numComps, numPixelsIn, data) {
     // compute min and max values per component
     const min = [];
@@ -1129,6 +1085,104 @@ function vtkOpenGLTexture(publicAPI, model) {
     return { scale, offset };
   }
 
+  // HalfFloat only represents numbers between [-2048, 2048] exactly accurate,
+  // for numbers outside of this range there is a precision limitation
+  function hasExactHalfFloat(offset, scale) {
+    // Per Component
+    for (let c = 0; c < offset.length; c++) {
+      const min = offset[c];
+      const max = scale[c] + min;
+      if (min < -2048 || min > 2048 || max < -2048 || max > 2048) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function checkUseHalfFloat(dataType, offset, scale, preferSizeOverAccuracy) {
+    const useHalfFloatType = true;
+    publicAPI.getOpenGLDataType(dataType, useHalfFloatType);
+
+    const halfFloatExt = model.context.getExtension('OES_texture_half_float');
+    const useHalfFloat = model.openGLRenderWindow.getWebgl2()
+      ? model.openGLDataType === model.context.HALF_FLOAT
+      : halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
+
+    if (!useHalfFloat) {
+      return false;
+    }
+
+    // Don't consider halfFloat and convert back to Float when the range of data does not generate an accurate halfFloat
+    // AND it is not preferable to have a smaller texture than an exact texture.
+    if (!hasExactHalfFloat(offset, scale) && !preferSizeOverAccuracy) {
+      return false;
+    }
+
+    return true;
+  }
+
+  //----------------------------------------------------------------------------
+  publicAPI.create3DFromRaw = (
+    width,
+    height,
+    depth,
+    numComps,
+    dataType,
+    data
+  ) => {
+    // Permit OpenGLDataType to be half float, if applicable, for 3D
+    const useHalfFloatType = true;
+    publicAPI.getOpenGLDataType(dataType, useHalfFloatType);
+
+    // Now determine the texture parameters using the arguments.
+    publicAPI.getInternalFormat(dataType, numComps);
+    publicAPI.getFormat(dataType, numComps);
+
+    if (!model.internalFormat || !model.format || !model.openGLDataType) {
+      vtkErrorMacro('Failed to determine texture parameters.');
+      return false;
+    }
+
+    model.target = model.context.TEXTURE_3D;
+    model.components = numComps;
+    model.width = width;
+    model.height = height;
+    model.depth = depth;
+    model.numberOfDimensions = 3;
+    model.openGLRenderWindow.activateTexture(publicAPI);
+    publicAPI.createTexture();
+    publicAPI.bind();
+    // Create an array of texture with one texture
+    const dataArray = [data];
+    const is3DArray = true;
+    const pixData = updateArrayDataType(dataType, dataArray, is3DArray);
+    const scaledData = scaleTextureToHighestPowerOfTwo(pixData);
+
+    // Source texture data from the PBO.
+    // model.context.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+    // model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
+
+    model.context.texImage3D(
+      model.target,
+      0,
+      model.internalFormat,
+      model.width,
+      model.height,
+      model.depth,
+      0,
+      model.format,
+      model.openGLDataType,
+      scaledData[0]
+    );
+
+    if (model.generateMipmap) {
+      model.context.generateMipmap(model.target);
+    }
+
+    publicAPI.deactivate();
+    return true;
+  };
+
   //----------------------------------------------------------------------------
   // This method simulates a 3D texture using 2D
   publicAPI.create3DFilterableFromRaw = (
@@ -1137,7 +1191,8 @@ function vtkOpenGLTexture(publicAPI, model) {
     depth,
     numComps,
     dataType,
-    data
+    data,
+    preferSizeOverAccuracy = false
   ) => {
     const numPixelsIn = width * height * depth;
 
@@ -1156,9 +1211,26 @@ function vtkOpenGLTexture(publicAPI, model) {
     // and texture = (data - offset)/scale
     model.volumeInfo = { scale, offset, width, height, depth };
 
+    // Check if we can accurately use halfFloat or whether it is preferred to have a smaller size texture
+    // compute min and max values
+    const { offset: computedOffset, scale: computedScale } =
+      computeScaleOffsets(numComps, numPixelsIn, data);
+
+    const useHalfFloat = checkUseHalfFloat(
+      dataType,
+      computedOffset,
+      computedScale,
+      preferSizeOverAccuracy
+    );
+
     // WebGL2 path, we have 3d textures etc
     if (model.openGLRenderWindow.getWebgl2()) {
-      if (dataType === VtkDataTypes.FLOAT) {
+      if (
+        dataType === VtkDataTypes.FLOAT ||
+        (useHalfFloat &&
+          (dataType === VtkDataTypes.SHORT ||
+            dataType === VtkDataTypes.UNSIGNED_SHORT))
+      ) {
         return publicAPI.create3DFromRaw(
           width,
           height,
@@ -1184,8 +1256,6 @@ function vtkOpenGLTexture(publicAPI, model) {
       // otherwise convert to float
       const newArray = new Float32Array(numPixelsIn * numComps);
       // compute min and max values
-      const { offset: computedOffset, scale: computedScale } =
-        computeScaleOffsets(numComps, numPixelsIn, data);
       model.volumeInfo.offset = computedOffset;
       model.volumeInfo.scale = computedScale;
       let count = 0;

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1377,7 +1377,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         dims[2],
         numComp,
         scalars.getDataType(),
-        scalars.getData()
+        scalars.getData(),
+        model.renderable.getPreferSizeOverAccuracy()
       );
       // console.log(model.scalarTexture.get());
       model.scalarTextureString = toString;

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -182,6 +182,9 @@ uniform float cshift3;
 uniform float cscale3;
 #endif
 
+uniform vec4 ipScalarRangeMin;
+uniform vec4 ipScalarRangeMax;
+
 // declaration for intermixed geometry
 //VTK::ZBuffer::Dec
 
@@ -795,17 +798,6 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
     gl_FragData[0] = getColorForValue(value, posIS, tstep);
   #endif
   #if vtkBlendMode == 3 || vtkBlendMode == 4 //AVERAGE_INTENSITY_BLEND || ADDITIVE_BLEND
-    vec4 ipScalarRangeMin = vec4 (
-      //VTK::IPScalarRangeMin,
-      //VTK::IPScalarRangeMin,
-      //VTK::IPScalarRangeMin,
-      //VTK::IPScalarRangeMax);
-    vec4 ipScalarRangeMax = vec4(
-      //VTK::IPScalarRangeMax,
-      //VTK::IPScalarRangeMax,
-      //VTK::IPScalarRangeMax,
-      //VTK::IPScalarRangeMax);
-
     vec4 sum = vec4(0.);
 
     if (valueWithinScalarRange(tValue, ipScalarRangeMin, ipScalarRangeMax)) {


### PR DESCRIPTION
Recently half float precision for 2D textures was [added](https://github.com/sedghi/vtk-js/commit/29f0cb94b57485ccbe008d0a44ed16a6004a5d89), this PR will try to add it for the 3D textures too.  

Data used is a full body CT from [TCIA](https://wiki.cancerimagingarchive.net/display/Public/Head-Neck+Cetuximab) (download .vti from [here](https://www.dropbox.com/sh/4pq08njcfmos2nf/AACFoqprysqp5migPtLS9rUua?dl=0)). 

run `npm run example -- VolumeMapperBlendModes` with the data


### Before
https://user-images.githubusercontent.com/7490180/131192577-9433a02b-084e-41de-b866-0324261749c7.mp4

Chrome task manager before 
![image](https://user-images.githubusercontent.com/7490180/131192370-bd7154f2-f56b-4d25-a076-ace716e58146.png)

### After

https://user-images.githubusercontent.com/7490180/131192631-bae03a2a-79e6-4b68-b948-601772f5186f.mp4



Chrome task manager after 

![image](https://user-images.githubusercontent.com/7490180/131192392-e0859a04-5327-465d-8fdc-a6f447b704e3.png)


### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: latest master
  - **OS**: macOS 10.15.7
  - **Browser**: Chrome  92.0.4515.159 



CC'ing @swederik 