### PR TITLE
fix(XR): Resolve mobile AR issue with absent gripspace

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -420,7 +420,10 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   publicAPI.updateXRGamepads = (xrSession, xrFrame, xrRefSpace) => {
     // watch for when buttons change state and fire events
     xrSession.inputSources.forEach((inputSource) => {
-      const pose = xrFrame.getPose(inputSource.gripSpace, xrRefSpace);
+      const gripPose =
+        inputSource.gripSpace == null
+          ? null
+          : xrFrame.getPose(inputSource.gripSpace, xrRefSpace);
       const gp = inputSource.gamepad;
       const hand = inputSource.handedness;
       if (gp) {
@@ -436,12 +439,13 @@ function vtkRenderWindowInteractor(publicAPI, model) {
           }
           if (
             model.lastGamepadValues[gp.index][hand].buttons[b] !==
-            gp.buttons[b].pressed
+              gp.buttons[b].pressed &&
+            gripPose != null
           ) {
             publicAPI.button3DEvent({
               gamepad: gp,
-              position: pose.transform.position,
-              orientation: pose.transform.orientation,
+              position: gripPose.transform.position,
+              orientation: gripPose.transform.orientation,
               pressed: gp.buttons[b].pressed,
               device:
                 inputSource.handedness === 'left'
@@ -455,11 +459,14 @@ function vtkRenderWindowInteractor(publicAPI, model) {
             model.lastGamepadValues[gp.index][hand].buttons[b] =
               gp.buttons[b].pressed;
           }
-          if (model.lastGamepadValues[gp.index][hand].buttons[b]) {
+          if (
+            model.lastGamepadValues[gp.index][hand].buttons[b] &&
+            gripPose != null
+          ) {
             publicAPI.move3DEvent({
               gamepad: gp,
-              position: pose.transform.position,
-              orientation: pose.transform.orientation,
+              position: gripPose.transform.position,
+              orientation: gripPose.transform.orientation,
               device:
                 inputSource.handedness === 'left'
                   ? Device.LeftController


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

Fixes an issue where an XRInputSource is not guaranteed to have a `gripSpace` property. In the case of the [AR example](https://kitware.github.io/vtk-js/examples/AR.html) tapping the screen creates an input source with a `targetRaySpace` but not a `gripSpace` because there is no independently tracked game controller.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Handle absent `gripSpace` to prevent exceptions.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

Previous behavior: tapping the mobile device screen in the [AR example](https://kitware.github.io/vtk-js/examples/AR.html) causes an exception to be thrown and halts rendering.

New behavior: tapping the screen does not throw an exception or affect rendering.

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: `master`
  - **OS**: Windows
  - **Browser**: Chrome 97.0.4692.71 (Windows 10)
