### PR TITLE
style(vtkwebgputexture): fix for array type inference in place of har…

### DIFF
--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -93,7 +93,7 @@ function vtkWebGPUTexture(publicAPI, model) {
         const inWidth = currWidthInBytes / inArray.BYTES_PER_ELEMENT;
 
         const outArray = macro.newTypedArray(
-          halfFloat ? 'Uint16Array' : 'Uint8Array',
+          inArray.constructor.name,
           bufferWidth * model.height * model.depth
         );
 


### PR DESCRIPTION
Replaced hard-coded strings with a call to the "name" property of the constructor of the input array.
This doesn't fix any existing bug, but provides a better generalization for future texture formats.

### PR and Code Checklist
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
Replaces the hard-coded strings that represent the array type (e.g. Float16Array, Uint8Array)
with a call to object.constructor.name as discussed on google-chat with the vtk.js team.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
N/A

### Testing
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**:
  - **OS**: Windows 10 Pro, 19043.1237
  - **Browser**: Chrome 94.0.4606.61