### PR TITLE
fix(CubeAxesActor): fix bounds calculation

### DIFF
--- a/Sources/Rendering/Core/CubeAxesActor/index.js
+++ b/Sources/Rendering/Core/CubeAxesActor/index.js
@@ -781,7 +781,12 @@ function vtkCubeAxesActor(publicAPI, model) {
   publicAPI.getBounds = () => {
     publicAPI.update();
     vtkBoundingBox.setBounds(model.bounds, model.gridActor.getBounds());
-    vtkBoundingBox.scaleAboutCenter(model.bounds, model.boundsScaleFactor);
+    vtkBoundingBox.scaleAboutCenter(
+      model.bounds,
+      model.boundsScaleFactor,
+      model.boundsScaleFactor,
+      model.boundsScaleFactor
+    );
     return model.bounds;
   };
 }


### PR DESCRIPTION
Was only passing one parameter to the scaleAboutCenter method
