### PR TITLE
docs(reslicecursorwidget): fix "Reset Views" button in Reslice Cursor…

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -437,7 +437,7 @@ sliderSlabNumberofSlices.addEventListener('change', (ev) => {
 
 const buttonReset = document.getElementById('buttonReset');
 buttonReset.addEventListener('click', () => {
-  widgetState.setPlanes(initialPlanesState);
+  widgetState.setPlanes({ ...initialPlanesState });
   widget.setCenter(widget.getWidgetState().getImage().getCenter());
   updateViews();
 });


### PR DESCRIPTION
… Widget example

Reset Views was working the first time, but not the second time.

fix #2154

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
See #2154 

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results

### Testing

- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
