### PR TITLE
fix(getstate): fix getState() on VTK objects

### DIFF
--- a/Examples/Widgets/Box/BoxWidget.js
+++ b/Examples/Widgets/Box/BoxWidget.js
@@ -26,7 +26,7 @@ function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
     isDragging = true;
-    model.interactor.requestAnimation(publicAPI);
+    model._interactor.requestAnimation(publicAPI);
     return macro.EVENT_ABORT;
   };
 
@@ -39,7 +39,7 @@ function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
     }
     isDragging = false;
     model.widgetState.deactivate();

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -300,7 +300,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.beginSelection = () => {
     model._openGLRenderer = model._openGLRenderWindow.getViewNodeFor(
-      model.renderer
+      model._renderer
     );
     model.maxAttributeId = 0;
 
@@ -360,7 +360,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
   publicAPI.getSourceDataAsync = async (renderer, fx1, fy1, fx2, fy2) => {
     // assign the renderer
-    model.renderer = renderer;
+    model._renderer = renderer;
 
     // set area to all if no arguments provided
     if (fx1 === undefined) {
@@ -390,13 +390,13 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.captureBuffers = () => {
-    if (!model.renderer || !model._openGLRenderWindow) {
+    if (!model._renderer || !model._openGLRenderWindow) {
       vtkErrorMacro('Renderer and view must be set before calling Select.');
       return false;
     }
 
     model._openGLRenderer = model._openGLRenderWindow.getViewNodeFor(
-      model.renderer
+      model._renderer
     );
 
     // todo revisit making selection part of core
@@ -414,8 +414,8 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
     // Initialize renderer for selection.
     // change the renderer's background to black, which will indicate a miss
-    model.originalBackground = model.renderer.getBackgroundByReference();
-    model.renderer.setBackground(0.0, 0.0, 0.0);
+    model.originalBackground = model._renderer.getBackgroundByReference();
+    model._renderer.setBackground(0.0, 0.0, 0.0);
     const rpasses = model._openGLRenderWindow.getRenderPasses();
 
     publicAPI.beginSelection();
@@ -445,7 +445,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
     publicAPI.endSelection();
 
     // restore original background
-    model.renderer.setBackground(model.originalBackground);
+    model._renderer.setBackground(model.originalBackground);
     publicAPI.invokeEvent({ type: 'EndEvent' });
 
     // restore image, not needed?
@@ -721,7 +721,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
       model.fieldAssociation,
       dataMap,
       model.captureZValues,
-      model.renderer,
+      model._renderer,
       model._openGLRenderWindow
     );
   };
@@ -730,7 +730,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
 
   publicAPI.attach = (w, r) => {
     model._openGLRenderWindow = w;
-    model.renderer = r;
+    model._renderer = r;
   };
 
   // override

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -187,7 +187,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   context: null,
-  _openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
   selector: null,
 };
 
@@ -203,6 +203,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.get(publicAPI, model, ['shaderCache']);
 
   macro.setGet(publicAPI, model, ['selector']);
+
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
 
   // Object methods
   vtkOpenGLRenderer(publicAPI, model);

--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -54,7 +54,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setScale1(moveHandle.getScale1());
     } else {
       isDragging = true;
-      model.apiSpecificRenderWindow.setCursor('grabbing');
+      model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
     }
 
@@ -76,10 +76,10 @@ export default function widgetBehavior(publicAPI, model) {
       !ignoreKey(callData)
     ) {
       model.manipulator.setOrigin(model.activeState.getOrigin());
-      model.manipulator.setNormal(model.camera.getDirectionOfProjection());
+      model.manipulator.setNormal(model._camera.getDirectionOfProjection());
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.apiSpecificRenderWindow
+        model._apiSpecificRenderWindow
       );
 
       if (
@@ -92,7 +92,7 @@ export default function widgetBehavior(publicAPI, model) {
       }
     }
     if (model.hasFocus) {
-      model.widgetManager.disablePicking();
+      model._widgetManager.disablePicking();
     }
     return macro.VOID;
   };
@@ -103,7 +103,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
-      model.apiSpecificRenderWindow.setCursor('pointer');
+      model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
@@ -116,7 +116,7 @@ export default function widgetBehavior(publicAPI, model) {
       (model.activeState && !model.activeState.getActive())
     ) {
       publicAPI.invokeEndInteractionEvent();
-      model.widgetManager.enablePicking();
+      model._widgetManager.enablePicking();
       model._interactor.render();
     }
 
@@ -158,7 +158,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.getMoveHandle().setVisible(false);
     model.activeState = null;
     model.hasFocus = false;
-    model.widgetManager.enablePicking();
+    model._widgetManager.enablePicking();
     model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -47,7 +47,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setScale1(moveHandle.getScale1());
     } else {
       isDragging = true;
-      model.apiSpecificRenderWindow.setCursor('grabbing');
+      model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
     }
 
@@ -78,7 +78,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.apiSpecificRenderWindow
+        model._apiSpecificRenderWindow
       );
 
       if (
@@ -100,7 +100,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
-      model.apiSpecificRenderWindow.setCursor('pointer');
+      model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
@@ -113,7 +113,7 @@ export default function widgetBehavior(publicAPI, model) {
       (model.activeState && !model.activeState.getActive())
     ) {
       publicAPI.invokeEndInteractionEvent();
-      model.widgetManager.enablePicking();
+      model._widgetManager.enablePicking();
       model._interactor.render();
     }
 
@@ -150,7 +150,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.getMoveHandle().setVisible(false);
     model.activeState = null;
     model.hasFocus = false;
-    model.widgetManager.enablePicking();
+    model._widgetManager.enablePicking();
     model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
@@ -55,10 +55,10 @@ export default function widgetBehavior(publicAPI, model) {
 
         if (type === 'corners') {
           // manipulator should be a plane manipulator
-          manipulator.setNormal(model.camera.getDirectionOfProjection());
+          manipulator.setNormal(model._camera.getDirectionOfProjection());
           worldCoords = manipulator.handleEvent(
             callData,
-            model.apiSpecificRenderWindow
+            model._apiSpecificRenderWindow
           );
         }
 
@@ -80,7 +80,7 @@ export default function widgetBehavior(publicAPI, model) {
           manipulator.setNormal(rotateVec3(constraintAxis, indexToWorldT));
           worldCoords = manipulator.handleEvent(
             callData,
-            model.apiSpecificRenderWindow
+            model._apiSpecificRenderWindow
           );
         }
 
@@ -91,7 +91,7 @@ export default function widgetBehavior(publicAPI, model) {
           manipulator.setNormal(rotateVec3(edgeAxis, indexToWorldT));
           worldCoords = manipulator.handleEvent(
             callData,
-            model.apiSpecificRenderWindow
+            model._apiSpecificRenderWindow
           );
         }
 
@@ -122,7 +122,7 @@ export default function widgetBehavior(publicAPI, model) {
   // initialization
   // --------------------------------------------------------------------------
 
-  model.camera = model.renderer.getActiveCamera();
+  model._camera = model._renderer.getActiveCamera();
 
   model.classHierarchy.push('vtkImageCroppingWidgetProp');
 }

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
@@ -21,16 +21,16 @@ function widgetBehavior(publicAPI, model) {
   publicAPI.updateCursor = () => {
     switch (model.activeState.getUpdateMethodName()) {
       case 'updateFromOrigin':
-        model.apiSpecificRenderWindow.setCursor('crosshair');
+        model._apiSpecificRenderWindow.setCursor('crosshair');
         break;
       case 'updateFromPlane':
-        model.apiSpecificRenderWindow.setCursor('move');
+        model._apiSpecificRenderWindow.setCursor('move');
         break;
       case 'updateFromNormal':
-        model.apiSpecificRenderWindow.setCursor('alias');
+        model._apiSpecificRenderWindow.setCursor('alias');
         break;
       default:
-        model.apiSpecificRenderWindow.setCursor('grabbing');
+        model._apiSpecificRenderWindow.setCursor('grabbing');
         break;
     }
   };
@@ -86,7 +86,7 @@ function widgetBehavior(publicAPI, model) {
     model.planeManipulator.setNormal(model.widgetState.getNormal());
     const worldCoords = model.planeManipulator.handleEvent(
       callData,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
 
     if (model.widgetState.containsPoint(worldCoords)) {
@@ -101,7 +101,7 @@ function widgetBehavior(publicAPI, model) {
     model.lineManipulator.setNormal(model.activeState.getNormal());
     const worldCoords = model.lineManipulator.handleEvent(
       callData,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
 
     if (model.widgetState.containsPoint(...worldCoords)) {
@@ -116,7 +116,7 @@ function widgetBehavior(publicAPI, model) {
 
     const newNormal = model.trackballManipulator.handleEvent(
       callData,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
     model.activeState.setNormal(newNormal);
   };

--- a/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
@@ -15,7 +15,7 @@ export default function widgetBehavior(publicAPI, model) {
       ...model.representations[1].getCircleProps(),
       visible: !text,
     });
-    model.interactor.render();
+    model._interactor.render();
   };
 
   publicAPI.getText = () => model.widgetState.getText().getText();
@@ -56,8 +56,8 @@ export default function widgetBehavior(publicAPI, model) {
       publicAPI.loseFocus();
     } else {
       model.isDragging = true;
-      model.apiSpecificRenderWindow.setCursor('grabbing');
-      model.interactor.requestAnimation(publicAPI);
+      model._apiSpecificRenderWindow.setCursor('grabbing');
+      model._interactor.requestAnimation(publicAPI);
     }
 
     publicAPI.invokeStartInteractionEvent();
@@ -70,9 +70,9 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (model.isDragging && model.pickable) {
-      model.apiSpecificRenderWindow.setCursor('pointer');
+      model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     } else if (model.activeState !== model.widgetState.getMoveHandle()) {
       model.widgetState.deactivate();
@@ -83,8 +83,8 @@ export default function widgetBehavior(publicAPI, model) {
       (model.activeState && !model.activeState.getActive())
     ) {
       publicAPI.invokeEndInteractionEvent();
-      model.widgetManager.enablePicking();
-      model.interactor.render();
+      model._widgetManager.enablePicking();
+      model._interactor.render();
     }
 
     model.isDragging = false;
@@ -105,7 +105,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.apiSpecificRenderWindow
+        model._apiSpecificRenderWindow
       );
 
       if (
@@ -139,7 +139,7 @@ export default function widgetBehavior(publicAPI, model) {
 
       model.activeState = model.widgetState.getMoveHandle();
       model.widgetState.getMoveHandle().activate();
-      model.interactor.requestAnimation(publicAPI);
+      model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
     model.hasFocus = true;
@@ -147,14 +147,14 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.loseFocus = () => {
     if (model.hasFocus) {
-      model.interactor.cancelAnimation(publicAPI);
+      model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
     }
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
     model.activeState = null;
     model.hasFocus = false;
-    model.widgetManager.enablePicking();
-    model.interactor.render();
+    model._widgetManager.enablePicking();
+    model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -39,9 +39,12 @@ export default function widgetBehavior(publicAPI, model) {
   function updateCursor(callData) {
     model.isDragging = true;
     model.previousPosition = [
-      ...model.manipulator.handleEvent(callData, model.apiSpecificRenderWindow),
+      ...model.manipulator.handleEvent(
+        callData,
+        model._apiSpecificRenderWindow
+      ),
     ];
-    model.apiSpecificRenderWindow.setCursor('grabbing');
+    model._apiSpecificRenderWindow.setCursor('grabbing');
     model._interactor.requestAnimation(publicAPI);
   }
 
@@ -104,11 +107,11 @@ export default function widgetBehavior(publicAPI, model) {
 
   function computeMousePosition(p1, callData) {
     const displayMousePos = publicAPI.computeWorldToDisplay(
-      model.renderer,
+      model._renderer,
       ...p1
     );
     const worldMousePos = publicAPI.computeDisplayToWorld(
-      model.renderer,
+      model._renderer,
       callData.position.x,
       callData.position.y,
       displayMousePos[2]
@@ -147,10 +150,10 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.rotateHandlesToFaceCamera = () => {
     model.representations[0].setViewMatrix(
-      Array.from(model.camera.getViewMatrix())
+      Array.from(model._camera.getViewMatrix())
     );
     model.representations[1].setViewMatrix(
-      Array.from(model.camera.getViewMatrix())
+      Array.from(model._camera.getViewMatrix())
     );
   };
 
@@ -263,7 +266,7 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.apiSpecificRenderWindow
+        model._apiSpecificRenderWindow
       );
       const translation = model.previousPosition
         ? vtkMath.subtract(worldCoords, model.previousPosition, [])
@@ -320,12 +323,12 @@ export default function widgetBehavior(publicAPI, model) {
       if (!wasTextActive) {
         model._interactor.cancelAnimation(publicAPI);
       }
-      model.apiSpecificRenderWindow.setCursor('pointer');
+      model._apiSpecificRenderWindow.setCursor('pointer');
 
       model.hasFocus = false;
 
       publicAPI.invokeEndInteractionEvent();
-      model.widgetManager.enablePicking();
+      model._widgetManager.enablePicking();
       model._interactor.render();
     }
 
@@ -365,7 +368,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.getMoveHandle().deactivate();
     model.activeState = null;
     model.hasFocus = false;
-    model.widgetManager.enablePicking();
+    model._widgetManager.enablePicking();
     model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -35,8 +35,8 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState &&
       model.activeState.getActive()
     ) {
-      const normal = model.camera.getDirectionOfProjection();
-      const up = model.camera.getViewUp();
+      const normal = model._camera.getDirectionOfProjection();
+      const up = model._camera.getViewUp();
       const right = [];
       vec3.cross(right, up, normal);
       model.activeState.setUp(...up);
@@ -46,7 +46,7 @@ export default function widgetBehavior(publicAPI, model) {
 
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.apiSpecificRenderWindow
+        model._apiSpecificRenderWindow
       );
 
       if (worldCoords.length) {
@@ -79,7 +79,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState.activate();
       model._interactor.requestAnimation(publicAPI);
 
-      const canvas = model.apiSpecificRenderWindow.getCanvas();
+      const canvas = model._apiSpecificRenderWindow.getCanvas();
       canvas.onmouseenter = () => {
         if (
           model.hasFocus &&

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -70,7 +70,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setScale1(moveHandle.getScale1());
     } else {
       isDragging = true;
-      model.apiSpecificRenderWindow.setCursor('grabbing');
+      model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
     }
 
@@ -92,10 +92,10 @@ export default function widgetBehavior(publicAPI, model) {
       !ignoreKey(callData)
     ) {
       model.manipulator.setOrigin(model.activeState.getOrigin());
-      model.manipulator.setNormal(model.camera.getDirectionOfProjection());
+      model.manipulator.setNormal(model._camera.getDirectionOfProjection());
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.apiSpecificRenderWindow
+        model._apiSpecificRenderWindow
       );
 
       if (
@@ -108,7 +108,7 @@ export default function widgetBehavior(publicAPI, model) {
       }
     }
     if (model.hasFocus) {
-      model.widgetManager.disablePicking();
+      model._widgetManager.disablePicking();
     }
     return macro.VOID;
   };
@@ -119,7 +119,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonRelease = () => {
     if (isDragging && model.pickable) {
-      model.apiSpecificRenderWindow.setCursor('pointer');
+      model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
@@ -132,7 +132,7 @@ export default function widgetBehavior(publicAPI, model) {
       (model.activeState && !model.activeState.getActive())
     ) {
       publicAPI.invokeEndInteractionEvent();
-      model.widgetManager.enablePicking();
+      model._widgetManager.enablePicking();
       model._interactor.render();
     }
 
@@ -176,7 +176,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.getMoveHandle().setVisible(false);
     model.activeState = null;
     model.hasFocus = false;
-    model.widgetManager.enablePicking();
+    model._widgetManager.enablePicking();
     model._interactor.render();
   };
 }

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -46,16 +46,16 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.updateCursor = () => {
     switch (model.activeState.getUpdateMethodName()) {
       case InteractionMethodsName.TranslateCenter:
-        model.apiSpecificRenderWindow.setCursor('move');
+        model._apiSpecificRenderWindow.setCursor('move');
         break;
       case InteractionMethodsName.RotateLine:
-        model.apiSpecificRenderWindow.setCursor('alias');
+        model._apiSpecificRenderWindow.setCursor('alias');
         break;
       case InteractionMethodsName.TranslateAxis:
-        model.apiSpecificRenderWindow.setCursor('pointer');
+        model._apiSpecificRenderWindow.setCursor('pointer');
         break;
       default:
-        model.apiSpecificRenderWindow.setCursor('default');
+        model._apiSpecificRenderWindow.setCursor('default');
         break;
     }
   };
@@ -238,7 +238,7 @@ export default function widgetBehavior(publicAPI, model) {
     const stateLine = model.widgetState.getActiveLineState();
     const worldCoords = model.planeManipulator.handleEvent(
       calldata,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
 
     const point1 = stateLine.getPoint1();
@@ -300,7 +300,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI[InteractionMethodsName.TranslateCenter] = (calldata) => {
     let worldCoords = model.planeManipulator.handleEvent(
       calldata,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
     worldCoords = publicAPI.getBoundedCenter(worldCoords);
     model.activeState.setCenter(worldCoords);
@@ -312,7 +312,7 @@ export default function widgetBehavior(publicAPI, model) {
     const planeNormal = model.planeManipulator.getNormal();
     const worldCoords = model.planeManipulator.handleEvent(
       calldata,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
 
     const center = model.widgetState.getCenter();

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -275,20 +275,20 @@ export default function widgetBehavior(publicAPI, model) {
   const computeTextPosition = (worldBounds, textPosition, worldMargin = 0) => {
     const viewPlaneOrigin = model.manipulator.getOrigin();
     const viewPlaneNormal = model.manipulator.getNormal();
-    const viewUp = model.renderer.getActiveCamera().getViewUp();
+    const viewUp = model._renderer.getActiveCamera().getViewUp();
 
     const positionMargin = Array.isArray(worldMargin)
       ? [...worldMargin]
       : [worldMargin, worldMargin, viewPlaneOrigin ? worldMargin : 0];
 
     // Map bounds from world positions to display positions
-    const minPoint = model.apiSpecificRenderWindow.worldToDisplay(
+    const minPoint = model._apiSpecificRenderWindow.worldToDisplay(
       ...vtkBoundingBox.getMinPoint(worldBounds),
-      model.renderer
+      model._renderer
     );
-    const maxPoint = model.apiSpecificRenderWindow.worldToDisplay(
+    const maxPoint = model._apiSpecificRenderWindow.worldToDisplay(
       ...vtkBoundingBox.getMaxPoint(worldBounds),
-      model.renderer
+      model._renderer
     );
     const displayBounds = vtkMath.computeBoundsFromPoints(
       minPoint,
@@ -313,9 +313,9 @@ export default function widgetBehavior(publicAPI, model) {
       )
     ) {
       // Map plane origin from world positions to display positions
-      const displayPlaneOrigin = model.apiSpecificRenderWindow.worldToDisplay(
+      const displayPlaneOrigin = model._apiSpecificRenderWindow.worldToDisplay(
         ...viewPlaneOrigin,
-        model.renderer
+        model._renderer
       );
       // Map plane normal from world positions to display positions
       const planeNormalPoint = vtkMath.add(
@@ -324,9 +324,9 @@ export default function widgetBehavior(publicAPI, model) {
         []
       );
       const displayPlaneNormalPoint =
-        model.apiSpecificRenderWindow.worldToDisplay(
+        model._apiSpecificRenderWindow.worldToDisplay(
           ...planeNormalPoint,
-          model.renderer
+          model._renderer
         );
       const displayPlaneNormal = vtkMath.subtract(
         displayPlaneNormalPoint,
@@ -395,9 +395,9 @@ export default function widgetBehavior(publicAPI, model) {
     vtkMath.add(finalPosition, w, finalPosition);
     vtkMath.add(finalPosition, positionMargin, finalPosition);
 
-    return model.apiSpecificRenderWindow.displayToWorld(
+    return model._apiSpecificRenderWindow.displayToWorld(
       ...finalPosition,
-      model.renderer
+      model._renderer
     );
   };
 
@@ -460,8 +460,8 @@ export default function widgetBehavior(publicAPI, model) {
     if (!model.point2) {
       // Update orientation to match the camera's plane
       // if the corners are not yet placed
-      const normal = model.camera.getDirectionOfProjection();
-      const up = model.camera.getViewUp();
+      const normal = model._camera.getDirectionOfProjection();
+      const up = model._camera.getViewUp();
       const right = [];
       vec3.cross(right, up, normal);
       model.shapeHandle.setUp(up);
@@ -471,7 +471,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
     const worldCoords = model.manipulator.handleEvent(
       callData,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
     if (!worldCoords.length) {
       return macro.VOID;
@@ -539,7 +539,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.activeState === model.point2Handle)
     ) {
       model.isDragging = true;
-      model.apiSpecificRenderWindow.setCursor('grabbing');
+      model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
 
@@ -556,7 +556,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleLeftButtonRelease = (e) => {
     if (model.isDragging) {
       model.isDragging = false;
-      model.apiSpecificRenderWindow.setCursor('pointer');
+      model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);
       publicAPI.invokeEndInteractionEvent();
@@ -568,7 +568,7 @@ export default function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
 
-    const viewSize = model.apiSpecificRenderWindow.getSize();
+    const viewSize = model._apiSpecificRenderWindow.getSize();
     if (
       e.position.x < 0 ||
       e.position.x > viewSize[0] - 1 ||
@@ -671,7 +671,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.point2Handle.deactivate();
     model.activeState = null;
     model._interactor.render();
-    model.widgetManager.enablePicking();
+    model._widgetManager.enablePicking();
 
     superClass.loseFocus();
   };

--- a/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
@@ -54,11 +54,11 @@ export default function widgetBehavior(publicAPI, model) {
     shapeHandle.setVisible(true);
     shapeHandle.setOrigin(center);
     shapeHandle.setScale1(radius * 2);
-    model.interactor.render();
+    model._interactor.render();
   }
 
   function currentWorldCoords(e) {
-    return model.manipulator.handleEvent(e, model.apiSpecificRenderWindow);
+    return model.manipulator.handleEvent(e, model._apiSpecificRenderWindow);
   }
 
   // Update the sphere's center and radius.  Example:
@@ -83,7 +83,7 @@ export default function widgetBehavior(publicAPI, model) {
     centerHandle.setOrigin(newCenter);
     borderHandle.setOrigin(newBorder);
     updateSphere();
-    model.widgetManager.enablePicking();
+    model._widgetManager.enablePicking();
   };
 
   publicAPI.handleLeftButtonPress = (e) => {
@@ -103,7 +103,7 @@ export default function widgetBehavior(publicAPI, model) {
       updateSphere();
     }
     model.isDragging = true;
-    model.apiSpecificRenderWindow.setCursor('grabbing');
+    model._apiSpecificRenderWindow.setCursor('grabbing');
     model.previousPosition = [...currentWorldCoords(e)];
     publicAPI.invokeStartInteractionEvent();
     return macro.EVENT_ABORT;
@@ -116,8 +116,8 @@ export default function widgetBehavior(publicAPI, model) {
     }
     if (isPlaced()) {
       model.previousPosition = null;
-      model.widgetManager.enablePicking();
-      model.apiSpecificRenderWindow.setCursor('pointer');
+      model._widgetManager.enablePicking();
+      model._apiSpecificRenderWindow.setCursor('pointer');
       model.isDragging = false;
       model.activeState = null;
       state.deactivate();
@@ -167,7 +167,7 @@ export default function widgetBehavior(publicAPI, model) {
     borderHandle.setOrigin(null);
     model.isDragging = true;
     model.activeState = moveHandle;
-    model.interactor.render();
+    model._interactor.render();
   };
 
   publicAPI.loseFocus = () => {

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -46,7 +46,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.firstHandle = model.lastHandle;
       }
 
-      model.apiSpecificRenderWindow.setCursor('grabbing');
+      model._apiSpecificRenderWindow.setCursor('grabbing');
     }
   };
 
@@ -58,8 +58,8 @@ export default function widgetBehavior(publicAPI, model) {
     const scale =
       model.moveHandle.getScale1() *
       vec3.distance(
-        model.apiSpecificRenderWindow.displayToWorld(0, 0, 0, model.renderer),
-        model.apiSpecificRenderWindow.displayToWorld(1, 0, 0, model.renderer)
+        model._apiSpecificRenderWindow.displayToWorld(0, 0, 0, model._renderer),
+        model._apiSpecificRenderWindow.displayToWorld(1, 0, 0, model._renderer)
       );
 
     return handles.reduce(
@@ -224,7 +224,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.freeHand = publicAPI.getAllowFreehand() && !model.isDragging;
     } else {
       model.isDragging = true;
-      model.apiSpecificRenderWindow.setCursor('grabbing');
+      model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
     }
@@ -239,7 +239,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleLeftButtonRelease = (e) => {
     if (model.isDragging) {
       if (!model.hasFocus) {
-        model.apiSpecificRenderWindow.setCursor(model.defaultCursor);
+        model._apiSpecificRenderWindow.setCursor(model.defaultCursor);
         model.widgetState.deactivate();
         model._interactor.cancelAnimation(publicAPI);
         publicAPI.invokeEndInteractionEvent();
@@ -299,22 +299,22 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       return macro.VOID;
     }
-    model.manipulator.setNormal(model.camera.getDirectionOfProjection());
+    model.manipulator.setNormal(model._camera.getDirectionOfProjection());
 
     const worldCoords = model.manipulator.handleEvent(
       callData,
-      model.apiSpecificRenderWindow
+      model._apiSpecificRenderWindow
     );
 
     const hoveredHandle = getHoveredHandle();
     if (hoveredHandle) {
       model.moveHandle.setVisible(false);
       if (hoveredHandle !== model.firstHandle) {
-        model.apiSpecificRenderWindow.setCursor('grabbing');
+        model._apiSpecificRenderWindow.setCursor('grabbing');
       }
     } else if (!model.isDragging && model.hasFocus) {
       model.moveHandle.setVisible(true);
-      model.apiSpecificRenderWindow.setCursor(model.defaultCursor);
+      model._apiSpecificRenderWindow.setCursor(model.defaultCursor);
     }
 
     if (model.lastHandle) {


### PR DESCRIPTION
Commit ac8b26ce1f5c36f7c577f2363820416bd625a72b (merged in master, tag v24.0.0) made many model variables protected by suffixing them with _, but some variables have been forgotten. 
This commit fix this by renaming the remaining variables, mainly in the Widgets3D directory.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: 24.0.0
  - **OS**: Ubuntu 20.04 LTS
  - **Browser**: Chromium 98.0.4697.0


