### PR TITLE
fix(widgets): fix paintWidget ignore keys alt, control and shift

### DIFF
--- a/Sources/Rendering/Core/CubeAxesActor/index.js
+++ b/Sources/Rendering/Core/CubeAxesActor/index.js
@@ -682,11 +682,12 @@ function vtkCubeAxesActor(publicAPI, model) {
     publicAPI.update();
   });
 
-  publicAPI.setVisibility = macro.chain(
+  const setVisibility = macro.chain(
     publicAPI.setVisibility,
     model.pixelActor.setVisibility,
     model.tmActor.setVisibility
   );
+  publicAPI.setVisibility = (...args) => setVisibility(...args).some(Boolean);
 
   publicAPI.setTickTextStyle = (tickStyle) => {
     model.tickTextStyle = { ...model.tickTextStyle, ...tickStyle };

--- a/Sources/Rendering/Core/ScalarBarActor/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/index.js
@@ -758,11 +758,12 @@ function vtkScalarBarActor(publicAPI, model) {
     publicAPI.modified();
   };
 
-  publicAPI.setVisibility = macro.chain(
+  const setVisibility = macro.chain(
     publicAPI.setVisibility,
     model.barActor.setVisibility,
     model.tmActor.setVisibility
   );
+  publicAPI.setVisibility = (...args) => setVisibility(...args).some(Boolean);
 
   publicAPI.resetAutoLayoutToDefault = () => {
     model.autoLayout = defaultAutoLayout(publicAPI, model);

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -1,5 +1,6 @@
-import { vtkAlgorithm, vtkObject } from "../../../interfaces";
-import { Vector2, Vector3 } from "../../../types";
+import { vtkAlgorithm, vtkObject } from '../../../interfaces';
+import { Vector2, Vector3 } from '../../../types';
+import { vtkRenderer } from '../../../Rendering/Core/Renderer';
 
 /**
  *
@@ -51,12 +52,12 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	/**
 	 * 
 	 */
-	getContainerSize(): Array</* ?,? */ any>;
+	getContainerSize(): Vector2;
 
 	/**
 	 * 
 	 */
-	getFramebufferSize(): Array<number>;
+	getFramebufferSize(): Vector2;
 
 	/**
 	 * 
@@ -64,19 +65,19 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param y 
 	 * @param viewport 
 	 */
-	isInViewport(x : any, y : any, viewport : any): boolean;
+	isInViewport(x : number, y : number, viewport : vtkRenderer): boolean;
 
 	/**
 	 * 
 	 * @param viewport 
 	 */
-	getViewportSize(viewport : any): VtkOpenGLRenderWindow0.GetViewportSizeRet;
+	getViewportSize(viewport : vtkRenderer): Vector2;
 
 	/**
 	 * 
 	 * @param viewport 
 	 */
-	getViewportCenter(viewport : any): VtkOpenGLRenderWindow0.GetViewportCenterRet;
+	getViewportCenter(viewport : vtkRenderer): Vector2;
 
 	/**
 	 * 
@@ -84,7 +85,7 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param y 
 	 * @param z 
 	 */
-	displayToNormalizedDisplay(x : any, y : any, z : any): VtkOpenGLRenderWindow0.DisplayToNormalizedDisplayRet;
+	displayToNormalizedDisplay(x : number, y : number, z : number): Vector3;
 
 	/**
 	 * 
@@ -92,16 +93,7 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param y 
 	 * @param z 
 	 */
-	normalizedDisplayToDisplay(x : number, y : number, z : number): VtkOpenGLRenderWindow0.NormalizedDisplayToDisplayRet;
-
-	/**
-	 * 
-	 * @param x 
-	 * @param y 
-	 * @param z 
-	 * @param renderer 
-	 */
-	worldToView(x : any, y : any, z : any, renderer : any): void;
+	normalizedDisplayToDisplay(x : number, y : number, z : number): Vector3;
 
 	/**
 	 * 
@@ -110,7 +102,7 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param z 
 	 * @param renderer 
 	 */
-	viewToWorld(x : any, y : any, z : any, renderer : any): void;
+	worldToView(x : number, y : number, z : number, renderer : vtkRenderer): Vector3;
 
 	/**
 	 * 
@@ -119,7 +111,7 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param z 
 	 * @param renderer 
 	 */
-	worldToDisplay(x : any, y : any, z : any, renderer : any): Array</* number,number,number */ any>;
+	viewToWorld(x : number, y : number, z : number, renderer : vtkRenderer): Vector3;
 
 	/**
 	 * 
@@ -128,7 +120,7 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param z 
 	 * @param renderer 
 	 */
-	displayToWorld(x : any, y : any, z : any, renderer : any): void;
+	worldToDisplay(x : number, y : number, z : number, renderer : vtkRenderer): Vector3;
 
 	/**
 	 * 
@@ -137,7 +129,7 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param z 
 	 * @param renderer 
 	 */
-	normalizedDisplayToViewport(x : any, y : any, z : any, renderer : any): VtkOpenGLRenderWindow0.NormalizedDisplayToViewportRet;
+	displayToWorld(x : number, y : number, z : number, renderer : vtkRenderer): Vector3;
 
 	/**
 	 * 
@@ -146,23 +138,7 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param z 
 	 * @param renderer 
 	 */
-	viewportToNormalizedViewport(x : any, y : any, z : any, renderer : any): VtkOpenGLRenderWindow0.ViewportToNormalizedViewportRet;
-
-	/**
-	 * 
-	 * @param x 
-	 * @param y 
-	 * @param z 
-	 */
-	normalizedViewportToViewport(x : any, y : any, z : any): VtkOpenGLRenderWindow0.NormalizedViewportToViewportRet;
-
-	/**
-	 * 
-	 * @param x 
-	 * @param y 
-	 * @param z 
-	 */
-	displayToLocalDisplay(x : any, y : any, z : any): VtkOpenGLRenderWindow0.DisplayToLocalDisplayRet;
+	normalizedDisplayToViewport(x : number, y : number, z : number, renderer : vtRenderer): Vector3;
 
 	/**
 	 * 
@@ -171,7 +147,32 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param z 
 	 * @param renderer 
 	 */
-	viewportToNormalizedDisplay(x : any, y : any, z : any, renderer : any): Array</* number,number,? */ any>;
+	viewportToNormalizedViewport(x : number, y : number, z : number, renderer : vtkRenderer): Vector3;
+
+	/**
+	 * 
+	 * @param x 
+	 * @param y 
+	 * @param z 
+	 */
+	normalizedViewportToViewport(x : number, y : number, z : number): Vector3;
+
+	/**
+	 * 
+	 * @param x 
+	 * @param y 
+	 * @param z 
+	 */
+	displayToLocalDisplay(x : number, y : number, z : number): Vector3;
+
+	/**
+	 * 
+	 * @param x 
+	 * @param y 
+	 * @param z 
+	 * @param renderer 
+	 */
+	viewportToNormalizedDisplay(x : number, y number, z : number, renderer : vtkRenderer): Vector3;
 
 	/**
 	 * 
@@ -180,13 +181,13 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param x2 
 	 * @param y2 
 	 */
-	getPixelData(x1 : any, y1 : any, x2 : any, y2 : any): Float32Array;
+	getPixelData(x1 : number, y1 : number, x2 : number, y2 : number): Uint8Array;
 
 	/**
 	 * 
 	 * @param options 
 	 */
-	get3DContext(options : object): void;
+	get3DContext(options : object): WebGLRenderingContext | null;
 
 	/**
 	 * 
@@ -260,12 +261,12 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param format 
 	 * @param options 
 	 */
-	captureNextImage(format : any, options: object): /* VtkOpenGLRenderWindow0.+Promise */ any;
+	captureNextImage(format : string, options: object): Promise<string> | null;
 
 	/**
 	 * 
 	 */
-	getGLInformations(): VtkOpenGLRenderWindow0.GetGLInformationsRet;
+	getGLInformations(): object;
 
 	/**
 	 * 
@@ -350,21 +351,6 @@ export function extend(publicAPI: object, model: object, initialValues?: ILineSo
  */
 export function newInstance(initialValues?: ILineSourceInitialValues): vtkOpenGLRenderWindow;
 
-/**
- * vtkOpenGLRenderWindow creates a polygonal cylinder centered at Center;
- * The axis of the cylinder is aligned along the global y-axis.
- * The height and radius of the cylinder can be specified, as well as the number of sides.
- * It is also possible to control whether the cylinder is open-ended or capped.
- * If you have the end points of the cylinder, you should use a vtkOpenGLRenderWindow followed by a vtkTubeFilter instead of the vtkOpenGLRenderWindow.
- * 
- * @example
- * ```js
- * import vtkOpenGLRenderWindow from 'vtk.js/Sources/Filters/Sources/LineSource';
- * 
- * const line = vtkOpenGLRenderWindow.newInstance({ resolution: 10 });
- * const polydata = line.getOutputData();
- * ```
- */
 export declare const vtkOpenGLRenderWindow: {
 	newInstance: typeof newInstance,
 	extend: typeof extend,


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->
The paintWidget does not follow the guidelines of ignoring the alt, control and shift keys like the other widgets. Example DistanceWidget
### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- Add function ignoreKey that checks if the alt, control or shift keys are pressed

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- The painting action does not work if any of the alt, control or shift keys are pressed when painting begins
### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: v20.2.1 <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: Windows 10 <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: Chrome 94.0.4606.81 <!-- ex: Chrome 89.0.4389.128 -->

<!-- Remove the line below if it is not relevant -->

