### PR TITLE
Fix(pick): null actor object when returning selection

### DIFF
--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -65,7 +65,7 @@ function getPixelInformationWithData(
       buffdata.pixBuffer[PassTypes.ACTOR_PASS],
       buffdata.area
     );
-    if (actorid <= 0) {
+    if (actorid <= 0 || actorid - idOffset >= buffdata.props.length) {
       // the pixel did not hit any actor.
       return null;
     }
@@ -585,7 +585,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
         model.pixBuffer[PassTypes.ACTOR_PASS],
         model.area
       );
-      if (actorid <= 0) {
+      if (actorid <= 0 || actorid - idOffset >= model.props.length) {
         // the pixel did not hit any actor.
         return null;
       }


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->
In `vtkOpenglHardwareSelector`, functions `getPixelInformation()` and `getPixelInformationWithData()` return a valid flag when actor id read from the pixel buffer is positive. However, the actor id may not correspond to a valid actor object stored
in the model.props array. 

### Changes
An additional check is added for validating that the actor id corresponds to a valid array index. Else, a null selection is returned. This fix is related to a corresponding fix in react-vtk-js [PR 47](https://github.com/Kitware/react-vtk-js/pull/47) for picking the closest object from the mouse pointer position.
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] ~~Documentation and TypeScript definitions were updated to match those changes~~ NA

### Results
Actors that are not explicitly registered with the selector through a call to [`vtkOpenGLHardwareSelector.renderProp(prop)`](https://github.com/Kitware/vtk-js/blob/f7ee7bfd7bf3bb568d44a0d722ad732cb54a9ea4/Sources/Rendering/OpenGL/HardwareSelector/index.js#L506) will not participate in hardware picking, since the pointer to those actors will not be available to populate [`info.prop`](https://github.com/Kitware/vtk-js/blob/f7ee7bfd7bf3bb568d44a0d722ad732cb54a9ea4/Sources/Rendering/OpenGL/HardwareSelector/index.js#L597)
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] ~~This change adds or fixes unit tests~~ No
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: Windows 10 pro 21H2 19044.1466
  - **Browser**: Chrome 97.0.4692.99 (Windows 10)