### PR TITLE
fix(OBBTree): send almost-zero components to zero

### DIFF
--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -867,7 +867,7 @@ export function jacobiN(a, n, w, v) {
     tmp = w[k];
     for (i = j + 1; i < n; i++) {
       // boundary incorrect, shifted already
-      if (w[i] >= tmp) {
+      if (w[i] >= tmp || Math.abs(w[i] - tmp) < VTK_SMALL_NUMBER) {
         // why exchange if same?
         k = i;
         tmp = w[k];

--- a/Sources/Filters/General/OBBTree/index.js
+++ b/Sources/Filters/General/OBBTree/index.js
@@ -157,6 +157,10 @@ function vtkOBBTree(publicAPI, model) {
     for (let i = 0; i < 3; i++) {
       for (let j = 0; j < 3; j++) {
         a[i][j] = a[i][j] / totMass - mean[i] * mean[j];
+        // send to zero if close to zero
+        if (Math.abs(a[i][j]) < 1e-12) {
+          a[i][j] = 0;
+        }
       }
     }
 

--- a/Sources/Filters/General/OBBTree/test/testOBBTree.js
+++ b/Sources/Filters/General/OBBTree/test/testOBBTree.js
@@ -27,10 +27,10 @@ test('Test OBB tree constructor', (t) => {
   const size = [0, 0, 0];
   const computedValues = [corner, max, mid, min, size];
   const expectedValues = [
-    { name: 'corner', value: [0.675, -0.1366, 0] },
-    { name: 'max', value: [-1, 0, 0] },
-    { name: 'mid', value: [0, 0.1366, 0.1366] },
-    { name: 'min', value: [0, 0.1366, -0.1366] },
+    { name: 'corner', value: [-0.325, -0.1, -0.0866] },
+    { name: 'max', value: [1, 0, 0] },
+    { name: 'mid', value: [0, 0, 0.1732] },
+    { name: 'min', value: [0, 0.2, 0] },
     { name: 'size', value: [0.0658262, 0.00126738, 0.00126738] },
   ];
 
@@ -65,8 +65,8 @@ test('Test OBB tree transform', (t) => {
   const expectedValues = [
     { name: 'corner', value: [-0.5, -0.5, -0.5] },
     { name: 'max', value: [0, 0, 1] },
-    { name: 'mid', value: [0, 1, 0] },
-    { name: 'min', value: [1, 0, 0] },
+    { name: 'mid', value: [1, 0, 0] },
+    { name: 'min', value: [0, 1, 0] },
     { name: 'size', value: [0.13888, 0.13888, 0.13888] },
   ];
   computedValues.forEach((value, index) => {


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
~`vtkMath.jacobi` is giving some strange results when off-diagonal components are not quite zero. In the below code, if `v=0`, then we get what we'd expect: the eigenvectors are the unit basis vectors. But if `v=1e-12`, then we do not get that, as shown below the code listing.~

Upon some more testing, the values are valid. I will do some last-minute testing to verify OBB outputs.

```
const vals = [0, 0, 0];
const vecs = [
  [0, 0, 0],
  [0, 0, 0],
  [0, 0, 0],
];
const v = 1e-12;
vtkMath.jacobi(
  [
    [0.5, v, v],
    [v, 0.5, v],
    [v, v, 0.5],
  ],
  vals,
  vecs
);

console.log(vals)
console.log(vecs)

// eigenvalues: [0.500000000002, 0.499999999999, 0.49999999999899997]
// eigenvectors: 
//  [0.577348850073642, 0.7071067811853349, 0.40825029739163465]
//  [0.5773488500736421, -0.7071067811877602, 0.40825029738743396]
//  [0.5773531074111288, 2.425284842538276e-12, -0.8164945739946553]
```

In the interest of getting the `beta` branch ready, I'm opting to add the zeroing logic to OBBTree, and reserve the `vtkMath.jacobi` fix+discussion for later.

### Results
- OBBTree should(?) be more correct

### Changes
- updated tests for OBBTree
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
