### PR TITLE
fix(WebGL): zvalue hardware selection of translucent actors

### DIFF
--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -45,7 +45,19 @@ function vtkOpenGLActor(publicAPI, model) {
   };
 
   publicAPI.traverseOpaqueZBufferPass = (renderPass) => {
-    publicAPI.traverseOpaquePass(renderPass);
+    if (
+      !model.renderable ||
+      !model.renderable.getNestedVisibility() ||
+      (model.openGLRenderer.getSelector() &&
+        !model.renderable.getNestedPickable())
+    ) {
+      return;
+    }
+
+    publicAPI.apply(renderPass, true);
+    model.oglmapper.traverse(renderPass);
+
+    publicAPI.apply(renderPass, false);
   };
 
   // we draw textures, then mapper, then post pass textures


### PR DESCRIPTION
The zbuffer values were not being computed on translucent
actors in WebGL. So when zbuffer values were needed to compute
world coordinates on translucent actors they were incorrect.

Fixes issue https://github.com/Kitware/react-vtk-js/issues/37