### PR TITLE
ci(GraphicalTesting): Bump Docker image to thewtex/opengl:ubuntu2004

### DIFF
--- a/Utilities/ci/run-tests-in-docker.sh
+++ b/Utilities/ci/run-tests-in-docker.sh
@@ -3,7 +3,7 @@
 # Source: https://github.com/thewtex/docker-opengl/tree/webgl
 
 container=webgl
-image=thewtex/opengl:ubuntu1804
+image=thewtex/opengl:ubuntu2004
 port=6080
 extra_run_args=""
 quiet=""


### PR DESCRIPTION
Firefox bump from 76.0 to 94.0.
