### PR TITLE
perf: further improve fastComputeRange performance (~20% boost in some cases)

### DIFF
--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -13,17 +13,25 @@ const TUPLE_HOLDER = [];
 // Modified to accept type arrays
 function fastComputeRange(arr, offset, numberOfComponents) {
   const len = arr.length;
-  let min;
-  let max;
-  let x;
-  let i;
 
   if (len === 0) {
     return { min: Number.MAX_VALUE, max: -Number.MAX_VALUE };
   }
-  min = arr[offset];
-  max = min;
-  for (i = offset; i < len; i += numberOfComponents) {
+
+  if (numberOfComponents === 1) {
+    const offsetArr = offset !== 0 ? arr.slice(offset) : arr;
+    const sorted = offsetArr.sort();
+
+    const min = sorted[0];
+    const max = sorted[sorted.length - 1];
+    return { min, max };
+  }
+
+  let x;
+  let min = arr[offset];
+  let max = min;
+
+  for (let i = offset; i < len; i += numberOfComponents) {
     x = arr[i];
     if (x < min) {
       min = x;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
-->
`Array.prototype.sort` can be used to speed up the range computation when `numberOfComponents` equals `1`.

Benchmarks: [jsbench.me/kokzo24f6t/1](https://jsbench.me/kokzo24f6t/1)

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why. Tests should be added for new functionality and existing tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests
- [ ] All tests complete without errors on the following environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!-- Remove the line below if it is not relevant -->
_This contribution is funded by [Example](https://example.com)._
