### PR TITLE
docs: fix vtkLineSource api documentation

### DIFF
--- a/Sources/Filters/Sources/LineSource/index.d.ts
+++ b/Sources/Filters/Sources/LineSource/index.d.ts
@@ -44,7 +44,7 @@ export interface vtkLineSource extends vtkLineSourceBase {
 	getPoint2ByReference(): Vector3;
 
 	/**
-	 * Get the x resolution of the line.
+	 * Get the resolution of the line.
 	 * @default 6
 	 */
 	getResolution(): number;
@@ -91,8 +91,8 @@ export interface vtkLineSource extends vtkLineSourceBase {
 	setPoint2From(point2: Vector3): boolean;
 
 	/**
-	 * Set the number of facets used to represent the cone.
-	 * @param {Number} resolution The number of facets.
+	 * Set the number of segments used to represent the line.
+	 * @param {Number} resolution The number of segments.
 	 */
 	setResolution(resolution: number): boolean;
 }
@@ -113,11 +113,9 @@ export function extend(publicAPI: object, model: object, initialValues?: ILineSo
 export function newInstance(initialValues?: ILineSourceInitialValues): vtkLineSource;
 
 /**
- * vtkLineSource creates a polygonal cylinder centered at Center;
- * The axis of the cylinder is aligned along the global y-axis.
- * The height and radius of the cylinder can be specified, as well as the number of sides.
- * It is also possible to control whether the cylinder is open-ended or capped.
- * If you have the end points of the cylinder, you should use a vtkLineSource followed by a vtkTubeFilter instead of the vtkLineSource.
+ * vtkLineSource creates a line segment from point1 to point2;
+ * The resolution can be specified, which determines the number of points along the line.
+ * Following a vtkLineSource by a vtkTubeFilter is a convenient way to create a cylinder based on endpoints.
  * 
  * @example
  * ```js

--- a/Sources/Filters/Sources/LineSource/index.js
+++ b/Sources/Filters/Sources/LineSource/index.js
@@ -32,8 +32,8 @@ function vtkLineSource(publicAPI, model) {
     }
 
     // hand create a line with special scalars
-    const xres = model.resolution;
-    const numPts = xres + 1;
+    const res = model.resolution;
+    const numPts = res + 1;
 
     // Points
     const points = macro.newTypedArray(pointDataType, numPts * 3);
@@ -45,8 +45,8 @@ function vtkLineSource(publicAPI, model) {
 
     let idx = 0;
     let t = 0.0;
-    for (let i = 0; i < xres + 1; i++) {
-      t = i / xres;
+    for (let i = 0; i < res + 1; i++) {
+      t = i / res;
 
       points[idx * 3] = model.point1[0] + t * v21[0];
       points[idx * 3 + 1] = model.point1[1] + t * v21[1];


### PR DESCRIPTION
It looks like some things were forgotten when `vtkCylinderSource` docs were copied to create `vtkLineSource` docs.