### PR TITLE
fix: setters should return bool

### DIFF
--- a/Sources/Rendering/Core/CubeAxesActor/index.js
+++ b/Sources/Rendering/Core/CubeAxesActor/index.js
@@ -682,11 +682,12 @@ function vtkCubeAxesActor(publicAPI, model) {
     publicAPI.update();
   });
 
-  publicAPI.setVisibility = macro.chain(
+  const setVisibility = macro.chain(
     publicAPI.setVisibility,
     model.pixelActor.setVisibility,
     model.tmActor.setVisibility
   );
+  publicAPI.setVisibility = (...args) => setVisibility(...args).some(Boolean);
 
   publicAPI.setTickTextStyle = (tickStyle) => {
     model.tickTextStyle = { ...model.tickTextStyle, ...tickStyle };

--- a/Sources/Rendering/Core/ScalarBarActor/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/index.js
@@ -758,11 +758,12 @@ function vtkScalarBarActor(publicAPI, model) {
     publicAPI.modified();
   };
 
-  publicAPI.setVisibility = macro.chain(
+  const setVisibility = macro.chain(
     publicAPI.setVisibility,
     model.barActor.setVisibility,
     model.tmActor.setVisibility
   );
+  publicAPI.setVisibility = (...args) => setVisibility(...args).some(Boolean);
 
   publicAPI.resetAutoLayoutToDefault = () => {
     model.autoLayout = defaultAutoLayout(publicAPI, model);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
- setters should return bool based on if changes occurred. macro.chain returns an array, which is invalid.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
`setVisibility()` for ScalarBarActor and CubeAxesActor now return boolean.

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
