### PR TITLE
feat(WebGPU): add debugging support

### DIFF
--- a/Sources/Rendering/WebGPU/BindGroup/index.js
+++ b/Sources/Rendering/WebGPU/BindGroup/index.js
@@ -58,6 +58,7 @@ function vtkWebGPUBindGroup(publicAPI, model) {
     model.bindGroup = device.getHandle().createBindGroup({
       layout: publicAPI.getBindGroupLayout(device),
       entries,
+      label: model.label,
     });
     model.bindGroupTime.modified();
 
@@ -66,7 +67,7 @@ function vtkWebGPUBindGroup(publicAPI, model) {
 
   publicAPI.getShaderCode = (pipeline) => {
     const lines = [];
-    const bgroup = pipeline.getBindGroupLayoutCount(model.name);
+    const bgroup = pipeline.getBindGroupLayoutCount(model.label);
     for (let i = 0; i < model.bindables.length; i++) {
       lines.push(model.bindables[i].getShaderCode(i, bgroup));
     }
@@ -81,7 +82,7 @@ function vtkWebGPUBindGroup(publicAPI, model) {
 const DEFAULT_VALUES = {
   device: null,
   handle: null,
-  name: null,
+  label: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -104,7 +105,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'usage',
   ]);
   macro.setGet(publicAPI, model, [
-    'name',
+    'label',
     'device',
     'arrayInformation',
     'sourceTime',

--- a/Sources/Rendering/WebGPU/Buffer/index.js
+++ b/Sources/Rendering/WebGPU/Buffer/index.js
@@ -37,6 +37,7 @@ function vtkWebGPUBuffer(publicAPI, model) {
     model.handle = model.device.getHandle().createBuffer({
       size: sizeInBytes,
       usage,
+      label: model.label,
     });
     model.sizeInBytes = sizeInBytes;
     model.usage = usage;
@@ -51,6 +52,7 @@ function vtkWebGPUBuffer(publicAPI, model) {
       size: data.byteLength,
       usage,
       mappedAtCreation: true,
+      label: model.label,
     });
     model.sizeInBytes = data.byteLength;
     model.usage = usage;
@@ -77,6 +79,7 @@ const DEFAULT_VALUES = {
   strideInBytes: 0,
   arrayInformation: null,
   usage: null,
+  label: null,
   sourceTime: null,
 };
 
@@ -93,6 +96,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'strideInBytes',
     'device',
     'arrayInformation',
+    'label',
     'sourceTime',
   ]);
 

--- a/Sources/Rendering/WebGPU/BufferManager/index.js
+++ b/Sources/Rendering/WebGPU/BufferManager/index.js
@@ -429,7 +429,7 @@ function vtkWebGPUBufferManager(publicAPI, model) {
     }
 
     // create one
-    const buffer = vtkWebGPUBuffer.newInstance();
+    const buffer = vtkWebGPUBuffer.newInstance({ label: req.label });
     buffer.setDevice(model.device);
 
     let gpuUsage = null;

--- a/Sources/Rendering/WebGPU/Device/index.js
+++ b/Sources/Rendering/WebGPU/Device/index.js
@@ -72,7 +72,7 @@ function vtkWebGPUDevice(publicAPI, model) {
   };
 
   publicAPI.createPipeline = (hash, pipeline) => {
-    pipeline.initialize(publicAPI);
+    pipeline.initialize(publicAPI, hash);
     model.pipelines[hash] = pipeline;
   };
 

--- a/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
+++ b/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
@@ -153,8 +153,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.glyphBOBuildTime = {};
   macro.obj(model.glyphBOBuildTime, { mtime: 0 });
 
-  model.SSBO = vtkWebGPUStorageBuffer.newInstance();
-  model.SSBO.setName('glyphSSBO');
+  model.SSBO = vtkWebGPUStorageBuffer.newInstance({ label: 'glyphSSBO' });
 
   // Object methods
   vtkWebGPUGlyph3DMapper(publicAPI, model);

--- a/Sources/Rendering/WebGPU/HardwareSelectionPass/index.js
+++ b/Sources/Rendering/WebGPU/HardwareSelectionPass/index.js
@@ -31,7 +31,9 @@ function vtkWebGPUHardwareSelectionPass(publicAPI, model) {
       publicAPI.createRenderEncoder();
 
       // create color texture
-      model.colorTexture = vtkWebGPUTexture.newInstance();
+      model.colorTexture = vtkWebGPUTexture.newInstance({
+        label: 'hardwareSelectorColor',
+      });
       model.colorTexture.create(device, {
         width: viewNode.getCanvas().width,
         height: viewNode.getCanvas().height,
@@ -40,12 +42,13 @@ function vtkWebGPUHardwareSelectionPass(publicAPI, model) {
         /* eslint-disable no-bitwise */
         usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
       });
-      const v1 = model.colorTexture.createView();
-      v1.setName('hardwareSelectColorTexture');
+      const v1 = model.colorTexture.createView('hardwareSelectColorTexture');
       model.selectionRenderEncoder.setColorTextureView(0, v1);
 
       // create depth texture
-      model.depthTexture = vtkWebGPUTexture.newInstance();
+      model.depthTexture = vtkWebGPUTexture.newInstance({
+        label: 'hardwareSelectorDepth',
+      });
       model.depthTexture.create(device, {
         width: viewNode.getCanvas().width,
         height: viewNode.getCanvas().height,
@@ -54,8 +57,7 @@ function vtkWebGPUHardwareSelectionPass(publicAPI, model) {
         /* eslint-disable no-bitwise */
         usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
       });
-      const v2 = model.depthTexture.createView();
-      v2.setName('hardwareSelectDepthTexture');
+      const v2 = model.depthTexture.createView('hardwareSelectDepthTexture');
       model.selectionRenderEncoder.setDepthTextureView(v2);
     } else {
       model.colorTexture.resize(
@@ -76,7 +78,9 @@ function vtkWebGPUHardwareSelectionPass(publicAPI, model) {
   };
 
   publicAPI.createRenderEncoder = () => {
-    model.selectionRenderEncoder = vtkWebGPURenderEncoder.newInstance();
+    model.selectionRenderEncoder = vtkWebGPURenderEncoder.newInstance({
+      label: 'HardwareSelectionPass',
+    });
     // default settings are fine for this
     model.selectionRenderEncoder.setPipelineHash('sel');
     model.selectionRenderEncoder.setReplaceShaderCodeFunction((pipeline) => {

--- a/Sources/Rendering/WebGPU/HardwareSelector/index.js
+++ b/Sources/Rendering/WebGPU/HardwareSelector/index.js
@@ -326,7 +326,9 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
     result.colorBufferWidth = 16 * Math.floor((result.width + 15) / 16);
     result.colorBufferSizeInBytes =
       result.colorBufferWidth * result.height * 4 * 4;
-    const colorBuffer = vtkWebGPUBuffer.newInstance();
+    const colorBuffer = vtkWebGPUBuffer.newInstance({
+      label: 'hardwareSelectColorBuffer',
+    });
     colorBuffer.setDevice(device);
     /* eslint-disable no-bitwise */
     /* eslint-disable no-undef */
@@ -357,7 +359,9 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
     let zbuffer;
     if (model.captureZValues) {
       result.zbufferBufferWidth = 64 * Math.floor((result.width + 63) / 64);
-      zbuffer = vtkWebGPUBuffer.newInstance();
+      zbuffer = vtkWebGPUBuffer.newInstance({
+        label: 'hardwareSelectDepthBuffer',
+      });
       zbuffer.setDevice(device);
       result.zbufferSizeInBytes = result.height * result.zbufferBufferWidth * 4;
       /* eslint-disable no-bitwise */

--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -330,8 +330,7 @@ function vtkWebGPUImageMapper(publicAPI, model) {
           format: 'rgba8unorm',
         };
         const newTex = device.getTextureManager().getTexture(treq);
-        const tview = newTex.createView();
-        tview.setName('tfunTexture');
+        const tview = newTex.createView('tfunTexture');
         const tViews = model.helper.getTextureViews();
         tViews[1] = tview;
       }
@@ -349,8 +348,7 @@ function vtkWebGPUImageMapper(publicAPI, model) {
     const tViews = model.helper.getTextureViews();
 
     if (!tViews[0] || tViews[0].getTexture() !== newTex) {
-      const tview = newTex.createView();
-      tview.setName(`imgTexture`);
+      const tview = newTex.createView('imgTexture');
       tViews[0] = tview;
     }
 
@@ -373,8 +371,9 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       !model.clampSampler ||
       iType !== model.clampSampler.getOptions().minFilter
     ) {
-      model.clampSampler = vtkWebGPUSampler.newInstance();
-      model.clampSampler.setName('clampSampler');
+      model.clampSampler = vtkWebGPUSampler.newInstance({
+        label: 'clampSampler',
+      });
       model.clampSampler.create(device, {
         minFilter: iType,
         magFilter: iType,
@@ -492,8 +491,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.helper = vtkWebGPUFullScreenQuad.newInstance();
   model.helper.setFragmentShaderTemplate(imgFragTemplate);
 
-  model.UBO = vtkWebGPUUniformBuffer.newInstance();
-  model.UBO.setName('mapperUBO');
+  model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
   model.UBO.addEntry('SCTCMatrix', 'mat4x4<f32>');
   model.UBO.addEntry('Origin', 'vec4<f32>');
   model.UBO.addEntry('Axis2', 'vec4<f32>');
@@ -502,11 +500,11 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.UBO.addEntry('cShift', 'vec4<f32>');
   model.helper.setUBO(model.UBO);
 
-  model.SSBO = vtkWebGPUStorageBuffer.newInstance();
-  model.SSBO.setName('volumeSSBO');
+  model.SSBO = vtkWebGPUStorageBuffer.newInstance({ label: 'volumeSSBO' });
 
-  model.componentSSBO = vtkWebGPUStorageBuffer.newInstance();
-  model.componentSSBO.setName('componentSSBO');
+  model.componentSSBO = vtkWebGPUStorageBuffer.newInstance({
+    label: 'componentSSBO',
+  });
 
   model.lutBuildTime = {};
   macro.obj(model.lutBuildTime, { mtime: 0 });

--- a/Sources/Rendering/WebGPU/MapperHelper/index.js
+++ b/Sources/Rendering/WebGPU/MapperHelper/index.js
@@ -351,8 +351,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.textureViews = [];
   model.vertexInput = vtkWebGPUVertexInput.newInstance();
 
-  model.bindGroup = vtkWebGPUBindGroup.newInstance();
-  model.bindGroup.setName('mapperBG');
+  model.bindGroup = vtkWebGPUBindGroup.newInstance({ label: 'mapperBG' });
 
   model.additionalBindables = [];
 

--- a/Sources/Rendering/WebGPU/OpaquePass/index.js
+++ b/Sources/Rendering/WebGPU/OpaquePass/index.js
@@ -25,7 +25,9 @@ function vtkWebGPUOpaquePass(publicAPI, model) {
 
     if (!model.renderEncoder) {
       publicAPI.createRenderEncoder();
-      model.colorTexture = vtkWebGPUTexture.newInstance();
+      model.colorTexture = vtkWebGPUTexture.newInstance({
+        label: 'opaquePassColor',
+      });
       model.colorTexture.create(device, {
         width: viewNode.getCanvas().width,
         height: viewNode.getCanvas().height,
@@ -37,12 +39,13 @@ function vtkWebGPUOpaquePass(publicAPI, model) {
           GPUTextureUsage.TEXTURE_BINDING |
           GPUTextureUsage.COPY_SRC,
       });
-      const ctView = model.colorTexture.createView();
-      ctView.setName('opaquePassColorTexture');
+      const ctView = model.colorTexture.createView('opaquePassColorTexture');
       model.renderEncoder.setColorTextureView(0, ctView);
 
       model.depthFormat = 'depth32float';
-      model.depthTexture = vtkWebGPUTexture.newInstance();
+      model.depthTexture = vtkWebGPUTexture.newInstance({
+        label: 'opaquePassDepth',
+      });
       model.depthTexture.create(device, {
         width: viewNode.getCanvas().width,
         height: viewNode.getCanvas().height,
@@ -52,8 +55,7 @@ function vtkWebGPUOpaquePass(publicAPI, model) {
           GPUTextureUsage.TEXTURE_BINDING |
           GPUTextureUsage.COPY_SRC,
       });
-      const dView = model.depthTexture.createView();
-      dView.setName('opaquePassDepthTexture');
+      const dView = model.depthTexture.createView('opaquePassDepthTexture');
       model.renderEncoder.setDepthTextureView(dView);
     } else {
       model.colorTexture.resize(
@@ -79,7 +81,9 @@ function vtkWebGPUOpaquePass(publicAPI, model) {
     model.renderEncoder.getDepthTextureView();
 
   publicAPI.createRenderEncoder = () => {
-    model.renderEncoder = vtkWebGPURenderEncoder.newInstance();
+    model.renderEncoder = vtkWebGPURenderEncoder.newInstance({
+      label: 'OpaquePass',
+    });
     // default settings are fine for this
     model.renderEncoder.setPipelineHash('op');
   };

--- a/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
@@ -57,7 +57,9 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
     if (!model.translucentRenderEncoder) {
       publicAPI.createRenderEncoder();
       publicAPI.createFinalEncoder();
-      model.translucentColorTexture = vtkWebGPUTexture.newInstance();
+      model.translucentColorTexture = vtkWebGPUTexture.newInstance({
+        label: 'translucentPassColor',
+      });
       model.translucentColorTexture.create(device, {
         width: viewNode.getCanvas().width,
         height: viewNode.getCanvas().height,
@@ -67,11 +69,12 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
         usage:
           GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
       });
-      const v1 = model.translucentColorTexture.createView();
-      v1.setName('oitpColorTexture');
+      const v1 = model.translucentColorTexture.createView('oitpColorTexture');
       model.translucentRenderEncoder.setColorTextureView(0, v1);
 
-      model.translucentAccumulateTexture = vtkWebGPUTexture.newInstance();
+      model.translucentAccumulateTexture = vtkWebGPUTexture.newInstance({
+        label: 'translucentPassAccumulate',
+      });
       model.translucentAccumulateTexture.create(device, {
         width: viewNode.getCanvas().width,
         height: viewNode.getCanvas().height,
@@ -81,8 +84,8 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
         usage:
           GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
       });
-      const v2 = model.translucentAccumulateTexture.createView();
-      v2.setName('oitpAccumTexture');
+      const v2 =
+        model.translucentAccumulateTexture.createView('oitpAccumTexture');
       model.translucentRenderEncoder.setColorTextureView(1, v2);
       model.fullScreenQuad = vtkWebGPUFullScreenQuad.newInstance();
       model.fullScreenQuad.setDevice(viewNode.getDevice());
@@ -131,7 +134,9 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
   ];
 
   publicAPI.createRenderEncoder = () => {
-    model.translucentRenderEncoder = vtkWebGPURenderEncoder.newInstance();
+    model.translucentRenderEncoder = vtkWebGPURenderEncoder.newInstance({
+      label: 'translucentRender',
+    });
     const rDesc = model.translucentRenderEncoder.getDescription();
     rDesc.colorAttachments = [
       {
@@ -207,7 +212,9 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
   };
 
   publicAPI.createFinalEncoder = () => {
-    model.translucentFinalEncoder = vtkWebGPURenderEncoder.newInstance();
+    model.translucentFinalEncoder = vtkWebGPURenderEncoder.newInstance({
+      label: 'translucentFinal',
+    });
     model.translucentFinalEncoder.setDescription({
       colorAttachments: [
         {

--- a/Sources/Rendering/WebGPU/Pipeline/index.js
+++ b/Sources/Rendering/WebGPU/Pipeline/index.js
@@ -9,13 +9,15 @@ function vtkWebGPUPipeline(publicAPI, model) {
 
   publicAPI.getShaderDescriptions = () => model.shaderDescriptions;
 
-  publicAPI.initialize = (device) => {
+  publicAPI.initialize = (device, hash) => {
     // start with the renderencoder settings
     model.pipelineDescription = model.renderEncoder.getPipelineSettings();
 
     model.pipelineDescription.primitive.topology = model.topology;
 
     model.pipelineDescription.vertex = model.vertexState;
+
+    model.pipelineDescription.label = hash;
 
     // add in bind group layouts
     const bindGroupLayouts = [];
@@ -59,15 +61,15 @@ function vtkWebGPUPipeline(publicAPI, model) {
     }
     model.layouts.push({
       layout: bindGroup.getBindGroupLayout(model.device),
-      name: bindGroup.getName(),
+      label: bindGroup.getLabel(),
     });
   };
 
   publicAPI.getBindGroupLayout = (idx) => model.layouts[idx].layout;
 
-  publicAPI.getBindGroupLayoutCount = (lname) => {
+  publicAPI.getBindGroupLayoutCount = (llabel) => {
     for (let i = 0; i < model.layouts.length; i++) {
-      if (model.layouts[i].name === lname) {
+      if (model.layouts[i].label === llabel) {
         return i;
       }
     }

--- a/Sources/Rendering/WebGPU/PolyDataMapper/index.js
+++ b/Sources/Rendering/WebGPU/PolyDataMapper/index.js
@@ -558,7 +558,7 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
     const idata = model.renderable.getColorTextureMap(); // returns an imagedata
     if (idata) {
       if (!model.colorTexture) {
-        model.colorTexture = vtkTexture.newInstance();
+        model.colorTexture = vtkTexture.newInstance({ label: 'polyDataColor' });
       }
       model.colorTexture.setInputData(idata);
       newTextures.push(model.colorTexture);
@@ -600,8 +600,7 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
         }
         if (!found) {
           usedTextures[model.textures.length] = true;
-          const tview = newTex.createView();
-          tview.setName(`Texture${usedCount++}`);
+          const tview = newTex.createView(`Texture${usedCount++}`);
           model.textures.push(newTex);
           model.textureViews.push(tview);
           const interpolate = srcTexture.getInterpolate()
@@ -794,8 +793,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.vertexShaderTemplate =
     model.vertexShaderTemplate || vtkWebGPUPolyDataVS;
 
-  model.UBO = vtkWebGPUUniformBuffer.newInstance();
-  model.UBO.setName('mapperUBO');
+  model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
   model.UBO.addEntry('BCWCMatrix', 'mat4x4<f32>');
   model.UBO.addEntry('BCSCMatrix', 'mat4x4<f32>');
   model.UBO.addEntry('MCWCNormals', 'mat4x4<f32>');

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -13,9 +13,15 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
 
   publicAPI.begin = (encoder) => {
     model.handle = encoder.beginRenderPass(model.description);
+    if (model.label) {
+      model.handle.pushDebugGroup(model.label);
+    }
   };
 
   publicAPI.end = () => {
+    if (model.label) {
+      model.handle.popDebugGroup();
+    }
     model.handle.endPass();
   };
 
@@ -70,7 +76,7 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
 
   publicAPI.activateBindGroup = (bg) => {
     const device = model.boundPipeline.getDevice();
-    const midx = model.boundPipeline.getBindGroupLayoutCount(bg.getName());
+    const midx = model.boundPipeline.getBindGroupLayoutCount(bg.getLabel());
     model.handle.setBindGroup(midx, bg.getBindGroup(device));
     // verify bind group layout matches
     const bgl1 = device.getBindGroupLayoutDescription(
@@ -122,6 +128,7 @@ const DEFAULT_VALUES = {
   pipelineSettings: null,
   replaceShaderCodeFunction: null,
   depthTextureView: null,
+  label: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -191,6 +198,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'depthTextureView',
     'description',
     'handle',
+    'label',
     'pipelineHash',
     'pipelineSettings',
     'replaceShaderCodeFunction',

--- a/Sources/Rendering/WebGPU/Renderer/index.js
+++ b/Sources/Rendering/WebGPU/Renderer/index.js
@@ -235,8 +235,7 @@ function vtkWebGPURenderer(publicAPI, model) {
       model.clearFSQ.setDevice(device);
       model.clearFSQ.setPipelineHash('clearfsq');
       model.clearFSQ.setFragmentShaderTemplate(clearFragTemplate);
-      const ubo = vtkWebGPUUniformBuffer.newInstance();
-      ubo.setName('mapperUBO');
+      const ubo = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
       ubo.addEntry('BackgroundColor', 'vec4<f32>');
       model.clearFSQ.setUBO(ubo);
     }
@@ -395,8 +394,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkViewNode.extend(publicAPI, model, initialValues);
 
-  model.UBO = vtkWebGPUUniformBuffer.newInstance();
-  model.UBO.setName('rendererUBO');
+  model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'rendererUBO' });
   model.UBO.addEntry('WCVCMatrix', 'mat4x4<f32>');
   model.UBO.addEntry('SCPCMatrix', 'mat4x4<f32>');
   model.UBO.addEntry('PCSCMatrix', 'mat4x4<f32>');
@@ -406,8 +404,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.UBO.addEntry('viewportSize', 'vec2<f32>');
   model.UBO.addEntry('cameraParallel', 'u32');
 
-  model.bindGroup = vtkWebGPUBindGroup.newInstance();
-  model.bindGroup.setName('rendererBG');
+  model.bindGroup = vtkWebGPUBindGroup.newInstance({ label: 'rendererBG' });
   model.bindGroup.setBindables([model.UBO]);
 
   model.tmpMat4 = mat4.identity(new Float64Array(16));

--- a/Sources/Rendering/WebGPU/Sampler/index.js
+++ b/Sources/Rendering/WebGPU/Sampler/index.js
@@ -14,12 +14,13 @@ function vtkWebGPUSampler(publicAPI, model) {
     model.device = device;
     model.options.magFilter = options.magFilter ? options.magFilter : 'nearest';
     model.options.minFilter = options.minFilter ? options.minFilter : 'nearest';
+    model.options.label = model.label;
     model.handle = model.device.getHandle().createSampler(model.options);
     model.bindGroupTime.modified();
   };
 
   publicAPI.getShaderCode = (binding, group) => {
-    const result = `@binding(${binding}) @group(${group}) var ${model.name}: sampler;`;
+    const result = `@binding(${binding}) @group(${group}) var ${model.label}: sampler;`;
     return result;
   };
 
@@ -38,7 +39,7 @@ function vtkWebGPUSampler(publicAPI, model) {
 const DEFAULT_VALUES = {
   device: null,
   handle: null,
-  name: null,
+  label: null,
   options: null,
 };
 
@@ -64,7 +65,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.obj(model.bindGroupTime, { mtime: 0 });
 
   macro.get(publicAPI, model, ['bindGroupTime', 'handle', 'options']);
-  macro.setGet(publicAPI, model, ['bindGroupLayoutEntry', 'device', 'name']);
+  macro.setGet(publicAPI, model, ['bindGroupLayoutEntry', 'device', 'label']);
 
   vtkWebGPUSampler(publicAPI, model);
 }

--- a/Sources/Rendering/WebGPU/StorageBuffer/index.js
+++ b/Sources/Rendering/WebGPU/StorageBuffer/index.js
@@ -44,6 +44,7 @@ function vtkWebGPUStorageBuffer(publicAPI, model) {
         nativeArray: model.Float32Array,
         time: 0,
         usage: BufferUsage.Storage,
+        label: model.label,
       };
       model._buffer = device.getBufferManager().getBuffer(req);
       model.bindGroupTime.modified();
@@ -165,18 +166,18 @@ function vtkWebGPUStorageBuffer(publicAPI, model) {
 
   publicAPI.getSendTime = () => model._sendTime.getMTime();
   publicAPI.getShaderCode = (binding, group) => {
-    const lines = [`struct ${model.name}StructEntry\n{`];
+    const lines = [`struct ${model.label}StructEntry\n{`];
     for (let i = 0; i < model.bufferEntries.length; i++) {
       const entry = model.bufferEntries[i];
       lines.push(`  ${entry.name}: ${entry.type};`);
     }
     lines.push(`
 };
-struct ${model.name}Struct
+struct ${model.label}Struct
 {
-  values: array<${model.name}StructEntry>;
+  values: array<${model.label}StructEntry>;
 };
-@binding(${binding}) @group(${group}) var<storage, read> ${model.name}: ${model.name}Struct;
+@binding(${binding}) @group(${group}) var<storage, read> ${model.label}: ${model.label}Struct;
 `);
 
     return lines.join('\n');
@@ -210,7 +211,7 @@ const DEFAULT_VALUES = {
   bufferEntries: null,
   bufferEntryNames: null,
   sizeInBytes: 0,
-  name: null,
+  label: null,
   numberOfInstances: 1,
 };
 
@@ -243,7 +244,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, [
     'device',
     'bindGroupLayoutEntry',
-    'name',
+    'label',
     'numberOfInstances',
     'sizeInBytes',
   ]);

--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -36,6 +36,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       size: [model.width, model.height, model.depth],
       format: model.format, // 'rgba8unorm',
       usage: model.usage,
+      label: model.label,
       dimension,
     });
   };
@@ -203,6 +204,7 @@ function vtkWebGPUTexture(publicAPI, model) {
         size: [model.width, model.height, model.depth],
         format: model.format,
         usage: model.usage,
+        label: model.label,
       });
     }
   };
@@ -220,16 +222,17 @@ function vtkWebGPUTexture(publicAPI, model) {
         size: [model.width, model.height, model.depth],
         format: model.format,
         usage: model.usage,
+        label: model.label,
       });
     }
   };
 
-  publicAPI.createView = (options = {}) => {
+  publicAPI.createView = (label, options = {}) => {
     // if options is missing values try to add them in
     if (!options.dimension) {
       options.dimension = model.depth === 1 ? '2d' : '3d';
     }
-    const view = vtkWebGPUTextureView.newInstance();
+    const view = vtkWebGPUTextureView.newInstance({ label });
     view.create(publicAPI, options);
     return view;
   };
@@ -244,6 +247,7 @@ const DEFAULT_VALUES = {
   handle: null,
   buffer: null,
   ready: false,
+  label: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -263,7 +267,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'format',
     'usage',
   ]);
-  macro.setGet(publicAPI, model, ['device']);
+  macro.setGet(publicAPI, model, ['device', 'label']);
 
   vtkWebGPUTexture(publicAPI, model);
 }

--- a/Sources/Rendering/WebGPU/TextureView/index.js
+++ b/Sources/Rendering/WebGPU/TextureView/index.js
@@ -16,6 +16,7 @@ function vtkWebGPUTextureView(publicAPI, model) {
     model.texture = texture;
     model.options = options;
     model.options.dimension = model.options.dimension || '2d';
+    model.options.label = model.label;
     model.textureHandle = texture.getHandle();
     model.handle = model.textureHandle.createView(model.options);
     model.bindGroupLayoutEntry.texture.viewDimension = model.options.dimension;
@@ -39,29 +40,19 @@ function vtkWebGPUTextureView(publicAPI, model) {
     } else if (model.bindGroupLayoutEntry.texture.sampleType === 'uint') {
       ttype = 'u32';
     }
-    let result = `@binding(${binding}) @group(${group}) var ${model.name}: texture_${model.options.dimension}<${ttype}>;`;
+    let result = `@binding(${binding}) @group(${group}) var ${model.label}: texture_${model.options.dimension}<${ttype}>;`;
     if (model.bindGroupLayoutEntry.texture.sampleType === 'depth') {
-      result = `@binding(${binding}) @group(${group}) var ${model.name}: texture_depth_${model.options.dimension};`;
+      result = `@binding(${binding}) @group(${group}) var ${model.label}: texture_depth_${model.options.dimension};`;
     }
     return result;
   };
 
   publicAPI.addSampler = (device, options) => {
-    const newSamp = vtkWebGPUSampler.newInstance();
+    const newSamp = vtkWebGPUSampler.newInstance({
+      label: `${model.label}Sampler`,
+    });
     newSamp.create(device, options);
     publicAPI.setSampler(newSamp);
-    model.sampler.setName(`${model.name}Sampler`);
-  };
-
-  publicAPI.setName = (val) => {
-    if (model.sampler) {
-      model.sampler.setName(`${val}Sampler`);
-    }
-    if (model.name === val) {
-      return;
-    }
-    model.name = val;
-    publicAPI.modified();
   };
 
   publicAPI.getBindGroupTime = () => {
@@ -92,8 +83,8 @@ function vtkWebGPUTextureView(publicAPI, model) {
 const DEFAULT_VALUES = {
   texture: null,
   handle: null,
-  name: null,
   sampler: null,
+  label: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -118,8 +109,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.bindGroupTime = {};
   macro.obj(model.bindGroupTime, { mtime: 0 });
 
-  macro.get(publicAPI, model, ['bindGroupTime', 'name', 'texture']);
-  macro.setGet(publicAPI, model, ['bindGroupLayoutEntry', 'sampler']);
+  macro.get(publicAPI, model, ['bindGroupTime', 'texture']);
+  macro.setGet(publicAPI, model, ['bindGroupLayoutEntry', 'label', 'sampler']);
 
   vtkWebGPUTextureView(publicAPI, model);
 }

--- a/Sources/Rendering/WebGPU/UniformBuffer/index.js
+++ b/Sources/Rendering/WebGPU/UniformBuffer/index.js
@@ -193,6 +193,7 @@ function vtkWebGPUUniformBuffer(publicAPI, model) {
         nativeArray: model.Float32Array,
         time: 0,
         usage: BufferUsage.UniformArray,
+        label: model.label,
       };
       model.UBO = device.getBufferManager().getBuffer(req);
       model.bindGroupTime.modified();
@@ -281,13 +282,13 @@ function vtkWebGPUUniformBuffer(publicAPI, model) {
     // sort the entries
     publicAPI.sortBufferEntries();
 
-    const lines = [`struct ${model.name}Struct\n{`];
+    const lines = [`struct ${model.label}Struct\n{`];
     for (let i = 0; i < model.bufferEntries.length; i++) {
       const entry = model.bufferEntries[i];
       lines.push(`  ${entry.name}: ${entry.type};`);
     }
     lines.push(
-      `};\n@binding(${binding}) @group(${group}) var<uniform> ${model.name}: ${model.name}Struct;`
+      `};\n@binding(${binding}) @group(${group}) var<uniform> ${model.label}: ${model.label}Struct;`
     );
     return lines.join('\n');
   };
@@ -301,7 +302,7 @@ const DEFAULT_VALUES = {
   bufferEntries: null,
   bufferEntryNames: null,
   sizeInBytes: 0,
-  name: null,
+  label: null,
   bindGroupLayoutEntry: null,
   bindGroupEntry: null,
 };
@@ -338,7 +339,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, [
     'bindGroupLayoutEntry',
     'device',
-    'name',
+    'label',
     'sizeInBytes',
   ]);
 

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -590,8 +590,7 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
         format: 'rgba8unorm',
       };
       const newTex = device.getTextureManager().getTexture(treq);
-      const tview = newTex.createView();
-      tview.setName('tfunTexture');
+      const tview = newTex.createView('tfunTexture');
       model.textureViews[2] = tview;
     }
 
@@ -604,8 +603,7 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
         format: 'r16float',
       };
       const newTex = device.getTextureManager().getTexture(treq);
-      const tview = newTex.createView();
-      tview.setName('ofunTexture');
+      const tview = newTex.createView('ofunTexture');
       model.textureViews[3] = tview;
     }
 
@@ -855,8 +853,7 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
         !model.textureViews[vidx + 4] ||
         model.textureViews[vidx + 4].getTexture() !== newTex
       ) {
-        const tview = newTex.createView();
-        tview.setName(`volTexture${vidx}`);
+        const tview = newTex.createView(`volTexture${vidx}`);
         model.textureViews[vidx + 4] = tview;
       }
     }
@@ -908,8 +905,9 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
     publicAPI.updateBuffers(device);
 
     if (!model.clampSampler) {
-      model.clampSampler = vtkWebGPUSampler.newInstance();
-      model.clampSampler.setName('clampSampler');
+      model.clampSampler = vtkWebGPUSampler.newInstance({
+        label: 'clampSampler',
+      });
       model.clampSampler.create(device, {
         minFilter: 'linear',
         magFilter: 'linear',
@@ -948,15 +946,14 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.fragmentShaderTemplate = volFragTemplate;
 
-  model.UBO = vtkWebGPUUniformBuffer.newInstance();
-  model.UBO.setName('mapperUBO');
+  model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
   model.UBO.addEntry('SampleDistance', 'f32');
 
-  model.SSBO = vtkWebGPUStorageBuffer.newInstance();
-  model.SSBO.setName('volumeSSBO');
+  model.SSBO = vtkWebGPUStorageBuffer.newInstance({ label: 'volumeSSBO' });
 
-  model.componentSSBO = vtkWebGPUStorageBuffer.newInstance();
-  model.componentSSBO.setName('componentSSBO');
+  model.componentSSBO = vtkWebGPUStorageBuffer.newInstance({
+    label: 'componentSSBO',
+  });
 
   model.lutBuildTime = {};
   macro.obj(model.lutBuildTime, { mtime: 0 });


### PR DESCRIPTION
Make use of pushDebugGroup and labels in WebGPU to
provide better debugging support.

Renamed the "name" property of many webgpu objects to "label"
to match what WebGPU uses to provide debugging hints.

