### PR TITLE
fix(View): Fix center of rotation when used with world up vector setting

### DIFF
--- a/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballRotateManipulator/index.js
@@ -61,9 +61,7 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
           vtkMath.dot(model.worldUpVec, model.worldUpVec)
       );
 
-      if (model.useFocalPointAsCenterOfRotation) {
-        vtkMath.add(center, centerOfRotation, centerOfRotation);
-      }
+      vtkMath.add(center, centerOfRotation, centerOfRotation);
 
       mat4.translate(trans, trans, centerOfRotation);
       mat4.rotate(
@@ -74,19 +72,11 @@ function vtkMouseCameraTrackballRotateManipulator(publicAPI, model) {
       );
 
       // Translate back
-      if (model.useFocalPointAsCenterOfRotation) {
-        centerOfRotation[0] = -centerOfRotation[0];
-        centerOfRotation[1] = -centerOfRotation[1];
-        centerOfRotation[2] = -centerOfRotation[2];
-        mat4.translate(trans, trans, centerOfRotation);
-        mat4.translate(trans, trans, center);
-      } else {
-        mat4.translate(
-          trans,
-          trans,
-          vtkMath.subtract(center, centerOfRotation, centerOfRotation)
-        );
-      }
+      centerOfRotation[0] = -centerOfRotation[0];
+      centerOfRotation[1] = -centerOfRotation[1];
+      centerOfRotation[2] = -centerOfRotation[2];
+      mat4.translate(trans, trans, centerOfRotation);
+      mat4.translate(trans, trans, center);
     } else {
       mat4.translate(trans, trans, center);
       mat4.rotate(


### PR DESCRIPTION
Fixes an error when the world up vector setting is used with a non-origin center of rotation as mentioned [here](https://github.com/Kitware/vtk-js/pull/2043#issuecomment-898999801)