### PR TITLE
fix(WebGPU): fix an issue with half float texture management

### DIFF
--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -93,7 +93,7 @@ function vtkWebGPUTexture(publicAPI, model) {
         const inWidth = currWidthInBytes / inArray.BYTES_PER_ELEMENT;
 
         const outArray = macro.newTypedArray(
-          inArray.constructor.name,
+          halfFloat ? 'Uint16Array' : inArray.constructor.name,
           bufferWidth * model.height * model.depth
         );
 


### PR DESCRIPTION
A recent change broke some halfFloat texture management
