### PR TITLE
fix(WebGL): translucent rendering without webgl2

### DIFF
--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -325,7 +325,7 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
     if (model._supported) {
       return translucentShaderReplacement;
     }
-    return {};
+    return null;
   };
 
   publicAPI.releaseGraphicsResources = (viewNode) => {


### PR DESCRIPTION
Used {} for empty function when null should have been used

Addresses https://github.com/Kitware/vtk-js/issues/2349

