### PR TITLE
docs(core/matrixbuilder): fix typo in documented example MatrixBuilder

### DIFF
--- a/Sources/Common/Core/MatrixBuilder/index.d.ts
+++ b/Sources/Common/Core/MatrixBuilder/index.d.ts
@@ -119,7 +119,7 @@ declare function buildFromRadian(): Transform;
  * @example
  * ```js
  * let point = [2,5,12];
- * vtkMatrixBuilder.buildfromDegree().translate(1,0,2).rotateZ(45).apply(point);
+ * vtkMatrixBuilder.buildFromDegree().translate(1,0,2).rotateZ(45).apply(point);
  * ```
  * 
  * The vtkMatrixBuilder class has two functions, `vtkMatrixBuilder.buildFromDegree()` and


### PR DESCRIPTION

Fix typo in the documented example of class vtkMatrixBuilder. Change of case: buildfromDegree ->
buildFromDegree.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: Windows 10 Pro, Version 10.0.19044 Build 19044 <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: Chrome 97.0.4692.71 <!-- ex: Chrome 89.0.4389.128 -->