### PR TITLE
fix(renderwindow): fix inconsistent depth mask value

### DIFF
--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -132,7 +132,7 @@ function vtkOpenGLActor(publicAPI, model) {
 
   publicAPI.opaquePass = (prepass, renderPass) => {
     if (prepass) {
-      model.openGLRenderWindow.enableDepthMask();
+      model.context.depthMask(true);
       publicAPI.activateTextures();
     } else if (model.activeTextures) {
       for (let index = 0; index < model.activeTextures.length; index++) {
@@ -144,7 +144,7 @@ function vtkOpenGLActor(publicAPI, model) {
   // Renders myself
   publicAPI.translucentPass = (prepass, renderPass) => {
     if (prepass) {
-      model.openGLRenderWindow.disableDepthMask();
+      model.context.depthMask(false);
       publicAPI.activateTextures();
     } else if (model.activeTextures) {
       for (let index = 0; index < model.activeTextures.length; index++) {

--- a/Sources/Rendering/OpenGL/Actor2D/index.js
+++ b/Sources/Rendering/OpenGL/Actor2D/index.js
@@ -17,8 +17,12 @@ function vtkOpenGLActor2D(publicAPI, model) {
       if (!model.renderable) {
         return;
       }
+      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
+      model.context = model.openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNodes(model.renderable.getTextures());
       publicAPI.addMissingNode(model.renderable.getMapper());
@@ -84,9 +88,6 @@ function vtkOpenGLActor2D(publicAPI, model) {
   // Renders myself
   publicAPI.opaquePass = (prepass, renderPass) => {
     if (prepass) {
-      model.context = publicAPI
-        .getFirstAncestorOfType('vtkOpenGLRenderWindow')
-        .getContext();
       model.context.depthMask(true);
       publicAPI.activateTextures();
     } else {
@@ -100,9 +101,6 @@ function vtkOpenGLActor2D(publicAPI, model) {
   // Renders myself
   publicAPI.translucentPass = (prepass, renderPass) => {
     if (prepass) {
-      model.context = publicAPI
-        .getFirstAncestorOfType('vtkOpenGLRenderWindow')
-        .getContext();
       model.context.depthMask(false);
       publicAPI.activateTextures();
     } else {

--- a/Sources/Rendering/OpenGL/ImageSlice/index.js
+++ b/Sources/Rendering/OpenGL/ImageSlice/index.js
@@ -22,9 +22,12 @@ function vtkOpenGLImageSlice(publicAPI, model) {
       if (!model.renderable) {
         return;
       }
-
+      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
+      model.context = model.openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getMapper());
       publicAPI.removeUnusedNodes();
@@ -92,23 +95,13 @@ function vtkOpenGLImageSlice(publicAPI, model) {
   // Renders myself
   publicAPI.opaquePass = (prepass, renderPass) => {
     if (prepass) {
-      model.context = publicAPI
-        .getFirstAncestorOfType('vtkOpenGLRenderWindow')
-        .getContext();
       model.context.depthMask(true);
     }
   };
 
   // Renders myself
   publicAPI.translucentPass = (prepass, renderPass) => {
-    if (prepass) {
-      model.context = publicAPI
-        .getFirstAncestorOfType('vtkOpenGLRenderWindow')
-        .getContext();
-      model.context.depthMask(false);
-    } else {
-      model.context.depthMask(true);
-    }
+    model.context.depthMask(!prepass);
   };
 
   publicAPI.getKeyMatrices = () => {

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -276,16 +276,6 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	/**
 	 * 
 	 */
-	disableDepthMask(): void;
-
-	/**
-	 * 
-	 */
-	enableDepthMask(): void;
-
-	/**
-	 * 
-	 */
 	disableCullFace(): void;
 
 	/**

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1045,20 +1045,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     }
   };
 
-  publicAPI.disableDepthMask = () => {
-    if (model.depthMaskEnabled) {
-      model.context.depthMask(false);
-      model.depthMaskEnabled = false;
-    }
-  };
-
-  publicAPI.enableDepthMask = () => {
-    if (!model.depthMaskEnabled) {
-      model.context.depthMask(true);
-      model.depthMaskEnabled = true;
-    }
-  };
-
   publicAPI.disableCullFace = () => {
     if (model.cullFaceEnabled) {
       model.context.disable(model.context.CULL_FACE);
@@ -1116,7 +1102,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   cullFaceEnabled: false,
-  depthMaskEnabled: true,
   shaderCache: null,
   initialized: false,
   context: null,

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -59,7 +59,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
       if (!model.renderable.getPreserveDepthBuffer()) {
         gl.clearDepth(1.0);
         clearMask |= gl.DEPTH_BUFFER_BIT;
-        gl.depthMask(true);
+        model.context.depthMask(true);
       }
 
       const ts = publicAPI.getTiledSizeAndOrigin();
@@ -146,7 +146,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
     if (!model.renderable.getPreserveDepthBuffer()) {
       gl.clearDepth(1.0);
       clearMask |= gl.DEPTH_BUFFER_BIT;
-      gl.depthMask(true);
+      model.context.depthMask(true);
     }
 
     gl.colorMask(true, true, true, true);

--- a/Sources/Rendering/OpenGL/Skybox/index.js
+++ b/Sources/Rendering/OpenGL/Skybox/index.js
@@ -49,7 +49,7 @@ function vtkOpenGLSkybox(publicAPI, model) {
     if (prepass && !model.openGLRenderer.getSelector()) {
       publicAPI.updateBufferObjects();
 
-      model.openGLRenderWindow.enableDepthMask();
+      model.context.depthMask(true);
 
       model.openGLRenderWindow
         .getShaderCache()

--- a/Sources/Rendering/OpenGL/Volume/index.js
+++ b/Sources/Rendering/OpenGL/Volume/index.js
@@ -19,8 +19,12 @@ function vtkOpenGLVolume(publicAPI, model) {
       return;
     }
     if (prepass) {
+      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
+      model.context = model.openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getMapper());
       publicAPI.removeUnusedNodes();
@@ -58,14 +62,7 @@ function vtkOpenGLVolume(publicAPI, model) {
     if (!model.renderable || !model.renderable.getVisibility()) {
       return;
     }
-    if (prepass) {
-      model.context = publicAPI
-        .getFirstAncestorOfType('vtkOpenGLRenderWindow')
-        .getContext();
-      model.context.depthMask(false);
-    } else {
-      model.context.depthMask(true);
-    }
+    model.context.depthMask(!prepass);
   };
 
   publicAPI.getKeyMatrices = () => {


### PR DESCRIPTION
When a scene contained only translucent actors, depth mask was never turned off before the translucent pass. This is because the renderer was setting it to true without notifying the render window.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context

Translucent actors without opaque actor:
![image](https://user-images.githubusercontent.com/219044/139329353-5bcf5ede-09b1-4005-b5e1-ce17bd6eed86.png)

Translucent actors with opaque actors:
![image](https://user-images.githubusercontent.com/219044/139329459-04324381-1e37-4639-8adf-e8f3579a13d3.png)


### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
Got the send image even without the opaque actors.
The issue with faces ordering is still there though... (different problem)

### Testing
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome
