### PR TITLE
feat(XR): Update to WebXR functionality in OpenGL RenderWindow

### DIFF
--- a/Examples/Applications/SkyboxViewer/index.js
+++ b/Examples/Applications/SkyboxViewer/index.js
@@ -41,7 +41,7 @@ let autoInit = true;
 const cameraFocalPoint = userParams.direction || [0, 0, -1];
 const cameraViewUp = userParams.up || [0, 1, 0];
 const cameraViewAngle = userParams.viewAngle || 100;
-const enableVR = !!userParams.vr;
+const enableXR = !!userParams.xr;
 const eyeSpacing = userParams.eye || 0.0;
 const grid = userParams.debug || false;
 const autoIncrementTimer = userParams.timer || 0;
@@ -189,13 +189,7 @@ function createVisualization(container, mapReader) {
     updateSkybox(allPositions[nextIdx]);
   }
 
-  if (enableVR && vtkDeviceOrientationToCamera.isDeviceOrientationSupported()) {
-    // vtkMobileVR.getVRHeadset().then((headset) => {
-    //   console.log('got headset');
-    //   console.log(headset);
-    //   console.log(vtkMobileVR.hardware);
-    // });
-
+  if (enableXR && navigator.xr.isSessionSupported('immersive-vr')) {
     leftRenderer = vtkRenderer.newInstance();
     rightRenderer = vtkRenderer.newInstance();
 
@@ -236,7 +230,7 @@ function createVisualization(container, mapReader) {
     distPass.setCameraCenterX1(-eyeSpacing);
     distPass.setCameraCenterX2(eyeSpacing);
     distPass.setDelegates([vtkForwardPass.newInstance()]);
-    fullScreenRenderer.getAPISpecificRenderWindow().setRenderPasses([distPass]);
+    fullScreenRenderer.getApiSpecificRenderWindow().setRenderPasses([distPass]);
 
     // Hide any controller
     fullScreenRenderer.setControllerVisibility(false);
@@ -278,29 +272,27 @@ function createVisualization(container, mapReader) {
     mainRenderer.addActor(actor);
 
     // add vr option button if supported
-    fullScreenRenderer.getApiSpecificRenderWindow().onHaveVRDisplay(() => {
-      if (
-        fullScreenRenderer.getApiSpecificRenderWindow().getVrDisplay()
-          .capabilities.canPresent
-      ) {
-        const button = document.createElement('button');
-        button.style.position = 'absolute';
-        button.style.left = '10px';
-        button.style.bottom = '10px';
-        button.style.zIndex = 10000;
-        button.textContent = 'Send To VR';
-        document.querySelector('body').appendChild(button);
-        button.addEventListener('click', () => {
-          if (button.textContent === 'Send To VR') {
-            fullScreenRenderer.getApiSpecificRenderWindow().startVR();
-            button.textContent = 'Return From VR';
-          } else {
-            fullScreenRenderer.getApiSpecificRenderWindow().stopVR();
-            button.textContent = 'Send To VR';
-          }
-        });
-      }
-    });
+    if (
+      navigator.xr !== undefined &&
+      navigator.xr.isSessionSupported('immersive-vr')
+    ) {
+      const button = document.createElement('button');
+      button.style.position = 'absolute';
+      button.style.left = '10px';
+      button.style.bottom = '10px';
+      button.style.zIndex = 10000;
+      button.textContent = 'Send To VR';
+      document.querySelector('body').appendChild(button);
+      button.addEventListener('click', () => {
+        if (button.textContent === 'Send To VR') {
+          fullScreenRenderer.getApiSpecificRenderWindow().startXR();
+          button.textContent = 'Return From VR';
+        } else {
+          fullScreenRenderer.getApiSpecificRenderWindow().stopXR();
+          button.textContent = 'Send To VR';
+        }
+      });
+    }
   }
 
   renderWindow.render();

--- a/Examples/Geometry/VR/index.js
+++ b/Examples/Geometry/VR/index.js
@@ -36,8 +36,7 @@ const renderWindow = fullScreenRenderer.getRenderWindow();
 // this
 // ----------------------------------------------------------------------------
 
-const coneSource = vtkConeSource.newInstance({ height: 100.0, radius: 50.0 });
-// const coneSource = vtkConeSource.newInstance({ height: 1.0, radius: 0.5 });
+const coneSource = vtkConeSource.newInstance({ height: 100.0, radius: 50 });
 const filter = vtkCalculator.newInstance();
 
 filter.setInputConnection(coneSource.getOutputPort());
@@ -67,7 +66,7 @@ mapper.setInputConnection(filter.getOutputPort());
 
 const actor = vtkActor.newInstance();
 actor.setMapper(mapper);
-actor.setPosition(20.0, 0.0, 0.0);
+actor.setPosition(0.0, 0.0, -20.0);
 
 renderer.addActor(actor);
 renderer.resetCamera();
@@ -96,10 +95,10 @@ resolutionChange.addEventListener('input', (e) => {
 
 vrbutton.addEventListener('click', (e) => {
   if (vrbutton.textContent === 'Send To VR') {
-    fullScreenRenderer.getApiSpecificRenderWindow().startVR();
+    fullScreenRenderer.getApiSpecificRenderWindow().startXR();
     vrbutton.textContent = 'Return From VR';
   } else {
-    fullScreenRenderer.getApiSpecificRenderWindow().stopVR();
+    fullScreenRenderer.getApiSpecificRenderWindow().stopXR();
     vrbutton.textContent = 'Send To VR';
   }
 });

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -366,7 +366,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       return;
     }
     animationRequesters.add(requestor);
-    if (animationRequesters.size === 1) {
+    if (animationRequesters.size === 1 && !model.xrAnimation) {
       model.lastFrameTime = 0.1;
       model.lastFrameStart = Date.now();
       model.animationRequest = requestAnimationFrame(publicAPI.handleAnimation);
@@ -375,7 +375,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   };
 
   publicAPI.isAnimating = () =>
-    model.vrAnimation || model.animationRequest !== null;
+    model.xrAnimation || model.animationRequest !== null;
 
   publicAPI.cancelAnimation = (requestor, skipWarning = false) => {
     if (!animationRequesters.has(requestor)) {
@@ -398,17 +398,17 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
   };
 
-  publicAPI.switchToVRAnimation = () => {
+  publicAPI.switchToXRAnimation = () => {
     // cancel existing animation if any
     if (model.animationRequest) {
       cancelAnimationFrame(model.animationRequest);
       model.animationRequest = null;
     }
-    model.vrAnimation = true;
+    model.xrAnimation = true;
   };
 
-  publicAPI.returnFromVRAnimation = () => {
-    model.vrAnimation = false;
+  publicAPI.returnFromXRAnimation = () => {
+    model.xrAnimation = false;
     if (animationRequesters.size !== 0) {
       model.FrameTime = -1;
       model.animationRequest = requestAnimationFrame(publicAPI.handleAnimation);
@@ -756,7 +756,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   // do not want extra renders as the make the apparent interaction
   // rate slower.
   publicAPI.render = () => {
-    if (model.animationRequest === null && !model.inRender) {
+    if (!publicAPI.isAnimating() && !model.inRender) {
       forceRender();
     }
   };


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

Replaces WebVR with WebXR methods for running an immersive VR session from an OpenGL RenderWindow.

[WebXR](https://immersiveweb.dev/) exposes methods for both VR and AR sessions across a diverse set of platforms, including standalone headsets, fixed displays, and mobile devices. These changes use WebXR to run a VR session in a dedicated headset or mobile viewer. `Applications/SkyboxViewer` and `Geometry/VR` examples are updated for API changes.

Planned future additions (outside the scope of this PR):
- WebXR polyfill
- XR gamepad API
- AR

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] `RenderWindow` now manages VR sessions with `startXR`, `enterXR`, `stopXR`, and `xrRender`
- [x] `Applications/SkyboxViewer` and `Geometry/VR` examples are updated to query availability/launch immersive sessions with VR
- [x] Gamepad support for VR examples is *deprecated* and will be reintroduced with the WebXR Gamepads API in the near future.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- `Applications/SkyboxViewer` and `Geometry/VR` examples query VR availability and launch/halt VR sessions correctly in WebXR-compatible browsers
- VR examples compatible with tethered headsets (such as HTC Vive Pro) or mobile headsets with dedicated processor (Quest)

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: v21.1.2
  - **OS**: Windows 10
  - **Browser**: Chrome 96.0.4664.45
- [x] VR examples run properly in WebXR-supported environment
  - [WebXR emulator](https://github.com/MozillaReality/WebXR-emulator-extension)
  - Oculus Browser
  - Chrome (via Oculus WebXR backend)


![xr-simulator](https://user-images.githubusercontent.com/40648863/143084365-f88977b9-7144-49c0-a4f3-1a4705f69e8c.png)


