### PR TITLE
fix(AbstractMapper): Cleanup mapper classes

### DIFF
--- a/Sources/Rendering/Core/AbstractMapper/index.d.ts
+++ b/Sources/Rendering/Core/AbstractMapper/index.d.ts
@@ -19,7 +19,7 @@ export interface vtkAbstractMapper extends vtkAbstractMapperBase {
 	 * Added plane needs to be a vtkPlane object.
 	 * @param {vtkPlane} plane
 	 */
-	addClippingPlane(plane: vtkPlane): void;
+	addClippingPlane(plane: vtkPlane): boolean;
 
 	/**
 	 * Get number of clipping planes.
@@ -39,10 +39,10 @@ export interface vtkAbstractMapper extends vtkAbstractMapperBase {
 	removeAllClippingPlanes(): void;
 
 	/**
-	 * Remove clipping plane at index i.
-	 * @param {Number} i 
+	 * Remove clipping plane.
+	 * @param {vtkPlane} plane
 	 */
-	removeClippingPlane(i: number): void;
+	removeClippingPlane(plane: vtkPlane): boolean;
 
 	/**
 	 * Set clipping planes.

--- a/Sources/Rendering/Core/AbstractMapper/index.js
+++ b/Sources/Rendering/Core/AbstractMapper/index.js
@@ -5,16 +5,21 @@ import macro from 'vtk.js/Sources/macros';
 // ----------------------------------------------------------------------------
 
 function vtkAbstractMapper(publicAPI, model) {
+  model.classHierarchy.push('vtkAbstractMapper');
   publicAPI.update = () => {
     publicAPI.getInputData();
   };
 
   publicAPI.addClippingPlane = (plane) => {
-    if (plane.getClassName() !== 'vtkPlane') {
-      return;
+    if (!plane.isA('vtkPlane')) {
+      return false;
     }
-    model.clippingPlanes.push(plane);
-    publicAPI.modified();
+    if (!model.clippingPlanes.includes(plane)) {
+      model.clippingPlanes.push(plane);
+      publicAPI.modified();
+      return true;
+    }
+    return false;
   };
 
   publicAPI.getNumberOfClippingPlanes = () => model.clippingPlanes.length;
@@ -23,11 +28,14 @@ function vtkAbstractMapper(publicAPI, model) {
     model.clippingPlanes.length = 0;
   };
 
-  publicAPI.removeClippingPlane = (i) => {
-    if (i < 0 || i >= 6) {
-      return;
+  publicAPI.removeClippingPlane = (clippingPlane) => {
+    const i = model.clippingPlanes.indexOf(clippingPlane);
+    if (i === -1) {
+      return false;
     }
     model.clippingPlanes.splice(i, 1);
+    publicAPI.modified();
+    return true;
   };
 
   publicAPI.getClippingPlanes = () => model.clippingPlanes;

--- a/Sources/Rendering/Core/AbstractMapper/test/testAbstractMapper.js
+++ b/Sources/Rendering/Core/AbstractMapper/test/testAbstractMapper.js
@@ -16,20 +16,20 @@ test('Test vtkAbstractMapper publicAPI', (t) => {
   const plane = vtkPlane.newInstance({ normal: normals[0] });
   mapper.addClippingPlane(plane);
   t.equal(mapper.getClippingPlanes().length, 1);
-  mapper.removeClippingPlane(0);
+  mapper.removeClippingPlane(plane);
   t.equal(mapper.getClippingPlanes().length, 0);
   mapper.setClippingPlanes(plane);
   t.equal(mapper.getClippingPlanes().length, 1);
   mapper.removeAllClippingPlanes();
   t.equal(mapper.getClippingPlanes().length, 0);
-  mapper.removeClippingPlane(0);
+  mapper.removeClippingPlane(plane);
 
   const plane2 = vtkPlane.newInstance({ normal: normals[1] });
   const plane3 = vtkPlane.newInstance({ normal: normals[2] });
 
   mapper.setClippingPlanes([plane, plane2, plane3]);
   t.equal(mapper.getClippingPlanes().length, 3);
-  mapper.removeClippingPlane(0);
+  mapper.removeClippingPlane(plane);
   t.equal(mapper.getClippingPlanes().length, 2);
   for (let i = 0; i < mapper.getClippingPlanes().length; i++) {
     const normal = mapper.getClippingPlanes()[i].getNormal();

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -98,10 +98,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   vtkAbstractMapper.extend(publicAPI, model, initialValues);
 
-  // Build VTK API
-  macro.obj(publicAPI, model);
-  macro.algo(publicAPI, model, 1, 0);
-
   macro.setGet(publicAPI, model, [
     'sampleDistance',
     'imageSampleDistance',


### PR DESCRIPTION
These changes fix problems with Mapper classes found during https://github.com/Kitware/vtk-js/pull/2113.
Specifically:

- The class hierarchy for AbstractMapper was missing
- VolumeMapper was calling `macro.obj` and `macro.algo` (once through parent)
- AbstractMapper.removeClippingPlane was using indexes instead of instances
- AbstractMapper.removeClippingPlane was checking classes too specifically
- AbstractMapper methods were not calling modified.

BREAKING CHANGE:
Changed removeClippingPlane to use instance instead of index.
