### PR TITLE
fix(ColorTransferFunction): updates to nodes don't update mtime

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -217,7 +217,10 @@ function vtkColorTransferFunction(publicAPI, model) {
       const before = JSON.stringify(model.nodes);
       model.nodes = nodes;
       const after = JSON.stringify(model.nodes);
-      return publicAPI.sortAndUpdateRange() || before !== after;
+      if (publicAPI.sortAndUpdateRange() || before !== after) {
+        publicAPI.modified();
+        return true;
+      }
     }
     return false;
   };


### PR DESCRIPTION
Change vtkColorTransferFunction.setNodes() to update mtime if the field changes.

The symptom is that when we use SynchronizableRenderWindow to update the
colormap from a remote server, the browser doesn't update the renderview unless
the update also changes other fields of vtkColorTransferFunction.
