### PR TITLE
feat(WebGPU): use invereted depth and improve edges

### DIFF
--- a/Sources/Rendering/WebGPU/BufferManager/index.js
+++ b/Sources/Rendering/WebGPU/BufferManager/index.js
@@ -548,12 +548,12 @@ function vtkWebGPUBufferManager(publicAPI, model) {
 
     // prettier-ignore
     const array = new Float32Array([
-      -1.0, -1.0, 1.0,
-       1.0, -1.0, 1.0,
-       1.0, 1.0, 1.0,
-      -1.0, -1.0, 1.0,
-       1.0, 1.0, 1.0,
-      -1.0, 1.0, 1.0,
+      -1.0, -1.0, 0.0,
+       1.0, -1.0, 0.0,
+       1.0, 1.0, 0.0,
+      -1.0, -1.0, 0.0,
+       1.0, 1.0, 0.0,
+      -1.0, 1.0, 0.0,
     ]);
     model.fullScreenQuadBuffer.createAndWrite(array, GPUBufferUsage.VERTEX);
     model.fullScreenQuadBuffer.setStrideInBytes(12);

--- a/Sources/Rendering/WebGPU/Camera/index.js
+++ b/Sources/Rendering/WebGPU/Camera/index.js
@@ -13,6 +13,67 @@ function vtkWebGPUCamera(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkWebGPUCamera');
 
+  publicAPI.getProjectionMatrix = (outMat, aspect, cRange, windowCenter) => {
+    mat4.identity(outMat);
+    if (model.renderable.getParallelProjection()) {
+      // set up a rectangular parallelipiped
+      const parallelScale = model.renderable.getParallelScale();
+      const width = parallelScale * aspect;
+      const height = parallelScale;
+
+      const xmin = (windowCenter[0] - 1.0) * width;
+      const xmax = (windowCenter[0] + 1.0) * width;
+      const ymin = (windowCenter[1] - 1.0) * height;
+      const ymax = (windowCenter[1] + 1.0) * height;
+
+      const xr = 1.0 / (xmax - xmin);
+      const yr = 1.0 / (ymax - ymin);
+      outMat[0] = 2.0 * xr;
+      outMat[5] = 2.0 * yr;
+      outMat[10] = 1.0 / (cRange[1] - cRange[0]);
+      outMat[12] = (xmax + xmin) * xr;
+      outMat[13] = (ymax + ymin) * yr;
+      outMat[14] = cRange[1] / (cRange[1] - cRange[0]);
+    } else {
+      const tmp = Math.tan((Math.PI * model.renderable.getViewAngle()) / 360.0);
+      let width;
+      let height;
+      if (model.renderable.getUseHorizontalViewAngle() === true) {
+        width = cRange[0] * tmp;
+        height = (cRange[0] * tmp) / aspect;
+      } else {
+        width = cRange[0] * tmp * aspect;
+        height = cRange[0] * tmp;
+      }
+
+      const xmin = (windowCenter[0] - 1.0) * width;
+      const xmax = (windowCenter[0] + 1.0) * width;
+      const ymin = (windowCenter[1] - 1.0) * height;
+      const ymax = (windowCenter[1] + 1.0) * height;
+
+      outMat[0] = (2.0 * cRange[0]) / (xmax - xmin);
+      outMat[5] = (2.0 * cRange[0]) / (ymax - ymin);
+      outMat[12] = (xmin + xmax) / (xmax - xmin);
+      outMat[13] = (ymin + ymax) / (ymax - ymin);
+      outMat[10] = 0.0;
+      outMat[14] = cRange[0];
+      outMat[11] = -1.0;
+      outMat[15] = 0.0;
+    }
+  };
+
+  publicAPI.convertToOpenGLDepth = (val) => {
+    if (model.renderable.getParallelProjection()) {
+      return 1.0 - val;
+    }
+    const cRange = model.renderable.getClippingRangeByReference();
+    let zval = -cRange[0] / val;
+    zval =
+      (cRange[0] + cRange[1]) / (cRange[1] - cRange[0]) +
+      (2.0 * cRange[0] * cRange[1]) / (zval * (cRange[1] - cRange[0]));
+    return 0.5 * zval + 0.5;
+  };
+
   publicAPI.getKeyMatrices = (webGPURenderer) => {
     // has the camera changed?
     const ren = webGPURenderer.getRenderable();
@@ -44,14 +105,13 @@ function vtkWebGPUCamera(publicAPI, model) {
 
       const aspectRatio = webGPURenderer.getAspectRatio();
 
-      const vcpc = model.renderable.getProjectionMatrix(aspectRatio, -1, 1);
-      mat4.transpose(model.keyMatrices.vcpc, vcpc);
-
-      // adjust due to WebGPU using a different coordinate system in Z
-      model.keyMatrices.vcpc[2] = 0.5 * vcpc[8] + 0.5 * vcpc[12];
-      model.keyMatrices.vcpc[6] = 0.5 * vcpc[9] + 0.5 * vcpc[13];
-      model.keyMatrices.vcpc[10] = 0.5 * vcpc[10] + 0.5 * vcpc[14];
-      model.keyMatrices.vcpc[14] = 0.5 * vcpc[11] + 0.5 * vcpc[15];
+      const cRange = model.renderable.getClippingRangeByReference();
+      publicAPI.getProjectionMatrix(
+        model.keyMatrices.vcpc,
+        aspectRatio,
+        cRange,
+        model.renderable.getWindowCenterByReference()
+      );
 
       mat4.multiply(
         model.keyMatrices.scpc,

--- a/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
+++ b/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
@@ -71,7 +71,7 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
   publicAPI.replaceShaderSelect = (hash, pipeline, vertexInput) => {
     if (hash.includes('sel')) {
       const vDesc = pipeline.getShaderDescription('vertex');
-      vDesc.addOutput('u32', 'compositeID');
+      vDesc.addOutput('u32', 'compositeID', 'flat');
       let code = vDesc.getCode();
       code = vtkWebGPUShaderCache.substitute(code, '//VTK::Select::Impl', [
         '  output.compositeID = input.instanceIndex;',

--- a/Sources/Rendering/WebGPU/HardwareSelectionPass/index.js
+++ b/Sources/Rendering/WebGPU/HardwareSelectionPass/index.js
@@ -98,7 +98,7 @@ function vtkWebGPUHardwareSelectionPass(publicAPI, model) {
       primitive: { cullMode: 'none' },
       depthStencil: {
         depthWriteEnabled: true,
-        depthCompare: 'less',
+        depthCompare: 'greater',
         format: 'depth32float',
       },
       fragment: {

--- a/Sources/Rendering/WebGPU/HardwareSelector/index.js
+++ b/Sources/Rendering/WebGPU/HardwareSelector/index.js
@@ -72,6 +72,7 @@ function getPixelInformationWithData(
           buffdata.zbufferBufferWidth +
         inDisplayPosition[0];
       info.zValue = buffdata.depthValues[offset];
+      info.zValue = buffdata.webGPURenderer.convertToOpenGLDepth(info.zValue);
       info.displayPosition = inDisplayPosition;
     }
     return info;

--- a/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
@@ -176,7 +176,7 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
       primitive: { cullMode: 'none' },
       depthStencil: {
         depthWriteEnabled: false,
-        depthCompare: 'less',
+        depthCompare: 'greater',
         format: 'depth32float',
       },
       fragment: {

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -141,7 +141,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     ],
     depthStencilAttachment: {
       view: undefined,
-      depthLoadValue: 1.0,
+      depthLoadValue: 0.0,
       depthStoreOp: 'store',
       stencilLoadValue: 0,
       stencilStoreOp: 'store',
@@ -164,7 +164,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     primitive: { cullMode: 'none' },
     depthStencil: {
       depthWriteEnabled: true,
-      depthCompare: 'less-equal',
+      depthCompare: 'greater-equal',
       format: 'depth32float',
     },
     fragment: {

--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -73,9 +73,9 @@ fn main(
 
   //VTK::VolumePass::Impl
 
-  // use the minimum (closest) of the current value and the zbuffer
-  // the blend func will then take the max to find the farthest stop value
-  var stopval: f32 = min(input.fragPos.z, textureLoad(opaquePassDepthTexture, vec2<i32>(i32(input.fragPos.x), i32(input.fragPos.y)), 0));
+  // use the maximum (closest) of the current value and the zbuffer
+  // the blend func will then take the min to find the farthest stop value
+  var stopval: f32 = max(input.fragPos.z, textureLoad(opaquePassDepthTexture, vec2<i32>(i32(input.fragPos.x), i32(input.fragPos.y)), 0));
 
   //VTK::RenderEncoder::Impl
   return output;

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -364,9 +364,9 @@ fn main(
     var winDims: vec2<f32> = vec2<f32>(f32(winDimsI32.x), f32(winDimsI32.y));
 
     // compute start and end ray positions in view coordinates
-    var minPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMin, 1.0);
+    var minPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMax, 1.0);
     minPosSC = minPosSC * (1.0 / minPosSC.w);
-    var maxPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMax, 1.0);
+    var maxPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMin, 1.0);
     maxPosSC = maxPosSC * (1.0 / maxPosSC.w);
 
     var rayLengthSC: f32 = distance(minPosSC.xyz, maxPosSC.xyz);


### PR DESCRIPTION
Switch the zbuffer on WebGPU to be an inverted
depth buffer. Update mappers to handle this. See the README
for more information on how it works.

Improve surface with edges by using thicker edges and
a tiny bit of offset.

Update for recent changes in WebGPU that require flat interpolation
for integral outputs/inputs.
