### PR TITLE
fix(RenderWindowInteractor): fix undefined error in publicAPI.getFirs…

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -701,7 +701,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   };
 
   publicAPI.getFirstRenderer = () =>
-    model.view.getRenderable().getRenderersByReference()[0];
+    model.view?.getRenderable()?.getRenderersByReference()?.[0];
 
   publicAPI.findPokedRenderer = (x = 0, y = 0) => {
     if (!model.view) {
@@ -709,7 +709,10 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
     // The original order of renderers needs to remain as
     // the first one is the one we want to manipulate the camera on.
-    const rc = model.view.getRenderable().getRenderers();
+    const rc = model.view?.getRenderable()?.getRenderers();
+    if (!rc) {
+      return null;
+    }
     rc.sort((a, b) => a.getLayer() - b.getLayer());
     let interactiveren = null;
     let viewportren = null;


### PR DESCRIPTION
### Context
UI Framework: Vue 3.x
Related Example: ResliceCursorWidget
Related File: RenderWindowInteractor
Description: Using compositon-api and calling genericRenderWindow.delete in unBeforeMount life cycle callback, there will be an error with `read property getRenderersByReference of undefined` in getFirstRenderer or `read property getRenderers of undefined` in findPokedRenderer, then the whole render broke down. It seems that vtkRenderWindowInteractor still doing something when render is deleting.


### Changes
Add some code for null value judgment.

### Results
Property is not read on null value and render will not break down. But Macro logs an error 'Can not forward events without a current renderer on the interactor' without influence of use.