### PR TITLE
fix(shapewidget): Fix and improve ShapeWidget

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,13 @@
+## From 19.x to 20
+
+In ShapeWidget: 
+- `setLabelTextCallback` is replaced by `text` substate.  
+- `setPixelScale` has been removed. It should be replaced by point handle `scale1` mixin and `scaleInPixels`.  
+- `useHandles` has been removed. It should be replaced by `setHandleVisibility`.
+- `resetAfterPointPlacement` is now false by default.
+
+RectangleWidget and EllipseWidget handles now scale up automatically.
+
 ## From 18.x to 19
 
 vtkWidgetRepresentation.updateActorVisibility(...) lost the widgetVisibility parameter.

--- a/Sources/Common/Core/Math/index.d.ts
+++ b/Sources/Common/Core/Math/index.d.ts
@@ -657,10 +657,10 @@ export function rgb2lab(rgb: number[], lab: number[]): void;
 export function lab2rgb(lab: number[], rgb: number[]): void;
 
 /**
- *
- * @param {Number[]} bounds 
+ * Returns bounds.
+ * @param {Number[]} bounds Output array that hold bounds, optionally empty.
  */
-export function uninitializeBounds(bounds: number[]): void;
+export function uninitializeBounds(bounds: number[]): number[];
 
 /**
  *
@@ -669,12 +669,12 @@ export function uninitializeBounds(bounds: number[]): void;
 export function areBoundsInitialized(bounds: number[]): boolean;
 
 /**
- *
- * @param {Number[]} point1 
- * @param {Number[]} point2 
- * @param {Number[]} bounds 
+ * Returns bounds.
+ * @param {Number[]} point1
+ * @param {Number[]} point2
+ * @param {Number[]} bounds Output array that hold bounds, optionally empty.
  */
-export function computeBoundsFromPoints(point1: number[], point2: number[], bounds: number[]): void;
+export function computeBoundsFromPoints(point1: number[], point2: number[], bounds: number[]): number[];
 
 /**
  *

--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -1949,6 +1949,7 @@ export function uninitializeBounds(bounds) {
   bounds[3] = -1.0;
   bounds[4] = 1.0;
   bounds[5] = -1.0;
+  return bounds;
 }
 
 export function areBoundsInitialized(bounds) {
@@ -1962,6 +1963,7 @@ export function computeBoundsFromPoints(point1, point2, bounds) {
   bounds[3] = Math.max(point1[1], point2[1]);
   bounds[4] = Math.min(point1[2], point2[2]);
   bounds[5] = Math.max(point1[2], point2[2]);
+  return bounds;
 }
 
 export function clampValue(value, minValue, maxValue) {

--- a/Sources/Common/DataModel/ImageData/index.js
+++ b/Sources/Common/DataModel/ImageData/index.js
@@ -322,9 +322,7 @@ function vtkImageData(publicAPI, model) {
     vec3.transformMat4(out1, in1, model.indexToWorld);
     vec3.transformMat4(out2, in2, model.indexToWorld);
 
-    vtkMath.computeBoundsFromPoints(out1, out2, bout);
-
-    return bout;
+    return vtkMath.computeBoundsFromPoints(out1, out2, bout);
   };
 
   publicAPI.worldToIndexBounds = (bin, bout = []) => {
@@ -337,9 +335,7 @@ function vtkImageData(publicAPI, model) {
     vec3.transformMat4(out1, in1, model.worldToIndex);
     vec3.transformMat4(out2, in2, model.worldToIndex);
 
-    vtkMath.computeBoundsFromPoints(out1, out2, bout);
-
-    return bout;
+    return vtkMath.computeBoundsFromPoints(out1, out2, bout);
   };
 
   // Make sure the transform is correct

--- a/Sources/Widgets/Representations/CircleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/CircleContextRepresentation/index.js
@@ -1,9 +1,9 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkCircleSource from 'vtk.js/Sources/Filters/Sources/CircleSource';
+import vtkContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ContextRepresentation';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
-import vtkHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/HandleRepresentation';
 import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkWidgetRepresentation from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
@@ -90,7 +90,7 @@ function vtkCircleContextRepresentation(publicAPI, model) {
 
   publicAPI.setGlyphResolution = macro.chain(
     publicAPI.setGlyphResolution,
-    (r) => model.glyph.setResolution(r)
+    (r) => model.pipelines.circle.glyph.setResolution(r)
   );
 
   // --------------------------------------------------------------------------
@@ -187,8 +187,6 @@ function vtkCircleContextRepresentation(publicAPI, model) {
   // --------------------------------------------------------------------------
   // Initialization
   // --------------------------------------------------------------------------
-
-  publicAPI.setActiveScaleFactor(1);
 }
 
 // ----------------------------------------------------------------------------
@@ -207,7 +205,7 @@ const DEFAULT_VALUES = {
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
-  vtkHandleRepresentation.extend(publicAPI, model, initialValues);
+  vtkContextRepresentation.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['glyphResolution', 'defaultScale']);
   macro.get(publicAPI, model, ['glyph', 'mapper', 'actor']);
 

--- a/Sources/Widgets/Representations/ContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/ContextRepresentation/index.js
@@ -14,6 +14,9 @@ function vtkContextRepresentation(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  activeScaleFactor: 1.2,
+  activeColor: 1,
+  useActiveColor: true,
   behavior: Behavior.CONTEXT,
   pickable: false,
   dragable: true,

--- a/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
@@ -1,6 +1,6 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/HandleRepresentation';
+import vtkContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ContextRepresentation';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 
@@ -116,7 +116,7 @@ const DEFAULT_VALUES = {
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
-  vtkHandleRepresentation.extend(publicAPI, model, initialValues);
+  vtkContextRepresentation.extend(publicAPI, model, initialValues);
   macro.setGetArray(publicAPI, model, ['color'], 1);
 
   macro.get(publicAPI, model, ['mapper', 'actor']);

--- a/Sources/Widgets/SVG/SVGLandmarkRepresentation/Constants.js
+++ b/Sources/Widgets/SVG/SVGLandmarkRepresentation/Constants.js
@@ -1,0 +1,25 @@
+export const VerticalTextAlignment = {
+  TOP: 'TOP',
+  BOTTOM: 'BOTTOM',
+  MIDDLE: 'MIDDLE',
+};
+
+/**
+ * fontSize can be a number or a string representing a size in px
+ * @param {Number|String} fontSize
+ * @returns Number representing the fontSize in pixels
+ */
+export function fontSizeToPixels(fontProperties, defaultFontSize = 16) {
+  if (fontProperties != null && fontProperties.fontSize) {
+    if (typeof fontProperties.fontSize === 'string') {
+      if (fontProperties.fontSize.slice(-2) === 'px') {
+        return window.devicePixelRatio * parseInt(fontProperties.fontSize, 10);
+      }
+    } else {
+      return window.devicePixelRatio * fontProperties.fontSize;
+    }
+  }
+  return window.devicePixelRatio * defaultFontSize;
+}
+
+export default VerticalTextAlignment;

--- a/Sources/Widgets/SVG/SVGLandmarkRepresentation/index.js
+++ b/Sources/Widgets/SVG/SVGLandmarkRepresentation/index.js
@@ -1,6 +1,11 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkSVGRepresentation from 'vtk.js/Sources/Widgets/SVG/SVGRepresentation';
 
+import {
+  VerticalTextAlignment,
+  fontSizeToPixels,
+} from 'vtk.js/Sources/Widgets/SVG/SVGLandmarkRepresentation/Constants';
+
 const { createSvgElement } = vtkSVGRepresentation;
 
 // ----------------------------------------------------------------------------
@@ -45,23 +50,31 @@ function vtkSVGLandmarkRepresentation(publicAPI, model) {
           texts[i] = '';
         }
         const splitText = texts[i].split('\n');
-        const newlineOffset =
-          model.fontProperties != null && model.fontProperties.fontSize
-            ? model.fontProperties.fontSize
-            : 15;
+        const fontSize = fontSizeToPixels(model.fontProperties);
         splitText.forEach((subText, j) => {
           const text = publicAPI.createListenableSvgElement('text', i);
           Object.keys(model.textProps || {}).forEach((prop) => {
-            let propValue = model.textProps[prop];
-            if (model.offsetText === true && prop === 'dy') {
-              propValue = model.textProps.dy + newlineOffset * j;
-            }
-            text.setAttribute(prop, propValue);
+            text.setAttribute(prop, model.textProps[prop]);
           });
           text.setAttribute('x', x);
           text.setAttribute('y', y);
+          // Vertical offset (dy) calculation based on VerticalTextAlignment
+          let dy = model.textProps.dy ? model.textProps.dy : 0;
+          switch (model.textProps.verticalAlign) {
+            case VerticalTextAlignment.MIDDLE:
+              dy -= fontSize * (0.5 * splitText.length - j - 1);
+              break;
+            case VerticalTextAlignment.TOP:
+              dy += fontSize * (j + 1);
+              break;
+            case VerticalTextAlignment.BOTTOM:
+            default:
+              dy -= fontSize * (splitText.length - j - 1);
+              break;
+          }
+          text.setAttribute('dy', dy);
           if (model.fontProperties != null) {
-            text.setAttribute('font-size', model.fontProperties.fontSize);
+            text.setAttribute('font-size', fontSize);
             text.setAttribute('font-family', model.fontProperties.fontFamily);
             text.setAttribute('font-weight', model.fontProperties.fontStyle);
             text.setAttribute('fill', model.fontProperties.fontColor);
@@ -97,8 +110,6 @@ function defaultValues(initialValues) {
     },
     textProps: {
       fill: 'white',
-      dx: 0,
-      dy: 0,
       ...initialValues.textProps,
     },
   };

--- a/Sources/Widgets/SVG/SVGLandmarkRepresentation/index.js
+++ b/Sources/Widgets/SVG/SVGLandmarkRepresentation/index.js
@@ -80,28 +80,34 @@ function vtkSVGLandmarkRepresentation(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 
+/**
+ * textProps can contain any "svg" attribute (e.g. text-anchor, text-align,
+ * alignment-baseline...)
+ * @param {*} initialValues
+ * @returns
+ */
 function defaultValues(initialValues) {
   return {
+    ...initialValues,
     circleProps: {
       r: 5,
       stroke: 'red',
       fill: 'red',
+      ...initialValues.circleProps,
     },
     textProps: {
       fill: 'white',
-      dx: 12,
-      dy: -12,
+      dx: 0,
+      dy: 0,
+      ...initialValues.textProps,
     },
-    ...initialValues,
   };
 }
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, defaultValues(initialValues));
-
-  vtkSVGRepresentation.extend(publicAPI, model, initialValues);
+  vtkSVGRepresentation.extend(publicAPI, model, defaultValues(initialValues));
 
   macro.setGet(publicAPI, model, [
     'circleProps',

--- a/Sources/Widgets/Widgets3D/EllipseWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/behavior.js
@@ -2,6 +2,12 @@ import shapeBehavior from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/behavior
 import { vec3 } from 'gl-matrix';
 
 export default function widgetBehavior(publicAPI, model) {
+  model.shapeHandle = model.widgetState.getEllipseHandle();
+  model.point1Handle = model.widgetState.getPoint1Handle();
+  model.point2Handle = model.widgetState.getPoint2Handle();
+  model.point1Handle.setManipulator(model.manipulator);
+  model.point2Handle.setManipulator(model.manipulator);
+
   // We inherit shapeBehavior
   shapeBehavior(publicAPI, model);
   const superClass = { ...publicAPI };

--- a/Sources/Widgets/Widgets3D/EllipseWidget/index.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/index.js
@@ -1,12 +1,11 @@
 import macro from 'vtk.js/Sources/macros';
-import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidgetFactory';
-import vtkPlanePointManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
-import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
 import vtkCircleContextRepresentation from 'vtk.js/Sources/Widgets/Representations/CircleContextRepresentation';
+import vtkPlanePointManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
+import vtkShapeWidget from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget';
+import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
+import vtkSVGLandmarkRepresentation from 'vtk.js/Sources/Widgets/SVG/SVGLandmarkRepresentation';
 import widgetBehavior from 'vtk.js/Sources/Widgets/Widgets3D/EllipseWidget/behavior';
 import stateGenerator from 'vtk.js/Sources/Widgets/Widgets3D/EllipseWidget/state';
-
-import SHAPE_DEFAULT_VALUES from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget';
 
 import {
   BehaviorCategory,
@@ -25,6 +24,7 @@ function vtkEllipseWidget(publicAPI, model) {
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
+    ...model.methodsToLink,
     'activeScaleFactor',
     'activeColor',
     'useActiveColor',
@@ -49,6 +49,15 @@ function vtkEllipseWidget(publicAPI, model) {
             builder: vtkCircleContextRepresentation,
             labels: ['ellipseHandle'],
           },
+          {
+            builder: vtkSVGLandmarkRepresentation,
+            initialValues: {
+              showCircle: false,
+              offsetText: true,
+              text: '',
+            },
+            labels: ['SVGtext'],
+          },
         ];
     }
   };
@@ -60,44 +69,36 @@ function vtkEllipseWidget(publicAPI, model) {
   // Default manipulator
   model.manipulator = vtkPlanePointManipulator.newInstance();
   model.widgetState = stateGenerator();
-  model.shapeHandle = model.widgetState.getEllipseHandle();
-  model.point1Handle = model.widgetState.getPoint1Handle();
-  model.point2Handle = model.widgetState.getPoint2Handle();
-  model.point1Handle.setManipulator(model.manipulator);
-  model.point2Handle.setManipulator(model.manipulator);
 }
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
-  modifierBehavior: {
-    None: {
-      [BehaviorCategory.PLACEMENT]:
-        ShapeBehavior[BehaviorCategory.PLACEMENT].CLICK_AND_DRAG,
-      [BehaviorCategory.POINTS]:
-        ShapeBehavior[BehaviorCategory.POINTS].CENTER_TO_CORNER,
-      [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
+function defaultValues(initialValues) {
+  return {
+    modifierBehavior: {
+      None: {
+        [BehaviorCategory.PLACEMENT]:
+          ShapeBehavior[BehaviorCategory.PLACEMENT].CLICK_AND_DRAG,
+        [BehaviorCategory.POINTS]:
+          ShapeBehavior[BehaviorCategory.POINTS].CENTER_TO_CORNER,
+        [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
+      },
+      Shift: {
+        [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FIXED,
+      },
+      Control: {
+        [BehaviorCategory.POINTS]:
+          ShapeBehavior[BehaviorCategory.POINTS].CORNER_TO_CORNER,
+      },
     },
-    Shift: {
-      [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FIXED,
-    },
-    Control: {
-      [BehaviorCategory.POINTS]:
-        ShapeBehavior[BehaviorCategory.POINTS].CORNER_TO_CORNER,
-    },
-  },
-};
+    ...initialValues,
+  };
+}
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(
-    model,
-    { ...SHAPE_DEFAULT_VALUES.DEFAULT_VALUES, ...DEFAULT_VALUES },
-    initialValues
-  );
-
-  vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
+  vtkShapeWidget.extend(publicAPI, model, defaultValues(initialValues));
   macro.setGet(publicAPI, model, ['manipulator', 'widgetState']);
 
   vtkEllipseWidget(publicAPI, model);

--- a/Sources/Widgets/Widgets3D/EllipseWidget/index.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/index.js
@@ -53,7 +53,6 @@ function vtkEllipseWidget(publicAPI, model) {
             builder: vtkSVGLandmarkRepresentation,
             initialValues: {
               showCircle: false,
-              offsetText: true,
               text: '',
             },
             labels: ['SVGtext'],

--- a/Sources/Widgets/Widgets3D/EllipseWidget/index.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/index.js
@@ -44,7 +44,13 @@ function vtkEllipseWidget(publicAPI, model) {
       case ViewTypes.VOLUME:
       default:
         return [
-          { builder: vtkSphereHandleRepresentation, labels: ['moveHandle'] },
+          {
+            builder: vtkSphereHandleRepresentation,
+            labels: ['moveHandle'],
+            initialValues: {
+              scaleInPixels: true,
+            },
+          },
           {
             builder: vtkCircleContextRepresentation,
             labels: ['ellipseHandle'],

--- a/Sources/Widgets/Widgets3D/EllipseWidget/state.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/state.js
@@ -1,8 +1,5 @@
 import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
-import {
-  HorizontalTextPosition,
-  VerticalTextPosition,
-} from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
+import { TextPosition } from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
 
 export default function generateState() {
   return (
@@ -52,13 +49,16 @@ export default function generateState() {
       })
       // FIXME: to move in text handle sub state
       .addField({
-        name: 'horizontalTextPosition',
-        initialValue: HorizontalTextPosition.MIDDLE,
+        name: 'textPosition',
+        initialValue: [
+          TextPosition.CENTER,
+          TextPosition.CENTER,
+          TextPosition.CENTER,
+        ],
       })
-      // FIXME: to move in text handle sub state
       .addField({
-        name: 'verticalTextPosition',
-        initialValue: VerticalTextPosition.MIDDLE,
+        name: 'textWorldMargin',
+        initialValue: 0,
       })
       .build()
   );

--- a/Sources/Widgets/Widgets3D/EllipseWidget/state.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/state.js
@@ -1,36 +1,65 @@
 import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+import {
+  HorizontalTextPosition,
+  VerticalTextPosition,
+} from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
 
 export default function generateState() {
-  return vtkStateBuilder
-    .createBuilder()
-    .addStateFromMixin({
-      labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
-      name: 'point1Handle',
-      initialValues: {
-        scale1: 10,
-        origin: [0, 0, 0],
-        visible: false,
-      },
-    })
-    .addStateFromMixin({
-      labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
-      name: 'point2Handle',
-      initialValues: {
-        scale1: 10,
-        origin: [0, 0, 0],
-        visible: false,
-      },
-    })
-    .addStateFromMixin({
-      labels: ['ellipseHandle'],
-      mixins: ['origin', 'color', 'scale3', 'visible', 'orientation'],
-      name: 'ellipseHandle',
-      initialValues: {
-        visible: false,
-        scale3: [1, 1, 1],
-      },
-    })
-    .build();
+  return (
+    vtkStateBuilder
+      .createBuilder()
+      .addStateFromMixin({
+        labels: ['moveHandle'],
+        mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
+        name: 'point1Handle',
+        initialValues: {
+          scale1: 10,
+          origin: [undefined, undefined, undefined],
+          visible: false,
+        },
+      })
+      .addStateFromMixin({
+        labels: ['moveHandle'],
+        mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
+        name: 'point2Handle',
+        initialValues: {
+          scale1: 10,
+          origin: [undefined, undefined, undefined],
+          visible: false,
+        },
+      })
+      .addStateFromMixin({
+        labels: ['ellipseHandle'],
+        mixins: ['origin', 'color', 'scale3', 'visible', 'orientation'],
+        name: 'ellipseHandle',
+        initialValues: {
+          visible: false,
+          scale3: [1, 1, 1],
+        },
+      })
+      // FIXME: How to not duplicate with RectangleWidget
+      .addStateFromMixin({
+        labels: ['SVGtext'],
+        mixins: ['origin', 'color', 'text', 'visible'],
+        name: 'text',
+        initialValues: {
+          /* text is empty to set a text filed in the SVGLayer and to avoid
+           * displaying text before positioning the handles */
+          text: '',
+          visible: false,
+          origin: [0, 0, 0],
+        },
+      })
+      // FIXME: to move in text handle sub state
+      .addField({
+        name: 'horizontalTextPosition',
+        initialValue: HorizontalTextPosition.MIDDLE,
+      })
+      // FIXME: to move in text handle sub state
+      .addField({
+        name: 'verticalTextPosition',
+        initialValue: VerticalTextPosition.MIDDLE,
+      })
+      .build()
+  );
 }

--- a/Sources/Widgets/Widgets3D/LineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/index.js
@@ -129,6 +129,10 @@ function vtkLineWidget(publicAPI, model) {
               isVisible: false,
               offsetText: true,
               text: '',
+              textProps: {
+                dx: 12,
+                dy: -12,
+              },
             },
             labels: ['SVGtext'],
           },

--- a/Sources/Widgets/Widgets3D/LineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/index.js
@@ -127,7 +127,6 @@ function vtkLineWidget(publicAPI, model) {
             initialValues: {
               showCircle: false,
               isVisible: false,
-              offsetText: true,
               text: '',
               textProps: {
                 dx: 12,

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -1,0 +1,112 @@
+import macro from 'vtk.js/Sources/macros';
+import { vec3 } from 'gl-matrix';
+
+export default function widgetBehavior(publicAPI, model) {
+  publicAPI.handleLeftButtonPress = (callData) => {
+    if (!model.activeState || !model.activeState.getActive()) {
+      return macro.VOID;
+    }
+
+    model.painting = true;
+    const trailCircle = model.widgetState.addTrail();
+    trailCircle.set(
+      model.activeState.get('origin', 'up', 'right', 'direction', 'scale1')
+    );
+    publicAPI.invokeStartInteractionEvent();
+    return macro.EVENT_ABORT;
+  };
+
+  publicAPI.handleMouseMove = (callData) => publicAPI.handleEvent(callData);
+
+  publicAPI.handleLeftButtonRelease = () => {
+    if (model.painting) {
+      publicAPI.invokeEndInteractionEvent();
+      model.widgetState.clearTrailList();
+    }
+    model.painting = false;
+    return model.hasFocus ? macro.EVENT_ABORT : macro.VOID;
+  };
+
+  publicAPI.handleEvent = (callData) => {
+    if (
+      model.manipulator &&
+      model.activeState &&
+      model.activeState.getActive()
+    ) {
+      const normal = model.camera.getDirectionOfProjection();
+      const up = model.camera.getViewUp();
+      const right = [];
+      vec3.cross(right, up, normal);
+      model.activeState.setUp(...up);
+      model.activeState.setRight(...right);
+      model.activeState.setDirection(...normal);
+      model.manipulator.setNormal(normal);
+
+      const worldCoords = model.manipulator.handleEvent(
+        callData,
+        model.apiSpecificRenderWindow
+      );
+
+      if (worldCoords.length) {
+        model.widgetState.setTrueOrigin(...worldCoords);
+        model.activeState.setOrigin(...worldCoords);
+
+        if (model.painting) {
+          const trailCircle = model.widgetState.addTrail();
+          trailCircle.set(
+            model.activeState.get(
+              'origin',
+              'up',
+              'right',
+              'direction',
+              'scale1'
+            )
+          );
+        }
+      }
+
+      publicAPI.invokeInteractionEvent();
+      return macro.EVENT_ABORT;
+    }
+    return macro.VOID;
+  };
+
+  publicAPI.grabFocus = () => {
+    if (!model.hasFocus) {
+      model.activeState = model.widgetState.getHandle();
+      model.activeState.activate();
+      model.interactor.requestAnimation(publicAPI);
+
+      const canvas = model.apiSpecificRenderWindow.getCanvas();
+      canvas.onmouseenter = () => {
+        if (
+          model.hasFocus &&
+          model.activeState === model.widgetState.getHandle()
+        ) {
+          model.activeState.setVisible(true);
+        }
+      };
+      canvas.onmouseleave = () => {
+        if (
+          model.hasFocus &&
+          model.activeState === model.widgetState.getHandle()
+        ) {
+          model.activeState.setVisible(false);
+        }
+      };
+    }
+    model.hasFocus = true;
+  };
+
+  publicAPI.loseFocus = () => {
+    if (model.hasFocus) {
+      model.interactor.cancelAnimation(publicAPI);
+    }
+    model.widgetState.deactivate();
+    model.widgetState.getHandle().deactivate();
+    model.activeState = null;
+    model.hasFocus = false;
+  };
+
+  macro.get(publicAPI, model, ['painting']);
+}

--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -18,6 +18,9 @@ import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransfe
 import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 
+// Force the loading of HttpDataAccessHelper to support gzip decompression
+import 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+
 import {
   BehaviorCategory,
   ShapeBehavior,

--- a/Sources/Widgets/Widgets3D/PaintWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/index.js
@@ -3,125 +3,11 @@ import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidget
 import vtkCircleContextRepresentation from 'vtk.js/Sources/Widgets/Representations/CircleContextRepresentation';
 import vtkPlaneManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
 import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
-import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+
+import widgetBehavior from 'vtk.js/Sources/Widgets/Widgets3D/PaintWidget/behavior';
+import stateGenerator from 'vtk.js/Sources/Widgets/Widgets3D/PaintWidget/state';
 
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
-
-import { vec3 } from 'gl-matrix';
-
-// ----------------------------------------------------------------------------
-// Widget linked to a view
-// ----------------------------------------------------------------------------
-
-function widgetBehavior(publicAPI, model) {
-  publicAPI.handleLeftButtonPress = (callData) => {
-    if (!model.activeState || !model.activeState.getActive()) {
-      return macro.VOID;
-    }
-
-    model.painting = true;
-    const trailCircle = model.widgetState.addTrail();
-    trailCircle.set(
-      model.activeState.get('origin', 'up', 'right', 'direction', 'scale1')
-    );
-    publicAPI.invokeStartInteractionEvent();
-    return macro.EVENT_ABORT;
-  };
-
-  publicAPI.handleMouseMove = (callData) => publicAPI.handleEvent(callData);
-
-  publicAPI.handleLeftButtonRelease = () => {
-    if (model.painting) {
-      publicAPI.invokeEndInteractionEvent();
-      model.widgetState.clearTrailList();
-    }
-    model.painting = false;
-    return model.hasFocus ? macro.EVENT_ABORT : macro.VOID;
-  };
-
-  publicAPI.handleEvent = (callData) => {
-    if (
-      model.manipulator &&
-      model.activeState &&
-      model.activeState.getActive()
-    ) {
-      const normal = model.camera.getDirectionOfProjection();
-      const up = model.camera.getViewUp();
-      const right = [];
-      vec3.cross(right, up, normal);
-      model.activeState.setUp(...up);
-      model.activeState.setRight(...right);
-      model.activeState.setDirection(...normal);
-      model.manipulator.setNormal(normal);
-
-      const worldCoords = model.manipulator.handleEvent(
-        callData,
-        model.apiSpecificRenderWindow
-      );
-
-      if (worldCoords.length) {
-        model.widgetState.setTrueOrigin(...worldCoords);
-        model.activeState.setOrigin(...worldCoords);
-
-        if (model.painting) {
-          const trailCircle = model.widgetState.addTrail();
-          trailCircle.set(
-            model.activeState.get(
-              'origin',
-              'up',
-              'right',
-              'direction',
-              'scale1'
-            )
-          );
-        }
-      }
-
-      publicAPI.invokeInteractionEvent();
-      return macro.EVENT_ABORT;
-    }
-    return macro.VOID;
-  };
-
-  publicAPI.grabFocus = () => {
-    if (!model.hasFocus) {
-      model.activeState = model.widgetState.getHandle();
-      model.activeState.activate();
-      model.interactor.requestAnimation(publicAPI);
-
-      const canvas = model.apiSpecificRenderWindow.getCanvas();
-      canvas.onmouseenter = () => {
-        if (
-          model.hasFocus &&
-          model.activeState === model.widgetState.getHandle()
-        ) {
-          model.activeState.setVisible(true);
-        }
-      };
-      canvas.onmouseleave = () => {
-        if (
-          model.hasFocus &&
-          model.activeState === model.widgetState.getHandle()
-        ) {
-          model.activeState.setVisible(false);
-        }
-      };
-    }
-    model.hasFocus = true;
-  };
-
-  publicAPI.loseFocus = () => {
-    if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
-    }
-    model.widgetState.deactivate();
-    model.widgetState.getHandle().deactivate();
-    model.activeState = null;
-    model.hasFocus = false;
-  };
-
-  macro.get(publicAPI, model, ['painting']);
-}
 
 // ----------------------------------------------------------------------------
 // Factory
@@ -132,6 +18,7 @@ function vtkPaintWidget(publicAPI, model) {
 
   // --- Widget Requirement ---------------------------------------------------
   model.behavior = widgetBehavior;
+  model.widgetState = stateGenerator(model.radius);
 
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
@@ -150,43 +37,6 @@ function vtkPaintWidget(publicAPI, model) {
     }
   };
   // --- Widget Requirement ---------------------------------------------------
-
-  // Default state
-  model.widgetState = vtkStateBuilder
-    .createBuilder()
-    .addField({
-      name: 'trueOrigin',
-      initialValue: [0, 0, 0],
-    })
-    .addStateFromMixin({
-      labels: ['handle'],
-      mixins: [
-        'origin',
-        'color',
-        'scale1',
-        'orientation',
-        'manipulator',
-        'visible',
-      ],
-      name: 'handle',
-      initialValues: {
-        scale1: model.radius * 2,
-        origin: [0, 0, 0],
-        orientation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
-        visible: true,
-      },
-    })
-    .addDynamicMixinState({
-      labels: ['trail'],
-      mixins: ['origin', 'color', 'scale1', 'orientation'],
-      name: 'trail',
-      initialValues: {
-        scale1: model.radius * 2,
-        origin: [0, 0, 0],
-        orientation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
-      },
-    })
-    .build();
 
   const handle = model.widgetState.getHandle();
 

--- a/Sources/Widgets/Widgets3D/PaintWidget/state.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/state.js
@@ -1,0 +1,39 @@
+import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+
+export default function generateState(radius) {
+  return vtkStateBuilder
+    .createBuilder()
+    .addField({
+      name: 'trueOrigin',
+      initialValue: [0, 0, 0],
+    })
+    .addStateFromMixin({
+      labels: ['handle'],
+      mixins: [
+        'origin',
+        'color',
+        'scale1',
+        'orientation',
+        'manipulator',
+        'visible',
+      ],
+      name: 'handle',
+      initialValues: {
+        scale1: radius * 2,
+        origin: [0, 0, 0],
+        orientation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+        visible: true,
+      },
+    })
+    .addDynamicMixinState({
+      labels: ['trail'],
+      mixins: ['origin', 'color', 'scale1', 'orientation'],
+      name: 'trail',
+      initialValues: {
+        scale1: radius * 2,
+        origin: [0, 0, 0],
+        orientation: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+      },
+    })
+    .build();
+}

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
@@ -54,7 +54,16 @@ function vtkPolyLineWidget(publicAPI, model) {
               scaleInPixels: true,
             },
           },
-          { builder: vtkSVGLandmarkRepresentation, labels: ['handles'] },
+          {
+            builder: vtkSVGLandmarkRepresentation,
+            initialValues: {
+              textProps: {
+                dx: 12,
+                dy: -12,
+              },
+            },
+            labels: ['handles'],
+          },
           {
             builder: vtkPolyLineRepresentation,
             labels: ['handles', 'moveHandle'],

--- a/Sources/Widgets/Widgets3D/RectangleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/behavior.js
@@ -1,6 +1,12 @@
 import shapeBehavior from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/behavior';
 
 export default function widgetBehavior(publicAPI, model) {
+  model.shapeHandle = model.widgetState.getRectangleHandle();
+  model.point1Handle = model.widgetState.getPoint1Handle();
+  model.point2Handle = model.widgetState.getPoint2Handle();
+  model.point1Handle.setManipulator(model.manipulator);
+  model.point2Handle.setManipulator(model.manipulator);
+
   // We inherit shapeBehavior
   shapeBehavior(publicAPI, model);
   const superClass = { ...publicAPI };

--- a/Sources/Widgets/Widgets3D/RectangleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/index.js
@@ -1,12 +1,11 @@
 import macro from 'vtk.js/Sources/macros';
-import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidgetFactory';
 import vtkPlanePointManipulator from 'vtk.js/Sources/Widgets/Manipulators/PlaneManipulator';
+import vtkShapeWidget from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget';
 import vtkSphereHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/SphereHandleRepresentation';
 import vtkRectangleContextRepresentation from 'vtk.js/Sources/Widgets/Representations/RectangleContextRepresentation';
+import vtkSVGLandmarkRepresentation from 'vtk.js/Sources/Widgets/SVG/SVGLandmarkRepresentation';
 import widgetBehavior from 'vtk.js/Sources/Widgets/Widgets3D/RectangleWidget/behavior';
 import stateGenerator from 'vtk.js/Sources/Widgets/Widgets3D/RectangleWidget/state';
-
-import SHAPE_DEFAULT_VALUES from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget';
 
 import {
   BehaviorCategory,
@@ -23,6 +22,7 @@ function vtkRectangleWidget(publicAPI, model) {
   model.classHierarchy.push('vtkRectangleWidget');
 
   model.methodsToLink = [
+    ...model.methodsToLink,
     'activeScaleFactor',
     'activeColor',
     'useActiveColor',
@@ -47,6 +47,15 @@ function vtkRectangleWidget(publicAPI, model) {
             builder: vtkRectangleContextRepresentation,
             labels: ['rectangleHandle'],
           },
+          {
+            builder: vtkSVGLandmarkRepresentation,
+            initialValues: {
+              showCircle: false,
+              offsetText: true,
+              text: '',
+            },
+            labels: ['SVGtext'],
+          },
         ];
     }
   };
@@ -58,44 +67,36 @@ function vtkRectangleWidget(publicAPI, model) {
   // Default manipulator
   model.manipulator = vtkPlanePointManipulator.newInstance();
   model.widgetState = stateGenerator();
-  model.shapeHandle = model.widgetState.getRectangleHandle();
-  model.point1Handle = model.widgetState.getPoint1Handle();
-  model.point2Handle = model.widgetState.getPoint2Handle();
-  model.point1Handle.setManipulator(model.manipulator);
-  model.point2Handle.setManipulator(model.manipulator);
 }
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
-  modifierBehavior: {
-    None: {
-      [BehaviorCategory.PLACEMENT]:
-        ShapeBehavior[BehaviorCategory.PLACEMENT].CLICK_AND_DRAG,
-      [BehaviorCategory.POINTS]:
-        ShapeBehavior[BehaviorCategory.POINTS].CORNER_TO_CORNER,
-      [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
+function defaultValues(initalValues) {
+  return {
+    modifierBehavior: {
+      None: {
+        [BehaviorCategory.PLACEMENT]:
+          ShapeBehavior[BehaviorCategory.PLACEMENT].CLICK_AND_DRAG,
+        [BehaviorCategory.POINTS]:
+          ShapeBehavior[BehaviorCategory.POINTS].CORNER_TO_CORNER,
+        [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
+      },
+      Shift: {
+        [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FIXED,
+      },
+      Control: {
+        [BehaviorCategory.POINTS]:
+          ShapeBehavior[BehaviorCategory.POINTS].CENTER_TO_CORNER,
+      },
     },
-    Shift: {
-      [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FIXED,
-    },
-    Control: {
-      [BehaviorCategory.POINTS]:
-        ShapeBehavior[BehaviorCategory.POINTS].CENTER_TO_CORNER,
-    },
-  },
-};
+    ...initalValues,
+  };
+}
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(
-    model,
-    { ...SHAPE_DEFAULT_VALUES.DEFAULT_VALUES, ...DEFAULT_VALUES },
-    initialValues
-  );
-
-  vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
+  vtkShapeWidget.extend(publicAPI, model, defaultValues(initialValues));
   macro.setGet(publicAPI, model, ['manipulator', 'widgetState']);
 
   vtkRectangleWidget(publicAPI, model);

--- a/Sources/Widgets/Widgets3D/RectangleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/index.js
@@ -51,7 +51,6 @@ function vtkRectangleWidget(publicAPI, model) {
             builder: vtkSVGLandmarkRepresentation,
             initialValues: {
               showCircle: false,
-              offsetText: true,
               text: '',
             },
             labels: ['SVGtext'],

--- a/Sources/Widgets/Widgets3D/RectangleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/index.js
@@ -42,7 +42,13 @@ function vtkRectangleWidget(publicAPI, model) {
       case ViewTypes.VOLUME:
       default:
         return [
-          { builder: vtkSphereHandleRepresentation, labels: ['moveHandle'] },
+          {
+            builder: vtkSphereHandleRepresentation,
+            labels: ['moveHandle'],
+            initialValues: {
+              scaleInPixels: true,
+            },
+          },
           {
             builder: vtkRectangleContextRepresentation,
             labels: ['rectangleHandle'],

--- a/Sources/Widgets/Widgets3D/RectangleWidget/state.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/state.js
@@ -1,8 +1,5 @@
 import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
-import {
-  HorizontalTextPosition,
-  VerticalTextPosition,
-} from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
+import { TextPosition } from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
 
 export default function generateState() {
   return (
@@ -51,13 +48,16 @@ export default function generateState() {
       })
       // FIXME: to move in text handle sub state
       .addField({
-        name: 'horizontalTextPosition',
-        initialValue: HorizontalTextPosition.MIDDLE,
+        name: 'textPosition',
+        initialValue: [
+          TextPosition.CENTER,
+          TextPosition.CENTER,
+          TextPosition.CENTER,
+        ],
       })
-      // FIXME: to move in text handle sub state
       .addField({
-        name: 'verticalTextPosition',
-        initialValue: VerticalTextPosition.MIDDLE,
+        name: 'textWorldMargin',
+        initialValue: 0,
       })
       .build()
   );

--- a/Sources/Widgets/Widgets3D/RectangleWidget/state.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/state.js
@@ -1,35 +1,64 @@
 import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
+import {
+  HorizontalTextPosition,
+  VerticalTextPosition,
+} from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
 
 export default function generateState() {
-  return vtkStateBuilder
-    .createBuilder()
-    .addStateFromMixin({
-      labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
-      name: 'point1Handle',
-      initialValues: {
-        scale1: 10,
-        origin: [1, 0, 0],
-        visible: false,
-      },
-    })
-    .addStateFromMixin({
-      labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
-      name: 'point2Handle',
-      initialValues: {
-        scale1: 10,
-        origin: [1, 0, 0],
-        visible: false,
-      },
-    })
-    .addStateFromMixin({
-      labels: ['rectangleHandle'],
-      mixins: ['origin', 'corner', 'color', 'visible', 'orientation'],
-      name: 'rectangleHandle',
-      initialValues: {
-        visible: false,
-      },
-    })
-    .build();
+  return (
+    vtkStateBuilder
+      .createBuilder()
+      .addStateFromMixin({
+        labels: ['moveHandle'],
+        mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
+        name: 'point1Handle',
+        initialValues: {
+          scale1: 10,
+          origin: [undefined, undefined, undefined],
+          visible: false,
+        },
+      })
+      .addStateFromMixin({
+        labels: ['moveHandle'],
+        mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
+        name: 'point2Handle',
+        initialValues: {
+          scale1: 10,
+          origin: [undefined, undefined, undefined],
+          visible: false,
+        },
+      })
+      .addStateFromMixin({
+        labels: ['rectangleHandle'],
+        mixins: ['origin', 'corner', 'color', 'visible', 'orientation'],
+        name: 'rectangleHandle',
+        initialValues: {
+          visible: false,
+        },
+      })
+      // FIXME: How to not duplicate with EllipseWidget
+      .addStateFromMixin({
+        labels: ['SVGtext'],
+        mixins: ['origin', 'color', 'text', 'visible'],
+        name: 'text',
+        initialValues: {
+          /* text is empty to set a text filed in the SVGLayer and to avoid
+           * displaying text before positioning the handles */
+          text: '',
+          visible: false,
+          origin: [0, 0, 0],
+        },
+      })
+      // FIXME: to move in text handle sub state
+      .addField({
+        name: 'horizontalTextPosition',
+        initialValue: HorizontalTextPosition.MIDDLE,
+      })
+      // FIXME: to move in text handle sub state
+      .addField({
+        name: 'verticalTextPosition',
+        initialValue: VerticalTextPosition.MIDDLE,
+      })
+      .build()
+  );
 }

--- a/Sources/Widgets/Widgets3D/ShapeWidget/Constants.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/Constants.js
@@ -22,73 +22,10 @@ export const ShapeBehavior = {
   },
 };
 
-export const HorizontalTextPosition = {
-  OUTSIDE_LEFT: 'OUSIDE_LEFT',
-  INSIDE_LEFT: 'INSIDE_LEFT',
-  OUTSIDE_RIGHT: 'OUSIDE_RIGHT',
-  INSIDE_RIGHT: 'INSIDE_RIGHT',
-  MIDDLE: 'MIDDLE',
+export const TextPosition = {
+  MIN: 'MIN',
+  CENTER: 'CENTER',
+  MAX: 'MAX',
 };
-
-export const VerticalTextPosition = {
-  OUTSIDE_TOP: 'OUSIDE_TOP',
-  INSIDE_TOP: 'INSIDE_TOP',
-  OUTSIDE_BOTTOM: 'OUSIDE_BOTTOM',
-  INSIDE_BOTTOM: 'INSIDE_BOTTOM',
-  MIDDLE: 'MIDDLE',
-};
-
-export function computeTextPosition(
-  bounds,
-  horizontalPosition,
-  verticalPosition,
-  textWidth,
-  textHeight,
-  margin = 0
-) {
-  let x = 0;
-  switch (horizontalPosition) {
-    case HorizontalTextPosition.OUTSIDE_LEFT:
-      x = bounds[0] - textWidth - margin;
-      break;
-    case HorizontalTextPosition.INSIDE_LEFT:
-      x = bounds[0] + margin;
-      break;
-    case HorizontalTextPosition.MIDDLE:
-      x = 0.5 * (bounds[0] + bounds[1] - textWidth);
-      break;
-    case HorizontalTextPosition.INSIDE_RIGHT:
-      x = bounds[1] - textWidth - margin;
-      break;
-    case HorizontalTextPosition.OUTSIDE_RIGHT:
-      x = bounds[1] + margin;
-      break;
-    default:
-      break;
-  }
-
-  let y = 0;
-  switch (verticalPosition) {
-    case VerticalTextPosition.OUTSIDE_TOP:
-      y = bounds[3] + textHeight + margin;
-      break;
-    case VerticalTextPosition.INSIDE_TOP:
-      y = bounds[3] - margin;
-      break;
-    case VerticalTextPosition.MIDDLE:
-      y = 0.5 * (bounds[2] + bounds[3] + textWidth);
-      break;
-    case VerticalTextPosition.INSIDE_BOTTOM:
-      y = bounds[2] + textHeight + margin;
-      break;
-    case VerticalTextPosition.OUTSIDE_BOTTOM:
-      y = bounds[2] - margin;
-      break;
-    default:
-      break;
-  }
-
-  return [x, y, 0];
-}
 
 export default ShapeBehavior;

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -3,6 +3,9 @@ import 'vtk.js/Sources/favicon';
 // Load the rendering pieces we want to use (for both WebGL and WebGPU)
 import 'vtk.js/Sources/Rendering/Profiles/All';
 
+// Force the loading of HttpDataAccessHelper to support gzip decompression
+import 'vtk.js/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+
 import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
 import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
 import vtkRectangleWidget from 'vtk.js/Sources/Widgets/Widgets3D/RectangleWidget';
@@ -12,19 +15,12 @@ import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';
 import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
 import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
 import vtkSphere from 'vtk.js/Sources/Common/DataModel/Sphere';
-import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 
 import {
   BehaviorCategory,
-  ShapeBehavior,
   HorizontalTextPosition,
-  VerticalTextPosition,
-  computeTextPosition,
+  ShapeBehavior,
 } from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
-import {
-  TextAlign,
-  VerticalAlign,
-} from 'vtk.js/Sources/Interaction/Widgets/LabelRepresentation/Constants';
 
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
@@ -78,8 +74,7 @@ scene.widgetManager.setRenderer(scene.renderer);
 // Widgets
 const widgets = {};
 widgets.rectangleWidget = vtkRectangleWidget.newInstance({
-  resetAfterPointPlacement: false,
-  useHandles: true,
+  resetAfterPointPlacement: true,
 });
 widgets.ellipseWidget = vtkEllipseWidget.newInstance({
   modifierBehavior: {
@@ -91,8 +86,6 @@ widgets.ellipseWidget = vtkEllipseWidget.newInstance({
       [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
     },
   },
-  resetAfterPointPlacement: false,
-  useHandles: true,
 });
 widgets.circleWidget = vtkEllipseWidget.newInstance({
   modifierBehavior: {
@@ -103,22 +96,39 @@ widgets.circleWidget = vtkEllipseWidget.newInstance({
       [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
     },
   },
-  resetAfterPointPlacement: false,
-  useHandles: true,
 });
+// Make a large handle for demo purpose
+widgets.circleWidget.getWidgetState().getPoint1Handle().setScale1(20);
+widgets.circleWidget
+  .getWidgetState()
+  .setHorizontalTextPosition(HorizontalTextPosition.OUTSIDE_RIGHT);
 
 scene.rectangleHandle = scene.widgetManager.addWidget(
   widgets.rectangleWidget,
   ViewTypes.SLICE
 );
+scene.rectangleHandle.setHandleVisibility(false);
+scene.rectangleHandle.setTextProps({
+  ...scene.rectangleHandle.getTextProps(),
+  'text-anchor': 'middle',
+  'alignment-baseline': 'middle',
+});
+
 scene.ellipseHandle = scene.widgetManager.addWidget(
   widgets.ellipseWidget,
   ViewTypes.SLICE
 );
+scene.ellipseHandle.setTextProps({
+  ...scene.ellipseHandle.getTextProps(),
+  'text-anchor': 'middle',
+  'alignment-baseline': 'middle',
+});
+
 scene.circleHandle = scene.widgetManager.addWidget(
   widgets.circleWidget,
   ViewTypes.SLICE
 );
+scene.circleHandle.setGlyphResolution(64);
 
 scene.widgetManager.grabFocus(widgets.ellipseWidget);
 let activeWidget = 'ellipseWidget';
@@ -148,6 +158,20 @@ function updateControlPanel(im, ds) {
   document
     .querySelector('.slice')
     .setAttribute('max', extent[slicingMode * 2 + 1]);
+}
+
+function updateWidgetVisibility(widget, slicePos, i, widgetIndex) {
+  /* testing if the widget is on the slice and has been placed to modify visibility */
+  const widgetVisibility =
+    !scene.widgetManager.getWidgets()[widgetIndex].getPoint1() ||
+    widget.getWidgetState().getPoint1Handle().getOrigin()[i] === slicePos[i];
+  return widget.setVisibility(widgetVisibility);
+}
+
+function updateWidgetsVisibility(slicePos, slicingMode) {
+  updateWidgetVisibility(widgets.rectangleWidget, slicePos, slicingMode, 0);
+  updateWidgetVisibility(widgets.ellipseWidget, slicePos, slicingMode, 1);
+  updateWidgetVisibility(widgets.circleWidget, slicePos, slicingMode, 2);
 }
 
 // ----------------------------------------------------------------------------
@@ -194,128 +218,67 @@ reader
     scene.ellipseHandle.getRepresentations()[1].setDrawFace(false);
     scene.ellipseHandle.getRepresentations()[1].setOpacity(1);
 
-    scene.rectangleHandle.updateHandlesSize();
-    scene.circleHandle.updateHandlesSize();
-    scene.ellipseHandle.updateHandlesSize();
-
     // set text display callback
-    scene.ellipseHandle.setLabelTextCallback(
-      (worldBounds, screenBounds, labelRep) => {
-        const { average, minimum, maximum } = image.data.computeHistogram(
-          worldBounds,
-          vtkSphere.isPointIn3DEllipse
-        );
+    scene.ellipseHandle.onInteractionEvent(() => {
+      const worldBounds = scene.ellipseHandle.getBounds();
+      const { average, minimum, maximum } = image.data.computeHistogram(
+        worldBounds,
+        vtkSphere.isPointIn3DEllipse
+      );
 
-        const text = `average: ${average.toFixed(
-          0
-        )} \nmin: ${minimum} \nmax: ${maximum} `;
+      const text = `average: ${average.toFixed(
+        0
+      )} \nmin: ${minimum} \nmax: ${maximum} `;
 
-        const { width, height } = labelRep.computeTextDimensions(text);
-        labelRep.setDisplayPosition(
-          computeTextPosition(
-            screenBounds,
-            HorizontalTextPosition.OUTSIDE_RIGHT,
-            VerticalTextPosition.INSIDE_TOP,
-            width,
-            height
-          )
-        );
+      widgets.ellipseWidget.getWidgetState().getText().setText(text);
+    });
 
-        labelRep.setLabelText(text);
-      }
-    );
+    scene.circleHandle.onInteractionEvent(() => {
+      const worldBounds = scene.circleHandle.getBounds();
 
-    scene.circleHandle.setLabelTextCallback(
-      (worldBounds, screenBounds, labelRep) => {
-        const center = vtkBoundingBox.getCenter(screenBounds);
-        const radius =
-          vec3.distance(center, [
-            screenBounds[0],
-            screenBounds[2],
-            screenBounds[4],
-          ]) / 2;
+      const text = `radius: ${(
+        vec3.distance(
+          [worldBounds[0], worldBounds[2], worldBounds[4]],
+          [worldBounds[1], worldBounds[3], worldBounds[5]]
+        ) / 2
+      ).toFixed(2)}`;
+      widgets.circleWidget.getWidgetState().getText().setText(text);
+    });
 
-        const position = [0, 0, 0];
-        vec3.scaleAndAdd(position, center, [1, 1, 1], radius);
-        labelRep.setDisplayPosition(position);
+    scene.rectangleHandle.onInteractionEvent(() => {
+      const worldBounds = scene.rectangleHandle.getBounds();
 
-        labelRep.setLabelText(
-          `radius: ${(
-            vec3.distance(
-              [worldBounds[0], worldBounds[2], worldBounds[4]],
-              [worldBounds[1], worldBounds[3], worldBounds[5]]
-            ) / 2
-          ).toFixed(2)}`
-        );
+      const dx = Math.abs(worldBounds[0] - worldBounds[1]);
+      const dy = Math.abs(worldBounds[2] - worldBounds[3]);
+      const dz = Math.abs(worldBounds[4] - worldBounds[5]);
 
-        labelRep.setTextAlign(TextAlign.CENTER);
-        labelRep.setVerticalAlign(VerticalAlign.CENTER);
-      }
-    );
+      const perimeter = 2 * (dx + dy + dz);
+      const area = dx * dy + dy * dz + dz * dx;
 
-    scene.rectangleHandle.setLabelTextCallback(
-      (worldBounds, screenBounds, labelRep) => {
-        const dx = Math.abs(worldBounds[0] - worldBounds[1]);
-        const dy = Math.abs(worldBounds[2] - worldBounds[3]);
-        const dz = Math.abs(worldBounds[4] - worldBounds[5]);
-
-        const perimeter = 2 * (dx + dy + dz);
-        const area = dx * dy + dy * dz + dz * dx;
-
-        const text = `perimeter: ${perimeter.toFixed(
-          1
-        )}mm\narea: ${area.toFixed(1)}mm²`;
-
-        const { width, height } = labelRep.computeTextDimensions(text);
-        labelRep.setDisplayPosition(
-          computeTextPosition(
-            screenBounds,
-            HorizontalTextPosition.OUTSIDE_RIGHT,
-            VerticalTextPosition.INSIDE_TOP,
-            width,
-            height
-          )
-        );
-
-        labelRep.setTextAlign(TextAlign.RIGHT);
-      }
-    );
-
-    const updateWidgetVisibility = (widget, slicePos, i, widgetIndex) => {
-      /* testing if the widget is on the slice and has been placed to modify visibility */
-      const widgetVisibility =
-        widget.getWidgetState().getPoint1Handle().getOrigin()[i] ===
-          slicePos[i] ||
-        !scene.widgetManager.getWidgets()[widgetIndex].getPoint1();
-      return widget.setVisibility(widgetVisibility);
-    };
-
-    const updateWidgetsVisibility = (position, slicingMode) => {
-      updateWidgetVisibility(widgets.rectangleWidget, position, slicingMode, 0);
-      updateWidgetVisibility(widgets.ellipseWidget, position, slicingMode, 1);
-      updateWidgetVisibility(widgets.circleWidget, position, slicingMode, 2);
-    };
+      const text = `perimeter: ${perimeter.toFixed(1)}mm\narea: ${area.toFixed(
+        1
+      )}mm²`;
+      widgets.rectangleWidget.getWidgetState().getText().setText(text);
+    });
 
     const update = () => {
       const slicingMode = image.imageMapper.getSlicingMode() % 3;
 
       if (slicingMode > -1) {
         const ijk = [0, 0, 0];
-        const position = [0, 0, 0];
+        const slicePos = [0, 0, 0];
 
         // position
         ijk[slicingMode] = image.imageMapper.getSlice();
-        data.indexToWorld(ijk, position);
+        data.indexToWorld(ijk, slicePos);
 
-        widgets.rectangleWidget.getManipulator().setOrigin(position);
-        widgets.ellipseWidget.getManipulator().setOrigin(position);
-        widgets.circleWidget.getManipulator().setOrigin(position);
+        widgets.rectangleWidget.getManipulator().setOrigin(slicePos);
+        widgets.ellipseWidget.getManipulator().setOrigin(slicePos);
+        widgets.circleWidget.getManipulator().setOrigin(slicePos);
 
-        updateWidgetsVisibility(position, slicingMode);
+        updateWidgetsVisibility(slicePos, slicingMode);
 
-        scene.rectangleHandle.updateRepresentationForRender();
-        scene.ellipseHandle.updateRepresentationForRender();
-        scene.circleHandle.updateRepresentationForRender();
+        scene.renderWindow.render();
 
         // update UI
         document
@@ -342,7 +305,8 @@ function resetWidgets() {
   scene.rectangleHandle.reset();
   scene.ellipseHandle.reset();
   scene.circleHandle.reset();
-  widgets[activeWidget].setVisibility(true);
+  const slicingMode = image.imageMapper.getSlicingMode() % 3;
+  updateWidgetsVisibility(null, slicingMode);
   scene.widgetManager.grabFocus(widgets[activeWidget]);
 }
 
@@ -360,8 +324,16 @@ document.querySelector('.axis').addEventListener('input', (ev) => {
 });
 
 document.querySelector('.widget').addEventListener('input', (ev) => {
+  // For demo purpose, hide ellipse handles when the widget loses focus
+  if (activeWidget === 'ellipseWidget') {
+    widgets.ellipseWidget.setHandleVisibility(false);
+  }
   scene.widgetManager.grabFocus(widgets[ev.target.value]);
   activeWidget = ev.target.value;
+  if (activeWidget === 'ellipseWidget') {
+    widgets.ellipseWidget.setHandleVisibility(true);
+    scene.ellipseHandle.updateRepresentationForRender();
+  }
 });
 
 document.querySelector('.reset').addEventListener('click', () => {

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -18,9 +18,11 @@ import vtkSphere from 'vtk.js/Sources/Common/DataModel/Sphere';
 
 import {
   BehaviorCategory,
-  HorizontalTextPosition,
   ShapeBehavior,
+  TextPosition,
 } from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
+
+import { VerticalTextAlignment } from 'vtk.js/Sources/Widgets/SVG/SVGLandmarkRepresentation/Constants';
 
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
@@ -57,10 +59,11 @@ function setCamera(sliceMode, renderer, data) {
   const ijk = [0, 0, 0];
   const position = [0, 0, 0];
   const focalPoint = [0, 0, 0];
+  const viewUp = sliceMode === 1 ? [0, 0, 1] : [0, 1, 0];
   data.indexToWorld(ijk, focalPoint);
   ijk[sliceMode] = 1;
   data.indexToWorld(ijk, position);
-  renderer.getActiveCamera().set({ focalPoint, position });
+  renderer.getActiveCamera().set({ focalPoint, position, viewUp });
   renderer.resetCamera();
 }
 
@@ -101,7 +104,11 @@ widgets.circleWidget = vtkEllipseWidget.newInstance({
 widgets.circleWidget.getWidgetState().getPoint1Handle().setScale1(20);
 widgets.circleWidget
   .getWidgetState()
-  .setHorizontalTextPosition(HorizontalTextPosition.OUTSIDE_RIGHT);
+  .setTextPosition([
+    TextPosition.MAX,
+    TextPosition.CENTER,
+    TextPosition.CENTER,
+  ]);
 
 scene.rectangleHandle = scene.widgetManager.addWidget(
   widgets.rectangleWidget,
@@ -111,8 +118,15 @@ scene.rectangleHandle.setHandleVisibility(false);
 scene.rectangleHandle.setTextProps({
   ...scene.rectangleHandle.getTextProps(),
   'text-anchor': 'middle',
-  'alignment-baseline': 'middle',
+  verticalAlign: VerticalTextAlignment.MIDDLE,
 });
+widgets.rectangleWidget
+  .getWidgetState()
+  .setTextPosition([
+    TextPosition.CENTER,
+    TextPosition.CENTER,
+    TextPosition.CENTER,
+  ]);
 
 scene.ellipseHandle = scene.widgetManager.addWidget(
   widgets.ellipseWidget,
@@ -121,7 +135,7 @@ scene.ellipseHandle = scene.widgetManager.addWidget(
 scene.ellipseHandle.setTextProps({
   ...scene.ellipseHandle.getTextProps(),
   'text-anchor': 'middle',
-  'alignment-baseline': 'middle',
+  verticalAlign: VerticalTextAlignment.MIDDLE,
 });
 
 scene.circleHandle = scene.widgetManager.addWidget(

--- a/Sources/Widgets/Widgets3D/ShapeWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/index.js
@@ -8,7 +8,7 @@ import {
 function vtkShapeWidget(publicAPI, model) {
   model.classHierarchy.push('vtkShapeWidget');
 
-  model.methodsToLink = ['scaleInPixels', 'textProps'];
+  model.methodsToLink = ['scaleInPixels', 'textProps', 'fontProperties'];
 }
 
 function defaultValues(initialValues) {

--- a/Sources/Widgets/Widgets3D/ShapeWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/index.js
@@ -1,24 +1,50 @@
+import macro from 'vtk.js/Sources/macros';
+import vtkAbstractWidgetFactory from 'vtk.js/Sources/Widgets/Core/AbstractWidgetFactory';
 import {
   BehaviorCategory,
   ShapeBehavior,
 } from 'vtk.js/Sources/Widgets/Widgets3D/ShapeWidget/Constants';
 
-export const DEFAULT_VALUES = {
-  manipulator: null,
-  visibleOnFocus: true,
-  modifierBehavior: {
-    None: {
-      [BehaviorCategory.PLACEMENT]:
-        ShapeBehavior[BehaviorCategory.PLACEMENT].CLICK_AND_DRAG,
-      [BehaviorCategory.POINTS]:
-        ShapeBehavior[BehaviorCategory.POINTS].CORNER_TO_CORNER,
-      [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
-    },
-  },
-  keysDown: {},
-  resetAfterPointPlacement: true,
-  useHandles: false,
-  pixelScale: 10,
-};
+function vtkShapeWidget(publicAPI, model) {
+  model.classHierarchy.push('vtkShapeWidget');
 
-export default { DEFAULT_VALUES };
+  model.methodsToLink = ['scaleInPixels', 'textProps'];
+}
+
+function defaultValues(initialValues) {
+  return {
+    manipulator: null,
+    modifierBehavior: {
+      None: {
+        [BehaviorCategory.PLACEMENT]:
+          ShapeBehavior[BehaviorCategory.PLACEMENT].CLICK_AND_DRAG,
+        [BehaviorCategory.POINTS]:
+          ShapeBehavior[BehaviorCategory.POINTS].CORNER_TO_CORNER,
+        [BehaviorCategory.RATIO]: ShapeBehavior[BehaviorCategory.RATIO].FREE,
+      },
+    },
+    resetAfterPointPlacement: false,
+    ...initialValues,
+  };
+}
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, defaultValues(initialValues));
+
+  vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, [
+    'modifierBehavior',
+    'resetAfterPointPlacement',
+  ]);
+
+  vtkShapeWidget(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkShapeWidget');
+
+export default { newInstance, extend };


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->
A recent change makes the widget behavior no longer share the widget factory model.
Furthermore, LabelRepresentation is about to be removed (old-style widget), so widgets using this should use SVGLandmarkRepresentation for text rendering.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->

- Fix ShapeWidget (use SVGLandmarkRepresentation instead of LabelRepresentation)
- Fix PaintWidget (use SVGLandmarkRepresentation instead of LabelRepresentation)
- Fix a bug in ShapeWidget example causing labels to not being centered
- Fix PaintWidget example by importing the module HttpDataAccessHelper
- Add a way of changing text alignment and position

- [x] Documentation and TypeScript definitions were updated to match those changes

### Results

**Behaviour of text alignment**

Possible values for horizontal alignment: 
- `start`
- `middle`
- `end`

Possible values for vertical alignement (defined in `SVGLandmarkRepresentation/Constants.js`):
- `VerticalTextAlignment.START`
- `VerticalTextAlignment.MIDDLE`
- `VerticalTextAlignment.END`

![Screenshot from 2021-09-13 16-26-35](https://user-images.githubusercontent.com/88332582/133102323-cf774334-a878-47c2-8b6b-a913bf0605b5.png)

**Behaviour of text position**

Possible values (defined in `ShapeWidget/Constants.js`):
- `TextPosition.MIX`
- `TextPosition.CENTER`
- `TextPosition.MAX`

![Screenshot from 2021-09-13 16-26-41](https://user-images.githubusercontent.com/88332582/133102342-707dc31c-2d9c-45e7-abfa-68f34c17361d.png)

**Example:**
```javascript
// Change text aligment
scene.rectangleHandle.setTextProps({
  ...scene.rectangleHandle.getTextProps(),
  'text-anchor': 'middle',                          // horizontal alignment
  verticalAlign: VerticalTextAlignment.MIDDLE,      // vertical alignment
});
// Change text position
widgets.rectangleWidget
  .getWidgetState()
  .setTextPosition([
    TextPosition.MIN,
    TextPosition.CENTER,
    TextPosition.MAX,
  ]);
```

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: 19.8.0
  - **OS**: Ubuntu 20.04
  - **Browser**: Chrome 94.0.4606.71

BREAKING CHANGE: in ShapeWidget: `setLabelTextCallback` is replaced by `text` substate \
BREAKING CHANGE: in ShapeWidget: `setPixelScale` has been removed. \
It should be replaced by point handle `scale1` mixin and `scaleInPixels` \
`useHandles` has been removed. It should be replaced by `setHandleVisibility`. \
`resetAfterPointPlacement` is now false by default.
BREAKING CHANGE: RectangleWidget and EllipseWidget handles now scale up automatically.


