### PR TITLE
fix(splinewidget): fix crash when moveHandle is not initialized

### DIFF
--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -64,16 +64,21 @@ export default function widgetBehavior(publicAPI, model) {
 
     return handles.reduce(
       ({ closestHandle, closestDistance }, handle) => {
-        const distance = vec3.squaredDistance(
-          model.moveHandle.getOrigin(),
+        if (
+          handle !== model.moveHandle &&
+          model.moveHandle.getOrigin() &&
           handle.getOrigin()
-        );
-        if (handle !== model.moveHandle) {
-          return {
-            closestHandle: distance < closestDistance ? handle : closestHandle,
-            closestDistance:
-              distance < closestDistance ? distance : closestDistance,
-          };
+        ) {
+          const distance = vec3.squaredDistance(
+            model.moveHandle.getOrigin(),
+            handle.getOrigin()
+          );
+          if (distance < closestDistance) {
+            return {
+              closestHandle: handle,
+              closestDistance: distance,
+            };
+          }
         }
 
         return {


### PR DESCRIPTION
Hovering a spline handle while the moveHandle was not initialized (origin=null) was causing errors.
Fix this by calculating the distance between moveHandle and handle only if their positions are set.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: 22.2.1
  - **OS**: Ubuntu 20.04 LTS
  - **Browser**: Chromium 98.0.4697.0

