### PR TITLE
perf(WebGPU): improve WebGPU volume rendering performance

### DIFF
--- a/Sources/Rendering/WebGPU/README.md
+++ b/Sources/Rendering/WebGPU/README.md
@@ -31,20 +31,20 @@ is needed.
 - eventually switch to using IBOs and flat interpolation
 - cropping planes for polydata mapper
 - update widgets to use the new async hardware selector API
+- image display (use 3d texture)
+- add rgb texture support to volume renderer
+- add lighting to volume rendering
 
-- create new volume renderer built for multivolume rendering - in progress
+Waiting on fixes/dev in WebGPU spec
+- more cross platform testing and bug fixing
+
+# Recently ToDone
+- create new volume renderer built for multivolume rendering
   - traverse all volumes and register with volume pass - done
   - render all volumes hexahedra to get depth buffer near and far
     merged with opaque pass depth buffer - done
   - render all volumes in single mapper using prior near/far depth textures - in progress
-
-Waiting on fixes/dev in WebGPU spec
-
-- 3d textures (as of April 21 2021 Dawn lacks support for 1d and 3d)
-- image display (use 3d texture)
-- more cross platform testing and bug fixing
-
-# Recently ToDone
+- 3d textures
 - added bind groups
 - actor matrix support with auto shift (handle in renderer?)
 - add an example of customizing WebGPU

--- a/Sources/Rendering/WebGPU/Volume/index.js
+++ b/Sources/Rendering/WebGPU/Volume/index.js
@@ -51,21 +51,33 @@ function vtkWebGPUVolume(publicAPI, model) {
     }
   };
 
+  // used in the method below
+  const idx = new Float64Array(3);
+  const vout = new Float64Array(3);
+
   publicAPI.getBoundingCubePoints = (result, offset) => {
-    const bounds = model.renderable.getMapper().getBounds();
+    const input = model.renderable.getMapper().getInputData();
+    if (!input) {
+      return;
+    }
+    const extent = input.getExtent();
     const m = model.renderable.getMatrix();
 
     let count = 0;
     for (let iz = 4; iz < 6; iz++) {
-      const z = bounds[iz];
+      idx[2] = extent[iz];
       for (let iy = 2; iy < 4; iy++) {
-        const y = bounds[iy];
+        idx[1] = extent[iy];
         for (let ix = 0; ix < 2; ix++) {
-          const x = bounds[ix];
+          idx[0] = extent[ix];
+          input.indexToWorld(idx, vout);
           let poffset = offset + count * 3;
-          result[poffset++] = m[0] * x + m[1] * y + m[2] * z + m[3];
-          result[poffset++] = m[4] * x + m[5] * y + m[6] * z + m[7];
-          result[poffset++] = m[8] * x + m[9] * y + m[10] * z + m[11];
+          result[poffset++] =
+            m[0] * vout[0] + m[1] * vout[1] + m[2] * vout[2] + m[3];
+          result[poffset++] =
+            m[4] * vout[0] + m[5] * vout[1] + m[6] * vout[2] + m[7];
+          result[poffset++] =
+            m[8] * vout[0] + m[9] * vout[1] + m[10] * vout[2] + m[11];
           count++;
         }
       }


### PR DESCRIPTION
Specifically for non axis aligned volumes. The old code took
the axis aligned bounding box form the image data while
this version uses the original corner points and transforms
them. This results in a much tighter bounding cube for oriented
image data.

