### PR TITLE
fix(WebGPU): fix an issue with typed array textursd in webgpu

### DIFF
--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -93,7 +93,7 @@ function vtkWebGPUTexture(publicAPI, model) {
         const inWidth = currWidthInBytes / inArray.BYTES_PER_ELEMENT;
 
         const outArray = macro.newTypedArray(
-          halfFloat ? 'Uint16Array' : inArray.name,
+          halfFloat ? 'Uint16Array' : 'Uint8Array',
           bufferWidth * model.height * model.depth
         );
 


### PR DESCRIPTION
Issue when a Uint8Array had a row length other than
256 bytes.
