### PR TITLE
fix(WebVR): controller movement was off for scales far from 1

### DIFF
--- a/Sources/Interaction/Manipulators/VRButtonPanManipulator/index.js
+++ b/Sources/Interaction/Manipulators/VRButtonPanManipulator/index.js
@@ -43,7 +43,7 @@ function vtkVRButtonPanManipulator(publicAPI, model) {
     const speed = data.gamepad.axes[1];
 
     // 0.05 meters / frame movement
-    const pscale = (speed * 0.05) / camera.getPhysicalScale();
+    const pscale = speed * 0.05 * camera.getPhysicalScale();
 
     // convert orientation to world coordinate direction
     const dir = camera.physicalOrientationToWorldDirection(data.orientation);

--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -94,7 +94,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
     const speed = ed.gamepad.axes[1];
 
     // 0.05 meters / frame movement
-    const pscale = (speed * 0.05) / camera.getPhysicalScale();
+    const pscale = speed * 0.05 * camera.getPhysicalScale();
 
     // convert orientation to world coordinate direction
     const dir = camera.physicalOrientationToWorldDirection(ed.orientation);


### PR DESCRIPTION
The physical scale was being divided by when it should have been
multiplied by.

