### PR TITLE
feat(WebGPU): support interactive volume rendering

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -59,6 +59,7 @@ const handledEvents = [
   'StartInteraction',
   'Interaction',
   'EndInteraction',
+  'AnimationFrameRateUpdate',
 ];
 
 function preventDefault(event) {
@@ -369,6 +370,8 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
     animationRequesters.add(requestor);
     if (animationRequesters.size === 1 && !model.xrAnimation) {
+      model._animationStartTime = Date.now();
+      model._animationFrameCount = 0;
       model.lastFrameTime = 0.1;
       model.lastFrameStart = Date.now();
       model.animationRequest = requestAnimationFrame(publicAPI.handleAnimation);
@@ -503,6 +506,18 @@ function vtkRenderWindowInteractor(publicAPI, model) {
 
   publicAPI.handleAnimation = () => {
     const currTime = Date.now();
+    model._animationFrameCount++;
+    if (
+      currTime - model._animationStartTime > 1000.0 &&
+      model._animationFrameCount > 1
+    ) {
+      model.recentAnimationFrameRate =
+        (1000.0 * (model._animationFrameCount - 1)) /
+        (currTime - model._animationStartTime);
+      publicAPI.animationFrameRateUpdateEvent();
+      model._animationStartTime = currTime;
+      model._animationFrameCount = 1;
+    }
     if (model.FrameTime === -1.0) {
       model.lastFrameTime = 0.1;
     } else {
@@ -551,7 +566,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     model.wheelTimeoutID = setTimeout(() => {
       publicAPI.endMouseWheelEvent();
       model.wheelTimeoutID = 0;
-    }, 200);
+    }, 800);
   };
 
   publicAPI.handleMouseEnter = (event) => {
@@ -984,6 +999,8 @@ function vtkRenderWindowInteractor(publicAPI, model) {
 
   publicAPI.handleVisibilityChange = () => {
     model.lastFrameStart = Date.now();
+    model._animationStartTime = Date.now();
+    model._animationFrameCount = 0;
   };
 
   publicAPI.setCurrentRenderer = (r) => {
@@ -1040,6 +1057,7 @@ const DEFAULT_VALUES = {
   currentGesture: 'Start',
   animationRequest: null,
   lastFrameTime: 0.1,
+  recentAnimationFrameRate: 10.0,
   wheelTimeoutID: 0,
   moveTimeoutID: 0,
   lastGamepadValues: {},
@@ -1064,6 +1082,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'container',
     'interactorStyle',
     'lastFrameTime',
+    'recentAnimationFrameRate',
     'view',
   ]);
 

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -360,13 +360,10 @@ fn main(
   if (rayMax <= rayMin) { discard; }
   else
   {
-    var winDimsI32: vec2<i32> = textureDimensions(minTexture);
-    var winDims: vec2<f32> = vec2<f32>(f32(winDimsI32.x), f32(winDimsI32.y));
-
     // compute start and end ray positions in view coordinates
-    var minPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMax, 1.0);
+    var minPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0 * input.tcoordVS.x - 1.0, 1.0 - 2.0 * input.tcoordVS.y, rayMax, 1.0);
     minPosSC = minPosSC * (1.0 / minPosSC.w);
-    var maxPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0*input.fragPos.x/winDims.x - 1.0, 1.0 - 2.0 * input.fragPos.y/winDims.y, rayMin, 1.0);
+    var maxPosSC: vec4<f32> = rendererUBO.PCSCMatrix*vec4<f32>(2.0 * input.tcoordVS.x - 1.0, 1.0 - 2.0 * input.tcoordVS.y, rayMin, 1.0);
     maxPosSC = maxPosSC * (1.0 / maxPosSC.w);
 
     var rayLengthSC: f32 = distance(minPosSC.xyz, maxPosSC.xyz);


### PR DESCRIPTION
The volume pass now uses the recentAnimaitonFrameRate
to render to a smaller texture when the view is animating to try
to reach the DesiredUpdateRate.

Added a new approach for checking frame rate to the
RenderWindowInteractor as web browsers are becoming more
strict about reporting exact elapsed times (due to fingerprinting)
so the new approach is designed to use a longer time frame thus
avoiding the anti fingerprint rounding the Date.now() does.

