### PR TITLE
perf(sources filters): use 64bits numbers for points coordinates

### DIFF
--- a/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
+++ b/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
@@ -49,7 +49,7 @@ test('Test vtkAppendPolyData execution', (t) => {
     'Make sure the number of points is correct.'
   );
   t.ok(
-    outPD.getPoints().getDataType() === VtkDataTypes.FLOAT,
+    outPD.getPoints().getDataType() === VtkDataTypes.DOUBLE,
     'Make sure the output data type is correct.'
   );
   const expNumPolys = [cone, cylinder].reduce(

--- a/Sources/Filters/Sources/Arrow2DSource/index.js
+++ b/Sources/Filters/Sources/Arrow2DSource/index.js
@@ -187,7 +187,7 @@ function defaultValues(initialValues) {
     center: [0, 0, 0],
     height: 1.0,
     direction: [1, 0, 0],
-    pointType: 'Float32Array',
+    pointType: 'Float64Array',
     thickness: 0,
     width: 1.0,
     ...initialValues,

--- a/Sources/Filters/Sources/ArrowSource/index.js
+++ b/Sources/Filters/Sources/ArrowSource/index.js
@@ -98,7 +98,7 @@ const DEFAULT_VALUES = {
   shaftRadius: 0.03,
   invert: false,
   direction: [1.0, 0.0, 0.0],
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/CircleSource/index.js
+++ b/Sources/Filters/Sources/CircleSource/index.js
@@ -74,7 +74,7 @@ function defaultValues(initialValues) {
     center: [0, 0, 0],
     lines: false,
     direction: [1, 0, 0],
-    pointType: 'Float32Array',
+    pointType: 'Float64Array',
     radius: 1.0,
     resolution: 6,
     ...initialValues,

--- a/Sources/Filters/Sources/ConcentricCylinderSource/index.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/index.js
@@ -414,7 +414,7 @@ const DEFAULT_VALUES = {
   direction: [0.0, 0.0, 1.0],
   skipInnerFaces: true,
   mask: null, // If present, array to know if a layer should be skipped(=true)
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/ConeSource/index.js
+++ b/Sources/Filters/Sources/ConeSource/index.js
@@ -91,7 +91,7 @@ const DEFAULT_VALUES = {
   center: [0, 0, 0],
   direction: [1.0, 0.0, 0.0],
   capping: true,
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/CubeSource/index.js
+++ b/Sources/Filters/Sources/CubeSource/index.js
@@ -192,7 +192,7 @@ function vtkCubeSource(publicAPI, model) {
       .apply(points);
 
     // Define quads
-    const polys = macro.newTypedArray(model.pointType, numberOfPolys * 5);
+    const polys = new Uint16Array(numberOfPolys * 5);
     polyData.getPolys().setData(polys, 1);
 
     let polyIndex = 0;
@@ -273,7 +273,7 @@ const DEFAULT_VALUES = {
   zLength: 1.0,
   center: [0.0, 0.0, 0.0],
   rotations: [0.0, 0.0, 0.0],
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
   generate3DTextureCoordinates: false,
 };
 

--- a/Sources/Filters/Sources/CylinderSource/index.js
+++ b/Sources/Filters/Sources/CylinderSource/index.js
@@ -186,7 +186,7 @@ const DEFAULT_VALUES = {
   center: [0, 0, 0],
   direction: [0.0, 1.0, 0.0],
   capping: true,
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/LineSource/index.js
+++ b/Sources/Filters/Sources/LineSource/index.js
@@ -22,9 +22,9 @@ function vtkLineSource(publicAPI, model) {
     // Check input
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
-      : 'Float32Array';
+      : model.pointType;
     const pd = vtkPolyData.newInstance();
-    const v21 = new Float32Array(3);
+    const v21 = [];
     vtkMath.subtract(model.point2, model.point1, v21);
     if (vtkMath.norm(v21) <= 0.0) {
       vtkWarningMacro('Zero-length line definition');
@@ -76,7 +76,7 @@ const DEFAULT_VALUES = {
   resolution: 10,
   point1: [-1, 0, 0],
   point2: [1, 0, 0],
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/PlaneSource/index.js
+++ b/Sources/Filters/Sources/PlaneSource/index.js
@@ -28,10 +28,10 @@ function vtkPlaneSource(publicAPI, model) {
     // Check input
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
-      : 'Float32Array';
+      : model.pointType;
     const pd = vtkPolyData.newInstance();
-    const v10 = new Float32Array(3);
-    const v20 = new Float32Array(3);
+    const v10 = [];
+    const v20 = [];
     vtkMath.subtract(model.point1, model.origin, v10);
     vtkMath.subtract(model.point2, model.origin, v20);
 
@@ -266,7 +266,7 @@ const DEFAULT_VALUES = {
   origin: [0, 0, 0],
   point1: [1, 0, 0],
   point2: [0, 1, 0],
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/PointSource/index.js
+++ b/Sources/Filters/Sources/PointSource/index.js
@@ -20,7 +20,7 @@ function vtkPointSource(publicAPI, model) {
     // Check input
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
-      : 'Float32Array';
+      : model.pointType;
     const pd = vtkPolyData.newInstance();
 
     // hand create a point cloud
@@ -70,7 +70,7 @@ const DEFAULT_VALUES = {
   numberOfPoints: 10,
   center: [0, 0, 0],
   radius: 0.5,
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/SLICSource/index.js
+++ b/Sources/Filters/Sources/SLICSource/index.js
@@ -7,7 +7,7 @@ import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 // ----------------------------------------------------------------------------
 
 function generateCoordinates(origin, dimensions, spacing) {
-  const coordinates = new Float32Array(
+  const coordinates = new Float64Array(
     dimensions[0] * dimensions[1] * dimensions[2] * 3
   );
   let offset = 0;
@@ -45,7 +45,7 @@ function vtkSLICSource(publicAPI, model) {
   ) => {
     const id = model.clusters.length;
     model.clusters.push(
-      new Float32Array([
+      new Float64Array([
         centerX,
         centerY,
         centerZ,
@@ -80,7 +80,7 @@ function vtkSLICSource(publicAPI, model) {
     fnDfDz
   ) => {
     if (!model.clusters[id]) {
-      model.clusters[id] = new Float32Array(7);
+      model.clusters[id] = new Float64Array(7);
     }
     model.clusters[id][0] = centerX;
     model.clusters[id][1] = centerY;

--- a/Sources/Filters/Sources/SphereSource/index.js
+++ b/Sources/Filters/Sources/SphereSource/index.js
@@ -18,7 +18,7 @@ function vtkSphereSource(publicAPI, model) {
     let dataset = outData[0];
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
-      : 'Float32Array';
+      : model.pointType;
     dataset = vtkPolyData.newInstance();
 
     // ----------------------------------------------------------------------
@@ -211,7 +211,7 @@ const DEFAULT_VALUES = {
   startPhi: 0.0,
   endPhi: 180.0,
   center: [0, 0, 0],
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/ViewFinderSource/index.js
+++ b/Sources/Filters/Sources/ViewFinderSource/index.js
@@ -96,7 +96,7 @@ const DEFAULT_VALUES = {
   radius: 1,
   spacing: 2,
   width: 4,
-  pointType: 'Float32Array',
+  pointType: 'Float64Array',
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
### Context
Use Float64 instead of Float32 to define points coordinate of all source filters. It will avoid precision error.

@finetjul @martinken 