### PR TITLE
Add support for defining a full url in array.refs in index.json 

### DIFF
--- a/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
+++ b/Sources/IO/Core/DataAccessHelper/HttpDataAccessHelper.js
@@ -63,11 +63,18 @@ function fetchBinary(url, options = {}) {
 function fetchArray(instance, baseURL, array, options = {}) {
   if (array.ref && !array.ref.pending) {
     return new Promise((resolve, reject) => {
-      const url = [
-        baseURL,
-        array.ref.basepath,
-        options.compression ? `${array.ref.id}.gz` : array.ref.id,
-      ].join('/');
+      let url = null;
+
+      if (array.ref.url) {
+        url = array.ref.url;
+      } else {
+        url = [
+          baseURL,
+          array.ref.basepath,
+          options.compression ? `${array.ref.id}.gz` : array.ref.id,
+        ].join('/');
+      }
+
       const xhr = openAsyncXHR('GET', url, options);
 
       xhr.onreadystatechange = (e) => {

--- a/Sources/IO/Core/DataAccessHelper/test/testHttpDataAccessHelperFetchArray.js
+++ b/Sources/IO/Core/DataAccessHelper/test/testHttpDataAccessHelperFetchArray.js
@@ -1,0 +1,27 @@
+import test from 'tape-catch';
+import HttpDataAccessHelper from '../HttpDataAccessHelper';
+
+test('Test array.ref.url is used', (t) => {
+  const expectedUrl = 'https://test.io/load_dataset?param1=testing';
+
+  const array = {
+    ref: {
+      url: expectedUrl,
+    },
+  };
+
+  const oldXmlHttpRequest = window.XMLHttpRequest;
+
+  // Mock XmlHttpRequest
+  window.XMLHttpRequest = function MockedXmlHttpRequestConstructor() {
+    this.open = (method, url, async = true) => {
+      t.equals(url, expectedUrl, 'xhr.open gets the same URL as array.ref.url');
+      t.end();
+
+      // Clear mock
+      window.XMLHttpRequest = oldXmlHttpRequest;
+    };
+  };
+
+  HttpDataAccessHelper.fetchArray({}, '', array);
+});


### PR DESCRIPTION
### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
The URL to fetch a dataset is currently built using a base url and the basepath and id  located in data.ref.
(See https://github.com/Kitware/vtk-js/blob/master/Data/volume/headsq.vti/index.json#L31)
Instead of building the url, it can be useful to directly provide the url where to fetch the array. A use case is for signed URLs.

### Changes
Add a check for array.ref.url in HttpDataAccessHelper.fetchArray, and use it if it exists, else use the default process.

- [ ] Documentation and TypeScript definitions were updated to match those changes

### Testing
- [x] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: master
  - **OS**: Ubuntu 20.04
  - **Browser**: Chrome 98.0.4758.80