### PR TITLE
fix(SynchronizableRenderWindow): prevent invalid object modification

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -214,22 +214,29 @@ function vtkColorTransferFunction(publicAPI, model) {
   // Set nodes directly
   publicAPI.setNodes = (nodes) => {
     if (model.nodes !== nodes) {
+      const before = JSON.stringify(model.nodes);
       model.nodes = nodes;
-      publicAPI.sortAndUpdateRange();
+      const after = JSON.stringify(model.nodes);
+      return publicAPI.sortAndUpdateRange() || before !== after;
     }
+    return false;
   };
 
   //----------------------------------------------------------------------------
   // Sort the vector in increasing order, then fill in
   // the Range
   publicAPI.sortAndUpdateRange = () => {
+    const before = JSON.stringify(model.nodes);
     model.nodes.sort((a, b) => a.x - b.x);
+    const after = JSON.stringify(model.nodes);
 
     const modifiedInvoked = publicAPI.updateRange();
     // If range is updated, Modified() has been called, don't call it again.
-    if (!modifiedInvoked) {
+    if (!modifiedInvoked && before !== after) {
       publicAPI.modified();
+      return true;
     }
+    return modifiedInvoked;
   };
 
   //----------------------------------------------------------------------------

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -298,8 +298,8 @@ export function obj(publicAPI = {}, model = {}) {
             `Warning: Set value to model directly ${name}, ${map[name]}`
           );
         }
+        ret = model[name] !== map[name] || ret;
         model[name] = map[name];
-        ret = true;
       }
     });
     return ret;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context

SynchronizedRenderWindow was rebuilding several objects even if their content were remaining the same.
This fix that issue which improve greatly the performances when using local rendering with remote vtk view object.

### Changes

No API change

### Results

See major perf boost when dealing with large geometries

### Testing

Manual testing using trame app in `examples/VTK/PerfTests/scene-export-time.py`. 
