### PR TITLE
fix(imagecropfilter): fix image crop filter instantiation

### DIFF
--- a/Sources/Filters/General/ImageCropFilter/index.js
+++ b/Sources/Filters/General/ImageCropFilter/index.js
@@ -41,7 +41,7 @@ function vtkImageCropFilter(publicAPI, model) {
 
     const extent = input.getExtent();
     const cropped =
-      model.croppingPlanes.length === 6
+      model.croppingPlanes && model.croppingPlanes.length === 6
         ? extent.map((e, i) => {
             if (i % 2 === 0) {
               // min plane
@@ -130,7 +130,7 @@ function vtkImageCropFilter(publicAPI, model) {
   };
 
   publicAPI.isResetAvailable = () => {
-    if (model.croppingPlanes.length === 0) {
+    if (model.croppingPlanes == null || model.croppingPlanes.length === 0) {
       return false;
     }
     const data = publicAPI.getInputData();
@@ -150,7 +150,7 @@ function vtkImageCropFilter(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  croppingPlanes: [],
+  // croppingPlanes: null,
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Since v21.0.0, default array values can be null but can't be empty array.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
https://discourse.vtk.org/t/unable-to-implement-imagecrop-filter/7254

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
Fix ImageCropFilter example 

### Testing
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome