### PR TITLE
fix(shapewidget): absorb mouseMove event while moving shapewidget handles

### DIFF
--- a/Documentation/content/docs/develop_widget.md
+++ b/Documentation/content/docs/develop_widget.md
@@ -199,6 +199,10 @@ The widget behavior has also access to the renderer, openGLRenderWindow and inte
 
 ##### Focus
 
+"Focus" as a widget concept means that a particular widget should be the only one interactable. This use-case arises when there is a primary widget.
+
+An example is the paint widget needs focus, since when it's active it shouldn't be possible to move rulers, crosshairs, etc. The widget manager should only allow the paint state to be active, and not activate any other state.
+
 When a widget is given the focus, the widget behavior is notified through the `grabFocus()` method. This is usually the place to setup complex interaction states such as initializing the widget behavior's internal state (distinct from the widget state), starting animations (see Animations) or setting up the active state (see Active State).
 
 The `loseFocus()` method is called when the widget manager removes the focus from the widget. It can also be called by the widget behavior itself if necessary. For example, a widget might decide to lose the focus after the escape key was pressed.

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -498,7 +498,7 @@ export default function widgetBehavior(publicAPI, model) {
       publicAPI.invokeInteractionEvent();
     }
 
-    return model.hasFocus ? macro.EVENT_ABORT : macro.VOID;
+    return model.hasFocus || model.isDragging ? macro.EVENT_ABORT : macro.VOID;
   };
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
Mouse move events are no longer propagated to other widgets when dragging ShapeWidget handles

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: 22.4.0
  - **OS**: Ubuntu 20.04 LTS
  - **Browser**: Chromium 98.0.4697.0 
