### PR TITLE
fix(Interaction): Remove getters/setters on zoomScale

### DIFF
--- a/Sources/Interaction/Manipulators/MouseCameraTrackballZoomManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballZoomManipulator/index.js
@@ -109,7 +109,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkCompositeMouseManipulator.extend(publicAPI, model, initialValues);
   vtkCompositeCameraManipulator.extend(publicAPI, model, initialValues);
 
-  macro.setGet(publicAPI, model, ['zoomScale', 'flipDirection']);
+  macro.setGet(publicAPI, model, ['flipDirection']);
 
   // Object specific methods
   vtkMouseCameraTrackballZoomManipulator(publicAPI, model);


### PR DESCRIPTION
### Changes
 It appears the zoomScale is overwritten on mouseDown event. I'm removing the setter/getter on this variable since it had no effect and I was able to achieve the desired behaviour (adjusting the speed of the zoom) using an alternate method that does not require any modification to the core library.