### PR TITLE
feat(XR): Enable translation with WebXR gamepad API

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -58,7 +58,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
       ed &&
       ed.pressed &&
       ed.device === Device.RightController &&
-      ed.input === Input.TrackPad
+      (ed.input === Input.Trigger || ed.input === Input.TrackPad)
     ) {
       publicAPI.startCameraPose();
       return;
@@ -67,7 +67,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
       ed &&
       !ed.pressed &&
       ed.device === Device.RightController &&
-      ed.input === Input.TrackPad &&
+      (ed.input === Input.Trigger || ed.input === Input.TrackPad) &&
       model.state === States.IS_CAMERA_POSE
     ) {
       publicAPI.endCameraPose();
@@ -91,13 +91,18 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
     const oldTrans = camera.getPhysicalTranslation();
 
     // look at the y axis to determine how fast / what direction to move
-    const speed = ed.gamepad.axes[1];
+    const speed = 0.5; // ed.gamepad.axes[1];
 
     // 0.05 meters / frame movement
     const pscale = speed * 0.05 * camera.getPhysicalScale();
 
     // convert orientation to world coordinate direction
-    const dir = camera.physicalOrientationToWorldDirection(ed.orientation);
+    const dir = camera.physicalOrientationToWorldDirection([
+      ed.orientation.x,
+      ed.orientation.y,
+      ed.orientation.z,
+      ed.orientation.w,
+    ]);
 
     camera.setPhysicalTranslation(
       oldTrans[0] + dir[0] * pscale,

--- a/Sources/Rendering/Core/RenderWindowInteractor/Constants.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/Constants.js
@@ -9,10 +9,22 @@ export const Input = {
   Trigger: 1,
   TrackPad: 2,
   Grip: 3,
-  ApplicationMenu: 4,
+  Thumbstick: 4,
+  A: 5,
+  B: 6,
+  ApplicationMenu: 7, // Not exposed in WebXR API
+};
+
+export const Axis = {
+  Unknown: 0,
+  TouchpadX: 1,
+  TouchpadY: 2,
+  ThumbstickX: 3,
+  ThumbstickY: 4,
 };
 
 export default {
   Device,
   Input,
+  Axis,
 };

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -354,6 +354,10 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   publicAPI.xrRender = async (t, frame) => {
     const xrSession = frame.session;
 
+    model.renderable
+      .getInteractor()
+      .updateXRGamepads(xrSession, frame, model.xrReferenceSpace);
+
     model.xrSceneFrame = model.xrSession.requestAnimationFrame(
       publicAPI.xrRender
     );


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

In moving from WebVR to WebXR we must also integrate changes from the updated [WebXR gamepad API](https://www.w3.org/TR/webxr-gamepads-module-1/). VR controllers are exposed solely under the [`xr-standard` extension to the Gamepad API](https://www.w3.org/TR/gamepad/#dom-gamepadmappingtype) which remaps buttons/axes and exposes controller transforms as XRPose objects.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] `updateXRGamepads` is updated to reflect WebXR gamepads where controllers are identified by handedness rather than ID or index (see [https://www.w3.org/TR/webxr-gamepads-module-1/#gamepad-differences](https://www.w3.org/TR/webxr-gamepads-module-1/#gamepad-differences)).
- [x] VR locomotion in `InteractorStyleTrackballCamera` is revised from variable-speed translation based on the touchpad direction to fixed-speed translation in the direction of the right-handed controller. The WebXR Gamepad API requires that VR gamepads report a trigger button, while the touchpad/thumbstick is not guaranteed. Locomotion can be triggered with either a trigger press or (if available) a touchpad press.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

- VR locomotion is re-introduced to `OpenGL/RenderWindow` and the `Geometry/VR` example so that the user may "fly" around their dataset. Locomotion is technically present in the `Applications/SkyboxViewer` example as well, but is not visible to the user as that example consist of just a skybox.

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: v21.1.4
  - **OS**: Windows 10
  - **Browser**: Chrome 96.0.4664.45
