### PR TITLE
fix(vtktubefilter): correcting the discrepancy in the number of point...

### DIFF
--- a/Sources/Filters/General/TubeFilter/index.js
+++ b/Sources/Filters/General/TubeFilter/index.js
@@ -661,10 +661,7 @@ function vtkTubeFilter(publicAPI, model) {
       size: numNewPts * 3,
       numberOfComponents: 3,
     });
-    let numNormals = 3 * numNewPts;
-    if (model.capping) {
-      numNormals = 3 * (numNewPts + 2 * model.numberOfSides);
-    }
+    const numNormals = 3 * numNewPts;
     const newNormalsData = new Float32Array(numNormals);
     const newNormals = vtkDataArray.newInstance({
       numberOfComponents: 3,

--- a/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
+++ b/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
@@ -112,7 +112,7 @@ test('Test vtkTubeFilter execution', (t) => {
     'Make sure the output number of points is correct with capping.'
   );
   t.ok(
-    tubeOutput2.getPointData().getNormals().getNumberOfTuples() === 24,
+    tubeOutput2.getPointData().getNormals().getNumberOfTuples() === 18,
     'Make sure the output number of normals is correct with capping.'
   );
   t.end();


### PR DESCRIPTION
…s and normals of vtkTubeFilter

The polyData returned by the vtkTubeFilter has different number of points and normals when the
capping is on. The normals data is allocated more number of points depending on the numberOfSides
attribute of vtkTubeFilter.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->
I encountered this issue while appending multiple tubeFilter outputs. The vtkTubeFilter has different number of points and normals when the capping is on. The normals in pointData has extra points which are all set to (0, 0, 0). I believe this line is to blame:
https://github.com/Kitware/vtk-js/blob/6e82cca81afe646206a1e12baed95b9aab329f73/Sources/Filters/General/TubeFilter/index.js#L666
The previous line isn't necessary as the points for capping are already accounted in `numNewPts` on this line:
https://github.com/Kitware/vtk-js/blob/6e82cca81afe646206a1e12baed95b9aab329f73/Sources/Filters/General/TubeFilter/index.js#L642

Here is a codepen to verify this claim.
https://codepen.io/nikhil216/pen/VwbWQME

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
The vtkTubeFilter returns output where number of normals and points are equal.

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: 21.1.2
  - **OS**: Windows 10
  - **Browser**: Chrome 96.0.4664.45
