### PR TITLE
fix(ArrowHandleRepresentation): do not zero out Z

### DIFF
--- a/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
@@ -199,7 +199,6 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
     const baseDir = [0, 1, 0];
 
     vec3.transformMat3(displayOrientation, model.orientation, viewMatrixInv);
-    displayOrientation[2] = 0;
 
     const displayMatrix = vtkMatrixBuilder
       .buildFromDegree()


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
- LineWidget example fails to have oriented handles when using a non-default plane manipulator normal.

### Changes
- [ ] remove code that zeros out the Z component of an orientation vector

### Results
- oriented handles work properly in the LineWidget example
