### PR TITLE
docs(svg): add SVG layer section in the Widgets concept documentation

### DIFF
--- a/Documentation/content/docs/concepts_widgets.md
+++ b/Documentation/content/docs/concepts_widgets.md
@@ -144,4 +144,22 @@ An example manipulator would be a plane manipulator. When instantiated with a
 plane point and normal, the plane manipulator will project mouse events onto the
 plane in 3D and return that projected point.
 
+## SVG Layer
+
+Below is a table that summarizes some widget feature needs and their availabilities 1) in vtk.js and in the Widgets framework 2) without and 3) with the SVG layer.
+
+|     Feature     | 1)vtk.js<br/>available | <br/>class, example | 2)widgets<br/>available | <br/>class, example | 3)SVG<br/>available | <br/>class, example |
+|-----------------|------------------------|---------------------|-------------------------|---------------------|---------------------|---------------------|
+| 3D depth test   | Yes | Actor, [Cone](https://kitware.github.io/vtk-js/examples/Cone.html) | Yes        | [ImageCroppingWidget](https://kitware.github.io/vtk-js/examples/ImageCroppingWidget.html)  | Never |   |
+| Always on top   | Yes | Actor2D, [Actor2D](https://kitware.github.io/vtk-js/examples/Actor2D.html) | No |   | Yes | [PolyLineWidget](https://kitware.github.io/vtk-js/examples/PolyLineWidget.html)
+| Line thickness  | Soon [#2208](https://github.com/Kitware/vtk-js/pull/2208) | Mapper2D | Hack | TubeFilter, [ResliceCursorWidget](https://kitware.github.io/vtk-js/examples/ResliceCursorWidget.html) |Yes
+| Smooth line     | Yes | Spline3D | Yes | [SplineWidget](https://kitware.github.io/vtk-js/examples/PolyLineWidget.html) | Yes |
+| Fill area       | Yes |   | Yes | SplineWidget + TriangleFilter, [SplineWidget](https://kitware.github.io/vtk-js/examples/PolyLineWidget.html) | Yes |
+| Handle          | Yes |   | Yes | ___HandleRepresentation, [LineWidget](https://kitware.github.io/vtk-js/examples/LineWidget.html) | Yes |
+| Thousands of handles | Yes | Glyph3DMapper, [Glyph3DMapper](https://kitware.github.io/vtk-js/examples/Glyph3DMapper.html) | Yes | Mixins + GlyphMapper | Never |
+| Text            | Yes | Texture, [CubeAxes](https://kitware.github.io/vtk-js/examples/CubeAxes.html) | No |  | Yes | [LineWidget](https://kitware.github.io/vtk-js/examples/LineWidget.html)
+| Screenshot      | Yes |   | Yes |   | No |
+| Mouse pick      | Yes |   | Yes | WidgetManager, [ImageCroppingWidget](https://kitware.github.io/vtk-js/examples/ImageCroppingWidget.html) | Yes | [LineWidget](https://kitware.github.io/vtk-js/examples/LineWidget.html) (text handle is pickable)
+| Mouse drag      | Yes |   | Yes | [ImageCroppingWidget](https://kitware.github.io/vtk-js/examples/ImageCroppingWidget.html)  | No |
+
 [WidgetsDiagram]: ./gallery/widgets_diagram.png


### PR DESCRIPTION

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [c] Run `npm run reformat` to have correctly formatted code

### Context
Following some discussion regarding the need for an extensive SVG layer support in the Widgets, I summarized the current state in the documentation. 

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
![image](https://user-images.githubusercontent.com/219044/151445576-ecf247c7-4bd6-4459-9c9b-d3bb93bcafe8.png)