### PR TITLE
fix(rendering): take fieldDataTupleId into account when mapping colors

### DIFF
--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -161,7 +161,11 @@ function vtkMapper(publicAPI, model) {
       if (lut) {
         // Ensure that the lookup table is built
         lut.build();
-        model.colorMapColors = lut.mapScalars(scalars, model.colorMode, -1);
+        model.colorMapColors = lut.mapScalars(
+          scalars,
+          model.colorMode,
+          model.fieldDataTupleId
+        );
       }
     }
     model.colorBuildString = `${publicAPI.getMTime()}${scalars.getMTime()}${alpha}`;

--- a/Sources/Rendering/Core/Mapper2D/index.js
+++ b/Sources/Rendering/Core/Mapper2D/index.js
@@ -133,7 +133,11 @@ function vtkMapper2D(publicAPI, model) {
     if (lut) {
       // Ensure that the lookup table is built
       lut.build();
-      model.colorMapColors = lut.mapScalars(scalars, model.colorMode, -1);
+      model.colorMapColors = lut.mapScalars(
+        scalars,
+        model.colorMode,
+        model.fieldDataTupleId
+      );
     }
     model.colorBuildString = `${publicAPI.getMTime()}${scalars.getMTime()}${alpha}`;
   };


### PR DESCRIPTION
Call `getFieldDataTupleId()` instead of a static `-1` when computing `colorMapColors`,
allowing `setFieldDataTupleId` to set the index of the data tuple by which the model should be colorized.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context

- fix #2266

### Changes
In both `Mapper` and `Mapper2D`, when mapping scalars to colors, pass `publicAPI.getFieldDataTupleId()` rather than a static `-1` as third argument to `lut.mapScalars()`.
As `fieldDataTupleId` defaults to `-1`, base behavior is not changed, while a call to `setFieldDataTupleId` is now taken into account.
- [ ] Documentation and TypeScript definitions were updated to match those changes --> No need, rather the behavior is aligned with current description of  `setFieldDataTupleId`.

### Results
- Before: call of `setFieldDataTupleId` was inoperant, the vector values at first index was always used
- After: values at expected index are used to color the geometry

### Testing
- [ ] This change adds or fixes unit tests
- [x] All tests complete without errors on the following environment:
  - **vtk.js**: 22.4.2
  - **OS**: Ubuntu 20
  - **Browser**: Any (Firefox, Chrome)
