### PR TITLE
chore(testUtils): set pixelmatch threshold to 0

### DIFF
--- a/Sources/Testing/testUtils.js
+++ b/Sources/Testing/testUtils.js
@@ -52,7 +52,7 @@ async function compareImages(
       {
         alpha: 0.5,
         includeAA: false,
-        threshold,
+        threshold: 0,
       }
     );
     const percentage = (mismatched / (width * height)) * 100;


### PR DESCRIPTION
### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context

Usage of pixelmatch threshold is incorrect. The threshold parameter for compareImages is meant to be a percent threshold, while the pixelmatch threshold is a color difference metric threshold.

pixelmatch uses a YIQ difference metric for color comparison with a
threshold, while resemblejs does component-level delta thresholding.

### Changes
- [x] Update pixelmatch usage to use a threshold of 0

### Results
Image tests should now be reporting correct deltas.
### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: 19.7.2
