### PR TITLE
fix(XMLReader): use xml library over builtins

### DIFF
--- a/Sources/IO/Core/BinaryHelper/index.js
+++ b/Sources/IO/Core/BinaryHelper/index.js
@@ -5,7 +5,7 @@
  * expect proper Unicode or any other encoding.
  */
 function arrayBufferToString(arrayBuffer) {
-  if ('TextDecoder' in window) {
+  if (typeof 'TextDecoder' !== 'undefined') {
     const decoder = new TextDecoder('latin1');
     return decoder.decode(arrayBuffer);
   }


### PR DESCRIPTION
### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
Should allow usage of XMLReaders in web workers

### Changes

- [x] remove usage of ActiveXObject and DOMParser

### Results
- [x] webworker usage of xml readers should work
