### PR TITLE
refactor(boundingbox): return updated bounds instead of nothing

### DIFF
--- a/Sources/Common/DataModel/BoundingBox/api.md
+++ b/Sources/Common/DataModel/BoundingBox/api.md
@@ -21,10 +21,12 @@ is less than the min point then the  min point will also be changed
 Change bounding box so it includes the point p
 Note that the bounding box may have 0 volume if its bounds
 were just initialized.
+Returns the updated bounds
 
 ### addBounds(bounds[6], xMin, xMax, yMin, yMax, zMin, zMax)
 
 Change the bounding box so it includes bounds (defined by vtk standard)
+Returns the updated bounds
 
 ### intersect(bounds[6], otherBounds[6]) : Boolean
 
@@ -87,6 +89,7 @@ Return the length of the diagonal or null if not valid.
 
 Expand the Box by delta on each side, the box will grow by
 2*delta in x, y and z
+Returns the updated bounds
 
 ### isValid(bounds[6])
 
@@ -103,4 +106,4 @@ Scale each dimension of the box by some given factor.
 If the box is not valid, it stays unchanged.
 If the scalar factor is negative, bounds are flipped: for example,
 if (xMin,xMax)=(-2,4) and sx=-3, (xMin,xMax) becomes (-12,6).
-
+Returns the updated bounds

--- a/Sources/Common/DataModel/BoundingBox/index.js
+++ b/Sources/Common/DataModel/BoundingBox/index.js
@@ -53,6 +53,7 @@ export function addPoint(bounds, ...xyz) {
   bounds[3] = yMax > xyz[1] ? yMax : xyz[1];
   bounds[4] = zMin < xyz[2] ? zMin : xyz[2];
   bounds[5] = zMax > xyz[2] ? zMax : xyz[2];
+  return bounds;
 }
 
 export function addBounds(bounds, xMin, xMax, yMin, yMax, zMin, zMax) {
@@ -72,6 +73,7 @@ export function addBounds(bounds, xMin, xMax, yMin, yMax, zMin, zMax) {
     bounds[4] = Math.min(zMin, _zMin);
     bounds[5] = Math.max(zMax, _zMax);
   }
+  return bounds;
 }
 
 export function setMinPoint(bounds, x, y, z) {
@@ -104,6 +106,7 @@ export function inflate(bounds, delta) {
   bounds[3] += delta;
   bounds[4] -= delta;
   bounds[5] += delta;
+  return bounds;
 }
 
 export function scale(bounds, sx, sy, sz) {
@@ -211,6 +214,7 @@ export function getCorners(bounds, corners) {
       }
     }
   }
+  return corners;
 }
 
 // Computes the two corners with minimal and miximal coordinates
@@ -222,6 +226,7 @@ export function computeCornerPoints(bounds, point1, point2) {
   point2[0] = bounds[1];
   point2[1] = bounds[3];
   point2[2] = bounds[5];
+  return point1;
 }
 
 export function computeScale3(bounds, scale3 = []) {
@@ -571,8 +576,7 @@ class BoundingBox {
   constructor(refBounds) {
     this.bounds = refBounds;
     if (!this.bounds) {
-      this.bounds = new Float64Array(6);
-      setBounds(this.bounds, INIT_BOUNDS);
+      this.bounds = new Float64Array(INIT_BOUNDS);
     }
   }
 

--- a/Sources/Common/DataModel/BoundingBox/test/testBoundingBox.js
+++ b/Sources/Common/DataModel/BoundingBox/test/testBoundingBox.js
@@ -1,5 +1,23 @@
 import test from 'tape-catch';
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
+
+test('Test vtkBoundingBox inflate', (t) => {
+  const bounds = [0, 10, 10, 20, -10, 10];
+  const inflated = [-0.5, 10.5, 9.5, 20.5, -10.5, 10.5];
+
+  const bbox = vtkBoundingBox.newInstance();
+  bbox.setBounds(bounds);
+  let inflatedBounds = bbox.inflate(0.5);
+  t.ok(vtkMath.areEquals(inflatedBounds, inflated));
+  t.ok(vtkMath.areEquals(bbox.getBounds(), inflated));
+
+  inflatedBounds = vtkBoundingBox.inflate(bounds, 0.5);
+  t.ok(vtkMath.areEquals(inflatedBounds, inflated));
+  t.ok(vtkMath.areEquals(bounds, inflated));
+
+  t.end();
+});
 
 test('Test vtkBoundingBox intersectBox', (t) => {
   const bounds = [-50, 50, -50, 50, -50, 50];


### PR DESCRIPTION
Also speed-up vtkBoundingBox constructor

### Context
Some vtkBoundingBox functions do not return anything.
It would be more convenient to return the updated bounds.

### Results
BEFORE:
```
const bbox = vtkBoundingBox.newInstance();
bbox.setBounds(originalBounds);
bbox.inflate(10);
return bbox.getBounds();
```
AFTER:
```
const bbox = vtkBoundingBox.newInstance();
bbox.setBounds(originalBounds);
return bbox.inflate(10);
```

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome 99.0.4844.82
