### PR TITLE
perf(WebGL): rework WebGL volumeMapper interactive rendering

### DIFF
--- a/Examples/Applications/VolumeViewer/index.js
+++ b/Examples/Applications/VolumeViewer/index.js
@@ -68,7 +68,7 @@ function createViewer(rootContainer, fileContents, options) {
   });
   const renderer = fullScreenRenderer.getRenderer();
   const renderWindow = fullScreenRenderer.getRenderWindow();
-  renderWindow.getInteractor().setDesiredUpdateRate(15);
+  renderWindow.getInteractor().setDesiredUpdateRate(30);
 
   const vtiReader = vtkXMLImageDataReader.newInstance();
   vtiReader.parseAsArrayBuffer(fileContents);


### PR DESCRIPTION
Update the renderwindowinteractor to set the recentFrameTime
from the new approach which uses at least a one second
timeframe to compute rendering rates.

Update the WebGL VolumeMapper to use a callback for when the
animation rate changes on the renderwindowinteractor
and simplify a bit how the use of the smaller viewport
is handled.

Adjust the volumeviewer example to be 30 fps because 15fps
feels slow.

