### PR TITLE
fix(Rendering): a few fixes for Rendering

### DIFF
--- a/Sources/Rendering/OpenGL/index.js
+++ b/Sources/Rendering/OpenGL/index.js
@@ -16,6 +16,7 @@ import vtkPolyDataMapper from './PolyDataMapper';
 import vtkPolyDataMapper2D from './PolyDataMapper2D';
 import vtkRenderer from './Renderer';
 import vtkRenderWindow from './RenderWindow';
+import './ScalarBarActor';
 import vtkShader from './Shader';
 import vtkShaderCache from './ShaderCache';
 import vtkShaderProgram from './ShaderProgram';

--- a/Sources/Rendering/WebGPU/BufferManager/Constants.js
+++ b/Sources/Rendering/WebGPU/BufferManager/Constants.js
@@ -12,6 +12,7 @@ export const BufferUsage = {
   Texture: 10,
   RawVertex: 11,
   Storage: 12,
+  CellIndex: 13,
 };
 
 export const PrimitiveTypes = {

--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -342,7 +342,7 @@ function vtkWebGPUImageMapper(publicAPI, model) {
   publicAPI.updateBuffers = (device) => {
     const treq = {
       imageData: model.currentInput,
-      source: model.currentInput,
+      owner: model.currentInput.getPointData().getScalars(),
     };
     const newTex = device.getTextureManager().getTexture(treq);
     const tViews = model.helper.getTextureViews();

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -22,7 +22,7 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
     if (model.label) {
       model.handle.popDebugGroup();
     }
-    model.handle.endPass();
+    model.handle.end();
   };
 
   publicAPI.setPipeline = (pl) => {

--- a/Sources/Rendering/WebGPU/SphereMapper/index.js
+++ b/Sources/Rendering/WebGPU/SphereMapper/index.js
@@ -173,8 +173,8 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
     const vertexInput = model.primitives[i].getVertexInput();
 
     let buffRequest = {
-      hash: points.getMTime(),
-      source: points,
+      owner: points,
+      hash: 'spm',
       time: points.getMTime(),
       usage: BufferUsage.RawVertex,
       format: 'float32x3',
@@ -215,8 +215,8 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
     const defaultRadius = model.renderable.getRadius();
     if (scales || defaultRadius !== model._lastRadius) {
       buffRequest = {
-        hash: scales,
-        source: scales,
+        owner: scales,
+        hash: 'spm',
         time: scales
           ? pointData.getArray(model.renderable.getScaleArray()).getMTime()
           : 0,
@@ -255,8 +255,8 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
       const c = model.renderable.getColorMapColors();
       if (c) {
         buffRequest = {
-          hash: c,
-          source: c,
+          owner: c,
+          hash: 'spm',
           time: c.getMTime(),
           usage: BufferUsage.RawVertex,
           format: 'unorm8x4',

--- a/Sources/Rendering/WebGPU/StickMapper/index.js
+++ b/Sources/Rendering/WebGPU/StickMapper/index.js
@@ -272,8 +272,8 @@ function vtkWebGPUStickMapper(publicAPI, model) {
     const vertexInput = model.primitives[i].getVertexInput();
 
     let buffRequest = {
-      hash: points.getMTime(),
-      source: points,
+      owner: points,
+      hash: 'stm',
       time: points.getMTime(),
       usage: BufferUsage.RawVertex,
       format: 'float32x3',
@@ -307,8 +307,8 @@ function vtkWebGPUStickMapper(publicAPI, model) {
     const defaultRadius = model.renderable.getRadius();
     if (scales || defaultRadius !== model._lastRadius) {
       buffRequest = {
-        hash: scales,
-        source: scales,
+        owner: scales,
+        hash: 'stm',
         time: scales
           ? pointData.getArray(model.renderable.getScaleArray()).getMTime()
           : 0,
@@ -349,8 +349,8 @@ function vtkWebGPUStickMapper(publicAPI, model) {
     }
 
     buffRequest = {
-      hash: scales,
-      source: orientationArray,
+      owner: orientationArray,
+      hash: 'stm',
       time: pointData
         .getArray(model.renderable.getOrientationArray())
         .getMTime(),
@@ -386,8 +386,8 @@ function vtkWebGPUStickMapper(publicAPI, model) {
       const c = model.renderable.getColorMapColors();
       if (c) {
         buffRequest = {
-          hash: c,
-          source: c,
+          owner: c,
+          hash: 'stm',
           time: c.getMTime(),
           usage: BufferUsage.RawVertex,
           format: 'unorm8x4',

--- a/Sources/Rendering/WebGPU/TextureManager/index.js
+++ b/Sources/Rendering/WebGPU/TextureManager/index.js
@@ -8,13 +8,6 @@ const { VtkDataTypes } = vtkDataArray;
 // Global methods
 // ----------------------------------------------------------------------------
 
-function requestMatches(req1, req2) {
-  if (req1.time !== req2.time) return false;
-  if (req1.nativeArray !== req2.nativeArray) return false;
-  if (req1.format !== req2.format) return false;
-  return true;
-}
-
 // ----------------------------------------------------------------------------
 // vtkWebGPUTextureManager methods
 // ----------------------------------------------------------------------------
@@ -23,13 +16,8 @@ function vtkWebGPUTextureManager(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkWebGPUTextureManager');
 
-  // The keys fields of a request are
-  // - source, this is what owns the data and when it does away
-  //   the data should be freed
-  // - imageData - when provided use as the source of the data
-  //
-
-  publicAPI.getTexture = (req) => {
+  // fills in request values based on what is missing/provided
+  function _fillRequest(req) {
     // fill in values based on imageData if the request has it
     if (req.imageData) {
       req.dataArray = req.imageData.getPointData().getScalars();
@@ -82,19 +70,10 @@ function vtkWebGPUTextureManager(publicAPI, model) {
       req.depth = 1;
       req.format = 'rgba8unorm';
     }
+  }
 
-    if (req.source) {
-      // if a matching texture already exists then return it
-      if (model.textures.has(req.source)) {
-        const dabuffers = model.textures.get(req.source);
-        for (let i = 0; i < dabuffers.length; i++) {
-          if (requestMatches(dabuffers[i].request, req)) {
-            return dabuffers[i].texture;
-          }
-        }
-      }
-    }
-
+  // create a texture (used by getTexture)
+  function _createTexture(req) {
     const newTex = vtkWebGPUTexture.newInstance();
 
     newTex.create(model.device, {
@@ -108,26 +87,22 @@ function vtkWebGPUTextureManager(publicAPI, model) {
     if (req.nativeArray || req.image) {
       newTex.writeImageData(req);
     }
-
-    // cache the texture if we have a source
-    // We create a new req that only has the fields required for
-    // a comparison to avoid GC cycles
-    if (req.source) {
-      if (!model.textures.has(req.source)) {
-        model.textures.set(req.source, []);
-      }
-
-      const dabuffers = model.textures.get(req.source);
-      dabuffers.push({
-        request: {
-          time: req.time,
-          nativeArray: req.nativeArray,
-          format: req.format,
-        },
-        texture: newTex,
-      });
-    }
     return newTex;
+  }
+
+  // get a texture or create it if not cached.
+  // this is the main entry point
+  publicAPI.getTexture = (req) => {
+    // if we have a source the get/create/cache the texture
+    if (req.owner) {
+      // fill out the req time and format based on imageData/image
+      _fillRequest(req);
+      // if a matching texture already exists then return it
+      const hash = req.time + req.format;
+      return model.device.getCachedObject(req.owner, hash, _createTexture, req);
+    }
+
+    return _createTexture(req);
   };
 }
 
@@ -136,7 +111,6 @@ function vtkWebGPUTextureManager(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  textures: null,
   handle: null,
   device: null,
 };
@@ -148,9 +122,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   macro.obj(publicAPI, model);
-
-  // this is a cache, and a cache with GC pretty much means WeakMap
-  model.textures = new WeakMap();
 
   macro.setGet(publicAPI, model, ['device']);
 

--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -344,19 +344,18 @@ function vtkWebGPUVolumePass(publicAPI, model) {
 
     const pd = model._boundsPoly;
     const cells = pd.getPolys();
-    const hash = cells.getMTime();
     // points
     const points = pd.getPoints();
     const buffRequest = {
-      hash: hash + points.getMTime(),
+      owner: points,
+      usage: BufferUsage.PointArray,
+      format: 'float32x4',
+      time: Math.max(points.getMTime(), cells.getMTime()),
+      hash: 'vp',
       dataArray: points,
-      source: points,
       cells,
       primitiveType: PrimitiveTypes.Triangles,
       representation: Representation.SURFACE,
-      time: Math.max(points.getMTime(), cells.getMTime()),
-      usage: BufferUsage.PointArray,
-      format: 'float32x4',
       packExtra: true,
     };
     const buff = viewNode.getDevice().getBufferManager().getBuffer(buffRequest);

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -870,7 +870,7 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
 
       const treq = {
         imageData: image,
-        source: image,
+        owner: image.getPointData().getScalars(),
       };
       const newTex = device.getTextureManager().getTexture(treq);
       if (

--- a/Sources/Rendering/WebGPU/index.js
+++ b/Sources/Rendering/WebGPU/index.js
@@ -1,4 +1,20 @@
 import vtkRenderWindow from './RenderWindow';
+import './Actor';
+import './Camera';
+import './ForwardPass';
+import './Glyph3DMapper';
+import './HardwareSelector';
+import './ImageMapper';
+import './ImageSlice';
+import './PixelSpaceCallbackMapper';
+import './PolyDataMapper';
+import './Renderer';
+import './ScalarBarActor';
+import './SphereMapper';
+import './StickMapper';
+import './Texture';
+import './ViewNodeFactory';
+import './Volume';
 
 export default {
   vtkRenderWindow,


### PR DESCRIPTION
### Changes

1) Fix for missing WebGL ScalarBarActor

2) Update to lates WebGPU that renamed endPass() to end()

3) move buffer and texture caches into a single
device based cache that can be used more generally.
This is a precurser to adding index buffers and a
mapping between original points and flat interpolated cell
data safe points (e.g. each point is only used as the provoking
vertex of a cell once)

Addresses https://discourse.vtk.org/t/typeerror-cannot-read-properties-of-undefined-reading-traverse/7803