### PR TITLE
feat(CubeAxesActor): add bounds extimate to CubeAxesActor

### DIFF
--- a/Sources/Common/DataModel/BoundingBox/index.js
+++ b/Sources/Common/DataModel/BoundingBox/index.js
@@ -148,6 +148,28 @@ export function getCenter(bounds) {
   ];
 }
 
+export function scaleAboutCenter(bounds, sx, sy, sz) {
+  if (!isValid(bounds)) {
+    return false;
+  }
+  const center = getCenter(bounds);
+  bounds[0] -= center[0];
+  bounds[1] -= center[0];
+  bounds[2] -= center[1];
+  bounds[3] -= center[1];
+  bounds[4] -= center[2];
+  bounds[5] -= center[2];
+  scale(bounds, sx, sy, sz);
+  bounds[0] += center[0];
+  bounds[1] += center[0];
+  bounds[2] += center[1];
+  bounds[3] += center[1];
+  bounds[4] += center[2];
+  bounds[5] += center[2];
+
+  return true;
+}
+
 export function getLength(bounds, index) {
   return bounds[index * 2 + 1] - bounds[index * 2];
 }
@@ -230,11 +252,9 @@ export function computeCornerPoints(bounds, point1, point2) {
 }
 
 export function computeScale3(bounds, scale3 = []) {
-  const center = getCenter(bounds);
-  scale3[0] = bounds[1] - center[0];
-  scale3[1] = bounds[3] - center[1];
-  scale3[2] = bounds[5] - center[2];
-
+  scale3[0] = 0.5 * (bounds[1] - bounds[0]);
+  scale3[1] = 0.5 * (bounds[3] - bounds[2]);
+  scale3[2] = 0.5 * (bounds[5] - bounds[4]);
   return scale3;
 }
 
@@ -729,6 +749,7 @@ export const STATIC = {
   setMaxPoint,
   inflate,
   scale,
+  scaleAboutCenter,
   getCenter,
   getLength,
   getLengths,

--- a/Sources/Rendering/Core/CubeAxesActor/index.js
+++ b/Sources/Rendering/Core/CubeAxesActor/index.js
@@ -771,6 +771,19 @@ function vtkCubeAxesActor(publicAPI, model) {
     model.axisTextStyle = { ...model.axisTextStyle, ...axisStyle };
     publicAPI.modified();
   };
+
+  publicAPI.get_tmAtlas = () => model._tmAtlas;
+
+  // try to get the bounds for the annotation. This is complicated
+  // as it relies on the pixel size of the window. Every time the camera
+  // changes the bounds change. This method simplifies by just expanding
+  // the grid bounds by a user specified factor.
+  publicAPI.getBounds = () => {
+    publicAPI.update();
+    vtkBoundingBox.setBounds(model.bounds, model.gridActor.getBounds());
+    vtkBoundingBox.scaleAboutCenter(model.bounds, model.boundsScaleFactor);
+    return model.bounds;
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -779,6 +792,7 @@ function vtkCubeAxesActor(publicAPI, model) {
 
 function defaultValues(initialValues) {
   return {
+    boundsScaleFactor: 1.3,
     camera: null,
     dataBounds: [...vtkBoundingBox.INIT_BOUNDS],
     faceVisibilityAngle: 8,
@@ -840,6 +854,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   macro.setGet(publicAPI, model, [
     'axisTitlePixelOffset',
+    'boundsScaleFactor',
     'faceVisibilityAngle',
     'gridLines',
     'tickLabelPixelOffset',
@@ -854,7 +869,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'tmTexture',
     'textValues',
     'textPolyData',
-    '_tmAtlas',
     'tickCounts',
     'gridActor',
   ]);


### PR DESCRIPTION
Add a basic getBounds method that expands the grid bounds
by a specified factor to accomodate text annotations.

Also fix an issue with get_tmAtlas which may have been introduced
with recent macros.js changes.

