### PR TITLE
fix(DataAccessHelper): ts defs default export

### DIFF
--- a/Sources/IO/Core/DataAccessHelper/index.d.ts
+++ b/Sources/IO/Core/DataAccessHelper/index.d.ts
@@ -29,4 +29,10 @@ export interface DataAccessHelper {
 	registerType(type: string, fn: any): void;
 }
 
+export declare const DataAccessHelper: {
+	has: typeof has,
+	get: typeof get,
+	registerType: typeof registerType,
+}
+
 export default DataAccessHelper;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
- https://discourse.vtk.org/t/dataaccesshelper-is-not-defined/8139/4

### Results
- `DataAccessHelper` default export now has `has`, `get`, and `registerType`.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: master

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
