### PR TITLE
feat(httpdatasetreader): allow dataset fetching using a user-provided object

### DIFF
--- a/Sources/IO/Core/HttpDataSetReader/index.d.ts
+++ b/Sources/IO/Core/HttpDataSetReader/index.d.ts
@@ -28,6 +28,56 @@ export interface IHttpDataSetReaderArray {
 	enable: boolean;
 }
 
+export interface IRange {
+	max: number,
+	component: unknown,
+	min: number
+}
+
+export interface IPointDataArray {
+	data: {
+		numberOfComponents: number,
+		name: string,
+		vtkClass: string,
+		dataType: string,
+		ranges: Array<IRange>,
+		ref: {
+			registration: string,
+			encode: string,
+			basepath: string,
+			id: string
+		},
+		size: number
+	}
+}
+
+export interface IDatasetManifest {
+	origin: [number, number, number],
+	cellData: {
+		arrays: Array<unknown>,
+		vtkClass: string
+	},
+	FieldData: {
+		arrays: Array<unknown>,
+		vtkClass: string,
+	},
+	vtkClass: string,	
+	pointData: {
+		arrays: Array<IPointDataArray>,
+		vtkClass: string
+	},
+	spacing: [number, number, number],
+	extent: [number, number, number, number, number, number],
+	direction: [number, number, number, number, number, number, number, number, number],
+	metadata?: Record<string, unknown>
+}
+
+export interface IParseObjectOptions {
+	loadData: boolean,
+	baseUrl: string,
+	deepCopy: boolean
+}
+
 type vtkHttpDataSetReaderBase = vtkObject & Omit<vtkAlgorithm,
 	| 'getInputData'
 	| 'setInputData'
@@ -165,6 +215,14 @@ export interface vtkHttpDataSetReader extends vtkHttpDataSetReaderBase {
 	 * @param {IHttpDataSetReaderOptions} [option] The Draco reader options.
 	 */
 	setUrl(url: string, option?: IHttpDataSetReaderOptions): Promise<any>;
+
+	/**
+	 * Set the dataset object to use for data fetching.
+	 * 
+	 * @param {IDatasetManifest} manifest The dataset manifest object
+	 * @param {IParseObjectOptions} options
+	 */
+	parseObject(manifest: IDatasetManifest, options: IParseObjectOptions): Promise<void>;
 
 	/**
 	 * 

--- a/Sources/IO/Core/HttpDataSetReader/index.js
+++ b/Sources/IO/Core/HttpDataSetReader/index.js
@@ -183,15 +183,12 @@ function vtkHttpDataSetReader(publicAPI, model) {
                     .fetchJSON(publicAPI, 'index.json')
                     .then(
                       (dataset) => {
-                        processDataSet(
-                          publicAPI,
-                          model,
-                          dataset,
-                          fetchArray,
-                          resolve,
-                          reject,
-                          loadData
-                        );
+                        publicAPI
+                          .parseObject(dataset, {
+                            loadData,
+                            deepCopy: false,
+                          })
+                          .then(resolve, reject);
                       },
                       (error) => {
                         reject(error);
@@ -210,15 +207,9 @@ function vtkHttpDataSetReader(publicAPI, model) {
     return new Promise((resolve, reject) => {
       model.dataAccessHelper.fetchJSON(publicAPI, model.url).then(
         (dataset) => {
-          processDataSet(
-            publicAPI,
-            model,
-            dataset,
-            fetchArray,
-            resolve,
-            reject,
-            loadData
-          );
+          publicAPI
+            .parseObject(dataset, { loadData, deepCopy: false })
+            .then(resolve, reject);
         },
         (error) => {
           reject(error);
@@ -245,6 +236,29 @@ function vtkHttpDataSetReader(publicAPI, model) {
 
     // Fetch metadata
     return publicAPI.updateMetadata(!!options.loadData);
+  };
+
+  publicAPI.parseObject = (
+    manifest,
+    { loadData, baseUrl, deepCopy = true }
+  ) => {
+    if (baseUrl) {
+      model.baseURL = baseUrl;
+    }
+
+    const dataset = deepCopy ? structuredClone(manifest) : manifest;
+
+    return new Promise((resolve, reject) => {
+      processDataSet(
+        publicAPI,
+        model,
+        dataset,
+        fetchArray,
+        resolve,
+        reject,
+        loadData
+      );
+    });
   };
 
   // Fetch the actual data arrays


### PR DESCRIPTION
### Context
Currently the only way to fetch a dataset is to provide a URL pointing to a JSON file, this change
aims to allow client-code to directly provide this object instead of making an extra round-trip to
the server. It is useful for some users who directly holds the dataset in their client application.

### Results
Before:
```javascript
reader.setUrl('data/index.json', { loadData: true }).then(() => {
 // ---
});
```
After:
```javascript
import dataset from "data/index.json";

reader.parseObject(dataset, { loadData: false, baseUrl: "data" }).then(() => {
  // ---
});
```

### Changes
A parseObject method have been added to the HttpDataSetReader public API.
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
Struggling to get a working test for now. (draft PR)
- [ ] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: archlinux
  - **Browser**: Firefox