### PR TITLE
docs: build doc fix

### DIFF
--- a/Documentation/content/docs/develop_build.md
+++ b/Documentation/content/docs/develop_build.md
@@ -7,9 +7,11 @@ The library can be built with webpack automatically. Webpack can either gather a
 
 ## Building vtk.js
 
-In order to build the library you can run `npm run dev` for quick development usage or `npm run build` for production usage.
+Install dependencies by running `npm install`.
 
-Either of these commands will generate a `dist/vtk.js` file that can then be used as an external script.
+In order to build the library you can run `npm run dev:esm` for quick development usage or `npm run build:esm` for production usage.
+
+These commands will generate an ES module in `dist/esm`.
 
 ## Building the website
 
@@ -36,3 +38,7 @@ $ npm run doc -- -s -f ExampleNameThatDoesNotExist
 ```
 
 `ExampleNameThatDoesNotExist` can be replaced by multiple real example names and the doc tool will only build those examples.
+
+## Building versus installing
+
+When you use vtk.js as a dependency in your project (e.g. [like this](https://kitware.github.io/vtk-js/docs/vtk_vanilla.html)) you are pulling a package that was put together by the continuous integration. When developing vtk.js, you will have to put that package together yourself, and we call that "building."

--- a/Documentation/content/index.pug
+++ b/Documentation/content/index.pug
@@ -1,7 +1,7 @@
 layout: index
 description: VTK.js a Visualization Toolkit for the Web
 subtitle: Visualize Your Data With vtk.js
-cmd: npm install vtk.js
+cmd: npm install @kitware/vtk.js
 comments: false
 ---
 


### PR DESCRIPTION
Update build docs to mention running `npm install` to install dependencies.

We might want to hold off on merging this until `npm run dev` and `npm run build` both work as build commands. They don't work for me at the moment.

I added a paragraph describing what building means in this case, since that was confusing for me as someone new to this type of development:

> When you use vtk.js as a dependency in your project (e.g. [like this](https://kitware.github.io/vtk-js/docs/vtk_vanilla.html)) you are pulling a package that was put together by the continuous integration. When developing vtk.js, you will have to put that package together yourself, and we call that "building."

Please let me know if I made any mistakes or could explain something more clearly.

Finally, there is a commit updating the install command on [this landing page](https://kitware.github.io/vtk-js/index.html).
