### PR TITLE
docs(ts): Add and update TypeScript definitions

### DIFF
--- a/Sources/IO/Core/ImageStream/DefaultProtocol.d.ts
+++ b/Sources/IO/Core/ImageStream/DefaultProtocol.d.ts
@@ -1,0 +1,25 @@
+import { Size, Vector3 } from '../../../types';
+
+declare function createMethods(session: any): {
+	subscribeToImageStream: (callback: any) => any;
+	unsubscribeToImageStream: (subscription: any) => any;
+	registerView: (viewId: number) => any;
+	unregisterView: (viewId: number) => any;
+	enableView: (viewId: number, enabled: boolean) => any;
+	render: (options?: {
+			size: Size;
+			view: number;
+	}) => any;
+	resetCamera: (view?: number) => any;
+	invalidateCache: (viewId: number) => any;
+	setQuality: (viewId: number, quality: number, ratio?: number) => any;
+	setSize: (viewId: number, width?: number, height?: number) => any;
+	setServerAnimationFPS: (fps?: number) => any;
+	getServerAnimationFPS: () => number;
+	startAnimation: (viewId?: number) => any;
+	stopAnimation: (viewId?: number) => any;
+	updateCamera: (viewId: number, focalPoint: Vector3, viewUp: Vector3, position: Vector3, forceUpdate?: boolean) => any;
+	updateCameraParameters: (viewId?: number, parameters?: {}, forceUpdate?: boolean) => any;
+}
+
+export default createMethods;

--- a/Sources/IO/Core/ImageStream/ViewStream.d.ts
+++ b/Sources/IO/Core/ImageStream/ViewStream.d.ts
@@ -1,10 +1,12 @@
 import { vtkObject } from '../../../interfaces';
-
+import { Size } from '../../../types';
+import vtkCamera from '../../../Rendering/Core/Camera';
+import DefaultProtocol from './DefaultProtocol';
 /**
  *
  */
 export interface IViewStreamInitialValues {
-  protocol?: any;
+  protocol?: typeof DefaultProtocol;
   api?: any;
   cameraUpdateRate?: number;
   decodeImage?: boolean;
@@ -13,11 +15,24 @@ export interface IViewStreamInitialValues {
   interactiveRatio?: number;
   isAnimating?: boolean;
   mimeType?: string;
-  size?: number[];
+  size?: Size;
   stillQuality?: number;
   stillRatio?: number;
   useCameraParameters?: boolean;
   viewId?: string;
+}
+
+interface IMetaData {
+  size: Size,
+  id: string,
+  memory: number,
+  workTime: number,
+}
+
+interface IEvent {
+  url: string,
+  fps: number[],
+  metadata: IMetaData,
 }
 
 export interface vtkViewStream extends vtkObject {
@@ -35,28 +50,28 @@ export interface vtkViewStream extends vtkObject {
   /**
    *
    */
-  getSize(): number[];
+  getSize(): Size;
 
   /**
    *
    */
-  getFps(): any;
+  getFps(): number[];
 
   /**
    *
    */
-  getLastImageEvent(): any;
+  getLastImageEvent(): IEvent;
 
   /**
    *
    */
-  getCamera(): any;
+  getCamera(): vtkCamera;
 
   /**
    *
    * @param camera
    */
-  setCamera(camera: any): boolean;
+  setCamera(camera: vtkCamera): boolean;
 
   /**
    *
@@ -72,7 +87,7 @@ export interface vtkViewStream extends vtkObject {
   /**
    *
    */
-  getDecodeImage(): any;
+  getDecodeImage(): boolean;
 
   /**
    *

--- a/Sources/IO/Core/ImageStream/ViewStream.d.ts
+++ b/Sources/IO/Core/ImageStream/ViewStream.d.ts
@@ -1,0 +1,241 @@
+import { vtkObject } from '../../../interfaces';
+
+/**
+ *
+ */
+export interface IViewStreamInitialValues {
+  protocol?: any;
+  api?: any;
+  cameraUpdateRate?: number;
+  decodeImage?: boolean;
+  fpsWindowSize?: number;
+  interactiveQuality?: number;
+  interactiveRatio?: number;
+  isAnimating?: boolean;
+  mimeType?: string;
+  size?: number[];
+  stillQuality?: number;
+  stillRatio?: number;
+  useCameraParameters?: boolean;
+  viewId?: string;
+}
+
+export interface vtkViewStream extends vtkObject {
+  /**
+   *
+   * @param callback
+   */
+  onImageReady(callback: () => void): any;
+
+  /**
+   *
+   */
+  getViewId(): string;
+
+  /**
+   *
+   */
+  getSize(): number[];
+
+  /**
+   *
+   */
+  getFps(): any;
+
+  /**
+   *
+   */
+  getLastImageEvent(): any;
+
+  /**
+   *
+   */
+  getCamera(): any;
+
+  /**
+   *
+   * @param camera
+   */
+  setCamera(camera: any): boolean;
+
+  /**
+   *
+   */
+  getCameraUpdateRate(): number;
+
+  /**
+   *
+   * @param cameraUpdateRate
+   */
+  setCameraUpdateRate(cameraUpdateRate: number): boolean;
+
+  /**
+   *
+   */
+  getDecodeImage(): any;
+
+  /**
+   *
+   * @param decodeImage
+   */
+  setDecodeImage(decodeImage: boolean): boolean;
+
+  /**
+   *
+   */
+  getFpsWindowSize(): number;
+
+  /**
+   *
+   * @param fpsWindowSize
+   */
+  setFpsWindowSize(fpsWindowSize: number): boolean;
+
+  /**
+   *
+   */
+  getInteractiveQuality(): number;
+
+  /**
+   *
+   * @param interactiveQuality
+   */
+  setInteractiveQuality(interactiveQuality: number): boolean;
+
+  /**
+   *
+   */
+  getInteractiveRatio(): number;
+
+  /**
+   *
+   * @param interactiveRatio
+   */
+  setInteractiveRatio(interactiveRatio: number): boolean;
+
+  /**
+   *
+   */
+  getStillQuality(): number;
+
+  /**
+   *
+   * @param stillQuality
+   */
+  setStillQuality(stillQuality: number): boolean;
+
+  /**
+   *
+   */
+  getStillRatio(): number;
+
+  /**
+   *
+   * @param stillRatio
+   */
+  setStillRatio(stillRatio: number): boolean;
+
+  /**
+   *
+   */
+  getUseCameraParameters(): boolean;
+
+  /**
+   *
+   * @param useCameraParameters
+   */
+  setUseCameraParameters(useCameraParameters: boolean): boolean;
+
+  /**
+   *
+   */
+  pushCamera(): any;
+
+  /**
+   *
+   */
+  invalidateCache(): any;
+
+  /**
+   *
+   */
+  render(): any;
+
+  /**
+   *
+   */
+  resetCamera(): any;
+
+  /**
+   *
+   */
+  startAnimation(): any;
+
+  /**
+   *
+   */
+  stopAnimation(): any;
+
+  /**
+   *
+   * @param width
+   * @param height
+   */
+  setSize(width: number, height: number): any;
+
+  /**
+   *
+   */
+  startInteraction(): any;
+
+  /**
+   *
+   */
+  endInteraction(): any;
+
+  /**
+   *
+   * @param viewId
+   */
+  setViewId(viewId: string): boolean;
+
+  /**
+   *
+   * @param msg
+   */
+  processMessage(msg: any): void;
+
+  /**
+   *
+   */
+  delete(): void;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkViewStream characteristics.
+ * @param publicAPI
+ * @param model
+ * @param initialValues
+ */
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: IViewStreamInitialValues
+): void;
+
+/**
+ * Method used to create a new instance of vtkViewStream
+ * @param {IViewStreamInitialValues} [initialValues] for pre-setting some of its content
+ */
+export function newInstance(
+  initialValues?: IViewStreamInitialValues
+): vtkViewStream;
+
+/**
+ * IViewStreamInitialValues provides a way to create a remote view.
+ */
+export declare const vtkViewStream: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+};
+export default vtkViewStream;

--- a/Sources/IO/Core/WSLinkClient/index.d.ts
+++ b/Sources/IO/Core/WSLinkClient/index.d.ts
@@ -1,4 +1,4 @@
-import { vtkObject, vtkSubscription } from "../../../interfaces";
+import { vtkObject, vtkSubscription } from '../../../interfaces';
 
 /**
  * Bind optional dependency from WSLink to our current class.
@@ -14,7 +14,6 @@ import { vtkObject, vtkSubscription } from "../../../interfaces";
  * @param smartConnectClass
  */
 export function setSmartConnectClass(smartConnectClass: object): void;
-
 
 export interface vtkWSLinkClient extends vtkObject {
 
@@ -117,21 +116,45 @@ export interface vtkWSLinkClient extends vtkObject {
    */
   getConfigDecorator(): (config: object) => object;
 
-  getConnection(): object;
-  getCongig(): object;
+  /**
+   *
+   */
+  getConnection(): any;
+
+  /**
+   *
+   */
+  getConfig(): object;
+
+  /**
+   *
+   */
   getRemote(): object;
+
+  /**
+   *
+   */
   getImageStream(): object;
 
+  /**
+   *
+   * @param callback
+   * @param priority
+   */
   onBusyChange(callback: Function, priority: number): vtkSubscription;
+
+  /**
+   *
+   */
   invokeBusyChange(): void;
 
-  onConnectionReady(callback: () => void): vtkSubscription;
+  onConnectionReady(callback: (httpReq: any) => void): vtkSubscription;
   // invokeConnectionReady(): void
 
-  onConnectionError(callback: () => void): vtkSubscription;
+  onConnectionError(callback: (httpReq: any) => void): vtkSubscription;
   // invokeConnectionError(): void
 
-  onConnectionClose(callback: () => void): vtkSubscription;
+  onConnectionClose(callback: (httpReq: any) => void): vtkSubscription;
   // invokeConnectionClose(): void
 }
 

--- a/Sources/Rendering/Misc/RemoteView/index.d.ts
+++ b/Sources/Rendering/Misc/RemoteView/index.d.ts
@@ -1,8 +1,9 @@
 import { vtkObject } from '../../../interfaces';
-import { vtkCanvasView } from '../CanvasView';
+import vtkCanvasView from '../CanvasView';
+import vtkViewStream from '../../../IO/Core/ImageStream/ViewStream';
 
 interface IRemoteViewInitialValues {
-  viewId?: number;
+  viewId?: string;
   interactiveQuality?: number;
   interactiveRatio?: number;
   stillQuality?: number;
@@ -21,7 +22,7 @@ export interface vtkRemoteView extends vtkObject {
   /**
    *
    */
-  getViewStream(): any;
+  getViewStream(): vtkViewStream;
 
   /**
    *
@@ -111,7 +112,7 @@ export interface vtkRemoteView extends vtkObject {
    *
    * @param viewStream
    */
-  setViewStream(viewStream: any): boolean; // viewStream is vtkViewStream
+  setViewStream(viewStream: vtkViewStream): boolean;
 
   /**
    *

--- a/Sources/Rendering/Misc/RemoteView/index.d.ts
+++ b/Sources/Rendering/Misc/RemoteView/index.d.ts
@@ -1,0 +1,198 @@
+import { vtkObject } from '../../../interfaces';
+import { vtkCanvasView } from '../CanvasView';
+
+interface IRemoteViewInitialValues {
+  viewId?: number;
+  interactiveQuality?: number;
+  interactiveRatio?: number;
+  stillQuality?: number;
+  stillRatio?: number;
+  rpcMouseEvent?: string;
+  rpcGestureEvent?: any;
+  rpcWheelEvent?: any;
+}
+
+export interface vtkRemoteView extends vtkObject {
+  /**
+   * Get container element
+   */
+  getContainer(): HTMLElement;
+
+  /**
+   *
+   */
+  getViewStream(): any;
+
+  /**
+   *
+   */
+  getCanvasView(): vtkCanvasView;
+
+  /**
+   *
+   */
+  getInteractor(): any;
+
+  /**
+   *
+   */
+  getInteractorStyle(): any;
+
+  /**
+   *
+   */
+  getInteractiveQuality(): number;
+
+  /**
+   *
+   */
+  getInteractiveRatio(): number;
+
+  /**
+   *
+   */
+  getStillQuality(): number;
+
+  /**
+   *
+   */
+  getStillRatio(): number;
+
+  /**
+   *
+   */
+  getSession(): any;
+
+  /**
+   *
+   * @param session
+   */
+  setSession(session: any): boolean;
+
+  /**
+   *
+   */
+  getRpcMouseEvent(): string;
+
+  /**
+   *
+   * @param rpcMouseEvent
+   */
+  setRpcMouseEvent(rpcMouseEvent: string): boolean;
+
+  /**
+   *
+   */
+  getRpcGestureEvent(): any;
+
+  /**
+   *
+   * @param rpcGestureEvent
+   */
+  setRpcGestureEvent(rpcGestureEvent: any): boolean;
+
+  /**
+   *
+   */
+  getRpcWheelEvent(): any;
+
+  /**
+   *
+   * @param rpcWheelEvent
+   */
+  setRpcWheelEvent(rpcWheelEvent: any): boolean;
+
+  /**
+   * Release GL context
+   */
+  delete(): void;
+
+  /**
+   *
+   * @param viewStream
+   */
+  setViewStream(viewStream: any): boolean; // viewStream is vtkViewStream
+
+  /**
+   *
+   * @param viewId
+   */
+  setViewId(viewId: string): void;
+
+  /**
+   *
+   * @param {HTMLElement} container The container HTML element.
+   */
+  setContainer(container: HTMLElement): boolean;
+
+  /**
+   * Handle window resize
+   */
+  resize(): void;
+
+  /**
+   *
+   */
+  render(): void;
+
+  /**
+   *
+   */
+  resetCamera(): void;
+
+  /**
+   *
+   * @param interactiveQuality
+   */
+  setInteractiveQuality(interactiveQuality: number): boolean;
+
+  /**
+   *
+   * @param interactiveRatio
+   */
+  setInteractiveRatio(interactiveRatio: number): boolean;
+
+  /**
+   *
+   * @param stillQuality
+   */
+  setStillQuality(stillQuality: number): boolean;
+
+  /**
+   *
+   * @param stillRatio
+   */
+  setStillRatio(stillRatio: number): boolean;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkRemoteView characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {IRemoteViewInitialValues} [initialValues] (default: {})
+ */
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: IRemoteViewInitialValues
+): void;
+
+/**
+ * Method used to create a new instance of vtkCanvasView
+ * @param {IRemoteViewInitialValues} [initialValues] for pre-setting some of its content
+ */
+export function newInstance(
+  initialValues?: IRemoteViewInitialValues
+): vtkRemoteView;
+
+export function connectImageStream(session: any): any;
+/**
+ * vtkRemoteView provides a way to create a remote view.
+ */
+export declare const vtkRemoteView: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+  connectImageStream: typeof connectImageStream;
+};
+export default vtkRemoteView;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

Adds definitions for ViewStream, RemoteView, fixes definitions for WSLinkClient

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!-- Remove the line below if it is not relevant -->
_This contribution is funded by [Example](https://example.com)._
