### PR TITLE
Touch support with the widget manager

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -217,8 +217,14 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       rootElm[method]('mouseup', publicAPI.handleMouseUp);
       rootElm[method]('mousemove', publicAPI.handleMouseMove);
       rootElm[method]('touchend', publicAPI.handleTouchEnd, false);
-      rootElm[method]('touchcancel', publicAPI.handleTouchEnd, false);
-      rootElm[method]('touchmove', publicAPI.handleTouchMove, false);
+      rootElm[method]('touchcancel', publicAPI.handleTouchEnd, {
+        passive: false,
+        capture: false,
+      });
+      rootElm[method]('touchmove', publicAPI.handleTouchMove, {
+        passive: false,
+        capture: false,
+      });
     }
 
     if (!force && addListeners) {
@@ -245,7 +251,10 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       publicAPI.handlePointerLockChange
     );
 
-    container.addEventListener('touchstart', publicAPI.handleTouchStart, false);
+    container.addEventListener('touchstart', publicAPI.handleTouchStart, {
+      passive: false,
+      capture: false,
+    });
   };
 
   publicAPI.unbindEvents = () => {
@@ -277,7 +286,11 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     );
     model.container.removeEventListener(
       'touchstart',
-      publicAPI.handleTouchStart
+      publicAPI.handleTouchStart,
+      {
+        passive: false,
+        capture: false,
+      }
     );
     model.container = null;
   };

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -278,37 +278,38 @@ function vtkWidgetManager(publicAPI, model) {
     }
   }
 
-  let guardAgainst = '';
-
-  const handleEvent = (eventName) => (callData) => {
-    if (
-      guardAgainst === eventName ||
-      model.isAnimating ||
-      !model.pickingEnabled ||
-      model._selectionInProgress
-    ) {
-      return macro.VOID;
-    }
-
-    const updatePromise = updateSelection(callData);
-    macro.measurePromiseExecution(updatePromise, (elapsed) => {
-      // 100ms is deemed fast enough. Anything higher can degrade usability.
-      if (elapsed > 100) {
-        macro.vtkWarningMacro(
-          `vtkWidgetManager updateSelection() took ${elapsed}ms on ${eventName}`
-        );
+  const handleEvent = (eventName) => {
+    let guard = false;
+    return (callData) => {
+      if (
+        guard ||
+        model.isAnimating ||
+        !model.pickingEnabled ||
+        model._selectionInProgress
+      ) {
+        return macro.VOID;
       }
-    });
 
-    updatePromise.then(() => {
-      if (model._interactor) {
-        // re-trigger the event, ignoring our own handler
-        guardAgainst = eventName;
-        model._interactor[`invoke${eventName}`](callData);
-        guardAgainst = '';
-      }
-    });
-    return macro.EVENT_ABORT;
+      const updatePromise = updateSelection(callData);
+      macro.measurePromiseExecution(updatePromise, (elapsed) => {
+        // 100ms is deemed fast enough. Anything higher can degrade usability.
+        if (elapsed > 100) {
+          macro.vtkWarningMacro(
+            `vtkWidgetManager updateSelection() took ${elapsed}ms on ${eventName}`
+          );
+        }
+      });
+
+      updatePromise.then(() => {
+        if (model._interactor) {
+          // re-trigger the event, ignoring our own handler
+          guard = true;
+          model._interactor[`invoke${eventName}`](callData);
+          guard = false;
+        }
+      });
+      return macro.EVENT_ABORT;
+    };
   };
 
   function updateWidgetForRender(w) {

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -291,6 +291,15 @@ function vtkWidgetManager(publicAPI, model) {
     }
 
     const updatePromise = updateSelection(callData);
+    macro.measurePromiseExecution(updatePromise, (elapsed) => {
+      // 100ms is deemed fast enough. Anything higher can degrade usability.
+      if (elapsed > 100) {
+        macro.vtkWarningMacro(
+          `vtkWidgetManager updateSelection() took ${elapsed}ms on ${eventName}`
+        );
+      }
+    });
+
     updatePromise.then(() => {
       if (model._interactor) {
         // re-trigger the event, ignoring our own handler

--- a/Sources/macros.d.ts
+++ b/Sources/macros.d.ts
@@ -642,6 +642,7 @@ declare const Macro: {
   isVtkObject: typeof isVtkObject,
   keystore: typeof keystore,
   measurePromiseExecution: typeof measurePromiseExecution,
+  moveToProtected: typeof moveToProtected,
   newInstance: typeof newInstance,
   normalizeWheel: typeof normalizeWheel,
   obj: typeof obj,

--- a/Sources/macros.d.ts
+++ b/Sources/macros.d.ts
@@ -139,6 +139,16 @@ declare function getStateArrayMapFunc(item: any): any;
 export function setImmediateVTK(fn: () => void ): void;
 
 /**
+ * Measures the time it takes for a promise to finish from the time this function is invoked.
+ *
+ * The callback receives the time it took for the promise to resolve or reject.
+ *
+ * @param promise promise to measure
+ * @param callback called with the elapsed time for the promise
+ */
+export function measurePromiseExecution(promise: Promise<any>, callback: (elapsed: number) => void): void;
+
+/**
  * Turns the provided publicAPI into a VtkObject
  *
  * @param publicAPI (default: {}) object on which public methods get attached to
@@ -631,6 +641,7 @@ declare const Macro: {
   getStateArrayMapFunc: typeof getStateArrayMapFunc,
   isVtkObject: typeof isVtkObject,
   keystore: typeof keystore,
+  measurePromiseExecution: typeof measurePromiseExecution,
   newInstance: typeof newInstance,
   normalizeWheel: typeof normalizeWheel,
   obj: typeof obj,

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -214,6 +214,22 @@ export function setImmediateVTK(fn) {
 }
 
 // ----------------------------------------------------------------------------
+// measurePromiseExecution
+//
+// Measures the time it takes for a promise to finish from
+//   the time this function is invoked.
+// The callback receives the time it took for the promise to resolve or reject.
+// ----------------------------------------------------------------------------
+
+export function measurePromiseExecution(promise, callback) {
+  const start = performance.now();
+  promise.finally(() => {
+    const delta = performance.now() - start;
+    callback(delta);
+  });
+}
+
+// ----------------------------------------------------------------------------
 // vtkObject: modified(), onModified(callback), delete()
 // ----------------------------------------------------------------------------
 
@@ -1700,6 +1716,7 @@ export default {
   getStateArrayMapFunc,
   isVtkObject,
   keystore,
+  measurePromiseExecution,
   moveToProtected,
   newInstance,
   newTypedArray,


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
- Touch events on widgets is currently not supported. Related issues: #2285

### Results
- Touch start should select widget handles.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes
- [x] Added a way to measure promise execution time
- [x] Add touch start support for widget handles
- [x] marks touchstart, touchmove, and touchend as non-passive events to suppress browser warnings about preventDefault in passive event handlers.
- [x] Adds a warning if widget selection takes longer than 0.1 seconds.

#### approach

This change means widget selection no longer happens asynchronously alongside interaction. Instead, widget selection occurs first, and then re-triggers the original event, allowing interactors to handle the event. If widget selection takes significant time, interaction will suffer (which was sort of the case prior to this PR, but only wrt widget picking).

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- Tested widgets:
  - PolyLineWidget
  - SphereWidget
  - ResliceCursorWidget

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
