### PR TITLE
fix(vtkMouseBoxSelectorManipulator.applyStyleToDiv): rectangle position

### DIFF
--- a/Sources/Interaction/Manipulators/MouseBoxSelectorManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseBoxSelectorManipulator/index.js
@@ -51,10 +51,12 @@ function vtkMouseBoxSelectionManipulator(publicAPI, model) {
       return;
     }
     const [viewWidth, viewHeight] = view.getSize();
-    const { width, height } = container.getBoundingClientRect();
+    const { width, height, top, left } = container.getBoundingClientRect();
     const [xMin, xMax, yMin, yMax] = getBounds();
-    div.style.left = `${(width * xMin) / viewWidth}px`;
-    div.style.top = `${height - (height * yMax) / viewHeight}px`;
+    const xShift = left + window.scrollX;
+    const yShift = top + window.scrollY;
+    div.style.left = `${xShift + (width * xMin) / viewWidth}px`;
+    div.style.top = `${yShift + height - (height * yMax) / viewHeight}px`;
     div.style.width = `${(width * (xMax - xMin)) / viewWidth}px`;
     div.style.height = `${(height * (yMax - yMin)) / viewHeight}px`;
   }


### PR DESCRIPTION
Fixed a problem with rectangle rendering. It didn't render to right
position if container is having margins or page is scrolled. This fix
closes issue #2177.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #2177 (from issue tracker)

### Changes

Add `xShift` and `yShift` to the calculated `div.style.left` and `div.style.top` to take margins into account. I also added `window.scrollX` and `window.scrollY`, which are fixing another issue (rectangle gets rendered to wrong position if page is scrolled).

### Testing

The problem can be spotted with the following code:

```html
<!DOCTYPE html>
<html>

<body>
  <div id="wrap" style="margin: 100px">
    <div id="container" style="width: 500px; height: 500px; margin: 0px; padding: 0px">
    </div>
  </div>

  <script type="module">
    import "https://cdn.skypack.dev/@kitware/vtk.js";

    const { vtkFullScreenRenderWindow } = vtk.Rendering.Misc;
    const { vtkXMLPolyDataReader } = vtk.IO.XML;
    const { vtkActor, vtkMapper } = vtk.Rendering.Core;
    const { vtkInteractorStyleManipulator } = vtk.Interaction.Style;
    const { Manipulators } = vtk.Interaction;

    const container = document.getElementById("container")

    // ----------------------------------------------------------------------------
    // Standard rendering code setup
    // ----------------------------------------------------------------------------

    const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({ container });
    const renderWindow = fullScreenRenderer.getRenderWindow();

    // ----------------------------------------------------------------------------
    // Example code
    // ----------------------------------------------------------------------------

    const boxSelector = Manipulators.vtkMouseBoxSelectorManipulator.newInstance({
      button: 1,
    });
    boxSelector.onBoxSelectChange(({ selection }) => {
      console.log('Apply selection:', selection.join(', '));
    });
    // boxSelector.onBoxSelectInput(console.log);

    const iStyle = vtkInteractorStyleManipulator.newInstance();
    iStyle.addMouseManipulator(boxSelector);
    renderWindow.getInteractor().setInteractorStyle(iStyle);
  </script>

</body>

</html>
```
