### PR TITLE
fix(rollup): force .js extension for all files

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,12 +73,12 @@ export default {
     chunkFileNames(chunkInfo) {
       let name = chunkInfo.name;
 
-      if (name.includes('node_modules')) {
-        return name.replace('node_modules', 'vendor');
-      }
-
       if (!name.endsWith('.js')) {
         name += '.js';
+      }
+
+      if (name.includes('node_modules')) {
+        return name.replace('node_modules', 'vendor');
       }
 
       // throw all subscript prefixed chunks into a virtual folder


### PR DESCRIPTION
All assets are considered js files. This ensures that bundlers treat
imports correctly, as some of the generated imports do not suffix with a
proper extension.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
Fixes #2072 

### Changes & Results
- [ESM] Forces all output chunks to end with .js

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete
