### PR TITLE
docs(ts): allow vtk classes discovery

### DIFF
--- a/Sources/index.d.ts
+++ b/Sources/index.d.ts
@@ -1,1 +1,0 @@
-export * from './types';

--- a/Sources/vtk.d.ts
+++ b/Sources/vtk.d.ts
@@ -1,0 +1,15 @@
+/**
+ * 
+ * @param obj 
+ * @return  
+ */
+declare function vtk(obj: object): any;
+
+/**
+ * Nest register method under the vtk function
+ * @param vtkClassName 
+ * @param constructor 
+ */
+declare function register(vtkClassName: string, constructor: any): void;
+
+export default vtk;

--- a/Utilities/rollup/plugin-generate-references.js
+++ b/Utilities/rollup/plugin-generate-references.js
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import path from 'path';
+
+export function generateDtsReferences(pluginOptions) {
+
+  const rootDts = 'index.d.ts';
+  const dtsReferences = [
+    '/// <reference path="./types.d.ts" />',
+    '/// <reference path="./interfaces.d.ts" />',
+  ];
+
+  return {
+    name: 'generate-references',
+    generateBundle(outputOptions, bundle, isWrite) {
+      const files = Object.keys(bundle);
+
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        let filename = file.replace('.js', '.d.ts');
+
+        const dts = path.join(pluginOptions['dest'], filename);
+
+        if (fs.existsSync(dts) && filename !== rootDts) {
+          filename = filename.replace(/\\/g, '/');
+          dtsReferences.push(`/// <reference path="./${filename}" />`);
+        }
+      }
+
+      this.emitFile({
+        type: 'asset',
+        fileName: rootDts,
+        source: dtsReferences.join("\r\n")
+      });
+    }
+  };
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,7 @@ import copy from 'rollup-plugin-copy';
 import pkg from './package.json';
 
 import { rewriteFilenames } from './Utilities/rollup/plugin-rewrite-filenames';
+import { generateDtsReferences } from './Utilities/rollup/plugin-generate-references';
 
 const absolutifyImports = require('./Utilities/build/absolutify-imports.js');
 
@@ -169,7 +170,10 @@ export default {
           dest: outputDir,
           rename(name, ext, fullPath) {
             const filename = `${name}.${ext}`;
-            if (filename === 'index.d.ts') {
+            if (
+              filename === 'index.d.ts' &&
+              path.dirname(fullPath) !== 'Sources'
+            ) {
               const moduleName = path.basename(path.dirname(fullPath));
               return `../${moduleName}.d.ts`;
             }
@@ -193,6 +197,9 @@ export default {
         },
       ],
     }),
+    generateDtsReferences({
+      dest: outputDir,
+    }),
     copy({
       flatten: true,
       targets: [
@@ -204,6 +211,7 @@ export default {
         { src: 'Utilities/build/macro-shim.js', dest: outputDir, rename: 'macro.js' },
         { src: '*.txt', dest: outputDir },
         { src: '*.md', dest: outputDir },
+        { src: 'tsconfig.json', dest: outputDir },
         { src: '.npmignore', dest: outputDir },
         { src: 'LICENSE', dest: outputDir },
         {
@@ -214,6 +222,7 @@ export default {
             pkg.name = '@kitware/vtk.js';
             pkg.main = './index.js';
             pkg.module = './index.js';
+            pkg.types = './index.d.ts';
             return JSON.stringify(pkg, null, 2);
           },
         },


### PR DESCRIPTION
### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
This changes will allow the discovery of the available vtk classes, types and interfaces

This changes only affects the ESM build.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
![image](https://user-images.githubusercontent.com/878518/150656738-8c70fd09-253d-4fac-8be7-008926e994ec.png)

![image](https://user-images.githubusercontent.com/878518/150656801-9c523b2d-5258-48a7-b77c-b6e2279e97e4.png)

### Testing
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->


<!-- Remove the line below if it is not relevant -->
_This contribution is funded by CSD._
