### PR TITLE
WIP: fix(vtkResliceCursor): Correctly bounds plane when reslice close to image bounds limits

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testBoundPlane.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testBoundPlane.js
@@ -58,11 +58,26 @@ test('Test boundPlane no intersection', (t) => {
 
   const bounds = [0, 1, 0, 1, 1, 2];
 
-  boundPlane(bounds, origin, point1, point2);
+  t.ok(boundPlane(bounds, origin, point1, point2) === -1);
 
   t.ok(areEquals(origin, [0, 0, 0]));
   t.ok(areEquals(point1, [2, 0, 0]));
   t.ok(areEquals(point2, [0, 2, 0]));
+
+  t.end();
+});
+
+test('Test boundPlane with points close to bounds limits', (t) => {
+  const origin = [-146.45421827279782, -101.95882636683, -64.91712337082552];
+  const p1 = [147.22047922902922, -101.95882636683, -64.91712337082552];
+  const p2 = [-146.45421827279782, -101.95882636683, 194.58407789818668];
+
+  const bounds = [
+    -117.53152848, 137.57958263142996, -101.95882637, 52.04117363,
+    -63.819600831429966, 191.29151028,
+  ];
+
+  t.ok(boundPlane(bounds, origin, p1, p2));
 
   t.end();
 });


### PR DESCRIPTION
When setting bounds on cube source, we want that the output data has the same bounds as input ones.
So we need to use 64bit numbers instead of 32bit in order to keep precision.

@finetjul 

After discussing with @finetjul , we thaught that it could be a good point to also "upgrade" source filter from float32 to float64 in order to avoid issue with precision. @martinken @jourdain WDYT ?