### PR TITLE
feat(vtkimageinterpolator): add linear interpolation

### DIFF
--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -1118,11 +1118,11 @@ export function extend(publicAPI, model, initialValues = {}) {
     'mirror',
     'border',
     'backgroundColor',
+    'interpolationMode',
     'slabMode',
     'slabTrapezoidIntegration',
     'slabNumberOfSlices',
     'slabSliceSpacingFraction',
-    'interpolationMode',
   ]);
 
   macro.setGetArray(publicAPI, model, ['outputOrigin', 'outputSpacing'], 3);

--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -1122,6 +1122,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'slabTrapezoidIntegration',
     'slabNumberOfSlices',
     'slabSliceSpacingFraction',
+    'interpolationMode',
   ]);
 
   macro.setGetArray(publicAPI, model, ['outputOrigin', 'outputSpacing'], 3);

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
@@ -40,8 +40,17 @@
     <td id='slabNumberValue'>1</td>
   </tr>
   <tr>
+    <td>Interpolation mode :</td>
     <td>
-      <button id="buttonReset">Reset views:</button>
+      <select id="selectInterpolation">
+        <option id="nearest" selected="selected">Nearest</option>
+        <option id="linear">Linear</option>
+      </select>
     </td>
-  </tr>  
+  </tr>
+  <tr>
+    <td>
+      <button id="buttonReset">Reset views</button>
+    </td>
+  </tr>
 </table>

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -441,3 +441,11 @@ buttonReset.addEventListener('click', () => {
   widget.setCenter(widget.getWidgetState().getImage().getCenter());
   updateViews();
 });
+
+const selectInterpolationMode = document.getElementById('selectInterpolation');
+selectInterpolationMode.addEventListener('change', (ev) => {
+  viewAttributes.forEach((obj) => {
+    obj.reslice.setInterpolationMode(Number(ev.target.selectedIndex));
+  });
+  updateViews();
+});


### PR DESCRIPTION
### Context
If we use data headsq.vti in the vtkResliceCursorWidget example, we can see that when we rotate a vue, there are artifacts in the rotated view because of the interpolation. A linear interpolation instead of a nearest interpolation is needed.
![image](https://user-images.githubusercontent.com/11785751/158350022-27cf446e-0e07-4a6f-b7cb-6067886c9915.png)

### Results
Before
![image](https://user-images.githubusercontent.com/11785751/158350265-719fd15c-5e30-4fd7-82e9-eb36532744e2.png)
After
![image](https://user-images.githubusercontent.com/11785751/158350305-419af0c7-8bd7-43c4-a10f-dccfd9205728.png)


### Changes
Add methods in vtkImageInterpolator called when interpolation mode is LINEAR.
Allow to set the interpolation mode from vtkImageReslice.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
