### PR TITLE
docs(imagestream): add ParaView 5.10 support

### DIFF
--- a/Sources/IO/Core/ImageStream/example/pvw-server.py
+++ b/Sources/IO/Core/ImageStream/example/pvw-server.py
@@ -92,8 +92,11 @@ class _Server(pv_wslink.PVServerProtocol):
         self.getApplication().SetImageEncoding(0);
 
         # Disable interactor-based render calls
-        simple.GetRenderView().EnableRenderOnInteraction = 0
-        simple.GetRenderView().Background = [0,0,0]
+        view = simple.GetRenderView()
+        view.EnableRenderOnInteraction = 0
+        view.BackgroundColorMode = "Gradient"
+        view.Background = [0, 0, 0]
+        view.Background2 = [0.5, 0.5, 0.5]
 
         # ProxyManager helper
         pxm = simple.servermanager.ProxyManager()
@@ -111,10 +114,8 @@ class _Server(pv_wslink.PVServerProtocol):
         rep = simple.Show()
         rep.Representation = 'Surface With Edges';
         rep.LineWidth = 2
-        view = simple.Render()
-        view.Background2 = [0.5, 0.5, 0.5]
-        view.UseGradientBackground = 1
 
+        simple.Render()
 
 # =============================================================================
 # Main: Parse args and start server


### PR DESCRIPTION
UseGradientBackground has been replaced by BackgroundColorMode

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
ImageStream example was crashing with ParaView 5.10

### Changes
Drop support of ParaView < 5.10
- [ ] Documentation and TypeScript definitions were updated to match those changes

### Results
Works with ParaView 5.10.
Gradient does not seem to work though.

### Testing
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->
