### PR TITLE
feat(XR): Handle WebXR XRInputSourceEvents

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -59,6 +59,12 @@ const handledEvents = [
   'StartInteraction',
   'Interaction',
   'EndInteraction',
+  'StartXrSelect',
+  'XrSelect',
+  'EndXrSelect',
+  'StartXrSqueeze',
+  'XrSqueeze',
+  'EndXrSqueeze',
 ];
 
 function preventDefault(event) {
@@ -247,6 +253,16 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     container.addEventListener('touchstart', publicAPI.handleTouchStart, false);
   };
 
+  publicAPI.bindXREvents = (xrSession) => {
+    model.xrSession = xrSession;
+    xrSession.addEventListener('selectstart', publicAPI.handleXRSelectStart);
+    xrSession.addEventListener('select', publicAPI.handleXRSelect);
+    xrSession.addEventListener('selectend', publicAPI.handleXRSelectEnd);
+    xrSession.addEventListener('squeezestart', publicAPI.handleXRSqueezeStart);
+    xrSession.addEventListener('squeeze', publicAPI.handleXRSqueeze);
+    xrSession.addEventListener('squeezeend', publicAPI.handleXRSqueezeEnd);
+  };
+
   publicAPI.unbindEvents = () => {
     // force unbinding listeners
     interactionRegistration(false, true);
@@ -279,6 +295,28 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       publicAPI.handleTouchStart
     );
     model.container = null;
+  };
+
+  publicAPI.unbindXREvents = () => {
+    model.xrSession.removeEventListener(
+      'selectstart',
+      publicAPI.handleXRSelectStart
+    );
+    model.xrSession.removeEventListener('select', publicAPI.handleXRSelect);
+    model.xrSession.removeEventListener(
+      'selectend',
+      publicAPI.handleXRSelectEnd
+    );
+    model.xrSession.removeEventListener(
+      'squeezestart',
+      publicAPI.handleXRSqueezeStart
+    );
+    model.xrSession.removeEventListener('squeeze', publicAPI.handleXRSqueeze);
+    model.xrSession.removeEventListener(
+      'squeezeend',
+      publicAPI.handleXRSqueezeEnd
+    );
+    model.xrSession = null;
   };
 
   publicAPI.handleKeyPress = (event) => {
@@ -323,6 +361,26 @@ function vtkRenderWindowInteractor(publicAPI, model) {
         vtkErrorMacro(`Unknown mouse button pressed: ${event.button}`);
         break;
     }
+  };
+
+  publicAPI.handleXRSelect = (event) => {
+    publicAPI.xrSelectEvent({ xrEvent: event });
+  };
+
+  publicAPI.handleXRSelectStart = (event) => {
+    publicAPI.startXrSelectEvent({ xrEvent: event });
+  };
+  publicAPI.handleXRSelectEnd = (event) => {
+    publicAPI.endXrSelectEvent({ xrEvent: event });
+  };
+  publicAPI.handleXRSqueezeStart = (event) => {
+    publicAPI.startXrSqueezeEvent({ xrEvent: event });
+  };
+  publicAPI.handleXRSqueeze = (event) => {
+    publicAPI.xrSqueezeEvent({ xrEvent: event });
+  };
+  publicAPI.handleXRSqueezeEnd = (event) => {
+    publicAPI.endXrSqueezeEvent({ xrEvent: event });
   };
 
   //----------------------------------------------------------------------
@@ -1036,6 +1094,7 @@ const DEFAULT_VALUES = {
   wheelTimeoutID: 0,
   moveTimeoutID: 0,
   lastGamepadValues: {},
+  xrSession: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -311,6 +311,8 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     model.xrSession = xrSession;
     model.oldCanvasSize = model.size.slice();
 
+    model.renderable.getInteractor().bindXREvents(xrSession);
+
     if (model.xrSession !== null) {
       const gl = publicAPI.get3DContext();
       await gl.makeXRCompatible();
@@ -384,6 +386,8 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     }
 
     if (model.xrSession !== null) {
+      model.renderable.getInteractor().unbindXREvents();
+
       model.xrSession.cancelAnimationFrame(model.xrSceneFrame);
       model.renderable.getInteractor().returnFromXRAnimation();
       const gl = publicAPI.get3DContext();


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

The [WebXR API](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSourceEvent) exposes a limited number of user input events, which we expose to the user here through `RenderWindowInteractor` alongside other typical browser events.

Note that the granularity offered through XR events does not match that of the XR gamepad API, through which we can query continuous values such as touchpad or joystick position through our [`updateXRGamepads`](https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/Core/RenderWindowInteractor/index.js#L420) method. Developers should take both approaches into account.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] WebXR events are exposed through `RenderWindowInteractor`.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

Exposes six new events ("select"/start/end, "squeeze"/start/end) that developers can choose to handle.

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: `master`
  - **OS**: Windows
  - **Browser**: Chrome 97.0.4692.71 (Windows 10)
