### PR TITLE
docs(ts): imageData optional arguments

### DIFF
--- a/Sources/Common/Core/MatrixBuilder/index.d.ts
+++ b/Sources/Common/Core/MatrixBuilder/index.d.ts
@@ -1,5 +1,5 @@
 import { mat4 } from 'gl-matrix';
-import { TypedArray } from '../../../types';
+import { TypedArray, Vector3 } from '../../../types';
 
 declare interface Transform {
 
@@ -22,9 +22,9 @@ declare interface Transform {
 	 * Normalizes the axis of rotation then rotates the current matrix `angle`
 	 * degrees/radians around the provided axis.
 	 * @param {Number} angle 
-	 * @param {Number} axis 
+	 * @param {Vector3} axis 
 	 */
-	rotate(angle: number, axis: number): Transform
+	rotate(angle: number, axis: Vector3): Transform
 
 	/**
 	 * Rotates `angle` degrees/radians around the X axis.

--- a/Sources/Common/DataModel/ImageData/index.d.ts
+++ b/Sources/Common/DataModel/ImageData/index.d.ts
@@ -201,17 +201,18 @@ export interface vtkImageData extends vtkDataSet {
 	/**
 	 * this is the fast version, requires vec3 arguments
 	 * @param {ReadonlyVec3} vin 
-	 * @param {vec3} vout 
+	 * @param {vec3} [vout] 
 	 */
-	indexToWorldVec3(vin: ReadonlyVec3, vout: vec3): vec3;
+	indexToWorldVec3(vin: ReadonlyVec3, vout?: vec3): vec3;
 
 	/**
-	 * Converts the input index vector `[i,j,k]` to world values `[x,y,z]`.
-	 * Modifies the out vector array in place, but also returns it.
+	 * Converts the input index vector `[i,j,k]` to world values `[x,y,z]`. 
+	 * If an out vector is not provided, a new one is created. If provided, it
+	 * modifies the out vector array in place, but also returns it.
 	 * @param {ReadonlyVec3} ain 
-	 * @param {vec3} aout 
+	 * @param {vec3} [aout] 
 	 */
-	indexToWorld(ain: ReadonlyVec3, aout: vec3): vec3;
+	indexToWorld(ain: ReadonlyVec3, aout?: vec3): vec3;
 
 	/**
 	 * Calculate the corresponding world bounds for the given index bounds
@@ -308,18 +309,19 @@ export interface vtkImageData extends vtkDataSet {
 	/**
 	 * this is the fast version, requires vec3 arguments
 	 * @param vin 
-	 * @param vout 
+	 * @param [vout] 
 	 */
-	worldToIndexVec3(vin: ReadonlyVec3, vout: vec3): vec3;
+	worldToIndexVec3(vin: ReadonlyVec3, vout?: vec3): vec3;
 
 	/**
 	 * Converts the input world vector `[x,y,z]` to approximate index values
 	 * `[i,j,k]`. Should be rounded to integers before attempting to access the
-	 * index. Modifies the out vector array in place, but also returns it.
+	 * index. If an out vector is not provided, a new one is created. If provided, it
+	 * modifies the out vector array in place, but also returns it.
 	 * @param ain 
-	 * @param aout 
+	 * @param [aout] 
 	 */
-	worldToIndex(ain: ReadonlyVec3, aout: vec3): vec3;
+	worldToIndex(ain: ReadonlyVec3, aout?: vec3): vec3;
 
 	/**
 	 * Calculate the corresponding index bounds for the given world bounds


### PR DESCRIPTION
I'm not sure how `.d.ts` types are generated in `vtk.js`, probably manually?
I found two wrong type definitions and this PR fixes them.

Affected files:
- `Sources/Common/Core/MatrixBuilder` 
- `Sources/Common/DataModel/ImageData` 
