### PR TITLE
feat(rendering): support wide lines with vtkMapper and vtkMapper2D

### DIFF
--- a/Examples/Rendering/Actor2D/index.js
+++ b/Examples/Rendering/Actor2D/index.js
@@ -39,8 +39,8 @@ fpsElm.style.bottom = '10px';
 fpsElm.style.background = 'rgba(255,255,255,0.5)';
 fpsElm.style.borderRadius = '5px';
 
-fpsMonitor.setContainer(document.querySelector('body'));
-fpsMonitor.setRenderWindow(renderWindow);
+// fpsMonitor.setContainer(document.querySelector('body'));
+// fpsMonitor.setRenderWindow(renderWindow);
 
 fullScreenRenderer.setResizeCallback(fpsMonitor.update);
 
@@ -92,6 +92,9 @@ mapper2D.setScalarVisibility(false);
 
 const actor = vtkActor.newInstance();
 actor.setMapper(mapper);
+actor.getProperty().setEdgeVisibility(true);
+actor.getProperty().setEdgeColor([0.5, 0, 0.6]);
+actor.getProperty().setLineWidth(3);
 const actor2D = vtkActor2D.newInstance();
 actor2D.setMapper(mapper2D);
 actor2D.getProperty().setColor([1, 0, 0]);
@@ -117,6 +120,7 @@ const resolutionChange = document.querySelector('.resolution');
 representationSelector.addEventListener('change', (e) => {
   const newRepValue = Number(e.target.value);
   actor2D.getProperty().setRepresentation(newRepValue);
+  actor.getProperty().setRepresentation(newRepValue);
   renderWindow.render();
   fpsMonitor.update();
 });
@@ -124,6 +128,7 @@ representationSelector.addEventListener('change', (e) => {
 resolutionChange.addEventListener('input', (e) => {
   const resolution = Number(e.target.value);
   sphereSource.setThetaResolution(resolution);
+  coneSource.setResolution(resolution);
   renderWindow.render();
   fpsMonitor.update();
 });

--- a/Examples/Rendering/Actor2D/index.js
+++ b/Examples/Rendering/Actor2D/index.js
@@ -96,6 +96,7 @@ const actor2D = vtkActor2D.newInstance();
 actor2D.setMapper(mapper2D);
 actor2D.getProperty().setColor([1, 0, 0]);
 actor2D.getProperty().setOpacity(0.5);
+actor2D.getProperty().setLineWidth(3);
 actor2D.getProperty().setDisplayLocation(DisplayLocation.FOREGROUND);
 actor2D.getProperty().setRepresentation(Representation.SURFACE);
 

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -462,10 +462,11 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
           drawSurfaceWithEdges &&
           (i === model.primTypes.TrisEdges ||
             i === model.primTypes.TriStripsEdges);
-        publicAPI.updateShaders(model.primitives[i], ren, actor);
+        model.lastBoundBO = model.primitives[i];
+        model.primitives[i].updateShaders(ren, actor, publicAPI);
         const program = model.primitives[i].getProgram();
 
-        const mode = publicAPI.getOpenGLMode(representation, i);
+        const mode = model.primitives[i].getOpenGLMode(representation);
         const normalMatrixUsed = program.isUniformUsed('normalMatrix');
         const mcvcMatrixUsed = program.isUniformUsed('MCVCMatrix');
 
@@ -615,6 +616,17 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
       return true;
     }
     return superClass.getNeedToRebuildBufferObjects(ren, actor);
+  };
+
+  publicAPI.getNeedToRebuildShaders = (cellBO, ren, actor) => {
+    if (
+      superClass.getNeedToRebuildShaders(cellBO, ren, actor) ||
+      cellBO.getShaderSourceTime().getMTime() < model.renderable.getMTime() ||
+      cellBO.getShaderSourceTime().getMTime() < model.currentInput.getMTime()
+    ) {
+      return true;
+    }
+    return false;
   };
 
   publicAPI.buildBufferObjects = (ren, actor) => {

--- a/Sources/Rendering/OpenGL/Helper/index.js
+++ b/Sources/Rendering/OpenGL/Helper/index.js
@@ -3,6 +3,19 @@ import vtkCellArrayBufferObject from 'vtk.js/Sources/Rendering/OpenGL/CellArrayB
 import vtkShaderProgram from 'vtk.js/Sources/Rendering/OpenGL/ShaderProgram';
 import vtkVertexArrayObject from 'vtk.js/Sources/Rendering/OpenGL/VertexArrayObject';
 
+import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
+
+export const primTypes = {
+  Start: 0,
+  Points: 0,
+  Lines: 1,
+  Tris: 2,
+  TriStrips: 3,
+  TrisEdges: 4,
+  TriStripsEdges: 5,
+  End: 6,
+};
+
 // ----------------------------------------------------------------------------
 // vtkOpenGLHelper methods
 // ----------------------------------------------------------------------------
@@ -12,7 +25,8 @@ function vtkOpenGLHelper(publicAPI, model) {
   model.classHierarchy.push('vtkOpenGLHelper');
 
   publicAPI.setOpenGLRenderWindow = (win) => {
-    model.program.setContext(win.getContext());
+    model.context = win.getContext();
+    model.program.setContext(model.context);
     model.VAO.setOpenGLRenderWindow(win);
     model.CABO.setOpenGLRenderWindow(win);
   };
@@ -22,6 +36,196 @@ function vtkOpenGLHelper(publicAPI, model) {
     model.CABO.releaseGraphicsResources();
     model.CABO.setElementCount(0);
   };
+
+  publicAPI.drawArrays = (ren, actor, rep, oglMapper) => {
+    // Are there any entries
+    if (model.CABO.getElementCount()) {
+      // are we drawing edges
+      const mode = publicAPI.getOpenGLMode(rep);
+      const wideLines = publicAPI.haveWideLines(ren, actor);
+      const gl = model.context;
+      const drawingLines = mode === gl.LINES;
+      if (drawingLines && wideLines) {
+        publicAPI.updateShaders(ren, actor, oglMapper);
+        gl.drawArraysInstanced(
+          mode,
+          0,
+          model.CABO.getElementCount(),
+          2 * Math.ceil(actor.getProperty().getLineWidth())
+        );
+      } else {
+        gl.lineWidth(actor.getProperty().getLineWidth());
+        publicAPI.updateShaders(ren, actor, oglMapper);
+        gl.drawArrays(mode, 0, model.CABO.getElementCount());
+        // reset the line width
+        gl.lineWidth(1);
+      }
+      const stride =
+        (mode === gl.POINTS ? 1 : 0) || (mode === gl.LINES ? 2 : 3);
+      return model.CABO.getElementCount() / stride;
+    }
+    return 0;
+  };
+
+  publicAPI.getOpenGLMode = (rep) => {
+    const type = model.primitiveType;
+    if (rep === Representation.POINTS || type === primTypes.Points) {
+      return model.context.POINTS;
+    }
+    if (
+      rep === Representation.WIREFRAME ||
+      type === primTypes.Lines ||
+      type === primTypes.TrisEdges ||
+      type === primTypes.TriStripsEdges
+    ) {
+      return model.context.LINES;
+    }
+    return model.context.TRIANGLES;
+  };
+
+  publicAPI.haveWideLines = (ren, actor) => {
+    if (actor.getProperty().getLineWidth() > 1.0) {
+      // we have wide lines, but the OpenGL implementation may
+      // actually support them, check the range to see if we
+      // really need have to implement our own wide lines
+      if (model.CABO.getOpenGLRenderWindow()) {
+        if (
+          model.CABO.getOpenGLRenderWindow().getHardwareMaximumLineWidth() >=
+          actor.getProperty().getLineWidth()
+        ) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return false;
+  };
+
+  publicAPI.getNeedToRebuildShaders = (ren, actor, oglMapper) => {
+    // has something changed that would require us to recreate the shader?
+    // candidates are
+    // property modified (representation interpolation and lighting)
+    // input modified
+    // mapper modified (lighting complexity)
+    if (
+      oglMapper.getNeedToRebuildShaders(publicAPI, ren, actor) ||
+      publicAPI.getProgram() === 0 ||
+      publicAPI.getShaderSourceTime().getMTime() < oglMapper.getMTime() ||
+      publicAPI.getShaderSourceTime().getMTime() < actor.getMTime()
+    ) {
+      return true;
+    }
+    return false;
+  };
+
+  publicAPI.updateShaders = (ren, actor, oglMapper) => {
+    // has something changed that would require us to recreate the shader?
+    if (publicAPI.getNeedToRebuildShaders(ren, actor, oglMapper)) {
+      const shaders = { Vertex: null, Fragment: null, Geometry: null };
+      oglMapper.buildShaders(shaders, ren, actor);
+
+      // compile and bind the program if needed
+      const newShader = model.CABO.getOpenGLRenderWindow()
+        .getShaderCache()
+        .readyShaderProgramArray(
+          shaders.Vertex,
+          shaders.Fragment,
+          shaders.Geometry
+        );
+
+      // if the shader changed reinitialize the VAO
+      if (newShader !== publicAPI.getProgram()) {
+        publicAPI.setProgram(newShader);
+        // reset the VAO as the shader has changed
+        publicAPI.getVAO().releaseGraphicsResources();
+      }
+
+      publicAPI.getShaderSourceTime().modified();
+    } else {
+      model.CABO.getOpenGLRenderWindow()
+        .getShaderCache()
+        .readyShaderProgram(publicAPI.getProgram());
+    }
+
+    publicAPI.getVAO().bind();
+
+    oglMapper.setMapperShaderParameters(publicAPI, ren, actor);
+    oglMapper.setPropertyShaderParameters(publicAPI, ren, actor);
+    oglMapper.setCameraShaderParameters(publicAPI, ren, actor);
+    oglMapper.setLightingShaderParameters(publicAPI, ren, actor);
+
+    oglMapper.invokeShaderCallbacks(publicAPI, ren, actor);
+  };
+
+  publicAPI.setMapperShaderParameters = (ren, actor, size) => {
+    if (publicAPI.haveWideLines(ren, actor)) {
+      publicAPI
+        .getProgram()
+        .setUniform2f('viewportSize', size.usize, size.vsize);
+      const lineWidth = parseFloat(actor.getProperty().getLineWidth());
+      const halfLineWidth = lineWidth / 2.0;
+      publicAPI
+        .getProgram()
+        .setUniformf('lineWidthStepSize', lineWidth / Math.ceil(lineWidth));
+      publicAPI.getProgram().setUniformf('halfLineWidth', halfLineWidth);
+    }
+  };
+
+  publicAPI.replaceShaderPositionVC = (shaders, ren, actor) => {
+    let VSSource = shaders.Vertex;
+
+    // for lines, make sure we add the width code
+    if (
+      publicAPI.getOpenGLMode(actor.getProperty().getRepresentation()) ===
+        model.context.LINES &&
+      publicAPI.haveWideLines(ren, actor)
+    ) {
+      VSSource = vtkShaderProgram.substitute(
+        VSSource,
+        '//VTK::PositionVC::Dec',
+        [
+          '//VTK::PositionVC::Dec',
+          'uniform vec2 viewportSize;',
+          'uniform float lineWidthStepSize;',
+          'uniform float halfLineWidth;',
+        ]
+      ).result;
+      VSSource = vtkShaderProgram.substitute(
+        VSSource,
+        '//VTK::PositionVC::Impl',
+        [
+          '//VTK::PositionVC::Impl',
+          ' if (halfLineWidth > 0.0)',
+          '   {',
+          '   float offset = float(gl_InstanceID / 2) * lineWidthStepSize - halfLineWidth;',
+          '   vec4 tmpPos = gl_Position;',
+          '   vec3 tmpPos2 = tmpPos.xyz / tmpPos.w;',
+          '   tmpPos2.x = tmpPos2.x + 2.0 * mod(float(gl_InstanceID), 2.0) * offset / viewportSize[0];',
+          '   tmpPos2.y = tmpPos2.y + 2.0 * mod(float(gl_InstanceID + 1), 2.0) * offset / viewportSize[1];',
+          '   gl_Position = vec4(tmpPos2.xyz * tmpPos.w, tmpPos.w);',
+          '   }',
+        ]
+      ).result;
+    }
+
+    // for points make sure to add in the point size
+    if (
+      actor.getProperty().getRepresentation() === Representation.POINTS ||
+      model.primitiveType === primTypes.Points
+    ) {
+      VSSource = vtkShaderProgram.substitute(
+        VSSource,
+        '//VTK::PositionVC::Impl',
+        [
+          '//VTK::PositionVC::Impl',
+          `  gl_PointSize = ${actor.getProperty().getPointSize()}.0;`,
+        ],
+        false
+      ).result;
+    }
+
+    shaders.Vertex = VSSource;
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -29,6 +233,7 @@ function vtkOpenGLHelper(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  context: null,
   program: null,
   shaderSourceTime: null,
   VAO: null,
@@ -74,4 +279,4 @@ export const newInstance = macro.newInstance(extend);
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend };
+export default { newInstance, extend, primTypes };

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -728,6 +728,12 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     });
   };
 
+  publicAPI.getHardwareMaximumLineWidth = () => {
+    const gl = publicAPI.get3DContext();
+    const lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
+    return lineWidthRange[1];
+  };
+
   publicAPI.getGLInformations = () => {
     const gl = publicAPI.get3DContext();
 


### PR DESCRIPTION
When the line width attribute on vtkProperty2D is more than 1, the 2D mapper makes multiple
instanced draw calls and the vertex shader offsets the vertex position based on the instance index.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ x ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ x ] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

![Screenshot from 2022-01-04 23-26-02](https://user-images.githubusercontent.com/936354/148160530-224f0dcb-deb1-4af4-ab40-2a81b595557d.png)
![Screenshot from 2022-01-04 23-25-31](https://user-images.githubusercontent.com/936354/148160534-40176366-2a6c-4d1e-8872-95a952b1e162.png)

