### PR TITLE
feat(macros.js): add a toJSON method to vtkObject publicAPI

### DIFF
--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -276,6 +276,9 @@ function vtkDataArray(publicAPI, model) {
 
   // Override serialization support
   publicAPI.getState = () => {
+    if (model.deleted) {
+      return null;
+    }
     const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
 
     // Convert typed array to regular array

--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.js
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.js
@@ -172,9 +172,11 @@ function vtkFieldData(publicAPI, model) {
 
   publicAPI.getState = () => {
     const result = superGetState();
-    result.arrays = model.arrays.map((item) => ({
-      data: item.data.getState(),
-    }));
+    if (result) {
+      result.arrays = model.arrays.map((item) => ({
+        data: item.data.getState(),
+      }));
+    }
     return result;
   };
 }

--- a/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
+++ b/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
@@ -66,9 +66,8 @@ test('Test vtkAppendPolyData execution', (t) => {
 });
 
 test('Test addInputData edge case', (t) => {
-  const gc = testUtils.createGarbageCollector(t);
-  const appender = gc.registerResource(vtkAppendPolyData.newInstance());
-  const input = gc.registerResource(vtkPolyData.newInstance());
+  const appender = vtkAppendPolyData.newInstance();
+  const input = vtkPolyData.newInstance();
 
   appender.addInputData(input);
   const output = appender.getOutputData();
@@ -76,7 +75,7 @@ test('Test addInputData edge case', (t) => {
   t.ok(input === output, 'Single add input matches output');
   t.ok(appender.getNumberOfInputPorts() === 1, 'Expect 1 port after 1 add');
 
-  const input2 = gc.registerResource(vtkPolyData.newInstance());
+  const input2 = vtkPolyData.newInstance();
   appender.addInputData(input2);
   const output2 = appender.getOutputData();
 

--- a/Sources/Interaction/Manipulators/KeyboardCameraManipulator/index.js
+++ b/Sources/Interaction/Manipulators/KeyboardCameraManipulator/index.js
@@ -96,7 +96,7 @@ function vtkKeyboardCameraManipulator(publicAPI, model) {
       internal.animationSub = null;
     }
 
-    model.interactor.cancelAnimation(ANIMATION_REQUESTER);
+    model._interactor.cancelAnimation(ANIMATION_REQUESTER);
 
     if (internal.cameraModifiedSub) {
       internal.cameraModifiedSub.unsubscribe();

--- a/Sources/Interaction/Style/InteractorStyleImage/index.js
+++ b/Sources/Interaction/Style/InteractorStyleImage/index.js
@@ -117,7 +117,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
   publicAPI.windowLevel = (renderer, position) => {
     model.windowLevelCurrentPosition[0] = position.x;
     model.windowLevelCurrentPosition[1] = position.y;
-    const rwi = model.interactor;
+    const rwi = model._interactor;
 
     if (model.currentImageProperty) {
       const size = rwi.getView().getViewportSize(renderer);
@@ -172,7 +172,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.slice = (renderer, position) => {
-    const rwi = model.interactor;
+    const rwi = model._interactor;
 
     const dy = position.y - model.lastSlicePosition;
 
@@ -216,7 +216,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
       return;
     }
 
-    const renderer = model.interactor.getCurrentRenderer();
+    const renderer = model._interactor.getCurrentRenderer();
     if (!renderer) {
       return;
     }

--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
@@ -110,7 +110,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   };
 
   publicAPI.handleMouseMove = macro.chain(publicAPI.handleMouseMove, () => {
-    const renderer = model.interactor.getCurrentRenderer();
+    const renderer = model._interactor.getCurrentRenderer();
     const camera = renderer.getActiveCamera();
     const dist = camera.getDistance();
     camera.setClippingRange(dist, dist + 0.1);
@@ -119,7 +119,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   const superSetVolumeMapper = publicAPI.setVolumeMapper;
   publicAPI.setVolumeMapper = (mapper) => {
     if (superSetVolumeMapper(mapper)) {
-      const renderer = model.interactor.getCurrentRenderer();
+      const renderer = model._interactor.getCurrentRenderer();
       const camera = renderer.getActiveCamera();
       if (mapper) {
         // prevent zoom manipulator from messing with our focal point
@@ -132,7 +132,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   };
 
   publicAPI.getSlice = () => {
-    const renderer = model.interactor.getCurrentRenderer();
+    const renderer = model._interactor.getCurrentRenderer();
     const camera = renderer.getActiveCamera();
     const sliceNormal = publicAPI.getSliceNormal();
 
@@ -148,7 +148,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   };
 
   publicAPI.setSlice = (slice) => {
-    const renderer = model.interactor.getCurrentRenderer();
+    const renderer = model._interactor.getCurrentRenderer();
     const camera = renderer.getActiveCamera();
 
     if (model.volumeMapper) {
@@ -235,7 +235,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   // Slice normal is just camera DOP
   publicAPI.getSliceNormal = () => {
     if (model.volumeMapper) {
-      const renderer = model.interactor.getCurrentRenderer();
+      const renderer = model._interactor.getCurrentRenderer();
       const camera = renderer.getActiveCamera();
       return camera.getDirectionOfProjection();
     }
@@ -244,7 +244,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
 
   // in world space
   publicAPI.setSliceNormal = (...normal) => {
-    const renderer = model.interactor.getCurrentRenderer();
+    const renderer = model._interactor.getCurrentRenderer();
     const camera = renderer.getActiveCamera();
 
     vtkMath.normalize(normal);

--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -345,11 +345,11 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       }
       model.currentManipulator.startInteraction();
       model.currentManipulator.onButtonDown(
-        model.interactor,
+        model._interactor,
         callData.pokedRenderer,
         callData.position
       );
-      model.interactor.requestAnimation(publicAPI.onButtonDown);
+      model._interactor.requestAnimation(publicAPI.onButtonDown);
       publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     } else {
       vtkDebugMacro('No manipulator found');
@@ -415,10 +415,10 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       model.currentManipulator.getButton &&
       model.currentManipulator.getButton() === button
     ) {
-      model.currentManipulator.onButtonUp(model.interactor);
+      model.currentManipulator.onButtonUp(model._interactor);
       model.currentManipulator.endInteraction();
       model.currentManipulator = null;
-      model.interactor.cancelAnimation(publicAPI.onButtonDown);
+      model._interactor.cancelAnimation(publicAPI.onButtonDown);
       publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
     }
   };
@@ -447,12 +447,12 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     if (manipulator) {
       model.currentWheelManipulator = manipulator;
       model.currentWheelManipulator.onStartScroll(
-        model.interactor,
+        model._interactor,
         callData.pokedRenderer,
         callData.spinY
       );
       model.currentWheelManipulator.startInteraction();
-      model.interactor.requestAnimation(publicAPI.handleStartMouseWheel);
+      model._interactor.requestAnimation(publicAPI.handleStartMouseWheel);
       publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     } else {
       vtkDebugMacro('No manipulator found');
@@ -465,10 +465,10 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       return;
     }
     if (model.currentWheelManipulator.onEndScroll) {
-      model.currentWheelManipulator.onEndScroll(model.interactor);
+      model.currentWheelManipulator.onEndScroll(model._interactor);
       model.currentWheelManipulator.endInteraction();
       model.currentWheelManipulator = null;
-      model.interactor.cancelAnimation(publicAPI.handleStartMouseWheel);
+      model._interactor.cancelAnimation(publicAPI.handleStartMouseWheel);
       publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
     }
   };
@@ -480,7 +480,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       model.currentWheelManipulator.onScroll
     ) {
       model.currentWheelManipulator.onScroll(
-        model.interactor,
+        model._interactor,
         callData.pokedRenderer,
         callData.spinY,
         model.cachedMousePosition
@@ -494,7 +494,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     model.cachedMousePosition = callData.position;
     if (model.currentManipulator && model.currentManipulator.onMouseMove) {
       model.currentManipulator.onMouseMove(
-        model.interactor,
+        model._interactor,
         callData.pokedRenderer,
         callData.position
       );
@@ -510,7 +510,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       .filter((m) => m.onKeyPress)
       .forEach((manipulator) => {
         manipulator.onKeyPress(
-          model.interactor,
+          model._interactor,
           callData.pokedRenderer,
           callData.key
         );
@@ -524,7 +524,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       .filter((m) => m.onKeyDown)
       .forEach((manipulator) => {
         manipulator.onKeyDown(
-          model.interactor,
+          model._interactor,
           callData.pokedRenderer,
           callData.key
         );
@@ -538,7 +538,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       .filter((m) => m.onKeyUp)
       .forEach((manipulator) => {
         manipulator.onKeyUp(
-          model.interactor,
+          model._interactor,
           callData.pokedRenderer,
           callData.key
         );
@@ -556,11 +556,11 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     while (count--) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isPinchEnabled()) {
-        manipulator.onStartPinch(model.interactor, callData.scale);
+        manipulator.onStartPinch(model._interactor, callData.scale);
         manipulator.startInteraction();
       }
     }
-    model.interactor.requestAnimation(publicAPI.handleStartPinch);
+    model._interactor.requestAnimation(publicAPI.handleStartPinch);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
   };
 
@@ -571,11 +571,11 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     while (count--) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isPinchEnabled()) {
-        manipulator.onEndPinch(model.interactor);
+        manipulator.onEndPinch(model._interactor);
         manipulator.endInteraction();
       }
     }
-    model.interactor.cancelAnimation(publicAPI.handleStartPinch);
+    model._interactor.cancelAnimation(publicAPI.handleStartPinch);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 
@@ -586,11 +586,11 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     while (count--) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isRotateEnabled()) {
-        manipulator.onStartRotate(model.interactor, callData.rotation);
+        manipulator.onStartRotate(model._interactor, callData.rotation);
         manipulator.startInteraction();
       }
     }
-    model.interactor.requestAnimation(publicAPI.handleStartRotate);
+    model._interactor.requestAnimation(publicAPI.handleStartRotate);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
   };
 
@@ -601,11 +601,11 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     while (count--) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isRotateEnabled()) {
-        manipulator.onEndRotate(model.interactor);
+        manipulator.onEndRotate(model._interactor);
         manipulator.endInteraction();
       }
     }
-    model.interactor.cancelAnimation(publicAPI.handleStartRotate);
+    model._interactor.cancelAnimation(publicAPI.handleStartRotate);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 
@@ -616,11 +616,11 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     while (count--) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isPanEnabled()) {
-        manipulator.onStartPan(model.interactor, callData.translation);
+        manipulator.onStartPan(model._interactor, callData.translation);
         manipulator.startInteraction();
       }
     }
-    model.interactor.requestAnimation(publicAPI.handleStartPan);
+    model._interactor.requestAnimation(publicAPI.handleStartPan);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
   };
 
@@ -631,11 +631,11 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     while (count--) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isPanEnabled()) {
-        manipulator.onEndPan(model.interactor);
+        manipulator.onEndPan(model._interactor);
         manipulator.endInteraction();
       }
     }
-    model.interactor.cancelAnimation(publicAPI.handleStartPan);
+    model._interactor.cancelAnimation(publicAPI.handleStartPan);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 
@@ -647,7 +647,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isPinchEnabled()) {
         manipulator.onPinch(
-          model.interactor,
+          model._interactor,
           callData.pokedRenderer,
           callData.scale
         );
@@ -667,7 +667,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isPanEnabled()) {
         manipulator.onPan(
-          model.interactor,
+          model._interactor,
           callData.pokedRenderer,
           callData.translation
         );
@@ -687,7 +687,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       const manipulator = model.gestureManipulators[count];
       if (manipulator && manipulator.isRotateEnabled()) {
         manipulator.onRotate(
-          model.interactor,
+          model._interactor,
           callData.pokedRenderer,
           callData.rotation
         );

--- a/Sources/Interaction/Style/InteractorStyleRemoteMouse/index.js
+++ b/Sources/Interaction/Style/InteractorStyleRemoteMouse/index.js
@@ -32,7 +32,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
     const action = buttonLeft || buttonMiddle || buttonRight ? 'down' : 'up';
 
     // Fixme x / y
-    const [width, height] = model.interactor.getView().getSizeByReference();
+    const [width, height] = model._interactor.getView().getSizeByReference();
     let { x, y } = callData.position;
     x /= width;
     y /= height;
@@ -95,7 +95,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
 
   //-------------------------------------------------------------------------
   publicAPI.onButtonDown = (button, callData) => {
-    model.interactor.requestAnimation(publicAPI.onButtonDown);
+    model._interactor.requestAnimation(publicAPI.onButtonDown);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteMouseEvent(createRemoteEvent(callData));
   };
@@ -104,13 +104,13 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
   publicAPI.onButtonUp = (button, callData) => {
     publicAPI.invokeRemoteMouseEvent(createRemoteEvent(callData));
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
-    model.interactor.cancelAnimation(publicAPI.onButtonDown);
+    model._interactor.cancelAnimation(publicAPI.onButtonDown);
   };
 
   //-------------------------------------------------------------------------
   publicAPI.handleStartMouseWheel = (callData) => {
     const { spinY, altKey, controlKey, shiftKey } = callData;
-    model.interactor.requestAnimation(publicAPI.handleStartMouseWheel);
+    model._interactor.requestAnimation(publicAPI.handleStartMouseWheel);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteWheelEvent({
       type: 'StartMouseWheel',
@@ -142,7 +142,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
       type: 'EndMouseWheel',
       ...model.remoteEventAddOn,
     });
-    model.interactor.cancelAnimation(publicAPI.handleStartMouseWheel);
+    model._interactor.cancelAnimation(publicAPI.handleStartMouseWheel);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 
@@ -173,7 +173,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
   publicAPI.handleStartPinch = (callData) => {
     publicAPI.startDolly();
     const { scale } = callData;
-    model.interactor.requestAnimation(publicAPI.handleStartPinch);
+    model._interactor.requestAnimation(publicAPI.handleStartPinch);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteGestureEvent({
       type: 'StartPinch',
@@ -201,7 +201,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
       type: 'EndPinch',
       ...model.remoteEventAddOn,
     });
-    model.interactor.cancelAnimation(publicAPI.handleStartPinch);
+    model._interactor.cancelAnimation(publicAPI.handleStartPinch);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 
@@ -210,7 +210,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
   publicAPI.handleStartRotate = (callData) => {
     publicAPI.startRotate();
     const { rotation } = callData;
-    model.interactor.requestAnimation(publicAPI.handleStartRotate);
+    model._interactor.requestAnimation(publicAPI.handleStartRotate);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteGestureEvent({
       type: 'StartRotate',
@@ -238,7 +238,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
       type: 'EndRotate',
       ...model.remoteEventAddOn,
     });
-    model.interactor.cancelAnimation(publicAPI.handleStartRotate);
+    model._interactor.cancelAnimation(publicAPI.handleStartRotate);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 
@@ -247,7 +247,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
   publicAPI.handleStartPan = (callData) => {
     publicAPI.startPan();
     const { translation } = callData;
-    model.interactor.requestAnimation(publicAPI.handleStartPan);
+    model._interactor.requestAnimation(publicAPI.handleStartPan);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteGestureEvent({
       type: 'StartPan',
@@ -275,7 +275,7 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
       type: 'EndPan',
       ...model.remoteEventAddOn,
     });
-    model.interactor.cancelAnimation(publicAPI.handleStartPan);
+    model._interactor.cancelAnimation(publicAPI.handleStartPan);
     publicAPI.invokeEndInteractionEvent(END_INTERACTION_EVENT);
   };
 }

--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -258,7 +258,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
       motionVector[2] + viewPoint[2]
     );
 
-    if (model.interactor.getLightFollowCamera()) {
+    if (model._interactor.getLightFollowCamera()) {
       callData.pokedRenderer.updateLightsGeometryToFollowCamera();
     }
 
@@ -277,7 +277,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //--------------------------------------------------------------------------
   publicAPI.handleMouseRotate = (renderer, position) => {
-    const rwi = model.interactor;
+    const rwi = model._interactor;
 
     const dx = position.x - model.previousPosition.x;
     const dy = position.y - model.previousPosition.y;
@@ -312,7 +312,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //--------------------------------------------------------------------------
   publicAPI.handleMouseSpin = (renderer, position) => {
-    const rwi = model.interactor;
+    const rwi = model._interactor;
     const camera = renderer.getActiveCamera();
     const center = rwi.getView().getViewportCenter(renderer);
 
@@ -383,7 +383,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
       motionVector[2] + viewPoint[2]
     );
 
-    if (model.interactor.getLightFollowCamera()) {
+    if (model._interactor.getLightFollowCamera()) {
       renderer.updateLightsGeometryToFollowCamera();
     }
   };
@@ -391,7 +391,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.handleMouseDolly = (renderer, position) => {
     const dy = position.y - model.previousPosition.y;
-    const rwi = model.interactor;
+    const rwi = model._interactor;
     const center = rwi.getView().getViewportCenter(renderer);
     const dyf = (model.motionFactor * dy) / center[1];
 
@@ -420,7 +420,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
       }
     }
 
-    if (model.interactor.getLightFollowCamera()) {
+    if (model._interactor.getLightFollowCamera()) {
       renderer.updateLightsGeometryToFollowCamera();
     }
   };

--- a/Sources/Interaction/Widgets/AbstractWidget/index.js
+++ b/Sources/Interaction/Widgets/AbstractWidget/index.js
@@ -22,8 +22,8 @@ function vtkAbstractWidget(publicAPI, model) {
       return;
     }
 
-    if (model.interactor) {
-      const renderer = model.interactor.getCurrentRenderer();
+    if (model._interactor) {
+      const renderer = model._interactor.getCurrentRenderer();
       if (renderer && model.widgetRep) {
         renderer.removeViewProp(model.widgetRep);
       }
@@ -34,10 +34,10 @@ function vtkAbstractWidget(publicAPI, model) {
 
     if (enable) {
       // Add representation to new interactor's renderer
-      if (!model.interactor) {
+      if (!model._interactor) {
         return;
       }
-      const renderer = model.interactor.getCurrentRenderer();
+      const renderer = model._interactor.getCurrentRenderer();
       if (!renderer) {
         return;
       }
@@ -50,13 +50,13 @@ function vtkAbstractWidget(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.render = () => {
-    if (!model.parent && model.interactor) {
-      model.interactor.render();
+    if (!model._parent && model._interactor) {
+      model._interactor.render();
     }
   };
 
   publicAPI.isDragable = () =>
-    model.dragable && (model.parent ? model.parent.isDragable() : true);
+    model.dragable && (model._parent ? model._parent.isDragable() : true);
 }
 
 // ----------------------------------------------------------------------------
@@ -67,7 +67,7 @@ const DEFAULT_VALUES = {
   enabled: false, // Make widgets disabled by default
   priority: 0.5, // Use a priority of 0.5, since default priority from vtkInteractorObserver is 0.0.
   widgetRep: null,
-  parent: null,
+  // _parent: null,
   dragable: true,
 };
 
@@ -79,7 +79,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkInteractorObserver.extend(publicAPI, model, newDefault);
 
-  macro.setGet(publicAPI, model, ['widgetRep', 'parent', 'dragable']);
+  macro.setGet(publicAPI, model, ['widgetRep', '_parent', 'dragable']);
+  macro.moveToProtected(publicAPI, model, ['parent']);
 
   // Object methods
   vtkAbstractWidget(publicAPI, model);

--- a/Sources/Interaction/Widgets/DistanceWidget/index.js
+++ b/Sources/Interaction/Widgets/DistanceWidget/index.js
@@ -16,7 +16,7 @@ function vtkDistanceWidget(publicAPI, model) {
   publicAPI.setInteractor = (i) => {
     superClass.setInteractor(i);
 
-    model.labelWidget.setInteractor(model.interactor);
+    model.labelWidget.setInteractor(model._interactor);
 
     publicAPI.modified();
   };

--- a/Sources/Interaction/Widgets/HandleWidget/index.js
+++ b/Sources/Interaction/Widgets/HandleWidget/index.js
@@ -54,11 +54,11 @@ function vtkHandleWidget(publicAPI, model) {
   publicAPI.setCursor = (state) => {
     switch (state) {
       case InteractionState.OUTSIDE: {
-        model.interactor.getView().setCursor('default');
+        model._interactor.getView().setCursor('default');
         break;
       }
       default: {
-        model.interactor.getView().setCursor('pointer');
+        model._interactor.getView().setCursor('pointer');
       }
     }
   };

--- a/Sources/Interaction/Widgets/LabelWidget/index.js
+++ b/Sources/Interaction/Widgets/LabelWidget/index.js
@@ -29,8 +29,8 @@ function vtkLabelWidget(publicAPI, model) {
     superClass.setEnabled(enabling);
 
     if (enabling) {
-      const container = model.interactor
-        ? model.interactor.getContainer()
+      const container = model._interactor
+        ? model._interactor.getContainer()
         : null;
       model.widgetRep.setContainer(container);
     }

--- a/Sources/Interaction/Widgets/LineWidget/index.js
+++ b/Sources/Interaction/Widgets/LineWidget/index.js
@@ -22,11 +22,11 @@ function vtkLineWidget(publicAPI, model) {
   publicAPI.setCursor = (state) => {
     switch (state) {
       case State.OUTSIDE: {
-        model.interactor.getView().setCursor('default');
+        model._interactor.getView().setCursor('default');
         break;
       }
       default: {
-        model.interactor.getView().setCursor('pointer');
+        model._interactor.getView().setCursor('pointer');
       }
     }
   };
@@ -38,8 +38,8 @@ function vtkLineWidget(publicAPI, model) {
   publicAPI.setInteractor = (i) => {
     superClass.setInteractor(i);
 
-    model.point1Widget.setInteractor(model.interactor);
-    model.point2Widget.setInteractor(model.interactor);
+    model.point1Widget.setInteractor(model._interactor);
+    model.point2Widget.setInteractor(model._interactor);
 
     publicAPI.modified();
   };

--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
@@ -28,11 +28,11 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
 
   publicAPI.computeViewport = () => {
     const parentRen =
-      model.parentRenderer || model.interactor.getCurrentRenderer();
+      model.parentRenderer || model._interactor.getCurrentRenderer();
 
     const [xMin, yMin, xMax, yMax] = parentRen.getViewport();
 
-    const view = model.interactor.getView();
+    const view = model._interactor.getView();
     const canvasSize = view.getSize();
     const [viewXSize, viewYSize] = view.getViewportSize(parentRen);
     const minViewSize = Math.min(viewXSize, viewYSize);
@@ -65,12 +65,12 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
   publicAPI.updateViewport = () => {
     if (model.enabled) {
       selfRenderer.setViewport(...publicAPI.computeViewport());
-      model.interactor.render();
+      model._interactor.render();
     }
   };
 
   publicAPI.updateMarkerOrientation = () => {
-    const ren = model.parentRenderer || model.interactor.getCurrentRenderer();
+    const ren = model.parentRenderer || model._interactor.getCurrentRenderer();
     const currentCamera = ren.getActiveCamera();
     if (!currentCamera) {
       return;
@@ -121,14 +121,15 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
         return;
       }
 
-      if (!model.interactor) {
+      if (!model._interactor) {
         vtkErrorMacro(
           'Must set interactor before enabling orientation marker.'
         );
         return;
       }
 
-      const ren = model.parentRenderer || model.interactor.getCurrentRenderer();
+      const ren =
+        model.parentRenderer || model._interactor.getCurrentRenderer();
       const renderWindow = ren.getRenderWindow();
       renderWindow.addRenderer(selfRenderer);
       if (renderWindow.getNumberOfLayers() < 2) {
@@ -141,14 +142,14 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
       selfRenderer.addViewProp(model.actor);
       model.actor.setVisibility(true);
 
-      onAnimationSub = model.interactor.onAnimation(
+      onAnimationSub = model._interactor.onAnimation(
         publicAPI.updateMarkerOrientation
       );
-      onEndAnimationSub = model.interactor.onEndAnimation(
+      onEndAnimationSub = model._interactor.onEndAnimation(
         publicAPI.updateMarkerOrientation
       );
 
-      resizeObserver.observe(model.interactor.getView().getCanvas());
+      resizeObserver.observe(model._interactor.getView().getCanvas());
 
       publicAPI.updateViewport();
       publicAPI.updateMarkerOrientation();
@@ -169,7 +170,7 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
       model.actor.setVisibility(false);
       selfRenderer.removeViewProp(model.actor);
 
-      const renderWindow = model.interactor
+      const renderWindow = model._interactor
         .findPokedRenderer()
         .getRenderWindow();
       if (renderWindow) {
@@ -250,7 +251,7 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
 
 export const DEFAULT_VALUES = {
   // actor: null,
-  // interactor: null,
+  // _interactor: null,
   viewportCorner: Constants.Corners.BOTTOM_LEFT,
   viewportSize: 0.2,
   minPixelSize: 50,
@@ -271,12 +272,13 @@ export function extend(publicAPI, model, initialValues = {}) {
   // NOTE: setting these while the widget is enabled will
   // not update the widget.
   macro.setGet(publicAPI, model, [
-    'interactor',
+    '_interactor',
     'minPixelSize',
     'maxPixelSize',
     'parentRenderer',
   ]);
   macro.get(publicAPI, model, ['actor']);
+  macro.moveToProtected(publicAPI, model, ['interactor']);
 
   // Object methods
   vtkOrientationMarkerWidget(publicAPI, model);

--- a/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorActor/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorActor/index.js
@@ -138,7 +138,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     ].setResolveCoincidentTopologyLineOffsetParameters(-1.0, -1.0);
 
     model.cursorCenterlineActor[i] = vtkActor.newInstance({
-      parentProp: publicAPI,
+      _parentProp: publicAPI,
     });
     model.cursorCenterlineActor[i].setMapper(model.cursorCenterlineMapper[i]);
 

--- a/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorLineRepresentation/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorLineRepresentation/index.js
@@ -484,7 +484,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   );
 
   model.resliceCursorActor = vtkResliceCursorActor.newInstance({
-    parentProp: publicAPI,
+    _parentProp: publicAPI,
   });
   model.startPickPosition = null;
   model.startCenterPosition = null;

--- a/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorWidget/index.js
+++ b/Sources/Interaction/Widgets/ResliceCursor/ResliceCursorWidget/index.js
@@ -28,11 +28,11 @@ function vtkResliceCursorWidget(publicAPI, model) {
       case InteractionState.ON_AXIS1:
       case InteractionState.ON_AXIS2:
       case InteractionState.ON_CENTER: {
-        model.interactor.getView().setCursor('pointer');
+        model._interactor.getView().setCursor('pointer');
         break;
       }
       default: {
-        model.interactor.getView().setCursor('default');
+        model._interactor.getView().setCursor('default');
       }
     }
   };
@@ -126,7 +126,7 @@ function vtkResliceCursorWidget(publicAPI, model) {
   publicAPI.setInteractor = (i) => {
     superClass.setInteractor(i);
 
-    model.imageInteractorStyle.setInteractor(model.interactor);
+    model.imageInteractorStyle.setInteractor(model._interactor);
     model.imageInteractorStyle.setEnabled(false);
   };
 }

--- a/Sources/Rendering/Core/InteractorObserver/index.js
+++ b/Sources/Rendering/Core/InteractorObserver/index.js
@@ -54,7 +54,7 @@ function vtkInteractorObserver(publicAPI, model) {
     vtkRenderWindowInteractor.handledEvents.forEach((eventName) => {
       if (publicAPI[`handle${eventName}`]) {
         model.subscribedEvents.push(
-          model.interactor[`on${eventName}`]((callData) => {
+          model._interactor[`on${eventName}`]((callData) => {
             if (model.processEvents) {
               return publicAPI[`handle${eventName}`](callData);
             }
@@ -69,13 +69,13 @@ function vtkInteractorObserver(publicAPI, model) {
   // Public API methods
   //----------------------------------------------------------------------------
   publicAPI.setInteractor = (i) => {
-    if (i === model.interactor) {
+    if (i === model._interactor) {
       return;
     }
 
     unsubscribeFromEvents();
 
-    model.interactor = i;
+    model._interactor = i;
 
     if (i && model.enabled) {
       subscribeToEvents();
@@ -93,7 +93,7 @@ function vtkInteractorObserver(publicAPI, model) {
     unsubscribeFromEvents();
 
     if (enable) {
-      if (model.interactor) {
+      if (model._interactor) {
         subscribeToEvents();
       } else {
         vtkErrorMacro(`
@@ -114,7 +114,7 @@ function vtkInteractorObserver(publicAPI, model) {
       return null;
     }
 
-    return model.interactor.getView().displayToWorld(x, y, z, renderer);
+    return model._interactor.getView().displayToWorld(x, y, z, renderer);
   };
 
   //----------------------------------------------------------------------------
@@ -125,7 +125,7 @@ function vtkInteractorObserver(publicAPI, model) {
       return null;
     }
 
-    return model.interactor.getView().worldToDisplay(x, y, z, renderer);
+    return model._interactor.getView().worldToDisplay(x, y, z, renderer);
   };
 
   //----------------------------------------------------------------------------
@@ -133,7 +133,7 @@ function vtkInteractorObserver(publicAPI, model) {
   publicAPI.setPriority = (priority) => {
     const modified = superClass.setPriority(priority);
 
-    if (modified && model.interactor) {
+    if (modified && model._interactor) {
       unsubscribeFromEvents();
       subscribeToEvents();
     }
@@ -146,7 +146,7 @@ function vtkInteractorObserver(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   enabled: true,
-  interactor: null,
+  // _interactor: null,
   priority: 0.0,
   processEvents: true,
   subscribedEvents: [],
@@ -165,10 +165,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.event(publicAPI, model, 'EndInteractionEvent');
 
   // Create get-only macros
-  macro.get(publicAPI, model, ['interactor', 'enabled']);
+  macro.get(publicAPI, model, ['_interactor', 'enabled']);
 
   // Create get-set macros
   macro.setGet(publicAPI, model, ['priority', 'processEvents']);
+
+  macro.moveToProtected(publicAPI, model, ['interactor']);
 
   // For more macro methods, see "Sources/macros.js"
 

--- a/Sources/Rendering/Core/InteractorStyle/index.js
+++ b/Sources/Rendering/Core/InteractorStyle/index.js
@@ -38,7 +38,7 @@ function vtkInteractorStyle(publicAPI, model) {
         return;
       }
       model.state = stateNames[key];
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent({ type: 'StartInteractionEvent' });
       publicAPI[`invokeStart${key}Event`]({ type: `Start${key}Event` });
     };
@@ -48,16 +48,16 @@ function vtkInteractorStyle(publicAPI, model) {
         return;
       }
       model.state = States.IS_NONE;
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent({ type: 'EndInteractionEvent' });
       publicAPI[`invokeEnd${key}Event`]({ type: `End${key}Event` });
-      model.interactor.render();
+      model._interactor.render();
     };
   });
 
   //----------------------------------------------------------------------------
   publicAPI.handleKeyPress = (callData) => {
-    const rwi = model.interactor;
+    const rwi = model._interactor;
     let ac = null;
     switch (callData.key) {
       case 'r':

--- a/Sources/Rendering/Core/Prop/index.js
+++ b/Sources/Rendering/Core/Prop/index.js
@@ -33,13 +33,13 @@ function vtkProp(publicAPI, model) {
 
   publicAPI.getNestedVisibility = () =>
     model.visibility &&
-    (!model.parentProp || model.parentProp.getNestedVisibility());
+    (!model._parentProp || model._parentProp.getNestedVisibility());
   publicAPI.getNestedPickable = () =>
     model.pickable &&
-    (!model.parentProp || model.parentProp.getNestedPickable());
+    (!model._parentProp || model._parentProp.getNestedPickable());
   publicAPI.getNestedDragable = () =>
     model.dragable &&
-    (!model.parentProp || model.parentProp.getNestedDragable());
+    (!model._parentProp || model._parentProp.getNestedDragable());
 
   publicAPI.getRedrawMTime = () => model.mtime;
 
@@ -92,6 +92,7 @@ function vtkProp(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  // _parentProp: null,
   visibility: true,
   pickable: true,
   dragable: true,
@@ -118,8 +119,9 @@ export function extend(publicAPI, model, initialValues = {}) {
     'dragable',
     'useBounds',
     'renderTimeMultiplier',
-    'parentProp',
+    '_parentProp',
   ]);
+  macro.moveToProtected(publicAPI, model, ['parentProp']);
 
   // Object methods
   vtkProp(publicAPI, model);

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -158,7 +158,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
 
   function getScreenEventPositionFor(source) {
     const bounds = model.container.getBoundingClientRect();
-    const canvas = model.view.getCanvas();
+    const canvas = model._view.getCanvas();
     const scaleX = canvas.width / bounds.width;
     const scaleY = canvas.height / bounds.height;
     const position = {
@@ -349,9 +349,9 @@ function vtkRenderWindowInteractor(publicAPI, model) {
 
   //----------------------------------------------------------------------
   function forceRender() {
-    if (model.view && model.enabled && model.enableRender) {
+    if (model._view && model.enabled && model.enableRender) {
       model.inRender = true;
-      model.view.traverseAllPasses();
+      model._view.traverseAllPasses();
       model.inRender = false;
     }
     // outside the above test so that third-party code can redirect
@@ -742,24 +742,24 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   };
 
   publicAPI.setView = (val) => {
-    if (model.view === val) {
+    if (model._view === val) {
       return;
     }
-    model.view = val;
-    model.view.getRenderable().setInteractor(publicAPI);
+    model._view = val;
+    model._view.getRenderable().setInteractor(publicAPI);
     publicAPI.modified();
   };
 
   publicAPI.getFirstRenderer = () =>
-    model.view?.getRenderable()?.getRenderersByReference()?.[0];
+    model._view?.getRenderable()?.getRenderersByReference()?.[0];
 
   publicAPI.findPokedRenderer = (x = 0, y = 0) => {
-    if (!model.view) {
+    if (!model._view) {
       return null;
     }
     // The original order of renderers needs to remain as
     // the first one is the one we want to manipulate the camera on.
-    const rc = model.view?.getRenderable()?.getRenderers();
+    const rc = model._view?.getRenderable()?.getRenderers();
     if (!rc) {
       return null;
     }
@@ -771,7 +771,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     let count = rc.length;
     while (count--) {
       const aren = rc[count];
-      if (model.view.isInViewport(x, y, aren) && aren.getInteractive()) {
+      if (model._view.isInViewport(x, y, aren) && aren.getInteractive()) {
         currentRenderer = aren;
         break;
       }
@@ -781,7 +781,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
         // is interactive.
         interactiveren = aren;
       }
-      if (viewportren === null && model.view.isInViewport(x, y, aren)) {
+      if (viewportren === null && model._view.isInViewport(x, y, aren)) {
         // Save this renderer in case we can't find one in the viewport that
         // is interactive.
         viewportren = aren;
@@ -1082,7 +1082,7 @@ const DEFAULT_VALUES = {
   desiredUpdateRate: 30.0,
   stillUpdateRate: 2.0,
   container: null,
-  view: null,
+  // _view: null,
   recognizeGestures: true,
   currentGesture: 'Start',
   animationRequest: null,
@@ -1116,7 +1116,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'interactorStyle',
     'lastFrameTime',
     'recentAnimationFrameRate',
-    'view',
+    '_view',
   ]);
 
   // Create get-set macros
@@ -1129,6 +1129,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'stillUpdateRate',
     'picker',
   ]);
+  macro.moveToProtected(publicAPI, model, ['view']);
 
   // For more macro methods, see "Sources/macros.js"
 

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -84,7 +84,7 @@ function vtkRenderer(publicAPI, model) {
   publicAPI.allocateTime = notImplemented('allocateTime');
   publicAPI.updateGeometry = notImplemented('updateGeometry');
 
-  publicAPI.getVTKWindow = () => model.renderWindow;
+  publicAPI.getVTKWindow = () => model._renderWindow;
 
   publicAPI.setLayer = (layer) => {
     vtkDebugMacro(
@@ -201,21 +201,21 @@ function vtkRenderer(publicAPI, model) {
       return;
     }
 
-    if (model.createdLight) {
-      publicAPI.removeLight(model.createdLight);
-      model.createdLight.delete();
-      model.createdLight = null;
+    if (model._createdLight) {
+      publicAPI.removeLight(model._createdLight);
+      model._createdLight.delete();
+      model._createdLight = null;
     }
 
-    model.createdLight = publicAPI.makeLight();
-    publicAPI.addLight(model.createdLight);
+    model._createdLight = publicAPI.makeLight();
+    publicAPI.addLight(model._createdLight);
 
-    model.createdLight.setLightTypeToHeadLight();
+    model._createdLight.setLightTypeToHeadLight();
 
     // set these values just to have a good default should LightFollowCamera
     // be turned off.
-    model.createdLight.setPosition(publicAPI.getActiveCamera().getPosition());
-    model.createdLight.setFocalPoint(
+    model._createdLight.setPosition(publicAPI.getActiveCamera().getPosition());
+    model._createdLight.setFocalPoint(
       publicAPI.getActiveCamera().getFocalPoint()
     );
   };
@@ -527,9 +527,9 @@ function vtkRenderer(publicAPI, model) {
   };
 
   publicAPI.setRenderWindow = (renderWindow) => {
-    if (renderWindow !== model.renderWindow) {
-      model.vtkWindow = renderWindow;
-      model.renderWindow = renderWindow;
+    if (renderWindow !== model._renderWindow) {
+      model._vtkWindow = renderWindow;
+      model._renderWindow = renderWindow;
     }
   };
 
@@ -543,7 +543,7 @@ function vtkRenderer(publicAPI, model) {
     if (m2 > m1) {
       m1 = m2;
     }
-    const m3 = model.createdLight ? model.createdLight.getMTime() : 0;
+    const m3 = model._createdLight ? model._createdLight.getMTime() : 0;
     if (m3 > m1) {
       m1 = m3;
     }
@@ -569,7 +569,6 @@ const DEFAULT_VALUES = {
   allocatedRenderTime: 100,
   timeFactor: 1,
 
-  createdLight: null,
   automaticLightCreation: true,
 
   twoSidedLighting: true,
@@ -632,7 +631,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Build VTK API
   macro.get(publicAPI, model, [
-    'renderWindow',
+    '_renderWindow',
 
     'allocatedRenderTime',
     'timeFactor',
@@ -667,6 +666,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
   macro.getArray(publicAPI, model, ['actors', 'volumes', 'lights']);
   macro.setGetArray(publicAPI, model, ['background'], 4, 1.0);
+  macro.moveToProtected(publicAPI, model, ['renderWindow']);
 
   // Object methods
   vtkRenderer(publicAPI, model);

--- a/Sources/Rendering/Core/Viewport/index.js
+++ b/Sources/Rendering/Core/Viewport/index.js
@@ -139,7 +139,7 @@ function vtkViewport(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  vtkWindow: null,
+  // _vtkWindow: null,
   background: [0, 0, 0],
   background2: [0.2, 0.2, 0.2],
   gradientBackground: false,

--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -16,12 +16,12 @@ function vtkOpenGLActor(publicAPI, model) {
   // Builds myself.
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNodes(model.renderable.getTextures());
       publicAPI.addMissingNode(model.renderable.getMapper());

--- a/Sources/Rendering/OpenGL/Actor2D/index.js
+++ b/Sources/Rendering/OpenGL/Actor2D/index.js
@@ -17,12 +17,12 @@ function vtkOpenGLActor2D(publicAPI, model) {
       if (!model.renderable) {
         return;
       }
-      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNodes(model.renderable.getTextures());
       publicAPI.addMissingNode(model.renderable.getMapper());

--- a/Sources/Rendering/OpenGL/BufferObject/index.js
+++ b/Sources/Rendering/OpenGL/BufferObject/index.js
@@ -105,14 +105,14 @@ function vtkOpenGLBufferObject(publicAPI, model) {
   };
 
   publicAPI.setOpenGLRenderWindow = (rw) => {
-    if (model.openGLRenderWindow === rw) {
+    if (model._openGLRenderWindow === rw) {
       return;
     }
     publicAPI.releaseGraphicsResources();
-    model.openGLRenderWindow = rw;
+    model._openGLRenderWindow = rw;
     model.context = null;
     if (rw) {
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
     }
   };
 
@@ -125,7 +125,7 @@ function vtkOpenGLBufferObject(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   objectType: ObjectType.ARRAY_BUFFER,
-  openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
   context: null,
 };
 
@@ -137,7 +137,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Object methods
   macro.obj(publicAPI, model);
 
-  macro.get(publicAPI, model, ['openGLRenderWindow']);
+  macro.get(publicAPI, model, ['_openGLRenderWindow']);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
 
   vtkOpenGLBufferObject(publicAPI, model);
 }

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -17,8 +17,8 @@ function vtkOpenGLCamera(publicAPI, model) {
     if (prepass) {
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
-      model.context = model.openGLRenderWindow.getContext();
+      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model.context = model._openGLRenderWindow.getContext();
     }
   };
 
@@ -48,7 +48,7 @@ function vtkOpenGLCamera(publicAPI, model) {
     // has the camera changed?
     if (
       ren !== model.lastRenderer ||
-      model.openGLRenderWindow.getMTime() > model.keyMatrixTime.getMTime() ||
+      model._openGLRenderWindow.getMTime() > model.keyMatrixTime.getMTime() ||
       publicAPI.getMTime() > model.keyMatrixTime.getMTime() ||
       ren.getMTime() > model.keyMatrixTime.getMTime() ||
       model.renderable.getMTime() > model.keyMatrixTime.getMTime()

--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -111,7 +111,7 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
       if (!model.colorBO) {
         model.colorBO = vtkBufferObject.newInstance();
       }
-      model.colorBO.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.colorBO.setOpenGLRenderWindow(model._openGLRenderWindow);
     } else {
       model.colorBO = null;
     }

--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -34,7 +34,7 @@ function vtkFramebuffer(publicAPI, model) {
       model.context.FRAMEBUFFER_BINDING
     );
     model.previousActiveFramebuffer =
-      model.openGLRenderWindow.getActiveFramebuffer();
+      model._openGLRenderWindow.getActiveFramebuffer();
   };
 
   publicAPI.saveCurrentBuffers = (modeIn) => {
@@ -58,7 +58,7 @@ function vtkFramebuffer(publicAPI, model) {
 
     const gl = model.context;
     gl.bindFramebuffer(gl.FRAMEBUFFER, model.previousDrawBinding);
-    model.openGLRenderWindow.setActiveFramebuffer(
+    model._openGLRenderWindow.setActiveFramebuffer(
       model.previousActiveFramebuffer
     );
   };
@@ -76,7 +76,7 @@ function vtkFramebuffer(publicAPI, model) {
     for (let i = 0; i < model.colorBuffers.length; i++) {
       model.colorBuffers[i].bind();
     }
-    model.openGLRenderWindow.setActiveFramebuffer(publicAPI);
+    model._openGLRenderWindow.setActiveFramebuffer(publicAPI);
   };
 
   publicAPI.create = (width, height) => {
@@ -104,7 +104,7 @@ function vtkFramebuffer(publicAPI, model) {
 
     let glAttachment = gl.COLOR_ATTACHMENT0;
     if (attachment > 0) {
-      if (model.openGLRenderWindow.getWebgl2()) {
+      if (model._openGLRenderWindow.getWebgl2()) {
         glAttachment += attachment;
       } else {
         macro.vtkErrorMacro(
@@ -135,7 +135,7 @@ function vtkFramebuffer(publicAPI, model) {
 
     let glAttachment = gl.COLOR_ATTACHMENT0;
     if (attachment > 0) {
-      if (model.openGLRenderWindow.getWebgl2()) {
+      if (model._openGLRenderWindow.getWebgl2()) {
         glAttachment += attachment;
       } else {
         macro.vtkErrorMacro(
@@ -164,7 +164,7 @@ function vtkFramebuffer(publicAPI, model) {
       return;
     }
 
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       const gl = model.context;
       gl.framebufferTexture2D(
         gl.FRAMEBUFFER,
@@ -188,7 +188,7 @@ function vtkFramebuffer(publicAPI, model) {
       return;
     }
 
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       const gl = model.context;
       gl.framebufferTexture2D(
         gl.FRAMEBUFFER,
@@ -207,14 +207,14 @@ function vtkFramebuffer(publicAPI, model) {
   publicAPI.getGLFramebuffer = () => model.glFramebuffer;
 
   publicAPI.setOpenGLRenderWindow = (rw) => {
-    if (model.openGLRenderWindow === rw) {
+    if (model._openGLRenderWindow === rw) {
       return;
     }
     publicAPI.releaseGraphicsResources();
-    model.openGLRenderWindow = rw;
+    model._openGLRenderWindow = rw;
     model.context = null;
     if (rw) {
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
     }
   };
 
@@ -245,7 +245,7 @@ function vtkFramebuffer(publicAPI, model) {
     const gl = model.context;
 
     const texture = vtkOpenGLTexture.newInstance();
-    texture.setOpenGLRenderWindow(model.openGLRenderWindow);
+    texture.setOpenGLRenderWindow(model._openGLRenderWindow);
     texture.setMinificationFilter(Filter.LINEAR);
     texture.setMagnificationFilter(Filter.LINEAR);
     texture.create2DFromRaw(
@@ -283,7 +283,7 @@ function vtkFramebuffer(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 const DEFAULT_VALUES = {
-  openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
   glFramebuffer: null,
   colorBuffers: null,
   depthTexture: null,

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -52,7 +52,7 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
 
     // apply faceCulling
     const gl = model.context;
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       model.hardwareSupport = true;
       model.extension = null;
     } else if (!model.extension) {
@@ -66,12 +66,12 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
     const backfaceCulling = actor.getProperty().getBackfaceCulling();
     const frontfaceCulling = actor.getProperty().getFrontfaceCulling();
     if (!backfaceCulling && !frontfaceCulling) {
-      model.openGLRenderWindow.disableCullFace();
+      model._openGLRenderWindow.disableCullFace();
     } else if (frontfaceCulling) {
-      model.openGLRenderWindow.enableCullFace();
+      model._openGLRenderWindow.enableCullFace();
       gl.cullFace(gl.FRONT);
     } else {
-      model.openGLRenderWindow.enableCullFace();
+      model._openGLRenderWindow.enableCullFace();
       gl.cullFace(gl.BACK);
     }
 
@@ -625,13 +625,13 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
       const carray = model.renderable.getColorArray();
       if (!model.matrixBuffer) {
         model.matrixBuffer = vtkBufferObject.newInstance();
-        model.matrixBuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
+        model.matrixBuffer.setOpenGLRenderWindow(model._openGLRenderWindow);
         model.normalBuffer = vtkBufferObject.newInstance();
-        model.normalBuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
+        model.normalBuffer.setOpenGLRenderWindow(model._openGLRenderWindow);
         model.colorBuffer = vtkBufferObject.newInstance();
-        model.colorBuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
+        model.colorBuffer.setOpenGLRenderWindow(model._openGLRenderWindow);
         model.pickBuffer = vtkBufferObject.newInstance();
-        model.pickBuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
+        model.pickBuffer.setOpenGLRenderWindow(model._openGLRenderWindow);
       }
       if (
         model.renderable.getBuildTime().getMTime() >

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -54,12 +54,12 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
-      model.context = model.openGLRenderWindow.getContext();
-      model.tris.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.openGLTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.colorTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.pwfTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model.context = model._openGLRenderWindow.getContext();
+      model.tris.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.openGLTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.colorTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.pwfTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
       const ren = model.openGLRenderer.getRenderable();
       model.openGLCamera = model.openGLRenderer.getViewNodeFor(
         ren.getActiveCamera()
@@ -429,7 +429,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       publicAPI.buildShaders(shaders, ren, actor);
 
       // compile and bind the program if needed
-      const newShader = model.openGLRenderWindow
+      const newShader = model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgramArray(
           shaders.Vertex,
@@ -446,7 +446,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
       cellBO.getShaderSourceTime().modified();
     } else {
-      model.openGLRenderWindow
+      model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgram(cellBO.getProgram());
     }

--- a/Sources/Rendering/OpenGL/ImageSlice/index.js
+++ b/Sources/Rendering/OpenGL/ImageSlice/index.js
@@ -22,12 +22,12 @@ function vtkOpenGLImageSlice(publicAPI, model) {
       if (!model.renderable) {
         return;
       }
-      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getMapper());
       publicAPI.removeUnusedNodes();

--- a/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
+++ b/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
@@ -17,7 +17,7 @@ function vtkOpenGLPixelSpaceCallbackMapper(publicAPI, model) {
   publicAPI.opaquePass = (prepass, renderPass) => {
     model.openGLRenderer =
       publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-    model.openGLRenderWindow = model.openGLRenderer.getParent();
+    model._openGLRenderWindow = model.openGLRenderer.getParent();
     const aspectRatio = model.openGLRenderer.getAspectRatio();
     const camera = model.openGLRenderer
       ? model.openGLRenderer.getRenderable().getActiveCamera()
@@ -30,7 +30,7 @@ function vtkOpenGLPixelSpaceCallbackMapper(publicAPI, model) {
       const width = Math.floor(zbt.getWidth());
       const height = Math.floor(zbt.getHeight());
 
-      const gl = model.openGLRenderWindow.getContext();
+      const gl = model._openGLRenderWindow.getContext();
       zbt.bind();
 
       // Here we need to use vtkFramebuffer to save current settings (bindings/buffers)

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -49,7 +49,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       model.openGLActor = publicAPI.getFirstAncestorOfType('vtkOpenGLActor');
       model.openGLRenderer =
         model.openGLActor.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model.openGLRenderer.getParent();
       model.openGLCamera = model.openGLRenderer.getViewNodeFor(
         model.openGLRenderer.getRenderable().getActiveCamera()
       );
@@ -80,11 +80,11 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
   };
 
   publicAPI.render = () => {
-    const ctx = model.openGLRenderWindow.getContext();
+    const ctx = model._openGLRenderWindow.getContext();
     if (model.context !== ctx) {
       model.context = ctx;
       for (let i = primTypes.Start; i < primTypes.End; i++) {
-        model.primitives[i].setOpenGLRenderWindow(model.openGLRenderWindow);
+        model.primitives[i].setOpenGLRenderWindow(model._openGLRenderWindow);
       }
     }
     const actor = model.openGLActor.getRenderable();
@@ -1134,7 +1134,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       publicAPI.buildShaders(shaders, ren, actor);
 
       // compile and bind the program if needed
-      const newShader = model.openGLRenderWindow
+      const newShader = model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgramArray(
           shaders.Vertex,
@@ -1151,7 +1151,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
 
       cellBO.getShaderSourceTime().modified();
     } else {
-      model.openGLRenderWindow
+      model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgram(cellBO.getProgram());
     }
@@ -1750,12 +1750,12 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     const backfaceCulling = actor.getProperty().getBackfaceCulling();
     const frontfaceCulling = actor.getProperty().getFrontfaceCulling();
     if (!backfaceCulling && !frontfaceCulling) {
-      model.openGLRenderWindow.disableCullFace();
+      model._openGLRenderWindow.disableCullFace();
     } else if (frontfaceCulling) {
-      model.openGLRenderWindow.enableCullFace();
+      model._openGLRenderWindow.enableCullFace();
       gl.cullFace(gl.FRONT);
     } else {
-      model.openGLRenderWindow.enableCullFace();
+      model._openGLRenderWindow.enableCullFace();
       gl.cullFace(gl.BACK);
     }
 
@@ -1855,7 +1855,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       tex.setMagnificationFilter(Filter.NEAREST);
       tex.setWrapS(Wrap.CLAMP_TO_EDGE);
       tex.setWrapT(Wrap.CLAMP_TO_EDGE);
-      tex.setOpenGLRenderWindow(model.openGLRenderWindow);
+      tex.setOpenGLRenderWindow(model._openGLRenderWindow);
 
       const input = model.renderable.getColorTextureMap();
       const ext = input.getExtent();
@@ -1936,10 +1936,10 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       } else {
         // otherwise free them
         model.primitives[primTypes.TrisEdges].releaseGraphicsResources(
-          model.openGLRenderWindow
+          model._openGLRenderWindow
         );
         model.primitives[primTypes.TriStripsEdges].releaseGraphicsResources(
-          model.openGLRenderWindow
+          model._openGLRenderWindow
         );
       }
 

--- a/Sources/Rendering/OpenGL/PolyDataMapper/test/testMoreClippingPlanes.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/test/testMoreClippingPlanes.js
@@ -17,7 +17,9 @@ test('Test PolyDataMapper Clipping Planes 2', (t) => {
   // TODO switch back to onlyIfWebGL
   // Create some control UI
   const container = document.querySelector('body');
-  const renderWindowContainer = document.createElement('div');
+  const renderWindowContainer = gc.registerDOMElement(
+    document.createElement('div')
+  );
   container.appendChild(renderWindowContainer);
 
   // Create what we will view
@@ -123,7 +125,14 @@ test('Test PolyDataMapper Clipping Planes 2', (t) => {
   }
 
   glwindow.captureNextImage().then((image) => {
-    testUtils.compareImages(image, [baseline], 'TestMoreClippingPlanes', t, 2);
+    testUtils.compareImages(
+      image,
+      [baseline],
+      'TestMoreClippingPlanes',
+      t,
+      2,
+      gc.releaseResources
+    );
   });
   renderWindow.render();
 });

--- a/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
@@ -39,7 +39,7 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
         publicAPI.getFirstAncestorOfType('vtkOpenGLActor2D');
       model.openGLRenderer =
         model.openGLActor2D.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model.openGLRenderer.getParent();
       model.openGLCamera = model.openGLRenderer.getViewNodeFor(
         model.openGLRenderer.getRenderable().getActiveCamera()
       );
@@ -84,11 +84,11 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
   };
 
   publicAPI.render = () => {
-    const ctx = model.openGLRenderWindow.getContext();
+    const ctx = model._openGLRenderWindow.getContext();
     if (model.context !== ctx) {
       model.context = ctx;
       for (let i = primTypes.Start; i < primTypes.End; i++) {
-        model.primitives[i].setOpenGLRenderWindow(model.openGLRenderWindow);
+        model.primitives[i].setOpenGLRenderWindow(model._openGLRenderWindow);
       }
     }
     const actor = model.openGLActor2D.getRenderable();
@@ -543,7 +543,7 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
       publicAPI.buildShaders(shaders, ren, actor);
 
       // compile and bind the program if needed
-      const newShader = model.openGLRenderWindow
+      const newShader = model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgramArray(
           shaders.Vertex,
@@ -560,7 +560,7 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
 
       cellBO.getShaderSourceTime().modified();
     } else {
-      model.openGLRenderWindow
+      model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgram(cellBO.getProgram());
     }

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -82,7 +82,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
   };
 
   publicAPI.getAspectRatio = () => {
-    const size = model.parent.getSizeByReference();
+    const size = model._parent.getSizeByReference();
     const viewport = model.renderable.getViewportByReference();
     return (
       (size[0] * (viewport[2] - viewport[0])) /
@@ -102,7 +102,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
     const vpv = vport[1] - tileViewPort[1];
 
     // store the result as a pixel value
-    const ndvp = model.parent.normalizedDisplayToDisplay(vpu, vpv);
+    const ndvp = model._parent.normalizedDisplayToDisplay(vpu, vpv);
     const lowerLeftU = Math.round(ndvp[0]);
     const lowerLeftV = Math.round(ndvp[1]);
 
@@ -110,7 +110,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
     // lower left boundary of this tile
     const vpu2 = vport[2] - tileViewPort[0];
     const vpv2 = vport[3] - tileViewPort[1];
-    const ndvp2 = model.parent.normalizedDisplayToDisplay(vpu2, vpv2);
+    const ndvp2 = model._parent.normalizedDisplayToDisplay(vpu2, vpv2);
 
     // now compute the size of the intersection of the viewport with the
     // current tile
@@ -169,14 +169,14 @@ function vtkOpenGLRenderer(publicAPI, model) {
   };
 
   publicAPI.setOpenGLRenderWindow = (rw) => {
-    if (model.openGLRenderWindow === rw) {
+    if (model._openGLRenderWindow === rw) {
       return;
     }
     publicAPI.releaseGraphicsResources();
-    model.openGLRenderWindow = rw;
+    model._openGLRenderWindow = rw;
     model.context = null;
     if (rw) {
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
     }
   };
 }
@@ -187,7 +187,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   context: null,
-  openGLRenderWindow: null,
+  _openGLRenderWindow: null,
   selector: null,
 };
 

--- a/Sources/Rendering/OpenGL/ReplacementShaderMapper/index.js
+++ b/Sources/Rendering/OpenGL/ReplacementShaderMapper/index.js
@@ -46,7 +46,7 @@ function implementReplaceShaderCoincidentOffset(
           ).result;
         }
       }
-      if (model.openGLRenderWindow.getWebgl2()) {
+      if (model._openGLRenderWindow.getWebgl2()) {
         if (cp.factor !== 0.0) {
           FSSource = vtkShaderProgram.substitute(
             FSSource,

--- a/Sources/Rendering/OpenGL/ScalarBarActor/index.js
+++ b/Sources/Rendering/OpenGL/ScalarBarActor/index.js
@@ -16,7 +16,7 @@ function vtkOpenGLScalarBarActor(publicAPI, model) {
     if (prepass) {
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model.openGLRenderer.getParent();
 
       if (!model.scalarBarActorHelper.getRenderable()) {
         model.scalarBarActorHelper.setRenderable(model.renderable);
@@ -39,7 +39,7 @@ function vtkOpenGLScalarBarActor(publicAPI, model) {
       model.scalarBarActorHelper.updateAPISpecificData(
         [tsize.usize, tsize.vsize],
         camera,
-        model.openGLRenderWindow.getRenderable()
+        model._openGLRenderWindow.getRenderable()
       );
     }
   };

--- a/Sources/Rendering/OpenGL/ShaderCache/index.js
+++ b/Sources/Rendering/OpenGL/ShaderCache/index.js
@@ -5,7 +5,7 @@ import vtkShaderProgram from 'vtk.js/Sources/Rendering/OpenGL/ShaderProgram';
 
 // ----------------------------------------------------------------------------
 
-const SET_GET_FIELDS = ['lastShaderBound', 'context', 'openGLRenderWindow'];
+const SET_GET_FIELDS = ['lastShaderBound', 'context', '_openGLRenderWindow'];
 
 // ----------------------------------------------------------------------------
 // vtkShaderCache methods
@@ -31,7 +31,7 @@ function vtkShaderCache(publicAPI, model) {
       ).result;
     }
 
-    const gl2 = model.openGLRenderWindow.getWebgl2();
+    const gl2 = model._openGLRenderWindow.getWebgl2();
 
     let fragDepthString = '\n';
 
@@ -238,7 +238,7 @@ const DEFAULT_VALUES = {
   lastShaderBound: null,
   shaderPrograms: null,
   context: null,
-  openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -252,6 +252,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Build VTK API
   macro.obj(publicAPI, model);
   macro.setGet(publicAPI, model, SET_GET_FIELDS);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
 
   // Object methods
   vtkShaderCache(publicAPI, model);

--- a/Sources/Rendering/OpenGL/Skybox/index.js
+++ b/Sources/Rendering/OpenGL/Skybox/index.js
@@ -25,10 +25,10 @@ function vtkOpenGLSkybox(publicAPI, model) {
     if (prepass) {
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
-      model.context = model.openGLRenderWindow.getContext();
-      model.tris.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.openGLTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model.context = model._openGLRenderWindow.getContext();
+      model.tris.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.openGLTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
       const ren = model.openGLRenderer.getRenderable();
       model.openGLCamera = model.openGLRenderer.getViewNodeFor(
         ren.getActiveCamera()
@@ -51,11 +51,11 @@ function vtkOpenGLSkybox(publicAPI, model) {
 
       model.context.depthMask(true);
 
-      model.openGLRenderWindow
+      model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgram(model.tris.getProgram());
 
-      model.openGLTexture.render(model.openGLRenderWindow);
+      model.openGLTexture.render(model._openGLRenderWindow);
 
       const texUnit = model.openGLTexture.getTextureUnit();
       model.tris.getProgram().setUniformi('sbtexture', texUnit);
@@ -140,7 +140,7 @@ function vtkOpenGLSkybox(publicAPI, model) {
         // https://stackoverflow.com/questions/11685608/convention-of-faces-in-opengl-cubemapping
         //
         model.tris.setProgram(
-          model.openGLRenderWindow.getShaderCache().readyShaderProgramArray(
+          model._openGLRenderWindow.getShaderCache().readyShaderProgramArray(
             `//VTK::System::Dec
              attribute vec3 vertexMC;
              uniform mat4 IMCPCMatrix;
@@ -179,7 +179,7 @@ function vtkOpenGLSkybox(publicAPI, model) {
       if (model.lastFormat === 'background') {
         // maps the texture to the window
         model.tris.setProgram(
-          model.openGLRenderWindow.getShaderCache().readyShaderProgramArray(
+          model._openGLRenderWindow.getShaderCache().readyShaderProgramArray(
             `//VTK::System::Dec
              attribute vec3 vertexMC;
              uniform mat4 IMCPCMatrix;
@@ -229,7 +229,7 @@ function vtkOpenGLSkybox(publicAPI, model) {
       vtkErrorMacro('vtkSkybox requires a texture map');
     }
     if (model.openGLTexture.getRenderable() !== tmaps[0]) {
-      model.openGLTexture.releaseGraphicsResources(model.openGLRenderWindow);
+      model.openGLTexture.releaseGraphicsResources(model._openGLRenderWindow);
       model.openGLTexture.setRenderable(tmaps[0]);
     }
   };

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -73,7 +73,7 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
     if (model.context.getExtension('EXT_frag_depth')) {
       fragString = 'gl_FragDepthEXT = (pos.z / pos.w + 1.0) / 2.0;\n';
     }
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       fragString = 'gl_FragDepth = (pos.z / pos.w + 1.0) / 2.0;\n';
     }
     FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::Depth::Impl', [
@@ -246,7 +246,7 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
       if (!vbo.getColorBO()) {
         vbo.setColorBO(vtkBufferObject.newInstance());
       }
-      vbo.getColorBO().setOpenGLRenderWindow(model.openGLRenderWindow);
+      vbo.getColorBO().setOpenGLRenderWindow(model._openGLRenderWindow);
     } else if (vbo.getColorBO()) {
       vbo.setColorBO(null);
     }

--- a/Sources/Rendering/OpenGL/StickMapper/index.js
+++ b/Sources/Rendering/OpenGL/StickMapper/index.js
@@ -74,7 +74,7 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     if (model.context.getExtension('EXT_frag_depth')) {
       fragString = '  gl_FragDepthEXT = (pos.z / pos.w + 1.0) / 2.0;\n';
     }
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       fragString = 'gl_FragDepth = (pos.z / pos.w + 1.0) / 2.0;\n';
     }
     // see https://www.cl.cam.ac.uk/teaching/1999/AGraphHCI/SMAG/node2.html
@@ -305,7 +305,7 @@ function vtkOpenGLStickMapper(publicAPI, model) {
     if (!vbo.getColorBO()) {
       vbo.setColorBO(vtkBufferObject.newInstance());
     }
-    vbo.getColorBO().setOpenGLRenderWindow(model.openGLRenderWindow);
+    vbo.getColorBO().setOpenGLRenderWindow(model._openGLRenderWindow);
     if (c) {
       colorComponents = c.getNumberOfComponents();
       vbo.setColorOffset(4);

--- a/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/index.js
@@ -56,7 +56,7 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
   model.classHierarchy.push('vtkLineIntegralConvolution2D');
 
   publicAPI.buildAShader = (fSource) =>
-    model.openGLRenderWindow
+    model._openGLRenderWindow
       .getShaderCache()
       .readyShaderProgramArray(
         vtkLineIntegralConvolution2D_quadVS,
@@ -68,7 +68,7 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
     texture,
     [width, height],
     context = model.context,
-    openGLRenderWindow = model.openGLRenderWindow,
+    openGLRenderWindow = model._openGLRenderWindow,
     nComp = 4
   ) => {
     // To get texture values in es 2.0, we need to attach the texture to a fbo,
@@ -99,7 +99,7 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
     texture,
     size,
     context = model.context,
-    openGLRenderWindow = model.openGLRenderWindow
+    openGLRenderWindow = model._openGLRenderWindow
   ) => {
     const values = publicAPI.dumpTextureValues(
       texture,
@@ -184,7 +184,7 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
     openGLRenderWindow,
     options
   ) => {
-    model.openGLRenderWindow = openGLRenderWindow;
+    model._openGLRenderWindow = openGLRenderWindow;
     model.context = openGLRenderWindow.getContext();
     Object.assign(model, options);
     if (size[0] <= 0.0 || size[1] <= 0.0) {
@@ -204,7 +204,7 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
     let fb = model.framebuffer;
     if (!fb || size[0] !== fb.getSize()[0] || size[1] !== fb.getSize()[1]) {
       fb = vtkFrameBuffer.newInstance();
-      fb.setOpenGLRenderWindow(model.openGLRenderWindow);
+      fb.setOpenGLRenderWindow(model._openGLRenderWindow);
       fb.saveCurrentBindingsAndBuffers();
       fb.create(...size);
       fb.populateFramebuffer();
@@ -247,7 +247,7 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
     const dx = 1.0 / size[0];
     const dy = 1.0 / size[1];
 
-    const shaderCache = model.openGLRenderWindow.getShaderCache();
+    const shaderCache = model._openGLRenderWindow.getShaderCache();
 
     if (model.transformVectors) {
       const VTShaderProgram = model.VTProgram;
@@ -444,13 +444,13 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
   };
 
   publicAPI.contrastEnhance = (isSecondStage, size) => {
-    const shaderCache = model.openGLRenderWindow.getShaderCache();
+    const shaderCache = model._openGLRenderWindow.getShaderCache();
 
     let { min, max } = publicAPI.getTextureMinMax(
       model.bufs.getLastLICBuffer(),
       size,
       model.context,
-      model.openGLRenderWindow
+      model._openGLRenderWindow
     );
 
     if (max <= min || max > 1.0 || min < 0) {
@@ -500,7 +500,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   macro.setGet(publicAPI, model, [
     'context',
-    'openGLRenderWindow',
+    '_openGLRenderWindow',
 
     'nuberOfSteps',
     'stepSize',
@@ -514,6 +514,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'componentIds',
     'isComposite',
   ]);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
 
   // Object methods
   vtkLineIntegralConvolution2D(publicAPI, model);

--- a/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/pingpong.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/pingpong.js
@@ -106,24 +106,24 @@ function allocateVectorBuffer(openGLRenderWindow, size) {
 
 function vtkLICPingPongBufferManager(publicAPI, model) {
   model.classHierarchy.push('vtkLICPingPongBufferManager');
-  if (!model.openGLRenderWindow) {
+  if (!model._openGLRenderWindow) {
     console.error('Pass renderwindow to ping pong manager');
     return;
   }
 
   // Don't handle bind/restoring framebuffers, assume it has been done upstream
 
-  model.quad = getQuadPoly(model.openGLRenderWindow);
-  model.context = model.openGLRenderWindow.getContext();
-  model.licTexture0 = allocateLICBuffer(model.openGLRenderWindow, model.size);
-  model.seedTexture0 = allocateLICBuffer(model.openGLRenderWindow, model.size);
-  model.licTexture1 = allocateLICBuffer(model.openGLRenderWindow, model.size);
-  model.seedTexture1 = allocateLICBuffer(model.openGLRenderWindow, model.size);
+  model.quad = getQuadPoly(model._openGLRenderWindow);
+  model.context = model._openGLRenderWindow.getContext();
+  model.licTexture0 = allocateLICBuffer(model._openGLRenderWindow, model.size);
+  model.seedTexture0 = allocateLICBuffer(model._openGLRenderWindow, model.size);
+  model.licTexture1 = allocateLICBuffer(model._openGLRenderWindow, model.size);
+  model.seedTexture1 = allocateLICBuffer(model._openGLRenderWindow, model.size);
   model.eeTexture = model.doEEPass
-    ? allocateNoiseBuffer(model.openGLRenderWindow, model.size)
+    ? allocateNoiseBuffer(model._openGLRenderWindow, model.size)
     : null;
   model.imageVectorTexture = model.doVTPass
-    ? allocateVectorBuffer(model.openGLRenderWindow, model.size)
+    ? allocateVectorBuffer(model._openGLRenderWindow, model.size)
     : null;
 
   model.pingTextures[0] = model.licTexture0;
@@ -144,7 +144,7 @@ function vtkLICPingPongBufferManager(publicAPI, model) {
     let VAO = model.quadVAO;
     if (!VAO) {
       VAO = vtkVertexArrayObject.newInstance();
-      VAO.setOpenGLRenderWindow(model.openGLRenderWindow);
+      VAO.setOpenGLRenderWindow(model._openGLRenderWindow);
       model.quadVAO = VAO;
     }
 
@@ -445,7 +445,7 @@ function vtkLICPingPongBufferManager(publicAPI, model) {
 }
 
 const DEFAULT_VALUES = {
-  openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
   vectorTexture: null,
   maskVectorTexture: null,
   noiseTexture: null,
@@ -470,13 +470,14 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, [
     'doEEPass',
     'doVTPass',
-    'openGLRenderWindow',
+    '_openGLRenderWindow',
     'vectorTexture',
     'maskVectorTexture',
     'noiseTexture',
     'framebuffer',
     'size',
   ]);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
 
   // Object methods
   vtkLICPingPongBufferManager(publicAPI, model);

--- a/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICInterface/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICInterface/index.js
@@ -79,7 +79,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
     let VAO = model.licQuadVAO;
     if (!VAO) {
       VAO = vtkVertexArrayObject.newInstance();
-      VAO.setOpenGLRenderWindow(model.openGLRenderWindow);
+      VAO.setOpenGLRenderWindow(model._openGLRenderWindow);
       model.licQuadVAO = VAO;
     }
 
@@ -267,7 +267,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
         maxLevel: 0,
         autoParameters: false,
       });
-      texture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      texture.setOpenGLRenderWindow(model._openGLRenderWindow);
       texture.create2DFromRaw(length, length, 4, 'Float32Array', values);
       texture.activate();
       texture.sendParameters();
@@ -278,7 +278,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
   };
 
   publicAPI.buildAShader = (fSource) =>
-    model.openGLRenderWindow
+    model._openGLRenderWindow
       .getShaderCache()
       .readyShaderProgramArray(
         vtkLineIntegralConvolution2D_quadVS,
@@ -289,7 +289,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
   publicAPI.allocateTextures = () => {
     const nearest = vtkOpenGLTexture.Filter.NEAREST;
     const linear = vtkOpenGLTexture.Filter.LINEAR;
-    const rw = model.openGLRenderWindow;
+    const rw = model._openGLRenderWindow;
     if (!model.geometryImage) {
       model.geometryImage = publicAPI.allocateTexture(rw, nearest);
     }
@@ -354,7 +354,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
     if (!model.framebuffer) {
       model.licHelper = null; // All buffers need rebuilding
       const fb = vtkFrameBuffer.newInstance();
-      fb.setOpenGLRenderWindow(model.openGLRenderWindow);
+      fb.setOpenGLRenderWindow(model._openGLRenderWindow);
       fb.saveCurrentBindingsAndBuffers();
       fb.create(...model.size);
       fb.populateFramebuffer();
@@ -394,7 +394,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
     publicAPI.allocateTextures();
     publicAPI.buildAllShaders();
     if (!model.licQuad) {
-      model.licQuad = getQuadPoly(model.openGLRenderWindow);
+      model.licQuad = getQuadPoly(model._openGLRenderWindow);
     }
     if (!model.licHelper) {
       model.licHelper = vtkLineIntegralConvolution2D.newInstance();
@@ -441,7 +441,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
       publicAPI.initializeResources();
     }
     const copyPass = model.licCopyPass;
-    model.openGLRenderWindow.getShaderCache().readyShaderProgram(copyPass);
+    model._openGLRenderWindow.getShaderCache().readyShaderProgram(copyPass);
 
     const gl = model.context;
     gl.viewport(0, 0, ...windowSize);
@@ -483,7 +483,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
       publicAPI.initializeResources();
     }
     const colorPass = model.licColorPass;
-    model.openGLRenderWindow.getShaderCache().readyShaderProgram(colorPass);
+    model._openGLRenderWindow.getShaderCache().readyShaderProgram(colorPass);
     colorPass.setUniformi('texVectors', model.vectorImage.getTextureUnit());
     colorPass.setUniformi(
       'texGeomColors',
@@ -549,7 +549,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
         publicAPI.initializeResources();
       }
       const { enhanceContrastPass } = model;
-      model.openGLRenderWindow
+      model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgram(enhanceContrastPass);
       enhanceContrastPass.setUniformi(
@@ -597,7 +597,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
       model.vectorImage,
       model.maskVectorImage,
       model.noiseTexture,
-      model.openGLRenderWindow,
+      model._openGLRenderWindow,
       options
     );
 
@@ -661,7 +661,7 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   context: null,
-  openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
   shadersNeedBuilding: true,
   reallocateTextures: true,
   size: null,
@@ -679,11 +679,12 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   macro.setGet(publicAPI, model, [
     'context',
-    'openGLRenderWindow',
+    '_openGLRenderWindow',
     'reallocateTextures',
     'licInterface',
     'size',
   ]);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
 
   // Object methods
   vtkOpenGLSurfaceLICInterface(publicAPI, model);

--- a/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICMapper/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICMapper/index.js
@@ -140,7 +140,7 @@ function vtkOpenGLSurfaceLICMapper(publicAPI, model) {
   publicAPI.renderPiece = (ren, actor) => {
     let canDrawLIC = true;
     // Check for gl compatibility
-    const gl2 = model.openGLRenderWindow.getWebgl2();
+    const gl2 = model._openGLRenderWindow.getWebgl2();
     if (!gl2) {
       vtkErrorMacro('SurfaceLICMapper Requires WebGL 2');
       canDrawLIC = false;
@@ -208,22 +208,22 @@ function vtkOpenGLSurfaceLICMapper(publicAPI, model) {
     const backfaceCulling = actor.getProperty().getBackfaceCulling();
     const frontfaceCulling = actor.getProperty().getFrontfaceCulling();
     if (!backfaceCulling && !frontfaceCulling) {
-      model.openGLRenderWindow.disableCullFace();
+      model._openGLRenderWindow.disableCullFace();
     } else if (frontfaceCulling) {
-      model.openGLRenderWindow.enableCullFace();
+      model._openGLRenderWindow.enableCullFace();
       gl.cullFace(gl.FRONT);
     } else {
-      model.openGLRenderWindow.enableCullFace();
+      model._openGLRenderWindow.enableCullFace();
       gl.cullFace(gl.BACK);
     }
 
-    const windowSize = model.openGLRenderWindow.getSize();
+    const windowSize = model._openGLRenderWindow.getSize();
     const size = windowSize.map((i) =>
       Math.round(i * licInterface.getViewPortScale())
     );
 
     model.openGLLicInterface.setSize(size);
-    model.openGLLicInterface.setOpenGLRenderWindow(model.openGLRenderWindow);
+    model.openGLLicInterface.setOpenGLRenderWindow(model._openGLRenderWindow);
     model.openGLLicInterface.setContext(model.context);
 
     // Pre-render

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -21,14 +21,14 @@ function vtkOpenGLTexture(publicAPI, model) {
   // Renders myself
   publicAPI.render = (renWin = null) => {
     if (renWin) {
-      model.openGLRenderWindow = renWin;
+      model._openGLRenderWindow = renWin;
     } else {
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       // sync renderable properties
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model.openGLRenderer.getParent();
     }
-    model.context = model.openGLRenderWindow.getContext();
+    model.context = model._openGLRenderWindow.getContext();
     if (model.renderable.getInterpolate()) {
       if (model.generateMipmap) {
         publicAPI.setMinificationFilter(Filter.LINEAR_MIPMAP_LINEAR);
@@ -208,7 +208,7 @@ function vtkOpenGLTexture(publicAPI, model) {
           model.context.TEXTURE_WRAP_T,
           publicAPI.getOpenGLWrapMode(model.wrapT)
         );
-        if (model.openGLRenderWindow.getWebgl2()) {
+        if (model._openGLRenderWindow.getWebgl2()) {
           model.context.texParameteri(
             model.target,
             model.context.TEXTURE_WRAP_R,
@@ -223,8 +223,8 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //---------------------------------------------------------------------------
   publicAPI.getTextureUnit = () => {
-    if (model.openGLRenderWindow) {
-      return model.openGLRenderWindow.getTextureUnitForTexture(publicAPI);
+    if (model._openGLRenderWindow) {
+      return model._openGLRenderWindow.getTextureUnitForTexture(publicAPI);
     }
     return -1;
   };
@@ -232,14 +232,14 @@ function vtkOpenGLTexture(publicAPI, model) {
   //---------------------------------------------------------------------------
   publicAPI.activate = () => {
     // activate a free texture unit for this texture
-    model.openGLRenderWindow.activateTexture(publicAPI);
+    model._openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.bind();
   };
 
   //---------------------------------------------------------------------------
   publicAPI.deactivate = () => {
-    if (model.openGLRenderWindow) {
-      model.openGLRenderWindow.deactivateTexture(publicAPI);
+    if (model._openGLRenderWindow) {
+      model._openGLRenderWindow.deactivateTexture(publicAPI);
     }
   };
 
@@ -308,7 +308,7 @@ function vtkOpenGLTexture(publicAPI, model) {
       model.context.TEXTURE_WRAP_T,
       publicAPI.getOpenGLWrapMode(model.wrapT)
     );
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       model.context.texParameteri(
         model.target,
         model.context.TEXTURE_WRAP_R,
@@ -328,7 +328,7 @@ function vtkOpenGLTexture(publicAPI, model) {
       publicAPI.getOpenGLFilterMode(model.magnificationFilter)
     );
 
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       model.context.texParameteri(
         model.target,
         model.context.TEXTURE_BASE_LEVEL,
@@ -371,7 +371,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     let result = 0;
 
     // try default next
-    result = model.openGLRenderWindow.getDefaultTextureInternalFormat(
+    result = model._openGLRenderWindow.getDefaultTextureInternalFormat(
       vtktype,
       numComps,
       false
@@ -381,7 +381,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     }
 
     // try floating point
-    result = this.openGLRenderWindow.getDefaultTextureInternalFormat(
+    result = this._openGLRenderWindow.getDefaultTextureInternalFormat(
       vtktype,
       numComps,
       true
@@ -413,7 +413,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.getDefaultFormat = (vtktype, numComps) => {
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       switch (numComps) {
         case 1:
           return model.context.RED;
@@ -453,7 +453,7 @@ function vtkOpenGLTexture(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.getDefaultDataType = (vtkScalarType, useHalfFloatType = false) => {
     // DON'T DEAL with VTK_CHAR as this is platform dependent.
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       switch (vtkScalarType) {
         // case VtkDataTypes.SIGNED_CHAR:
         //   return model.context.BYTE;
@@ -643,7 +643,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     // if the opengl data type is half float
     // then the data array must be u16
     const halfFloatExt = model.context.getExtension('OES_texture_half_float');
-    const halfFloat = model.openGLRenderWindow.getWebgl2()
+    const halfFloat = model._openGLRenderWindow.getWebgl2()
       ? model.openGLDataType === model.context.HALF_FLOAT
       : halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
 
@@ -673,7 +673,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   function scaleTextureToHighestPowerOfTwo(data) {
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       // No need if webGL2
       return data;
     }
@@ -798,7 +798,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.openGLRenderWindow.activateTexture(publicAPI);
+    model._openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -854,7 +854,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.openGLRenderWindow.activateTexture(publicAPI);
+    model._openGLRenderWindow.activateTexture(publicAPI);
     model.maxLevel = data.length / 6 - 1;
     publicAPI.createTexture();
     publicAPI.bind();
@@ -933,7 +933,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     // Now determine the texture parameters using the arguments.
     publicAPI.getOpenGLDataType(dataType);
     model.format = model.context.DEPTH_COMPONENT;
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       if (dataType === VtkDataTypes.FLOAT) {
         model.internalFormat = model.context.DEPTH_COMPONENT32F;
       } else {
@@ -954,7 +954,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.openGLRenderWindow.activateTexture(publicAPI);
+    model._openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -1000,7 +1000,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = image.height;
     model.depth = 1;
     model.numberOfDimensions = 2;
-    model.openGLRenderWindow.activateTexture(publicAPI);
+    model._openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -1102,7 +1102,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     publicAPI.getOpenGLDataType(dataType, useHalfFloatType);
 
     const halfFloatExt = model.context.getExtension('OES_texture_half_float');
-    const useHalfFloat = model.openGLRenderWindow.getWebgl2()
+    const useHalfFloat = model._openGLRenderWindow.getWebgl2()
       ? model.openGLDataType === model.context.HALF_FLOAT
       : halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
 
@@ -1147,7 +1147,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.height = height;
     model.depth = depth;
     model.numberOfDimensions = 3;
-    model.openGLRenderWindow.activateTexture(publicAPI);
+    model._openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
     // Create an array of texture with one texture
@@ -1224,7 +1224,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     );
 
     // WebGL2 path, we have 3d textures etc
-    if (model.openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2()) {
       if (
         dataType === VtkDataTypes.FLOAT ||
         (useHalfFloat &&
@@ -1359,7 +1359,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     model.width = targetWidth;
     model.height = targetHeight;
-    model.openGLRenderWindow.activateTexture(publicAPI);
+    model._openGLRenderWindow.activateTexture(publicAPI);
     publicAPI.createTexture();
     publicAPI.bind();
 
@@ -1438,14 +1438,14 @@ function vtkOpenGLTexture(publicAPI, model) {
   };
 
   publicAPI.setOpenGLRenderWindow = (rw) => {
-    if (model.openGLRenderWindow === rw) {
+    if (model._openGLRenderWindow === rw) {
       return;
     }
     publicAPI.releaseGraphicsResources();
-    model.openGLRenderWindow = rw;
+    model._openGLRenderWindow = rw;
     model.context = null;
     if (rw) {
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
     }
   };
 
@@ -1464,7 +1464,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  openGLRenderWindow: null,
+  _openGLRenderWindow: null,
   context: null,
   handle: 0,
   sendParametersTime: null,

--- a/Sources/Rendering/OpenGL/VertexArrayObject/index.js
+++ b/Sources/Rendering/OpenGL/VertexArrayObject/index.js
@@ -16,15 +16,15 @@ function vtkOpenGLVertexArrayObject(publicAPI, model) {
 
   publicAPI.initialize = () => {
     model.instancingExtension = null;
-    if (!model.openGLRenderWindow.getWebgl2()) {
+    if (!model._openGLRenderWindow.getWebgl2()) {
       model.instancingExtension = model.context.getExtension(
         'ANGLE_instanced_arrays'
       );
     }
     if (
       !model.forceEmulation &&
-      model.openGLRenderWindow &&
-      model.openGLRenderWindow.getWebgl2()
+      model._openGLRenderWindow &&
+      model._openGLRenderWindow.getWebgl2()
     ) {
       model.extension = null;
       model.supported = true;
@@ -369,14 +369,14 @@ function vtkOpenGLVertexArrayObject(publicAPI, model) {
   };
 
   publicAPI.setOpenGLRenderWindow = (rw) => {
-    if (model.openGLRenderWindow === rw) {
+    if (model._openGLRenderWindow === rw) {
       return;
     }
     publicAPI.releaseGraphicsResources();
-    model.openGLRenderWindow = rw;
+    model._openGLRenderWindow = rw;
     model.context = null;
     if (rw) {
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
     }
   };
 }
@@ -392,7 +392,7 @@ const DEFAULT_VALUES = {
   supported: true,
   buffers: null,
   context: null,
-  openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/Volume/index.js
+++ b/Sources/Rendering/OpenGL/Volume/index.js
@@ -19,12 +19,12 @@ function vtkOpenGLVolume(publicAPI, model) {
       return;
     }
     if (prepass) {
-      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model.openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.context = model.openGLRenderWindow.getContext();
+      model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getMapper());
       publicAPI.removeUnusedNodes();
@@ -94,6 +94,7 @@ const DEFAULT_VALUES = {
   // keyMatrixTime: null,
   // normalMatrix: null,
   // MCWCMatrix: null,
+  // _openGLRenderWindow: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -67,18 +67,18 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
   // Renders myself
   publicAPI.volumePass = (prepass, renderPass) => {
     if (prepass) {
-      model.openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
-      model.context = model.openGLRenderWindow.getContext();
-      model.tris.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.jitterTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.framebuffer.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.context = model._openGLRenderWindow.getContext();
+      model.tris.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.jitterTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.framebuffer.setOpenGLRenderWindow(model._openGLRenderWindow);
 
       // Per Component?
-      model.scalarTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.colorTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
-      model.opacityTexture.setOpenGLRenderWindow(model.openGLRenderWindow);
+      model.scalarTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.colorTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
+      model.opacityTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
 
       model.openGLVolume = publicAPI.getFirstAncestorOfType('vtkOpenGLVolume');
       const actor = model.openGLVolume.getRenderable();
@@ -463,7 +463,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       publicAPI.buildShaders(shaders, ren, actor);
 
       // compile and bind the program if needed
-      const newShader = model.openGLRenderWindow
+      const newShader = model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgramArray(
           shaders.Vertex,
@@ -480,7 +480,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
       cellBO.getShaderSourceTime().modified();
     } else {
-      model.openGLRenderWindow
+      model._openGLRenderWindow
         .getShaderCache()
         .readyShaderProgram(cellBO.getProgram());
     }
@@ -686,7 +686,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     program.setUniform3f('vVCToIJK', vctoijk[0], vctoijk[1], vctoijk[2]);
     program.setUniform3i('volumeDimensions', dims[0], dims[1], dims[2]);
 
-    if (!model.openGLRenderWindow.getWebgl2()) {
+    if (!model._openGLRenderWindow.getWebgl2()) {
       const volInfo = model.scalarTexture.getVolumeInfo();
       program.setUniformf('texWidth', model.scalarTexture.getWidth());
       program.setUniformf('texHeight', model.scalarTexture.getHeight());
@@ -1009,7 +1009,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
             model.renderable.getImageSampleDistance() *
             model.renderable.getImageSampleDistance();
         }
-        const size = model.openGLRenderWindow.getFramebufferSize();
+        const size = model._openGLRenderWindow.getFramebufferSize();
         model._smallViewportWidth = Math.ceil(
           size[0] / Math.sqrt(model._lastScale)
         );
@@ -1021,7 +1021,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
     // use/create/resize framebuffer if needed
     if (model._useSmallViewport) {
-      const size = model.openGLRenderWindow.getFramebufferSize();
+      const size = model._openGLRenderWindow.getFramebufferSize();
 
       // adjust viewportSize to always be at most the dest fo size
       if (model._smallViewportHeight > size[1]) {
@@ -1113,7 +1113,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       model.framebuffer.restorePreviousBindingsAndBuffers();
 
       if (model.copyShader === null) {
-        model.copyShader = model.openGLRenderWindow
+        model.copyShader = model._openGLRenderWindow
           .getShaderCache()
           .readyShaderProgramArray(
             [
@@ -1135,7 +1135,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         const program = model.copyShader;
 
         model.copyVAO = vtkVertexArrayObject.newInstance();
-        model.copyVAO.setOpenGLRenderWindow(model.openGLRenderWindow);
+        model.copyVAO.setOpenGLRenderWindow(model._openGLRenderWindow);
 
         model.tris.getCABO().bind();
         if (
@@ -1153,12 +1153,12 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           vtkErrorMacro('Error setting vertexDC in copy shader VAO.');
         }
       } else {
-        model.openGLRenderWindow
+        model._openGLRenderWindow
           .getShaderCache()
           .readyShaderProgram(model.copyShader);
       }
 
-      const size = model.openGLRenderWindow.getFramebufferSize();
+      const size = model._openGLRenderWindow.getFramebufferSize();
       model.context.viewport(0, 0, size[0], size[1]);
 
       // activate texture
@@ -1294,7 +1294,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         }
       }
 
-      model.opacityTexture.releaseGraphicsResources(model.openGLRenderWindow);
+      model.opacityTexture.releaseGraphicsResources(model._openGLRenderWindow);
       model.opacityTexture.setMinificationFilter(Filter.LINEAR);
       model.opacityTexture.setMagnificationFilter(Filter.LINEAR);
 
@@ -1303,7 +1303,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       // visible artifacts. High values of opacity quickly terminate without
       // artifacts.
       if (
-        model.openGLRenderWindow.getWebgl2() ||
+        model._openGLRenderWindow.getWebgl2() ||
         (model.context.getExtension('OES_texture_float') &&
           model.context.getExtension('OES_texture_float_linear'))
       ) {
@@ -1348,7 +1348,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         }
       }
 
-      model.colorTexture.releaseGraphicsResources(model.openGLRenderWindow);
+      model.colorTexture.releaseGraphicsResources(model._openGLRenderWindow);
       model.colorTexture.setMinificationFilter(Filter.LINEAR);
       model.colorTexture.setMagnificationFilter(Filter.LINEAR);
 
@@ -1367,7 +1367,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     if (model.scalarTextureString !== toString) {
       // Build the textures
       const dims = image.getDimensions();
-      model.scalarTexture.releaseGraphicsResources(model.openGLRenderWindow);
+      model.scalarTexture.releaseGraphicsResources(model._openGLRenderWindow);
       model.scalarTexture.resetFormatAndType();
       model.scalarTexture.create3DFilterableFromRaw(
         dims[0],

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -61,13 +61,13 @@ function vtkViewNode(publicAPI, model) {
   };
 
   publicAPI.getFirstAncestorOfType = (type) => {
-    if (!model.parent) {
+    if (!model._parent) {
       return null;
     }
-    if (model.parent.isA(type)) {
-      return model.parent;
+    if (model._parent.isA(type)) {
+      return model._parent;
     }
-    return model.parent.getFirstAncestorOfType(type);
+    return model._parent.getFirstAncestorOfType(type);
   };
 
   publicAPI.addMissingNode = (dobj) => {
@@ -167,7 +167,7 @@ function vtkViewNode(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  parent: null,
+  // _parent: null,
   renderable: null,
   myFactory: null,
   children: [],
@@ -186,8 +186,9 @@ function extend(publicAPI, model, initialValues = {}) {
   model._renderableChildMap = new Map();
 
   macro.get(publicAPI, model, ['visited']);
-  macro.setGet(publicAPI, model, ['parent', 'renderable', 'myFactory']);
+  macro.setGet(publicAPI, model, ['_parent', 'renderable', 'myFactory']);
   macro.getArray(publicAPI, model, ['children']);
+  macro.moveToProtected(publicAPI, model, ['parent']);
 
   // Object methods
   vtkViewNode(publicAPI, model);

--- a/Sources/Rendering/WebGPU/Renderer/index.js
+++ b/Sources/Rendering/WebGPU/Renderer/index.js
@@ -142,7 +142,7 @@ function vtkWebGPURenderer(publicAPI, model) {
     // has the camera changed?
     const utime = model.UBO.getSendTime();
     if (
-      model.parent.getMTime() > utime ||
+      model._parent.getMTime() > utime ||
       publicAPI.getMTime() > utime ||
       model.camera.getMTime() > utime ||
       model.renderable.getMTime() > utime
@@ -162,7 +162,7 @@ function vtkWebGPURenderer(publicAPI, model) {
         model.camera.getParallelProjection()
       );
 
-      const device = model.parent.getDevice();
+      const device = model._parent.getDevice();
       model.UBO.sendIfNeeded(device);
     }
   };
@@ -200,7 +200,7 @@ function vtkWebGPURenderer(publicAPI, model) {
       // clear last pipelines
       model.pipelineCallbacks = [];
 
-      model.renderEncoder.begin(model.parent.getCommandEncoder());
+      model.renderEncoder.begin(model._parent.getCommandEncoder());
       publicAPI.updateUBO();
     } else {
       publicAPI.scissorAndViewport(model.renderEncoder);
@@ -229,7 +229,7 @@ function vtkWebGPURenderer(publicAPI, model) {
       return;
     }
 
-    const device = model.parent.getDevice();
+    const device = model._parent.getDevice();
     if (!model.clearFSQ) {
       model.clearFSQ = vtkWebGPUFullScreenQuad.newInstance();
       model.clearFSQ.setDevice(device);
@@ -250,7 +250,7 @@ function vtkWebGPURenderer(publicAPI, model) {
     if (prepass) {
       // clear last pipelines
       model.pipelineCallbacks = [];
-      model.renderEncoder.begin(model.parent.getCommandEncoder());
+      model.renderEncoder.begin(model._parent.getCommandEncoder());
     } else {
       publicAPI.scissorAndViewport(model.renderEncoder);
 
@@ -275,7 +275,7 @@ function vtkWebGPURenderer(publicAPI, model) {
     if (prepass) {
       // clear last pipelines
       model.pipelineCallbacks = [];
-      model.renderEncoder.begin(model.parent.getCommandEncoder());
+      model.renderEncoder.begin(model._parent.getCommandEncoder());
     } else {
       publicAPI.scissorAndViewport(model.renderEncoder);
 
@@ -297,7 +297,7 @@ function vtkWebGPURenderer(publicAPI, model) {
   };
 
   publicAPI.getAspectRatio = () => {
-    const size = model.parent.getSizeByReference();
+    const size = model._parent.getSizeByReference();
     const viewport = model.renderable.getViewportByReference();
     return (
       (size[0] * (viewport[2] - viewport[0])) /
@@ -310,7 +310,7 @@ function vtkWebGPURenderer(publicAPI, model) {
 
   publicAPI.getYInvertedTiledSizeAndOrigin = () => {
     const res = publicAPI.getTiledSizeAndOrigin();
-    const size = model.parent.getSizeByReference();
+    const size = model._parent.getSizeByReference();
     res.lowerLeftV = size[1] - res.vsize - res.lowerLeftV;
     return res;
   };
@@ -327,7 +327,7 @@ function vtkWebGPURenderer(publicAPI, model) {
     const vpv = vport[1] - tileViewPort[1];
 
     // store the result as a pixel value
-    const ndvp = model.parent.normalizedDisplayToDisplay(vpu, vpv);
+    const ndvp = model._parent.normalizedDisplayToDisplay(vpu, vpv);
     const lowerLeftU = Math.round(ndvp[0]);
     const lowerLeftV = Math.round(ndvp[1]);
 
@@ -335,7 +335,7 @@ function vtkWebGPURenderer(publicAPI, model) {
     // lower left boundary of this tile
     const vpu2 = vport[2] - tileViewPort[0];
     const vpv2 = vport[3] - tileViewPort[1];
-    const ndvp2 = model.parent.normalizedDisplayToDisplay(vpu2, vpv2);
+    const ndvp2 = model._parent.normalizedDisplayToDisplay(vpu2, vpv2);
 
     // now compute the size of the intersection of the viewport with the
     // current tile

--- a/Sources/Testing/testProxy.js
+++ b/Sources/Testing/testProxy.js
@@ -75,6 +75,7 @@ test('Proxy activation via config', (t) => {
   });
   proxy.activate();
 
+  proxy.getState();
   t.end();
 });
 

--- a/Sources/Testing/testSerialization.js
+++ b/Sources/Testing/testSerialization.js
@@ -86,7 +86,7 @@ classToTest.forEach((testName) => {
     t.notEqual(instance, instance2, 'We have two different instances');
     assertSameSerializedContent(t, state, state2);
 
-    /* Test JSON.stringify and JSON.parse behavior */
+    // Test JSON.stringify and JSON.parse behavior
     const jsonFromStringify = JSON.stringify(instance);
     const jsonFromGetState = JSON.stringify(state);
 
@@ -105,6 +105,15 @@ classToTest.forEach((testName) => {
     t.notEqual(instance3, instance4, 'We have two different instances');
     assertSameSerializedContent(t, state3, state4);
 
+    t.end();
+  });
+
+  test(`Test ${testName} serialization on deleted object`, (t) => {
+    t.ok(klass, 'Make sure the class definition exist');
+    const instance = klass.newInstance(initData);
+    t.ok(instance, 'Make sure the instance exist');
+    instance.delete();
+    t.equal(JSON.stringify(instance), 'null');
     t.end();
   });
 });

--- a/Sources/Widgets/Core/AbstractWidget/index.js
+++ b/Sources/Widgets/Core/AbstractWidget/index.js
@@ -76,9 +76,9 @@ function vtkAbstractWidget(publicAPI, model) {
   };
 
   publicAPI.getViewWidgets = () =>
-    model.factory
+    model._factory
       .getViewIds()
-      .map((viewId) => model.factory.getWidgetForView({ viewId }));
+      .map((viewId) => model._factory.getWidgetForView({ viewId }));
 
   // --------------------------------------------------------------------------
   // Initialization calls
@@ -99,7 +99,7 @@ const DEFAULT_VALUES = {
  * @param {*} publicAPI public methods to populate
  * @param {*} model internal values to populate
  * @param {object} initialValues Contains at least
- *   {viewType, renderer, camera, openGLRenderWindow, factory}
+ *   {viewType, _renderer, _camera, _openGLRenderWindow, _factory}
  */
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
@@ -110,9 +110,10 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, [
     'contextVisibility',
     'handleVisibility',
-    'widgetManager',
+    '_widgetManager',
   ]);
   macro.get(publicAPI, model, ['representations', 'widgetState']);
+  macro.moveToProtected(publicAPI, model, ['widgetManager']);
   macro.event(publicAPI, model, 'ActivateHandle');
 
   vtkAbstractWidget(publicAPI, model);

--- a/Sources/Widgets/Core/AbstractWidgetFactory/index.js
+++ b/Sources/Widgets/Core/AbstractWidgetFactory/index.js
@@ -43,6 +43,12 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
         apiSpecificRenderWindow,
         factory: publicAPI,
       });
+      macro.moveToProtected(widgetPublicAPI, widgetModel, [
+        'renderer',
+        'camera',
+        'apiSpecificRenderWindow',
+        'factory',
+      ]);
       macro.safeArrays(widgetModel);
       vtkAbstractWidget.extend(widgetPublicAPI, widgetModel, initialValues);
 
@@ -53,7 +59,7 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
         .getRepresentationsForViewType(viewType)
         .map(({ builder, labels, initialValues }) =>
           builder.newInstance({
-            parentProp: widgetPublicAPI,
+            _parentProp: widgetPublicAPI,
             labels,
             ...initialValues,
             ...widgetInitialValues,

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -97,8 +97,8 @@ function vtkWidgetManager(publicAPI, model) {
   const pendingSvgRenders = new WeakMap();
 
   function enableSvgLayer() {
-    const container = model.apiSpecificRenderWindow.getReferenceByName('el');
-    const canvas = model.apiSpecificRenderWindow.getCanvas();
+    const container = model._apiSpecificRenderWindow.getReferenceByName('el');
+    const canvas = model._apiSpecificRenderWindow.getCanvas();
     container.insertBefore(model.svgRoot, canvas.nextSibling);
     const containerStyles = window.getComputedStyle(container);
     if (containerStyles.position === 'static') {
@@ -107,7 +107,7 @@ function vtkWidgetManager(publicAPI, model) {
   }
 
   function disableSvgLayer() {
-    const container = model.apiSpecificRenderWindow.getReferenceByName('el');
+    const container = model._apiSpecificRenderWindow.getReferenceByName('el');
     container.removeChild(model.svgRoot);
   }
 
@@ -121,7 +121,7 @@ function vtkWidgetManager(publicAPI, model) {
   }
 
   function setSvgSize() {
-    const [cwidth, cheight] = model.apiSpecificRenderWindow.getSize();
+    const [cwidth, cheight] = model._apiSpecificRenderWindow.getSize();
     const ratio = window.devicePixelRatio || 1;
     const bwidth = String(cwidth / ratio);
     const bheight = String(cheight / ratio);
@@ -209,18 +209,18 @@ function vtkWidgetManager(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   function updateDisplayScaleParams() {
-    const { apiSpecificRenderWindow, camera, renderer } = model;
-    if (renderer && apiSpecificRenderWindow && camera) {
-      const [rwW, rwH] = apiSpecificRenderWindow.getSize();
-      const [vxmin, vymin, vxmax, vymax] = renderer.getViewport();
+    const { _apiSpecificRenderWindow, _camera, _renderer } = model;
+    if (_renderer && _apiSpecificRenderWindow && _camera) {
+      const [rwW, rwH] = _apiSpecificRenderWindow.getSize();
+      const [vxmin, vymin, vxmax, vymax] = _renderer.getViewport();
       const rendererPixelDims = [rwW * (vxmax - vxmin), rwH * (vymax - vymin)];
 
-      const cameraPosition = camera.getPosition();
-      const cameraDir = camera.getDirectionOfProjection();
-      const isParallel = camera.getParallelProjection();
+      const cameraPosition = _camera.getPosition();
+      const cameraDir = _camera.getDirectionOfProjection();
+      const isParallel = _camera.getParallelProjection();
       const dispHeightFactor = isParallel
-        ? 2 * camera.getParallelScale()
-        : 2 * Math.tan(radiansFromDegrees(camera.getViewAngle()) / 2);
+        ? 2 * _camera.getParallelScale()
+        : 2 * Math.tan(radiansFromDegrees(_camera.getViewAngle()) / 2);
 
       model.widgets.forEach((w) => {
         w.getNestedProps().forEach((r) => {
@@ -264,8 +264,8 @@ function vtkWidgetManager(publicAPI, model) {
     renderPickingBuffer();
 
     model._capturedBuffers = null;
-    model._capturedBuffers = await model.selector.getSourceDataAsync(
-      model.renderer,
+    model._capturedBuffers = await model._selector.getSourceDataAsync(
+      model._renderer,
       x1,
       y1,
       x2,
@@ -283,7 +283,7 @@ function vtkWidgetManager(publicAPI, model) {
 
   publicAPI.renderWidgets = () => {
     if (model.pickingEnabled && model.captureOn === CaptureOn.MOUSE_RELEASE) {
-      const [w, h] = model.apiSpecificRenderWindow.getSize();
+      const [w, h] = model._apiSpecificRenderWindow.getSize();
       captureBuffers(0, 0, w, h);
     }
 
@@ -296,41 +296,43 @@ function vtkWidgetManager(publicAPI, model) {
   };
 
   publicAPI.setRenderer = (renderer) => {
-    Object.assign(model, extractRenderingComponents(renderer));
+    const renderingComponents = extractRenderingComponents(renderer);
+    Object.assign(model, renderingComponents);
+    macro.moveToProtected({}, model, Object.keys(renderingComponents));
     while (subscriptions.length) {
       subscriptions.pop().unsubscribe();
     }
 
-    model.selector = model.apiSpecificRenderWindow.createSelector();
-    model.selector.setFieldAssociation(
+    model._selector = model._apiSpecificRenderWindow.createSelector();
+    model._selector.setFieldAssociation(
       FieldAssociations.FIELD_ASSOCIATION_POINTS
     );
 
-    subscriptions.push(model.interactor.onRenderEvent(updateSvg));
+    subscriptions.push(model._interactor.onRenderEvent(updateSvg));
 
-    subscriptions.push(model.apiSpecificRenderWindow.onModified(setSvgSize));
+    subscriptions.push(model._apiSpecificRenderWindow.onModified(setSvgSize));
     setSvgSize();
 
     subscriptions.push(
-      model.apiSpecificRenderWindow.onModified(updateDisplayScaleParams)
+      model._apiSpecificRenderWindow.onModified(updateDisplayScaleParams)
     );
-    subscriptions.push(model.camera.onModified(updateDisplayScaleParams));
+    subscriptions.push(model._camera.onModified(updateDisplayScaleParams));
     updateDisplayScaleParams();
 
     subscriptions.push(
-      model.interactor.onStartAnimation(() => {
+      model._interactor.onStartAnimation(() => {
         model.isAnimating = true;
       })
     );
     subscriptions.push(
-      model.interactor.onEndAnimation(() => {
+      model._interactor.onEndAnimation(() => {
         model.isAnimating = false;
         publicAPI.renderWidgets();
       })
     );
 
     subscriptions.push(
-      model.interactor.onMouseMove(async ({ position }) => {
+      model._interactor.onMouseMove(async ({ position }) => {
         if (
           model.isAnimating ||
           !model.pickingEnabled ||
@@ -349,13 +351,15 @@ function vtkWidgetManager(publicAPI, model) {
         }
 
         // Default cursor behavior
-        model.apiSpecificRenderWindow.setCursor(widget ? 'pointer' : 'default');
+        model._apiSpecificRenderWindow.setCursor(
+          widget ? 'pointer' : 'default'
+        );
 
         if (model.widgetInFocus === widget && widget.hasFocus()) {
           widget.activateHandle({ selectedState, representation });
           // Ken FIXME
-          model.interactor.render();
-          model.interactor.render();
+          model._interactor.render();
+          model._interactor.render();
         } else {
           for (let i = 0; i < model.widgets.length; i++) {
             const w = model.widgets[i];
@@ -367,8 +371,8 @@ function vtkWidgetManager(publicAPI, model) {
             }
           }
           // Ken FIXME
-          model.interactor.render();
-          model.interactor.render();
+          model._interactor.render();
+          model._interactor.render();
         }
       })
     );
@@ -390,25 +394,25 @@ function vtkWidgetManager(publicAPI, model) {
     updateDisplayScaleParams();
 
     // Register to renderer
-    model.renderer.addActor(viewWidget);
+    model._renderer.addActor(viewWidget);
   }
 
   publicAPI.addWidget = (widget, viewType, initialValues) => {
-    if (!model.renderer) {
+    if (!model._renderer) {
       vtkErrorMacro(
         'Widget manager MUST BE link to a view before registering widgets'
       );
       return null;
     }
-    const { viewId, renderer } = model;
+    const { viewId, _renderer } = model;
     const w = widget.getWidgetForView({
       viewId,
-      renderer,
+      renderer: _renderer,
       viewType: viewType || ViewTypes.DEFAULT,
       initialValues,
     });
 
-    if (model.widgets.indexOf(w) === -1) {
+    if (w != null && model.widgets.indexOf(w) === -1) {
       model.widgets.push(w);
       addWidgetInternal(w);
       publicAPI.modified();
@@ -418,13 +422,13 @@ function vtkWidgetManager(publicAPI, model) {
   };
 
   function removeWidgetInternal(viewWidget) {
-    model.renderer.removeActor(viewWidget);
+    model._renderer.removeActor(viewWidget);
     removeFromSvgLayer(viewWidget);
     viewWidget.delete();
   }
 
   function onWidgetRemoved() {
-    model.renderer.getRenderWindow().getInteractor().render();
+    model._renderer.getRenderWindow().getInteractor().render();
     publicAPI.renderWidgets();
   }
 
@@ -524,7 +528,7 @@ function vtkWidgetManager(publicAPI, model) {
       'updateSelectionFromMouseEvent is deprecated, please use getSelectedDataForXY'
     );
     const { pageX, pageY } = event;
-    const { top, left, height } = model.apiSpecificRenderWindow
+    const { top, left, height } = model._apiSpecificRenderWindow
       .getCanvas()
       .getBoundingClientRect();
     const x = pageX - left;
@@ -591,7 +595,7 @@ function vtkWidgetManager(publicAPI, model) {
     if (useSvgLayer !== model.useSvgLayer) {
       model.useSvgLayer = useSvgLayer;
 
-      if (model.renderer) {
+      if (model._renderer) {
         if (useSvgLayer) {
           enableSvgLayer();
           // force a render so svg widgets can be drawn
@@ -620,6 +624,8 @@ function vtkWidgetManager(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  // _camera: null,
+  // _selector: null,
   viewId: null,
   widgets: [],
   renderer: null,

--- a/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
+++ b/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
@@ -11,6 +11,24 @@ import noScaleInPixelsWithParallelBaseline from './testNoScaleInPixelsWithParall
 import scaleInPixelsWithPerspectiveBaseline from './testScaleInPixelsWithPerspectiveBaseline.png';
 // import scaleInPixelsWithParallelBaseline from './testScaleInPixelsWithParallelBaseline.png';
 
+test('Test vtkWidgetManager', (t) => {
+  const container = document.querySelector('body');
+  const rwContainer = document.createElement('div');
+  container.appendChild(rwContainer);
+  const grw = vtkGenericRenderWindow.newInstance({ listenWindowResize: false });
+  grw.setContainer(rwContainer);
+
+  const widgetManager = vtkWidgetManager.newInstance();
+  widgetManager.setRenderer(grw.getRenderer());
+
+  const widget = vtkPolyLineWidget.newInstance();
+  widgetManager.addWidget(widget);
+  widgetManager.getState();
+  t.end();
+
+  container.removeChild(rwContainer);
+});
+
 test.onlyIfWebGL('Test getPixelWorldHeightAtCoord', (t) => {
   const gc = testUtils.createGarbageCollector(t);
 

--- a/Sources/Widgets/Representations/CircleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/CircleContextRepresentation/index.js
@@ -68,7 +68,7 @@ function vtkCircleContextRepresentation(publicAPI, model) {
         colorByArrayName: 'color',
         scalarMode: ScalarMode.USE_POINT_FIELD_DATA,
       }),
-      actor: vtkActor.newInstance({ pickable: false, parentProp: publicAPI }),
+      actor: vtkActor.newInstance({ pickable: false, _parentProp: publicAPI }),
     },
   };
 

--- a/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
+++ b/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
@@ -107,31 +107,31 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
   model.pipelines.outline = {
     source: vtkCubeSource.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: false, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: false, _parentProp: publicAPI }),
   };
 
   model.pipelines.plane = {
     source: vtkClosedPolyLineToSurfaceFilter.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
 
   model.pipelines.origin = {
     source: vtkSphereSource.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
 
   model.pipelines.normal = {
     source: vtkCylinderSource.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
 
   model.pipelines.display2D = {
     source: publicAPI,
     mapper: vtkPixelSpaceCallbackMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: false, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: false, _parentProp: publicAPI }),
   };
 
   // Plane generation pipeline

--- a/Sources/Widgets/Representations/ResliceCursorContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/ResliceCursorContextRepresentation/index.js
@@ -48,34 +48,34 @@ function vtkResliceCursorContextRepresentation(publicAPI, model) {
   axis1.line = {
     source: vtkCylinderSource.newInstance(squarishCylinderProperties),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
   axis1.rotation1 = {
     source: vtkSphereSource.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
   axis1.rotation2 = {
     source: vtkSphereSource.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
   // Create axis 2
   const axis2 = {};
   axis2.line = {
     source: vtkCylinderSource.newInstance(squarishCylinderProperties),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
   axis2.rotation1 = {
     source: vtkSphereSource.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
   axis2.rotation2 = {
     source: vtkSphereSource.newInstance(),
     mapper: vtkMapper.newInstance(),
-    actor: vtkActor.newInstance({ pickable: true, parentProp: publicAPI }),
+    actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
 
   model.pipelines.axes.push(axis1);

--- a/Sources/Widgets/SVG/SVGRepresentation/index.js
+++ b/Sources/Widgets/SVG/SVGRepresentation/index.js
@@ -68,7 +68,7 @@ function vtkSVGRepresentation(publicAPI, model) {
 
   model.psActor = vtkActor.newInstance({
     pickable: false,
-    parentProp: publicAPI,
+    _parentProp: publicAPI,
   });
   model.psMapper = vtkPixelSpaceCallbackMapper.newInstance();
   model.points = vtkPolyData.newInstance();

--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -55,7 +55,7 @@ export default function widgetBehavior(publicAPI, model) {
     } else {
       isDragging = true;
       model.apiSpecificRenderWindow.setCursor('grabbing');
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
     }
 
     publicAPI.invokeStartInteractionEvent();
@@ -105,7 +105,7 @@ export default function widgetBehavior(publicAPI, model) {
     if (isDragging && model.pickable) {
       model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     } else if (model.activeState !== model.widgetState.getMoveHandle()) {
       model.widgetState.deactivate();
@@ -117,7 +117,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       publicAPI.invokeEndInteractionEvent();
       model.widgetManager.enablePicking();
-      model.interactor.render();
+      model._interactor.render();
     }
 
     // Don't make any more points
@@ -140,7 +140,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState = model.widgetState.getMoveHandle();
       model.activeState.activate();
       model.activeState.setVisible(true);
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
     model.hasFocus = true;
@@ -150,7 +150,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     }
     model.widgetState.deactivate();
@@ -159,6 +159,6 @@ export default function widgetBehavior(publicAPI, model) {
     model.activeState = null;
     model.hasFocus = false;
     model.widgetManager.enablePicking();
-    model.interactor.render();
+    model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -48,7 +48,7 @@ export default function widgetBehavior(publicAPI, model) {
     } else {
       isDragging = true;
       model.apiSpecificRenderWindow.setCursor('grabbing');
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
     }
 
     publicAPI.invokeStartInteractionEvent();
@@ -102,7 +102,7 @@ export default function widgetBehavior(publicAPI, model) {
     if (isDragging && model.pickable) {
       model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     } else if (model.activeState !== model.widgetState.getMoveHandle()) {
       model.widgetState.deactivate();
@@ -114,7 +114,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       publicAPI.invokeEndInteractionEvent();
       model.widgetManager.enablePicking();
-      model.interactor.render();
+      model._interactor.render();
     }
 
     isDragging = false;
@@ -132,7 +132,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState = model.widgetState.getMoveHandle();
       model.activeState.activate();
       model.activeState.setVisible(true);
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
     model.hasFocus = true;
@@ -142,7 +142,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     }
     model.widgetState.deactivate();
@@ -151,6 +151,6 @@ export default function widgetBehavior(publicAPI, model) {
     model.activeState = null;
     model.hasFocus = false;
     model.widgetManager.enablePicking();
-    model.interactor.render();
+    model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
@@ -22,7 +22,7 @@ export default function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
     isDragging = true;
-    model.interactor.requestAnimation(publicAPI);
+    model._interactor.requestAnimation(publicAPI);
     return macro.EVENT_ABORT;
   };
 
@@ -36,7 +36,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
       isDragging = false;
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       model.widgetState.deactivate();
     }
   };

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
@@ -47,7 +47,7 @@ function widgetBehavior(publicAPI, model) {
     model.lineManipulator.setOrigin(model.widgetState.getOrigin());
     model.planeManipulator.setOrigin(model.widgetState.getOrigin());
     model.trackballManipulator.reset(callData); // setup trackball delta
-    model.interactor.requestAnimation(publicAPI);
+    model._interactor.requestAnimation(publicAPI);
     publicAPI.invokeStartInteractionEvent();
 
     return macro.EVENT_ABORT;
@@ -63,7 +63,7 @@ function widgetBehavior(publicAPI, model) {
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
       publicAPI.invokeEndInteractionEvent();
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
     }
     isDragging = false;
     model.widgetState.deactivate();

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -42,7 +42,7 @@ export default function widgetBehavior(publicAPI, model) {
       ...model.manipulator.handleEvent(callData, model.apiSpecificRenderWindow),
     ];
     model.apiSpecificRenderWindow.setCursor('grabbing');
-    model.interactor.requestAnimation(publicAPI);
+    model._interactor.requestAnimation(publicAPI);
   }
 
   // --------------------------------------------------------------------------
@@ -80,12 +80,12 @@ export default function widgetBehavior(publicAPI, model) {
     const textPropsCp = { ...model.representations[3].getTextProps() };
     textPropsCp.dy = dySign * Math.abs(textPropsCp.dy);
     model.representations[3].setTextProps(textPropsCp);
-    model.interactor.render();
+    model._interactor.render();
   };
 
   publicAPI.setText = (text) => {
     model.widgetState.getText().setText(text);
-    model.interactor.render();
+    model._interactor.render();
   };
 
   // --------------------------------------------------------------------------
@@ -178,7 +178,7 @@ export default function widgetBehavior(publicAPI, model) {
       visibility && handle.getShape() !== ShapeType.NONE,
     ]);
     model.representations[handleIndex].updateActorVisibility();
-    model.interactor.render();
+    model._interactor.render();
   };
 
   /**
@@ -318,7 +318,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState = null;
 
       if (!wasTextActive) {
-        model.interactor.cancelAnimation(publicAPI);
+        model._interactor.cancelAnimation(publicAPI);
       }
       model.apiSpecificRenderWindow.setCursor('pointer');
 
@@ -326,7 +326,7 @@ export default function widgetBehavior(publicAPI, model) {
 
       publicAPI.invokeEndInteractionEvent();
       model.widgetManager.enablePicking();
-      model.interactor.render();
+      model._interactor.render();
     }
 
     if (
@@ -348,7 +348,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState.setShape(publicAPI.getHandle(0).getShape());
       publicAPI.setMoveHandleVisibility(true);
       model.activeState.activate();
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
     model.hasFocus = true;
@@ -358,7 +358,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     }
     model.widgetState.deactivate();
@@ -366,6 +366,6 @@ export default function widgetBehavior(publicAPI, model) {
     model.activeState = null;
     model.hasFocus = false;
     model.widgetManager.enablePicking();
-    model.interactor.render();
+    model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -2,7 +2,7 @@ import macro from 'vtk.js/Sources/macros';
 import { vec3 } from 'gl-matrix';
 
 export default function widgetBehavior(publicAPI, model) {
-  model.painting = model.factory.getPainting();
+  model.painting = model._factory.getPainting();
 
   publicAPI.handleLeftButtonPress = (callData) => {
     if (!model.activeState || !model.activeState.getActive()) {
@@ -77,7 +77,7 @@ export default function widgetBehavior(publicAPI, model) {
     if (!model.hasFocus) {
       model.activeState = model.widgetState.getHandle();
       model.activeState.activate();
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
 
       const canvas = model.apiSpecificRenderWindow.getCanvas();
       canvas.onmouseenter = () => {
@@ -102,7 +102,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
     }
     model.widgetState.deactivate();
     model.widgetState.getHandle().deactivate();

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -34,11 +34,11 @@ export default function widgetBehavior(publicAPI, model) {
     }
 
     if (model.activeState !== model.widgetState.getMoveHandle()) {
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       model.activeState.deactivate();
       model.widgetState.removeHandle(model.activeState);
       model.activeState = null;
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
     }
 
     publicAPI.invokeStartInteractionEvent();
@@ -71,7 +71,7 @@ export default function widgetBehavior(publicAPI, model) {
     } else {
       isDragging = true;
       model.apiSpecificRenderWindow.setCursor('grabbing');
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
     }
 
     publicAPI.invokeStartInteractionEvent();
@@ -121,7 +121,7 @@ export default function widgetBehavior(publicAPI, model) {
     if (isDragging && model.pickable) {
       model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     } else if (model.activeState !== model.widgetState.getMoveHandle()) {
       model.widgetState.deactivate();
@@ -133,7 +133,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       publicAPI.invokeEndInteractionEvent();
       model.widgetManager.enablePicking();
-      model.interactor.render();
+      model._interactor.render();
     }
 
     isDragging = false;
@@ -158,7 +158,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState = model.widgetState.getMoveHandle();
       model.activeState.activate();
       model.activeState.setVisible(true);
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
     model.hasFocus = true;
@@ -168,7 +168,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     }
     model.widgetState.deactivate();
@@ -177,6 +177,6 @@ export default function widgetBehavior(publicAPI, model) {
     model.activeState = null;
     model.hasFocus = false;
     model.widgetManager.enablePicking();
-    model.interactor.render();
+    model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -33,19 +33,19 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.setText = (text) => {
     model.widgetState.getText().setText(text);
     // Recompute position
-    model.interactor.render();
+    model._interactor.render();
   };
 
   // --------------------------------------------------------------------------
   // Public methods
   // --------------------------------------------------------------------------
   publicAPI.setResetAfterPointPlacement =
-    model.factory.setResetAfterPointPlacement;
+    model._factory.setResetAfterPointPlacement;
   publicAPI.getResetAfterPointPlacement =
-    model.factory.getResetAfterPointPlacement;
+    model._factory.getResetAfterPointPlacement;
 
-  publicAPI.setModifierBehavior = model.factory.setModifierBehavior;
-  publicAPI.getModifierBehavior = model.factory.getModifierBehavior;
+  publicAPI.setModifierBehavior = model._factory.setModifierBehavior;
+  publicAPI.getModifierBehavior = model._factory.getModifierBehavior;
 
   publicAPI.isBehaviorActive = (category, flag) =>
     Object.keys(model.keysDown).some(
@@ -540,7 +540,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       model.isDragging = true;
       model.apiSpecificRenderWindow.setCursor('grabbing');
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
 
       return macro.EVENT_ABORT;
@@ -558,7 +558,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.isDragging = false;
       model.apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
 
       return macro.EVENT_ABORT;
@@ -648,7 +648,7 @@ export default function widgetBehavior(publicAPI, model) {
 
       model.point1Handle.setVisible(true);
       model.shapeHandle.setVisible(false);
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
     }
 
     superClass.grabFocus();
@@ -658,7 +658,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
     }
 
     if (!model.point1) {
@@ -670,7 +670,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.point1Handle.deactivate();
     model.point2Handle.deactivate();
     model.activeState = null;
-    model.interactor.render();
+    model._interactor.render();
     model.widgetManager.enablePicking();
 
     superClass.loseFocus();

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -105,41 +105,41 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.setResetAfterPointPlacement =
-    model.factory.setResetAfterPointPlacement;
+    model._factory.setResetAfterPointPlacement;
   publicAPI.getResetAfterPointPlacement =
-    model.factory.getResetAfterPointPlacement;
+    model._factory.getResetAfterPointPlacement;
   publicAPI.setResetAfterPointPlacement(
     publicAPI.getResetAfterPointPlacement()
   );
 
-  publicAPI.setFreehandMinDistance = model.factory.setFreehandMinDistance;
-  publicAPI.getFreehandMinDistance = model.factory.getFreehandMinDistance;
+  publicAPI.setFreehandMinDistance = model._factory.setFreehandMinDistance;
+  publicAPI.getFreehandMinDistance = model._factory.getFreehandMinDistance;
   publicAPI.setFreehandMinDistance(publicAPI.getFreehandMinDistance());
 
-  publicAPI.setAllowFreehand = model.factory.setAllowFreehand;
-  publicAPI.getAllowFreehand = model.factory.getAllowFreehand;
+  publicAPI.setAllowFreehand = model._factory.setAllowFreehand;
+  publicAPI.getAllowFreehand = model._factory.getAllowFreehand;
   publicAPI.setAllowFreehand(publicAPI.getAllowFreehand());
 
-  publicAPI.setDefaultCursor = model.factory.setDefaultCursor;
-  publicAPI.getDefaultCursor = model.factory.getDefaultCursor;
+  publicAPI.setDefaultCursor = model._factory.setDefaultCursor;
+  publicAPI.getDefaultCursor = model._factory.getDefaultCursor;
   publicAPI.setDefaultCursor(publicAPI.getDefaultCursor());
 
   // --------------------------------------------------------------------------
 
   publicAPI.setHandleSizeInPixels = (size) => {
-    model.factory.setHandleSizeInPixels(size);
+    model._factory.setHandleSizeInPixels(size);
     updateHandlesSize();
   };
-  publicAPI.getHandleSizeInPixels = model.factory.getHandleSizeInPixels;
-  publicAPI.setHandleSizeInPixels(model.factory.getHandleSizeInPixels()); // set initial value
+  publicAPI.getHandleSizeInPixels = model._factory.getHandleSizeInPixels;
+  publicAPI.setHandleSizeInPixels(model._factory.getHandleSizeInPixels()); // set initial value
 
   // --------------------------------------------------------------------------
 
   publicAPI.setResolution = (resolution) => {
-    model.factory.setResolution(resolution);
+    model._factory.setResolution(resolution);
     model.representations[1].setResolution(resolution);
   };
-  publicAPI.setResolution(model.factory.getResolution()); // set initial value
+  publicAPI.setResolution(model._factory.getResolution()); // set initial value
 
   // --------------------------------------------------------------------------
 
@@ -169,11 +169,11 @@ export default function widgetBehavior(publicAPI, model) {
     }
 
     if (model.activeState !== model.moveHandle) {
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       model.activeState.deactivate();
       model.widgetState.removeHandle(model.activeState);
       model.activeState = null;
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
     } else {
       const handle = getHoveredHandle();
       if (handle) {
@@ -225,7 +225,7 @@ export default function widgetBehavior(publicAPI, model) {
     } else {
       model.isDragging = true;
       model.apiSpecificRenderWindow.setCursor('grabbing');
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
 
@@ -241,7 +241,7 @@ export default function widgetBehavior(publicAPI, model) {
       if (!model.hasFocus) {
         model.apiSpecificRenderWindow.setCursor(model.defaultCursor);
         model.widgetState.deactivate();
-        model.interactor.cancelAnimation(publicAPI);
+        model._interactor.cancelAnimation(publicAPI);
         publicAPI.invokeEndInteractionEvent();
       } else {
         model.moveHandle.setOrigin(...model.activeState.getOrigin());
@@ -273,7 +273,7 @@ export default function widgetBehavior(publicAPI, model) {
           }
         }
 
-        model.interactor.render();
+        model._interactor.render();
       }
     } else if (model.activeState !== model.moveHandle) {
       model.widgetState.deactivate();
@@ -387,7 +387,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState = model.moveHandle;
       model.activeState.activate();
       model.activeState.setVisible(true);
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       updateHandlesSize();
     }
 
@@ -398,14 +398,14 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
     }
 
     model.widgetState.deactivate();
     model.moveHandle.deactivate();
     model.moveHandle.setVisible(false);
     model.activeState = null;
-    model.interactor.render();
+    model._interactor.render();
 
     model.hasFocus = false;
   };

--- a/Sources/interfaces.d.ts
+++ b/Sources/interfaces.d.ts
@@ -255,6 +255,17 @@ export interface vtkObject {
 	getState(): object;
 
 	/**
+	 * Used internally by JSON.stringify to get the content to serialize.
+	 * Allow to call directly JSON.stringify on the vtkObject instead of using getState before doing so.
+	 *
+	 * ```
+	 * const actorStr = JSON.stringify(actor);
+	 * const newActor = vtk(JSON.parse(actorStr));
+	 * ```
+	 */
+	toJSON(): object;
+
+	/**
 	 * Try to copy the state of the other to ourselves by just using references.
 	 *
 	 * @param {vtkObject} other instance to copy the reference from

--- a/Sources/macros.d.ts
+++ b/Sources/macros.d.ts
@@ -65,11 +65,23 @@ export enum TYPED_ARRAYS {
  * ```
  * const set = `set${capitalize(fieldName)}`;
  * ```
+ * @param str String to capitalize
  */
 export function capitalize(str: string): string;
 
 /**
- * Lowercase the first letter of the provided string
+ * Capitalize provided string.
+ * This is typically used to convert the name of a field into its method name.
+ * Ignore the first letter if it starts with underscore (i.e. _).
+ *
+ * ```
+ * const set = `set${capitalize(fieldName)}`;
+ * ```
+ */
+export function _capitalize(str: string): string;
+
+/**
+ * Lowercase the first letter of the provided string.
  */
 export function uncapitalize(str: string): string;
 
@@ -208,6 +220,19 @@ export function setArray(publicAPI: object, model: object, fieldNames: Array<str
  */
 export function setGetArray(publicAPI: object, model: object, fieldNames: Array<string>, size: Number, defaultVal?: any): void;
 
+/**
+ * Convert model and publicAPI references to _fieldName into fieldName.
+ * It renames:
+ *   - model.fieldName into model._fieldName
+ *   - publicAPI.set_fieldName and publicAPI.set_fieldNameFrom into publicAPI.setFieldName and publicAPI.setFieldNameFrom
+ *   - publicAPI.get_fieldName and publicAPI.get_fieldNameByReference into publicAPI.getFieldName and publicAPI.getFieldNameByReference
+ * @param publicAPI
+ * @param model
+ * @param fieldNames List of field names to move to protected, e.g. ['interactor', 'renderWindow']
+ * @see get
+ * @see set
+ */
+export function moveToProtected(publicAPI: object, model: object, fieldNames: Array<string>): void;
 
 /**
  * Add algorithm methods onto the provided publicAPI

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -195,7 +195,7 @@ function enumToString(e, value) {
 }
 
 function getStateArrayMapFunc(item) {
-  if (item.isA) {
+  if (item && item.isA) {
     return item.getState();
   }
   return item;
@@ -331,6 +331,9 @@ export function obj(publicAPI = {}, model = {}) {
 
   // Add serialization support
   publicAPI.getState = () => {
+    if (model.deleted) {
+      return null;
+    }
     const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
 
     // Convert every vtkObject to its serializable form
@@ -1362,6 +1365,9 @@ export function proxy(publicAPI, model) {
     );
     parentDelete();
   };
+
+  // @todo fix infinite recursion due to active source
+  publicAPI.getState = () => null;
 
   function registerLinks() {
     // Allow dynamic registration of links at the application level

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -394,6 +394,12 @@ export function obj(publicAPI = {}, model = {}) {
     publicAPI.modified();
   };
 
+  // This function will get called when one invoke JSON.stringify(vtkObject)
+  // JSON.stringify will only stringify the return value of this function
+  publicAPI.toJSON = function vtkObjToJSON() {
+    return publicAPI.getState();
+  };
+
   // Allow usage as decorator
   return publicAPI;
 }

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -108,11 +108,15 @@ export function newTypedArrayFrom(type, ...args) {
 }
 
 // ----------------------------------------------------------------------------
-// capitilze provided string
+// capitilize provided string
 // ----------------------------------------------------------------------------
 
 export function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export function _capitalize(str) {
+  return capitalize(str[0] === '_' ? str.slice(1) : str);
 }
 
 export function uncapitalize(str) {
@@ -414,9 +418,9 @@ export function obj(publicAPI = {}, model = {}) {
 export function get(publicAPI, model, fieldNames) {
   fieldNames.forEach((field) => {
     if (typeof field === 'object') {
-      publicAPI[`get${capitalize(field.name)}`] = () => model[field.name];
+      publicAPI[`get${_capitalize(field.name)}`] = () => model[field.name];
     } else {
-      publicAPI[`get${capitalize(field)}`] = () => model[field];
+      publicAPI[`get${_capitalize(field)}`] = () => model[field];
     }
   });
 }
@@ -494,12 +498,12 @@ function findSetter(field) {
 export function set(publicAPI, model, fields) {
   fields.forEach((field) => {
     if (typeof field === 'object') {
-      publicAPI[`set${capitalize(field.name)}`] = findSetter(field)(
+      publicAPI[`set${_capitalize(field.name)}`] = findSetter(field)(
         publicAPI,
         model
       );
     } else {
-      publicAPI[`set${capitalize(field)}`] = findSetter(field)(
+      publicAPI[`set${_capitalize(field)}`] = findSetter(field)(
         publicAPI,
         model
       );
@@ -523,9 +527,9 @@ export function setGet(publicAPI, model, fieldNames) {
 
 export function getArray(publicAPI, model, fieldNames) {
   fieldNames.forEach((field) => {
-    publicAPI[`get${capitalize(field)}`] = () =>
+    publicAPI[`get${_capitalize(field)}`] = () =>
       model[field] ? [].concat(model[field]) : model[field];
-    publicAPI[`get${capitalize(field)}ByReference`] = () => model[field];
+    publicAPI[`get${_capitalize(field)}ByReference`] = () => model[field];
   });
 }
 
@@ -549,7 +553,7 @@ export function setArray(
       );
     }
 
-    publicAPI[`set${capitalize(field)}`] = (...args) => {
+    publicAPI[`set${_capitalize(field)}`] = (...args) => {
       if (model.deleted) {
         vtkErrorMacro('instance deleted - cannot call any method');
         return false;
@@ -595,7 +599,7 @@ export function setArray(
       return changeDetected;
     };
 
-    publicAPI[`set${capitalize(field)}From`] = (otherArray) => {
+    publicAPI[`set${_capitalize(field)}From`] = (otherArray) => {
       const target = model[field];
       otherArray.forEach((v, i) => {
         target[i] = v;
@@ -619,6 +623,15 @@ export function setGetArray(
   setArray(publicAPI, model, fieldNames, size, defaultVal);
 }
 
+export function moveToProtected(publicAPI, model, fieldNames) {
+  for (let i = 0; i < fieldNames.length; i++) {
+    const fieldName = fieldNames[i];
+    if (model[fieldName] !== undefined) {
+      model[`_${fieldName}`] = model[fieldName];
+      delete model[fieldName];
+    }
+  }
+}
 // ----------------------------------------------------------------------------
 // vtkAlgorithm: setInputData(), setInputConnection(), getOutputData(), getOutputPort()
 // ----------------------------------------------------------------------------
@@ -909,9 +922,9 @@ export function event(publicAPI, model, eventName) {
     /* eslint-enable prefer-rest-params */
   }
 
-  publicAPI[`invoke${capitalize(eventName)}`] = invoke;
+  publicAPI[`invoke${_capitalize(eventName)}`] = invoke;
 
-  publicAPI[`on${capitalize(eventName)}`] = (callback, priority = 0.0) => {
+  publicAPI[`on${_capitalize(eventName)}`] = (callback, priority = 0.0) => {
     if (!callback.apply) {
       console.error(`Invalid callback for event ${eventName}`);
       return null;
@@ -1178,7 +1191,7 @@ export function proxy(publicAPI, model) {
 
   publicAPI.activate = () => {
     if (model.proxyManager) {
-      const setActiveMethod = `setActive${capitalize(
+      const setActiveMethod = `setActive${_capitalize(
         publicAPI.getProxyGroup().slice(0, -1)
       )}`;
       if (model.proxyManager[setActiveMethod]) {
@@ -1235,7 +1248,7 @@ export function proxy(publicAPI, model) {
       }
 
       const newValue =
-        sourceLink.instance[`get${capitalize(sourceLink.propertyName)}`]();
+        sourceLink.instance[`get${_capitalize(sourceLink.propertyName)}`]();
       if (!shallowEquals(newValue, value) || force) {
         value = newValue;
         updateInProgress = true;
@@ -1321,7 +1334,7 @@ export function proxy(publicAPI, model) {
     const propertyNames = listProxyProperties(groupName) || [];
     for (let i = 0; i < propertyNames.length; i++) {
       const name = propertyNames[i];
-      const method = publicAPI[`get${capitalize(name)}`];
+      const method = publicAPI[`get${_capitalize(name)}`];
       const value = method ? method() : undefined;
       const prop = {
         id,
@@ -1407,8 +1420,8 @@ export function proxyPropertyMapping(publicAPI, model, map) {
   while (count--) {
     const propertyName = propertyNames[count];
     const { modelKey, property, modified = true } = map[propertyName];
-    const methodSrc = capitalize(property);
-    const methodDst = capitalize(propertyName);
+    const methodSrc = _capitalize(property);
+    const methodDst = _capitalize(propertyName);
     publicAPI[`get${methodDst}`] = model[modelKey][`get${methodSrc}`];
     publicAPI[`set${methodDst}`] = model[modelKey][`set${methodSrc}`];
     if (modified) {
@@ -1470,7 +1483,7 @@ export function proxyPropertyState(
 
     // Add set method
     const mapping = state[key];
-    publicAPI[`set${capitalize(key)}`] = (value) => {
+    publicAPI[`set${_capitalize(key)}`] = (value) => {
       if (value !== model[key]) {
         model[key] = value;
         const propValues = mapping[value];
@@ -1687,6 +1700,7 @@ export default {
   getStateArrayMapFunc,
   isVtkObject,
   keystore,
+  moveToProtected,
   newInstance,
   newTypedArray,
   newTypedArrayFrom,


### PR DESCRIPTION
The toJSON method simply returns the result of publicAPI.getState()
It allow user to call JSON.stringify directly on a vtkObject instead of doing JSON.stringify(vtkObject.getState())

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
To serialize an object to JSON you have to use JSON.stringify(vtkObj.getState())

### Changes
Now we can use JSON.stringify(vtkObj) and we will get the same result.
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results

### Testing
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->
