### PR TITLE
fix(WebGPU): Fix issue with the image mapper and colors

### DIFF
--- a/Sources/Rendering/Core/ImageMapper/test/testImageColorTransferFunction.js
+++ b/Sources/Rendering/Core/ImageMapper/test/testImageColorTransferFunction.js
@@ -11,9 +11,9 @@ import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransfe
 
 import baseline from './testImageColorTransferFunction.png';
 
-test('Test ImageMapper', (t) => {
+test('Test ImageMapper Color TFun', (t) => {
   const gc = testUtils.createGarbageCollector(t);
-  t.ok('rendering', 'vtkImageMapper testImage');
+  t.ok('rendering', 'vtkImageMapper Color Transfer Function testImage');
 
   // Create some control UI
   const container = document.querySelector('body');

--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -41,9 +41,6 @@ fn main(
   var output: fragmentOutput;
 
   //VTK::Image::Sample
-  computedColor.g = computedColor.r;
-  computedColor.b = computedColor.r;
-  computedColor.a = 1.0;
 
   // var computedColor: vec4<f32> = vec4<f32>(1.0,0.7, 0.5, 1.0);
 
@@ -300,13 +297,14 @@ function vtkWebGPUImageMapper(publicAPI, model) {
             }
           } else {
             for (let i = 0; i < model.rowLength; i++) {
-              colorArray[c * model.rowLength * 8 + i * 4] =
-                255.0 * tmpTable[i * 3];
-              colorArray[c * model.rowLength * 8 + i * 4 + 1] =
-                255.0 * tmpTable[i * 3 + 1];
-              colorArray[c * model.rowLength * 8 + i * 4 + 2] =
-                255.0 * tmpTable[i * 3 + 2];
-              colorArray[c * model.rowLength * 8 + i * 4 + 3] = 255.0;
+              const idx = c * model.rowLength * 8 + i * 4;
+              colorArray[idx] = 255.0 * tmpTable[i * 3];
+              colorArray[idx + 1] = 255.0 * tmpTable[i * 3 + 1];
+              colorArray[idx + 2] = 255.0 * tmpTable[i * 3 + 2];
+              colorArray[idx + 3] = 255.0;
+              for (let j = 0; j < 4; j++) {
+                colorArray[idx + model.rowLength * 4 + j] = colorArray[idx + j];
+              }
             }
           }
         }


### PR DESCRIPTION
Fix an issue where colored tfuns were being converted to
greyscale in the fragment shader.

Fix an issue where the color tfun texture was not
getting created correctly in one case.
