### PR TITLE
fix(Picking): fix a picking bug with WebGL and WebGPU

### DIFF
--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelector.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelector.js
@@ -69,7 +69,7 @@ test('Test HardwareSelector', (tapeContext) => {
   glwindow.setContainer(renderWindowContainer);
   renderWindow.addView(glwindow);
   glwindow.setSize(400, 400);
-  glwindow.traverseAllPasses();
+  renderWindow.render();
 
   const sel = glwindow.getSelector();
   sel.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_POINTS);

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorGlyph.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorGlyph.js
@@ -102,7 +102,7 @@ test('Test HardwareSelectorGlyph', (tapeContext) => {
   glwindow.setSize(400, 400);
   renderer.resetCamera();
   renderer.getActiveCamera().zoom(1.4);
-  glwindow.traverseAllPasses();
+  renderWindow.render();
 
   const sel = glwindow.getSelector();
   sel.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_POINTS);

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorSpeed.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorSpeed.js
@@ -87,7 +87,7 @@ test('Test HardwareSelector', (tapeContext) => {
         gc.releaseResources();
       });
     });
-    glwindow.traverseAllPasses();
+    renderWindow.render();
   });
-  glwindow.traverseAllPasses();
+  renderWindow.render();
 });

--- a/Sources/Rendering/Core/Picker/index.js
+++ b/Sources/Rendering/Core/Picker/index.js
@@ -112,11 +112,14 @@ function vtkPicker(publicAPI, model) {
     const camera = renderer.getActiveCamera();
     cameraPos = camera.getPosition();
     cameraFP = camera.getFocalPoint();
+    const dims = view.getViewportSize(renderer);
+    const aspect = dims[0] / dims[1];
 
     displayCoords = renderer.worldToNormalizedDisplay(
       cameraFP[0],
       cameraFP[1],
-      cameraFP[2]
+      cameraFP[2],
+      aspect
     );
     displayCoords = view.normalizedDisplayToDisplay(
       displayCoords[0],
@@ -131,8 +134,6 @@ function vtkPicker(publicAPI, model) {
       selectionY,
       selectionZ
     );
-    const dims = view.getViewportSize(renderer);
-    const aspect = dims[0] / dims[1];
     worldCoords = renderer.normalizedDisplayToWorld(
       normalizedDisplay[0],
       normalizedDisplay[1],

--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -75,7 +75,18 @@ function vtkRenderWindow(publicAPI, model) {
 
   publicAPI.hasView = (view) => model.views.indexOf(view) !== -1;
 
+  // handle any pre render initializations
+  publicAPI.preRender = () => {
+    model.renderers.forEach((ren) => {
+      // make sure we have a camera
+      if (!ren.isActiveCameraCreated()) {
+        ren.resetCamera();
+      }
+    });
+  };
+
   publicAPI.render = () => {
+    publicAPI.preRender();
     if (model.interactor) {
       model.interactor.render();
     } else {

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -399,6 +399,10 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
       model.renderer
     );
 
+    // todo revisit making selection part of core
+    // then we can do this in core
+    model.openGLRenderWindow.getRenderable().preRender();
+
     // int rgba[4];
     // rwin.getColorBufferSizes(rgba);
     // if (rgba[0] < 8 || rgba[1] < 8 || rgba[2] < 8) {

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -21,10 +21,6 @@ function vtkOpenGLRenderer(publicAPI, model) {
         return;
       }
 
-      // make sure we have a camera
-      if (!model.renderable.isActiveCameraCreated()) {
-        model.renderable.resetCamera();
-      }
       publicAPI.updateLights();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getActiveCamera());

--- a/Sources/Rendering/WebGPU/HardwareSelector/index.js
+++ b/Sources/Rendering/WebGPU/HardwareSelector/index.js
@@ -275,6 +275,10 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
       return false;
     }
 
+    // todo revisit making selection part of core
+    // then we can do this in core
+    model.WebGPURenderWindow.getRenderable().preRender();
+
     if (!model.WebGPURenderWindow.getInitialized()) {
       model.WebGPURenderWindow.initialize();
       await new Promise((resolve) =>

--- a/Sources/Rendering/WebGPU/Renderer/index.js
+++ b/Sources/Rendering/WebGPU/Renderer/index.js
@@ -51,10 +51,6 @@ function vtkWebGPURenderer(publicAPI, model) {
         return;
       }
 
-      // make sure we have a camera
-      if (!model.renderable.isActiveCameraCreated()) {
-        model.renderable.resetCamera();
-      }
       publicAPI.updateLights();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getActiveCamera());

--- a/Sources/Widgets/Widgets3D/SplineWidget/test/testSplineWidget.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/test/testSplineWidget.js
@@ -116,7 +116,7 @@ test.onlyIfWebGL('Test vtkSplineWidget rendering and picking', (t) => {
       );
     });
     // Trigger a next image
-    glwindow.traverseAllPasses();
+    renderWindow.render();
     return promise;
   }
 


### PR DESCRIPTION
An argument was missing from a call in the vtkPicker pick method

Views were modifying the data (renderables) by performing
camera creation and reset. Views should not modify the data
(renderables). This was also causing a picking failure for WebGPU
as one render was not enough to invoke the camera reset code.

Updated some tests that were calling traverseAllPasses instead of
render.  We want to limit interaction with API specific windows.

Invoke preRender in the hardware selectors for now since they
bypass render and directly call traverseAllPasses. In the future
we should change this

https://github.com/Kitware/vtk-js/issues/2122

