### PR TITLE
feat(manipulator): harmonize and improve widget manipulators

### DIFF
--- a/Examples/Widgets/Box/BoxWidget.js
+++ b/Examples/Widgets/Box/BoxWidget.js
@@ -202,7 +202,9 @@ function vtkBoxWidget(publicAPI, model) {
   const handles = model.widgetState.getStatesWithLabel('handles');
 
   // Default manipulator
-  model.manipulator = vtkPlaneManipulator.newInstance();
+  model.manipulator = vtkPlaneManipulator.newInstance({
+    useCameraNormal: true,
+  });
   handles.forEach((handle) => handle.setManipulator(model.manipulator));
 }
 

--- a/Sources/Widgets/Core/StateBuilder/manipulatorMixin.js
+++ b/Sources/Widgets/Core/StateBuilder/manipulatorMixin.js
@@ -6,21 +6,25 @@ function vtkManipulatorMixin(publicAPI, model) {
   publicAPI.updateManipulator = () => {
     if (model.manipulator) {
       const { origin, normal, direction } = model;
-      const { setOrigin, setCenter, setNormal, setDirection } =
-        model.manipulator;
+      const {
+        setHandleOrigin,
+        setHandleCenter,
+        setHandleNormal,
+        setHandleDirection,
+      } = model.manipulator;
 
-      if (origin && setOrigin) {
-        setOrigin(origin);
-      } else if (origin && setCenter) {
-        setCenter(origin);
+      if (origin && setHandleOrigin) {
+        setHandleOrigin(origin);
+      } else if (origin && setHandleCenter) {
+        setHandleCenter(origin);
       }
 
-      if (direction && setDirection) {
-        setDirection(direction);
-      } else if (direction && !normal && setNormal) {
-        setNormal(direction);
-      } else if (normal && setDirection) {
-        setDirection(normal);
+      if (direction && setHandleDirection) {
+        setHandleDirection(direction);
+      } else if (direction && !normal && setHandleNormal) {
+        setHandleNormal(direction);
+      } else if (normal && setHandleDirection) {
+        setHandleDirection(normal);
       }
     }
   };

--- a/Sources/Widgets/Manipulators/AbstractManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/AbstractManipulator/index.d.ts
@@ -1,0 +1,221 @@
+import { vtkObject } from "../../../interfaces";
+import { vtkOpenGLRenderWindow } from "../../../Rendering/OpenGL/RenderWindow"
+import { Vector3 } from "../../../types";
+
+/**
+ *
+ */
+export interface IAbstractManipulatorInitialValues {
+    userOrigin?: Vector3;
+    handleOrigin?: Vector3;
+    widgetOrigin?: Vector3;
+    userNormal?: Vector3;
+    handleNormal?: Vector3;
+    widgetNormal?: Vector3;
+}
+
+export interface vtkAbstractManipulator extends vtkObject {
+
+    /**
+     * Get the normal of the line
+     */
+    getNormal(callData: any): Vector3;
+
+    /**
+     * Get the origin of the line
+     */
+    getOrigin(callData: any): Vector3;
+
+    /**
+     * Get the value of useCameraFocalPoint
+     */
+    getUseCameraFocalPoint(): boolean;
+
+    /**
+     * Set the value of useCameraFocalPoint
+     * @param useCameraFocalPoint if true, the focal point of the camera will be used if userOrigin is not set.
+     */
+    setUseCameraFocalPoint(useCameraFocalPoint: boolean): boolean;
+
+    /**
+     * Get the value of useCameraNormal
+     */
+    getUseCameraNormal(): boolean;
+
+    /**
+     * Set the value of useCameraNormal
+     * @param useCameraNormal if true, the normal of the camera will be used if userNormal is not set.
+     */
+    setUseCameraNormal(useCameraNormal: boolean): boolean;
+
+    /**
+     * 
+     * @param callData 
+     * @param glRenderWindow 
+     */
+    handleEvent(callData: any, glRenderWindow: vtkOpenGLRenderWindow): Vector3;
+
+    /* ------------------------------------------------------------------- */
+
+    /**
+     * Set the user normal. 
+     * This normal take precedence on the handleNormal and the widgetNormal.
+     * This normal should not be set within the widget internal code.
+     * @param {Vector3} normal The normal coordinate.
+     */
+    setUserNormal(normal: Vector3): boolean;
+
+    /**
+     * Set the user normal (see setUserNormal).
+     * @param {Number} x The x coordinate.
+     * @param {Number} y The y coordinate.
+     * @param {Number} z The z coordinate.
+     */
+    setUserNormal(x: number, y: number, z: number): boolean;
+
+    /**
+     * Set the user normal (see setUserNormal).
+     * @param {Vector3} normal The normal coordinate.
+     */
+    setUserNormalFrom(normal: Vector3): boolean;
+
+    /**
+     * Set the user origin.
+     * This origin take precedence on the handleOrigin and the widgetOrigin.
+     * This origin should not be set within the widget internal code.
+     * @param {Vector3} origin The coordinate of the origin point.
+     */
+    setUserOrigin(origin: Vector3): boolean;
+
+    /**
+     * Set the user origin (see setUserOrigin).
+     * @param {Number} x The x coordinate of the origin point.
+     * @param {Number} y The y coordinate of the origin point.
+     * @param {Number} z The z coordinate of the origin point.
+     */
+    setUserOrigin(x: number, y: number, z: number): boolean;
+
+    /**
+     * Set the user origin (see setUserOrigin).
+     * @param {Vector3} origin The coordinate of the origin point.
+     */
+    setUserOriginFrom(origin: Vector3): boolean;
+
+    /* ------------------------------------------------------------------- */
+
+    /**
+     * Set the handle normal. 
+     * This normal is used after the userNormal and before the widgetNormal.
+     * This normal is automatically set by any state having a manipulatorMixin,
+     * and can be overridden in the widget code.
+     * @param {Vector3} normal The normal coordinate.
+     */
+    setHandleNormal(normal: Vector3): boolean;
+
+    /**
+     * Set the handle normal (see setHandleNormal).
+     * @param {Number} x The x coordinate.
+     * @param {Number} y The y coordinate.
+     * @param {Number} z The z coordinate.
+     */
+    setHandleNormal(x: number, y: number, z: number): boolean;
+
+    /**
+     * Set the handle normal (see setHandleNormal).
+     * @param {Vector3} normal The normal coordinate.
+     */
+    setHandleNormalFrom(normal: Vector3): boolean;
+
+    /**
+     * Set the handle origin.
+     * This origin is used after the userOrigin and before the widgetOrigin.
+     * This origin is automatically set by any state having a manipulatorMixin,
+     * and can be overridden in the widget code.
+     * @param {Vector3} origin The coordinate of the origin point.
+     */
+    setHandleOrigin(origin: Vector3): boolean;
+
+    /**
+     * Set the handle origin (see setHandleOrigin).
+     * @param {Number} x The x coordinate of the origin point.
+     * @param {Number} y The y coordinate of the origin point.
+     * @param {Number} z The z coordinate of the origin point.
+     */
+    setHandleOrigin(x: number, y: number, z: number): boolean;
+
+    /**
+     * Set the handle origin (see setHandleOrigin).
+     * @param {Vector3} origin The coordinate of the origin point.
+     */
+    setHandleOriginFrom(origin: Vector3): boolean;
+
+    /* ------------------------------------------------------------------- */
+
+    /**
+     * Set the widget normal. 
+     * This normal is used if no other normals are set. 
+     * It can be used to define a normal global to the whole widget.
+     * @param {Vector3} normal The normal coordinate.
+     */
+    setWidgetNormal(normal: Vector3): boolean;
+
+    /**
+     * Set the widget normal (see setWidgetNormal).
+     * @param {Number} x The x coordinate.
+     * @param {Number} y The y coordinate.
+     * @param {Number} z The z coordinate.
+     */
+    setWidgetNormal(x: number, y: number, z: number): boolean;
+
+    /**
+     * Set the widget normal (see setWidgetNormal).
+     * @param {Vector3} normal The normal coordinate.
+     */
+    setWidgetNormalFrom(normal: Vector3): boolean;
+
+    /**
+     * Set the widget origin.
+     * This origin is used if no other origins are set.
+     * It can be used to define an origin global to the whole widget.
+     * @param {Vector3} origin The coordinate of the origin point.
+     */
+    setWidgetOrigin(origin: Vector3): boolean;
+
+    /**
+     * Set the widget origin (see setWidgetOrigin).
+     * @param {Number} x The x coordinate of the origin point.
+     * @param {Number} y The y coordinate of the origin point.
+     * @param {Number} z The z coordinate of the origin point.
+     */
+    setWidgetOrigin(x: number, y: number, z: number): boolean;
+
+    /**
+     * Set the widget origin (see setWidgetOrigin).
+     * @param {Vector3} origin The coordinate of the origin point.
+     */
+    setWidgetOriginFrom(origin: Vector3): boolean;
+}
+
+
+/**
+ * Method use to decorate a given object (publicAPI+model) with vtkAbstractManipulator characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {IAbstractManipulatorInitialValues} [initialValues] (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IAbstractManipulatorInitialValues): void;
+
+/**
+ * Method use to create a new instance of vtkAbstractManipulator
+ */
+export function newInstance(initialValues?: IAbstractManipulatorInitialValues): vtkAbstractManipulator;
+
+/**
+ * vtkAbstractManipulator.
+ */
+export declare const vtkAbstractManipulator: {
+	newInstance: typeof newInstance,
+	extend: typeof extend,
+};
+export default vtkAbstractManipulator;

--- a/Sources/Widgets/Manipulators/AbstractManipulator/index.js
+++ b/Sources/Widgets/Manipulators/AbstractManipulator/index.js
@@ -1,0 +1,76 @@
+import macro from 'vtk.js/Sources/macros';
+
+// ----------------------------------------------------------------------------
+// vtkAbstractManipulator methods
+// ----------------------------------------------------------------------------
+
+function vtkAbstractManipulator(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkAbstractManipulator');
+
+  publicAPI.getOrigin = (callData) => {
+    if (model.userOrigin) return model.userOrigin;
+    if (model.useCameraFocalPoint)
+      return callData.pokedRenderer.getActiveCamera().getFocalPoint();
+    if (model.handleOrigin) return model.handleOrigin;
+    if (model.widgetOrigin) return model.widgetOrigin;
+    return [0, 0, 0];
+  };
+
+  publicAPI.getNormal = (callData) => {
+    if (model.userNormal) return model.userNormal;
+    if (model.useCameraNormal)
+      return callData.pokedRenderer
+        .getActiveCamera()
+        .getDirectionOfProjection();
+    if (model.handleNormal) return model.handleNormal;
+    if (model.widgetNormal) return model.widgetNormal;
+    return [0, 0, 1];
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  // userOrigin: null,
+  // handleOrigin: null,
+  // widgetOrigin: null,
+  // userNormal: null,
+  // handleNormal: null,
+  // widgetNormal: null
+  useCameraFocalPoint: false,
+  useCameraNormal: false,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+  macro.obj(publicAPI, model);
+  macro.setGet(publicAPI, model, ['useCameraFocalPoint', 'useCameraNormal']);
+  macro.setGetArray(
+    publicAPI,
+    model,
+    [
+      'userOrigin',
+      'handleOrigin',
+      'widgetOrigin',
+      'userNormal',
+      'handleNormal',
+      'widgetNormal',
+    ],
+    3
+  );
+
+  vtkAbstractManipulator(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkAbstractManipulator');
+
+// ----------------------------------------------------------------------------
+
+export default { extend, newInstance };

--- a/Sources/Widgets/Manipulators/LineManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/LineManipulator/index.d.ts
@@ -1,81 +1,15 @@
-import { vtkObject } from "../../../interfaces";
+import { IAbstractManipulatorInitialValues, vtkAbstractManipulator } from "../AbstractManipulator";
+import { Vector3 } from "../../../types";
 
 /**
  *
  */
-export interface ILineManipulatorInitialValues {
-	origin?: number[];
-	normal?: number[];
+export interface ILineManipulatorInitialValues extends IAbstractManipulatorInitialValues {
+
 }
 
-export interface vtkLineManipulator extends vtkObject {
+export interface vtkLineManipulator extends vtkAbstractManipulator {
 
-	/**
-	 * Set the normal of the line
-	 */
-	getNormal(): number[];
-
-	/**
-	 * Set the normal of the line
-	 */
-	getNormalByReference(): number[];
-
-	/**
-	 * Set the origin of the line
-	 */
-	getOrigin(): number[];
-
-	/**
-	 * Set the origin of the line
-	 */
-	getOriginByReference(): number[];
-
-	/**
-	 * 
-	 * @param callData 
-	 * @param glRenderWindow 
-	 */
-	handleEvent(callData: any, glRenderWindow: any): number[];
-
-	/**
-	 * Set the normal of the line
-	 * @param {Number[]} normal The normal coordinate.
-	 */
-	setNormal(normal: number[]): boolean;
-
-	/**
-	 * Set the normal of the line
-	 * @param {Number} x The x coordinate.
-	 * @param {Number} y The y coordinate.
-	 * @param {Number} z The z coordinate.
-	 */
-	setNormal(x: number, y: number, z: number): boolean;
-
-	/**
-	 * Set the normal of the line
-	 * @param {Number[]} normal The normal coordinate.
-	 */
-	setNormalFrom(normal: number[]): boolean;
-
-	/**
-	 * Set the origin of the line.
-	 * @param {Number[]} origin The coordinate of the origin point.
-	 */
-	setOrigin(origin: number[]): boolean;
-
-	/**
-	 * Set the origin of the line
-	 * @param {Number} x The x coordinate of the origin point.
-	 * @param {Number} y The y coordinate of the origin point.
-	 * @param {Number} z The z coordinate of the origin point.
-	 */
-	setOrigin(x: number, y: number, z: number): boolean;
-
-	/**
-	 * Set the origin of the line
-	 * @param {Number[]} origin The coordinate of the origin point.
-	 */
-	setOriginFrom(origin: number[]): boolean;
 }
 
 
@@ -97,12 +31,12 @@ export function newInstance(initialValues?: ILineManipulatorInitialValues): vtkL
  * 
  * @param {Number} x 
  * @param {Number} y 
- * @param {Number[]} lineOrigin 
- * @param {Number[]} lineDirection 
+ * @param {Vector3} lineOrigin 
+ * @param {Vector3} lineDirection 
  * @param renderer 
  * @param glRenderWindow 
  */
-export function projectDisplayToLine(x: number, y: number, lineOrigin: number[], lineDirection: number[], renderer: any, glRenderWindow: any): number[];
+export function projectDisplayToLine(x: number, y: number, lineOrigin: Vector3, lineDirection: Vector3, renderer: any, glRenderWindow: any): Vector3;
 
 /**
  * vtkLineManipulator.

--- a/Sources/Widgets/Manipulators/LineManipulator/index.js
+++ b/Sources/Widgets/Manipulators/LineManipulator/index.js
@@ -1,6 +1,8 @@
 import macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
+import vtkAbstractManipulator from 'vtk.js/Sources/Widgets/Manipulators/AbstractManipulator';
+
 export function projectDisplayToLine(
   x,
   y,
@@ -36,17 +38,15 @@ export function projectDisplayToLine(
 // ----------------------------------------------------------------------------
 
 function vtkLineManipulator(publicAPI, model) {
-  // Set our classNae
+  // Set our className
   model.classHierarchy.push('vtkLineManipulator');
-
-  // --------------------------------------------------------------------------
 
   publicAPI.handleEvent = (callData, glRenderWindow) =>
     projectDisplayToLine(
       callData.position.x,
       callData.position.y,
-      model.origin,
-      model.normal,
+      publicAPI.getOrigin(callData),
+      publicAPI.getNormal(callData),
       callData.pokedRenderer,
       glRenderWindow
     );
@@ -56,17 +56,16 @@ function vtkLineManipulator(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
-  origin: [0, 0, 0],
-  normal: [0, 0, 1],
-};
+function defaultValues(initialValues) {
+  return {
+    ...initialValues,
+  };
+}
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
-  macro.obj(publicAPI, model);
-  macro.setGetArray(publicAPI, model, ['origin', 'normal'], 3);
+  vtkAbstractManipulator.extend(publicAPI, model, defaultValues(initialValues));
 
   vtkLineManipulator(publicAPI, model);
 }

--- a/Sources/Widgets/Manipulators/PlaneManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/PlaneManipulator/index.d.ts
@@ -1,81 +1,15 @@
-import { vtkObject } from "../../../interfaces";
+import { IAbstractManipulatorInitialValues, vtkAbstractManipulator } from "../AbstractManipulator";
+import { Vector3 } from "../../../types";
 
 /**
  *
  */
-export interface IPlaneManipulatorInitialValues {
-	origin?: number[];
-	normal?: number[];
+export interface IPlaneManipulatorInitialValues extends IAbstractManipulatorInitialValues {
+
 }
 
-export interface vtkPlaneManipulator extends vtkObject {
+export interface vtkPlaneManipulator extends vtkAbstractManipulator {
 
-	/**
-	 * Get the normal of the plane
-	 */
-	getNormal(): number[];
-
-	/**
-	 * Get the normal of the plane
-	 */
-	getNormalByReference(): number[];
-
-	/**
-	 * Get the origin of the plane
-	 */
-	getOrigin(): number[];
-
-	/**
-	 * Get the origin of the plane
-	 */
-	getOriginByReference(): number[];
-
-	/**
-	 * 
-	 * @param callData 
-	 * @param glRenderWindow 
-	 */
-	handleEvent(callData: any, glRenderWindow: any): number[];
-
-	/**
-	 * Set the normal of the plane
-	 * @param {Number[]} normal The normal coordinate.
-	 */
-	setNormal(normal: number[]): boolean;
-
-	/**
-	 * Set the normal of the plane
-	 * @param {Number} x The x coordinate.
-	 * @param {Number} y The y coordinate.
-	 * @param {Number} z The z coordinate.
-	 */
-	setNormal(x: number, y: number, z: number): boolean;
-
-	/**
-	 * Set the normal of the plane
-	 * @param {Number[]} normal The normal coordinate.
-	 */
-	setNormalFrom(normal: number[]): boolean;
-
-	/**
-	 * Set the origin of the plane.
-	 * @param {Number[]} origin The coordinate of the origin point.
-	 */
-	setOrigin(origin: number[]): boolean;
-
-	/**
-	 * Set the origin of the plane.
-	 * @param {Number} x The x coordinate of the origin point.
-	 * @param {Number} y The y coordinate of the origin point.
-	 * @param {Number} z The z coordinate of the origin point.
-	 */
-	setOrigin(x: number, y: number, z: number): boolean;
-
-	/**
-	 * Set the origin of the plane.
-	 * @param {Number[]} origin The coordinate of the origin point.
-	 */
-	setOriginFrom(origin: number[]): boolean;
 }
 
 
@@ -97,12 +31,12 @@ export function newInstance(initialValues?: IPlaneManipulatorInitialValues): vtk
  * 
  * @param {Number} x 
  * @param {Number} y 
- * @param {Number[]} planeOrigin 
- * @param {Number[]} planeNormal 
+ * @param {Vector3} planeOrigin 
+ * @param {Vector3} planeNormal 
  * @param renderer 
  * @param glRenderWindow 
  */
-export function intersectDisplayWithPlane(x: number, y: number, planeOrigin: number[], planeNormal: number[], renderer: any, glRenderWindow: any): number[];
+export function intersectDisplayWithPlane(x: number, y: number, planeOrigin: Vector3, planeNormal: Vector3, renderer: any, glRenderWindow: any): Vector3;
 
 
 /**

--- a/Sources/Widgets/Manipulators/PlaneManipulator/index.js
+++ b/Sources/Widgets/Manipulators/PlaneManipulator/index.js
@@ -1,6 +1,8 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
 
+import vtkAbstractManipulator from 'vtk.js/Sources/Widgets/Manipulators/AbstractManipulator';
+
 export function intersectDisplayWithPlane(
   x,
   y,
@@ -23,14 +25,12 @@ function vtkPlaneManipulator(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkPlaneManipulator');
 
-  // --------------------------------------------------------------------------
-
   publicAPI.handleEvent = (callData, glRenderWindow) =>
     intersectDisplayWithPlane(
       callData.position.x,
       callData.position.y,
-      model.origin,
-      model.normal,
+      publicAPI.getOrigin(callData),
+      publicAPI.getNormal(callData),
       callData.pokedRenderer,
       glRenderWindow
     );
@@ -40,17 +40,16 @@ function vtkPlaneManipulator(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
-  normal: [0, 0, 1],
-  origin: [0, 0, 0],
-};
+function defaultValues(initialValues) {
+  return {
+    ...initialValues,
+  };
+}
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
-  macro.obj(publicAPI, model);
-  macro.setGetArray(publicAPI, model, ['normal', 'origin'], 3);
+  vtkAbstractManipulator.extend(publicAPI, model, defaultValues(initialValues));
 
   vtkPlaneManipulator(publicAPI, model);
 }

--- a/Sources/Widgets/Manipulators/TrackballManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/TrackballManipulator/index.d.ts
@@ -1,50 +1,14 @@
-import { vtkObject } from "../../../interfaces";
+import { IAbstractManipulatorInitialValues, vtkAbstractManipulator } from "../AbstractManipulator";
+import { Vector3 } from "../../../types";
 
 /**
  *
  */
-export interface ITrackballManipulatorInitialValues {
-	normal?: number[];
+export interface ITrackballManipulatorInitialValues extends IAbstractManipulatorInitialValues {
+
 }
 
-export interface vtkTrackballManipulator extends vtkObject {
-
-	/**
-	 * Get normal
-	 */
-	getNormal(): number[];
-
-	/**
-	 * Get normal
-	 */
-	getNormalByReference(): number[];
-
-	/**
-	 * 
-	 * @param callData 
-	 * @param glRenderWindow 
-	 */
-	handleEvent(callData: any, glRenderWindow: any): void;
-
-	/**
-	 * Set the normal of the line.
-	 * @param {Number[]} normal The normal coordinate.
-	 */
-	setNormal(normal: number[]): boolean;
-
-	/**
-	 * Set the normal of the line.
-	 * @param {Number} x The x coordinate.
-	 * @param {Number} y The y coordinate.
-	 * @param {Number} z The z coordinate.
-	 */
-	setNormal(x: number, y: number, z: number): boolean;
-
-	/**
-	 * Set the normal of the line.
-	 * @param {Number[]} normal The normal coordinate.
-	 */
-	setNormalFrom(normal: number[]): boolean;
+export interface vtkTrackballManipulator extends vtkAbstractManipulator {
 
 	/**
 	 * 
@@ -73,12 +37,12 @@ export function newInstance(initialValues?: ITrackballManipulatorInitialValues):
  * @param {Number} prevY 
  * @param {Number} curX 
  * @param {Number} curY 
- * @param {Number[]} origin 
- * @param {Number[]} direction 
+ * @param {Vector3} origin 
+ * @param {Vector3} direction 
  * @param renderer 
  * @param glRenderWindow 
  */
-export function trackballRotate(prevX: number, prevY: number, curX: number, curY: number, origin: number[], direction: number[], renderer: any, glRenderWindow: any): void;
+export function trackballRotate(prevX: number, prevY: number, curX: number, curY: number, origin: Vector3, direction: Vector3, renderer: any, glRenderWindow: any): void;
 
 
 /**

--- a/Sources/Widgets/Manipulators/TrackballManipulator/index.js
+++ b/Sources/Widgets/Manipulators/TrackballManipulator/index.js
@@ -2,6 +2,8 @@ import { mat4, vec3 } from 'gl-matrix';
 import macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
+import vtkAbstractManipulator from 'vtk.js/Sources/Widgets/Manipulators/AbstractManipulator';
+
 export function trackballRotate(
   prevX,
   prevY,
@@ -52,16 +54,14 @@ function vtkTrackballManipulator(publicAPI, model) {
   let prevX = 0;
   let prevY = 0;
 
-  // --------------------------------------------------------------------------
-
   publicAPI.handleEvent = (callData, glRenderWindow) => {
     const newDirection = trackballRotate(
       prevX,
       prevY,
       callData.position.x,
       callData.position.y,
-      model.origin,
-      model.normal,
+      publicAPI.getOrigin(callData),
+      publicAPI.getNormal(callData),
       callData.pokedRenderer,
       glRenderWindow
     );
@@ -69,8 +69,6 @@ function vtkTrackballManipulator(publicAPI, model) {
     prevY = callData.position.y;
     return newDirection;
   };
-
-  // --------------------------------------------------------------------------
 
   publicAPI.reset = (callData) => {
     prevX = callData.position.x;
@@ -82,16 +80,16 @@ function vtkTrackballManipulator(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
-  normal: [0, 0, 1],
-};
+function defaultValues(initialValues) {
+  return {
+    ...initialValues,
+  };
+}
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
-  macro.obj(publicAPI, model);
-  macro.setGetArray(publicAPI, model, ['normal'], 3);
+  vtkAbstractManipulator.extend(publicAPI, model, defaultValues(initialValues));
 
   vtkTrackballManipulator(publicAPI, model);
 }

--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -52,6 +52,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setOrigin(...moveHandle.getOrigin());
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
+      newHandle.setManipulator(model.manipulator);
     } else {
       isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');
@@ -67,17 +68,17 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleMouseMove = (callData) => {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
+      manipulator &&
       model.pickable &&
       model.dragable &&
-      model.manipulator &&
       model.activeState &&
       model.activeState.getActive() &&
       !ignoreKey(callData)
     ) {
-      model.manipulator.setOrigin(model.activeState.getOrigin());
-      model.manipulator.setNormal(model._camera.getDirectionOfProjection());
-      const worldCoords = model.manipulator.handleEvent(
+      const worldCoords = manipulator.handleEvent(
         callData,
         model._apiSpecificRenderWindow
       );

--- a/Sources/Widgets/Widgets3D/AngleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/index.js
@@ -17,6 +17,8 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkAngleWidget(publicAPI, model) {
   model.classHierarchy.push('vtkAngleWidget');
 
+  const superClass = { ...publicAPI };
+
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
@@ -69,6 +71,14 @@ function vtkAngleWidget(publicAPI, model) {
     return vtkMath.angleBetweenVectors(vec1, vec2);
   };
 
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getMoveHandle().setManipulator(manipulator);
+    model.widgetState.getHandleList().forEach((handle) => {
+      handle.setManipulator(manipulator);
+    });
+  };
+
   // --------------------------------------------------------------------------
   // initialization
   // --------------------------------------------------------------------------
@@ -83,7 +93,10 @@ function vtkAngleWidget(publicAPI, model) {
   });
 
   // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/AngleWidget/state.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/state.js
@@ -5,7 +5,7 @@ export default function generateState() {
     .createBuilder()
     .addStateFromMixin({
       labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'moveHandle',
       initialValues: {
         scale1: 0.1,
@@ -14,7 +14,7 @@ export default function generateState() {
     })
     .addDynamicMixinState({
       labels: ['handles'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'handle',
       initialValues: {
         scale1: 0.1,

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -45,6 +45,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setOrigin(...moveHandle.getOrigin());
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
+      newHandle.setManipulator(model.manipulator);
     } else {
       isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');
@@ -67,16 +68,17 @@ export default function widgetBehavior(publicAPI, model) {
       publicAPI.loseFocus();
       return macro.VOID;
     }
-
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
+      manipulator &&
       model.pickable &&
       model.dragable &&
-      model.manipulator &&
       model.activeState &&
       model.activeState.getActive() &&
       !ignoreKey(callData)
     ) {
-      const worldCoords = model.manipulator.handleEvent(
+      const worldCoords = manipulator.handleEvent(
         callData,
         model._apiSpecificRenderWindow
       );

--- a/Sources/Widgets/Widgets3D/DistanceWidget/index.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/index.js
@@ -17,6 +17,8 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkDistanceWidget(publicAPI, model) {
   model.classHierarchy.push('vtkDistanceWidget');
 
+  const superClass = { ...publicAPI };
+
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
@@ -62,6 +64,14 @@ function vtkDistanceWidget(publicAPI, model) {
     );
   };
 
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getMoveHandle().setManipulator(manipulator);
+    model.widgetState.getHandleList().forEach((handle) => {
+      handle.setManipulator(manipulator);
+    });
+  };
+
   // --------------------------------------------------------------------------
   // initialization
   // --------------------------------------------------------------------------
@@ -76,7 +86,10 @@ function vtkDistanceWidget(publicAPI, model) {
   });
 
   // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/DistanceWidget/state.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/state.js
@@ -5,7 +5,7 @@ export default function generateState() {
     .createBuilder()
     .addStateFromMixin({
       labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'moveHandle',
       initialValues: {
         scale1: 0.1,
@@ -14,7 +14,7 @@ export default function generateState() {
     })
     .addDynamicMixinState({
       labels: ['handles'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'handle',
       initialValues: {
         scale1: 0.1,

--- a/Sources/Widgets/Widgets3D/EllipseWidget/index.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/index.js
@@ -70,9 +70,11 @@ function vtkEllipseWidget(publicAPI, model) {
   // initialization
   // --------------------------------------------------------------------------
 
-  // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
   model.widgetState = stateGenerator();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 // ----------------------------------------------------------------------------
@@ -103,7 +105,7 @@ function defaultValues(initialValues) {
 
 export function extend(publicAPI, model, initialValues = {}) {
   vtkShapeWidget.extend(publicAPI, model, defaultValues(initialValues));
-  macro.setGet(publicAPI, model, ['manipulator', 'widgetState']);
+  macro.setGet(publicAPI, model, ['widgetState']);
 
   vtkEllipseWidget(publicAPI, model);
 }

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/behavior.js
@@ -55,7 +55,6 @@ export default function widgetBehavior(publicAPI, model) {
 
         if (type === 'corners') {
           // manipulator should be a plane manipulator
-          manipulator.setNormal(model._camera.getDirectionOfProjection());
           worldCoords = manipulator.handleEvent(
             callData,
             model._apiSpecificRenderWindow
@@ -76,8 +75,10 @@ export default function widgetBehavior(publicAPI, model) {
           ];
 
           // manipulator should be a line manipulator
-          manipulator.setOrigin(transformVec3(center, indexToWorldT));
-          manipulator.setNormal(rotateVec3(constraintAxis, indexToWorldT));
+          manipulator.setHandleOrigin(transformVec3(center, indexToWorldT));
+          manipulator.setHandleNormal(
+            rotateVec3(constraintAxis, indexToWorldT)
+          );
           worldCoords = manipulator.handleEvent(
             callData,
             model._apiSpecificRenderWindow
@@ -88,7 +89,7 @@ export default function widgetBehavior(publicAPI, model) {
           // constrain to a plane with a normal parallel to the edge
           const edgeAxis = index.map((a) => (a === 1 ? a : 0));
 
-          manipulator.setNormal(rotateVec3(edgeAxis, indexToWorldT));
+          manipulator.setHandleNormal(rotateVec3(edgeAxis, indexToWorldT));
           worldCoords = manipulator.handleEvent(
             callData,
             model._apiSpecificRenderWindow

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
@@ -24,6 +24,8 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkImageCroppingWidget(publicAPI, model) {
   model.classHierarchy.push('vtkImageCroppingWidget');
 
+  const superClass = { ...publicAPI };
+
   let stateSub = null;
 
   // --------------------------------------------------------------------------
@@ -131,24 +133,45 @@ function vtkImageCroppingWidget(publicAPI, model) {
     .getCroppingPlanes()
     .onModified(publicAPI.updateHandles);
 
-  // Add manipulators to our widgets.
-  const planeManipulator = vtkPlaneManipulator.newInstance();
-  const lineManipulator = vtkLineManipulator.newInstance();
+  publicAPI.setCornerManipulator = (manipulator) => {
+    superClass.setCornerManipulator(manipulator);
+    model.widgetState
+      .getStatesWithLabel('corners')
+      .forEach((handle) => handle.setManipulator(manipulator));
+  };
 
-  model.widgetState
-    .getStatesWithLabel('corners')
-    .forEach((handle) => handle.setManipulator(planeManipulator));
-  model.widgetState
-    .getStatesWithLabel('edges')
-    .forEach((handle) => handle.setManipulator(planeManipulator));
-  model.widgetState
-    .getStatesWithLabel('faces')
-    .forEach((handle) => handle.setManipulator(lineManipulator));
+  publicAPI.setEdgeManipulator = (manipulator) => {
+    superClass.setEdgeManipulator(manipulator);
+    model.widgetState
+      .getStatesWithLabel('edges')
+      .forEach((handle) => handle.setManipulator(manipulator));
+  };
+
+  publicAPI.setFaceManipulator = (manipulator) => {
+    superClass.setFaceManipulator(manipulator);
+    model.widgetState
+      .getStatesWithLabel('faces')
+      .forEach((handle) => handle.setManipulator(manipulator));
+  };
+
+  // --------------------------------------------------------------------------
+  // initialization
+  // --------------------------------------------------------------------------
+
+  publicAPI.setCornerManipulator(
+    vtkPlaneManipulator.newInstance({ useCameraNormal: true })
+  );
+  publicAPI.setEdgeManipulator(vtkPlaneManipulator.newInstance());
+  publicAPI.setFaceManipulator(vtkLineManipulator.newInstance());
 }
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {};
+const DEFAULT_VALUES = {
+  // cornerManipulator: null,
+  // edgeManipulator: null,
+  // faceManipulator: null
+};
 
 // ----------------------------------------------------------------------------
 
@@ -156,6 +179,11 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
+  macro.setGet(publicAPI, model, [
+    'cornerManipulator',
+    'edgeManipulator',
+    'faceManipulator',
+  ]);
 
   vtkImageCroppingWidget(publicAPI, model);
 }

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
@@ -44,8 +44,8 @@ function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
     isDragging = true;
-    model.lineManipulator.setOrigin(model.widgetState.getOrigin());
-    model.planeManipulator.setOrigin(model.widgetState.getOrigin());
+    model.lineManipulator.setWidgetOrigin(model.widgetState.getOrigin());
+    model.planeManipulator.setWidgetOrigin(model.widgetState.getOrigin());
     model.trackballManipulator.reset(callData); // setup trackball delta
     model._interactor.requestAnimation(publicAPI);
     publicAPI.invokeStartInteractionEvent();
@@ -83,7 +83,7 @@ function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.updateFromOrigin = (callData) => {
-    model.planeManipulator.setNormal(model.widgetState.getNormal());
+    model.planeManipulator.setWidgetNormal(model.widgetState.getNormal());
     const worldCoords = model.planeManipulator.handleEvent(
       callData,
       model._apiSpecificRenderWindow
@@ -98,7 +98,7 @@ function widgetBehavior(publicAPI, model) {
 
   publicAPI.updateFromPlane = (callData) => {
     // Move origin along normal axis
-    model.lineManipulator.setNormal(model.activeState.getNormal());
+    model.lineManipulator.setWidgetNormal(model.activeState.getNormal());
     const worldCoords = model.lineManipulator.handleEvent(
       callData,
       model._apiSpecificRenderWindow
@@ -112,7 +112,7 @@ function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.updateFromNormal = (callData) => {
-    model.trackballManipulator.setNormal(model.activeState.getNormal());
+    model.trackballManipulator.setWidgetNormal(model.activeState.getNormal());
 
     const newNormal = model.trackballManipulator.handleEvent(
       callData,

--- a/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/example/index.js
@@ -32,7 +32,7 @@ function majorAxis(vec3, idxA, idxB) {
 // ----------------------------------------------------------------------------
 
 const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
-  background: [0, 0, 0],
+  background: [0.2, 0.2, 0.2],
 });
 const renderer = fullScreenRenderer.getRenderer();
 const renderWindow = fullScreenRenderer.getRenderWindow();
@@ -47,7 +47,7 @@ orientationWidget.setEnabled(true);
 orientationWidget.setViewportCorner(
   vtkOrientationMarkerWidget.Corners.BOTTOM_LEFT
 );
-orientationWidget.setViewportSize(0.15);
+orientationWidget.setViewportSize(0.3);
 orientationWidget.setMinPixelSize(100);
 orientationWidget.setMaxPixelSize(300);
 
@@ -74,12 +74,12 @@ widgetManager.setRenderer(orientationWidget.getRenderer());
 
 const widget = vtkInteractiveOrientationWidget.newInstance();
 widget.placeWidget(axes.getBounds());
-widget.setBounds(axes.getBounds());
+// widget.setBounds(axes.getBounds());
 widget.setPlaceFactor(1);
 
 const vw = widgetManager.addWidget(widget);
 
-// Manage user interaction
+// // Manage user interaction
 vw.onOrientationChange(({ up, direction, action, event }) => {
   const focalPoint = camera.getFocalPoint();
   const position = camera.getPosition();

--- a/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
@@ -95,15 +95,17 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleMouseMove = (callData) => {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
+      manipulator &&
       model.pickable &&
       model.dragable &&
-      model.manipulator &&
       model.activeState &&
       model.activeState.getActive() &&
       !ignoreKey(callData)
     ) {
-      const worldCoords = model.manipulator.handleEvent(
+      const worldCoords = manipulator.handleEvent(
         callData,
         model._apiSpecificRenderWindow
       );

--- a/Sources/Widgets/Widgets3D/LabelWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LabelWidget/index.js
@@ -18,6 +18,8 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkLabelWidget(publicAPI, model) {
   model.classHierarchy.push('vtkLabelWidget');
 
+  const superClass = { ...publicAPI };
+
   // --- Widget Requirement ---------------------------------------------------
   model.methodsToLink = ['textProps', 'fontProperties', 'strokeFontProperties'];
 
@@ -56,8 +58,23 @@ function vtkLabelWidget(publicAPI, model) {
     }
   };
 
+  // --- Public methods -------------------------------------------------------
+
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getMoveHandle().setManipulator(manipulator);
+    model.widgetState.getText().setManipulator(manipulator);
+  };
+
+  // --------------------------------------------------------------------------
+  // initialization
+  // --------------------------------------------------------------------------
+
   // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/LabelWidget/state.js
+++ b/Sources/Widgets/Widgets3D/LabelWidget/state.js
@@ -5,7 +5,7 @@ export default function generateState() {
     .createBuilder()
     .addStateFromMixin({
       labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'moveHandle',
       initialValues: {
         scale1: 0.1,
@@ -14,7 +14,7 @@ export default function generateState() {
     })
     .addStateFromMixin({
       labels: ['SVGtext'],
-      mixins: ['origin', 'color', 'text', 'visible'],
+      mixins: ['origin', 'color', 'text', 'visible', 'manipulator'],
       name: 'text',
       initialValues: {
         visible: true,

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -38,11 +38,10 @@ export default function widgetBehavior(publicAPI, model) {
 
   function updateCursor(callData) {
     model.isDragging = true;
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     model.previousPosition = [
-      ...model.manipulator.handleEvent(
-        callData,
-        model._apiSpecificRenderWindow
-      ),
+      ...manipulator.handleEvent(callData, model._apiSpecificRenderWindow),
     ];
     model._apiSpecificRenderWindow.setCursor('grabbing');
     model._interactor.requestAnimation(publicAPI);
@@ -256,15 +255,17 @@ export default function widgetBehavior(publicAPI, model) {
       publicAPI.loseFocus();
       return macro.VOID;
     }
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
+      manipulator &&
       model.pickable &&
       model.dragable &&
-      model.manipulator &&
       model.activeState &&
       model.activeState.getActive() &&
       !ignoreKey(callData)
     ) {
-      const worldCoords = model.manipulator.handleEvent(
+      const worldCoords = manipulator.handleEvent(
         callData,
         model._apiSpecificRenderWindow
       );

--- a/Sources/Widgets/Widgets3D/LineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/index.js
@@ -19,6 +19,9 @@ import {
 
 function vtkLineWidget(publicAPI, model) {
   model.classHierarchy.push('vtkLineWidget');
+
+  const superClass = { ...publicAPI };
+
   model.widgetState = stateGenerator();
   model.behavior = widgetBehavior;
 
@@ -153,6 +156,13 @@ function vtkLineWidget(publicAPI, model) {
     return p1 && p2 ? Math.sqrt(distance2BetweenPoints(p1, p2)) : 0;
   };
 
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getMoveHandle().setManipulator(manipulator);
+    model.widgetState.getHandle1().setManipulator(manipulator);
+    model.widgetState.getHandle2().setManipulator(manipulator);
+  };
+
   // --------------------------------------------------------------------------
   // initialization
   // --------------------------------------------------------------------------
@@ -174,12 +184,16 @@ function vtkLineWidget(publicAPI, model) {
   });
 
   // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  // manipulator: null,
   isDragging: false,
 };
 

--- a/Sources/Widgets/Widgets3D/LineWidget/state.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/state.js
@@ -16,7 +16,7 @@ export default function generateState() {
     .createBuilder()
     .addStateFromMixin({
       labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible', 'shape'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator', 'shape'],
       name: 'moveHandle',
       initialValues: {
         scale1: 50,

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -30,11 +30,9 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.handleEvent = (callData) => {
-    if (
-      model.manipulator &&
-      model.activeState &&
-      model.activeState.getActive()
-    ) {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
+    if (manipulator && model.activeState && model.activeState.getActive()) {
       const normal = model._camera.getDirectionOfProjection();
       const up = model._camera.getViewUp();
       const right = [];
@@ -42,9 +40,8 @@ export default function widgetBehavior(publicAPI, model) {
       model.activeState.setUp(...up);
       model.activeState.setRight(...right);
       model.activeState.setDirection(...normal);
-      model.manipulator.setNormal(normal);
 
-      const worldCoords = model.manipulator.handleEvent(
+      const worldCoords = manipulator.handleEvent(
         callData,
         model._apiSpecificRenderWindow
       );

--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -271,12 +271,12 @@ reader
         ijk[slicingMode] = image.imageMapper.getSlice();
         data.indexToWorld(ijk, position);
 
-        widgets.paintWidget.getManipulator().setOrigin(position);
-        widgets.rectangleWidget.getManipulator().setOrigin(position);
-        widgets.ellipseWidget.getManipulator().setOrigin(position);
-        widgets.circleWidget.getManipulator().setOrigin(position);
-        widgets.splineWidget.getManipulator().setOrigin(position);
-        widgets.polygonWidget.getManipulator().setOrigin(position);
+        widgets.paintWidget.getManipulator().setUserOrigin(position);
+        widgets.rectangleWidget.getManipulator().setUserOrigin(position);
+        widgets.ellipseWidget.getManipulator().setUserOrigin(position);
+        widgets.circleWidget.getManipulator().setUserOrigin(position);
+        widgets.splineWidget.getManipulator().setUserOrigin(position);
+        widgets.polygonWidget.getManipulator().setUserOrigin(position);
 
         painter.setSlicingMode(slicingMode);
 

--- a/Sources/Widgets/Widgets3D/PaintWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/index.js
@@ -16,6 +16,8 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkPaintWidget(publicAPI, model) {
   model.classHierarchy.push('vtkPaintWidget');
 
+  const superClass = { ...publicAPI };
+
   // --- Widget Requirement ---------------------------------------------------
   model.behavior = widgetBehavior;
   model.widgetState = stateGenerator(model.radius);
@@ -36,27 +38,37 @@ function vtkPaintWidget(publicAPI, model) {
         return [{ builder: vtkSphereHandleRepresentation, labels: ['handle'] }];
     }
   };
-  // --- Widget Requirement ---------------------------------------------------
 
-  const handle = model.widgetState.getHandle();
+  // --- Public methods -------------------------------------------------------
 
-  // Default manipulator
-  model.manipulator = vtkPlaneManipulator.newInstance();
-  handle.setManipulator(model.manipulator);
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getHandle().setManipulator(manipulator);
+  };
 
   // override
   const superSetRadius = publicAPI.setRadius;
   publicAPI.setRadius = (r) => {
     if (superSetRadius(r)) {
-      handle.setScale1(r);
+      model.widgetState.getHandle().setScale1(r);
     }
   };
+
+  // --------------------------------------------------------------------------
+  // initialization
+  // --------------------------------------------------------------------------
+
+  // Default manipulator
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlaneManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  manipulator: null,
+  // manipulator: null,
   radius: 1,
   painting: false,
   color: [1],

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -20,9 +20,13 @@ export default function widgetBehavior(publicAPI, model) {
   }
 
   function updateMoveHandle(callData) {
-    model.manipulator.setOrigin(model._camera.getFocalPoint());
-    model.manipulator.setNormal(model._camera.getDirectionOfProjection());
-    const worldCoords = model.manipulator.handleEvent(
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
+    if (!manipulator) {
+      return macro.VOID;
+    }
+
+    const worldCoords = manipulator.handleEvent(
       callData,
       model._apiSpecificRenderWindow
     );
@@ -88,6 +92,7 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setOrigin(...moveHandle.getOrigin());
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
+      newHandle.setManipulator(model.manipulator);
     } else {
       isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');
@@ -106,7 +111,6 @@ export default function widgetBehavior(publicAPI, model) {
     if (
       model.pickable &&
       model.dragable &&
-      model.manipulator &&
       model.activeState &&
       model.activeState.getActive() &&
       !ignoreKey(callData)

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
@@ -17,6 +17,8 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkPolyLineWidget(publicAPI, model) {
   model.classHierarchy.push('vtkPolyLineWidget');
 
+  const superClass = { ...publicAPI };
+
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
@@ -72,6 +74,15 @@ function vtkPolyLineWidget(publicAPI, model) {
     }
   };
 
+  // --- Public methods -------------------------------------------------------
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getMoveHandle().setManipulator(manipulator);
+    model.widgetState.getHandleList().forEach((handle) => {
+      handle.setManipulator(manipulator);
+    });
+  };
+
   // --------------------------------------------------------------------------
   // initialization
   // --------------------------------------------------------------------------
@@ -86,7 +97,13 @@ function vtkPolyLineWidget(publicAPI, model) {
   });
 
   // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlanePointManipulator.newInstance({
+        useCameraFocalPoint: true,
+        useCameraNormal: true,
+      })
+  );
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/state.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/state.js
@@ -5,7 +5,7 @@ export default function generateState() {
     .createBuilder()
     .addStateFromMixin({
       labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'moveHandle',
       initialValues: {
         // when scaleInPixels=true, the handles have 30px height
@@ -15,7 +15,7 @@ export default function generateState() {
     })
     .addDynamicMixinState({
       labels: ['handles'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'handle',
       initialValues: {
         scale1: 30,

--- a/Sources/Widgets/Widgets3D/RectangleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/index.js
@@ -68,14 +68,15 @@ function vtkRectangleWidget(publicAPI, model) {
   // initialization
   // --------------------------------------------------------------------------
 
-  // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
   model.widgetState = stateGenerator();
+  model.manipulator = vtkPlanePointManipulator.newInstance({
+    useCameraNormal: true,
+  });
 }
 
 // ----------------------------------------------------------------------------
 
-function defaultValues(initalValues) {
+function defaultValues(initialValues) {
   return {
     modifierBehavior: {
       None: {
@@ -93,7 +94,7 @@ function defaultValues(initalValues) {
           ShapeBehavior[BehaviorCategory.POINTS].CENTER_TO_CORNER,
       },
     },
-    ...initalValues,
+    ...initialValues,
   };
 }
 
@@ -101,7 +102,7 @@ function defaultValues(initalValues) {
 
 export function extend(publicAPI, model, initialValues = {}) {
   vtkShapeWidget.extend(publicAPI, model, defaultValues(initialValues));
-  macro.setGet(publicAPI, model, ['manipulator', 'widgetState']);
+  macro.setGet(publicAPI, model, ['widgetState']);
 
   vtkRectangleWidget(publicAPI, model);
 }

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -65,8 +65,8 @@ export default function widgetBehavior(publicAPI, model) {
       isDragging = true;
       const viewType = model.widgetState.getActiveViewType();
       const currentPlaneNormal = model.widgetState.getPlanes()[viewType].normal;
-      model.planeManipulator.setOrigin(model.widgetState.getCenter());
-      model.planeManipulator.setNormal(currentPlaneNormal);
+      model.planeManipulator.setWidgetOrigin(model.widgetState.getCenter());
+      model.planeManipulator.setWidgetNormal(currentPlaneNormal);
 
       publicAPI.startInteraction();
     } else if (
@@ -263,7 +263,7 @@ export default function widgetBehavior(publicAPI, model) {
     if (dot === 1 || dot === -1) {
       vtkMath.cross(
         currentLineVector,
-        model.planeManipulator.getNormal(),
+        model.planeManipulator.getWidgetNormal(),
         axisTranslation
       );
     }
@@ -309,7 +309,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI[InteractionMethodsName.RotateLine] = (calldata) => {
     const activeLine = model.widgetState.getActiveLineState();
-    const planeNormal = model.planeManipulator.getNormal();
+    const planeNormal = model.planeManipulator.getWidgetNormal();
     const worldCoords = model.planeManipulator.handleEvent(
       calldata,
       model._apiSpecificRenderWindow

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -273,8 +273,10 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   const computeTextPosition = (worldBounds, textPosition, worldMargin = 0) => {
-    const viewPlaneOrigin = model.manipulator.getOrigin();
-    const viewPlaneNormal = model.manipulator.getNormal();
+    const viewPlaneOrigin = vtkBoundingBox.getCenter(worldBounds);
+    const viewPlaneNormal = model._renderer
+      .getActiveCamera()
+      .getDirectionOfProjection();
     const viewUp = model._renderer.getActiveCamera().getViewUp();
 
     const positionMargin = Array.isArray(worldMargin)
@@ -448,12 +450,14 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleMouseMove = (callData) => {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
+      !manipulator ||
       !model.activeState ||
       !model.activeState.getActive() ||
       !model.pickable ||
-      !model.dragable ||
-      !model.manipulator
+      !model.dragable
     ) {
       return macro.VOID;
     }
@@ -467,9 +471,8 @@ export default function widgetBehavior(publicAPI, model) {
       model.shapeHandle.setUp(up);
       model.shapeHandle.setRight(right);
       model.shapeHandle.setDirection(normal);
-      model.manipulator.setNormal(normal);
     }
-    const worldCoords = model.manipulator.handleEvent(
+    const worldCoords = manipulator.handleEvent(
       callData,
       model._apiSpecificRenderWindow
     );

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -286,9 +286,9 @@ reader
         ijk[slicingMode] = image.imageMapper.getSlice();
         data.indexToWorld(ijk, slicePos);
 
-        widgets.rectangleWidget.getManipulator().setOrigin(slicePos);
-        widgets.ellipseWidget.getManipulator().setOrigin(slicePos);
-        widgets.circleWidget.getManipulator().setOrigin(slicePos);
+        widgets.rectangleWidget.getManipulator().setUserOrigin(slicePos);
+        widgets.ellipseWidget.getManipulator().setUserOrigin(slicePos);
+        widgets.circleWidget.getManipulator().setUserOrigin(slicePos);
 
         updateWidgetsVisibility(slicePos, slicingMode);
 

--- a/Sources/Widgets/Widgets3D/ShapeWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/index.js
@@ -8,12 +8,21 @@ import {
 function vtkShapeWidget(publicAPI, model) {
   model.classHierarchy.push('vtkShapeWidget');
 
+  const superClass = { ...publicAPI };
+
   model.methodsToLink = ['scaleInPixels', 'textProps', 'fontProperties'];
+
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState
+      .getStatesWithLabel('moveHandle')
+      .forEach((handle) => handle.setManipulator(manipulator));
+  };
 }
 
 function defaultValues(initialValues) {
   return {
-    manipulator: null,
+    // manipulator: null,
     modifierBehavior: {
       None: {
         [BehaviorCategory.PLACEMENT]:
@@ -36,6 +45,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
 
   macro.setGet(publicAPI, model, [
+    'manipulator',
     'modifierBehavior',
     'resetAfterPointPlacement',
   ]);

--- a/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
@@ -13,8 +13,6 @@ export default function widgetBehavior(publicAPI, model) {
   // The last world coordinate of the mouse cursor during dragging.
   model.previousPosition = null;
 
-  centerHandle.setManipulator(model.manipulator);
-  borderHandle.setManipulator(model.manipulator);
   model.classHierarchy.push('vtkSphereWidgetProp');
 
   moveHandle.setVisible(true);
@@ -58,7 +56,9 @@ export default function widgetBehavior(publicAPI, model) {
   }
 
   function currentWorldCoords(e) {
-    return model.manipulator.handleEvent(e, model._apiSpecificRenderWindow);
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
+    return manipulator.handleEvent(e, model._apiSpecificRenderWindow);
   }
 
   // Update the sphere's center and radius.  Example:

--- a/Sources/Widgets/Widgets3D/SphereWidget/index.js
+++ b/Sources/Widgets/Widgets3D/SphereWidget/index.js
@@ -11,6 +11,8 @@ import stateGenerator from './state';
 function vtkSphereWidget(publicAPI, model) {
   model.classHierarchy.push('vtkSphereWidget');
 
+  const superClass = { ...publicAPI };
+
   model.behavior = widgetBehavior;
   publicAPI.getRepresentationsForViewType = (viewType) => [
     {
@@ -40,14 +42,30 @@ function vtkSphereWidget(publicAPI, model) {
     },
   ];
 
+  // --- Public methods -------------------------------------------------------
+
   publicAPI.getRadius = () => {
     const h1 = model.widgetState.getCenterHandle();
     const h2 = model.widgetState.getBorderHandle();
     return Math.sqrt(distance2BetweenPoints(h1.getOrigin(), h2.getOrigin()));
   };
 
-  model.manipulator = vtkPlanePointManipulator.newInstance();
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getMoveHandle().setManipulator(manipulator);
+    model.widgetState.getCenterHandle().setManipulator(manipulator);
+    model.widgetState.getBorderHandle().setManipulator(manipulator);
+  };
+
+  // --------------------------------------------------------------------------
+  // initialization
+  // --------------------------------------------------------------------------
+
   model.widgetState = stateGenerator();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 export function extend(publicAPI, model, initialValues = {}) {

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -41,6 +41,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.lastHandle.setOrigin(...model.moveHandle.getOrigin());
       model.lastHandle.setColor(model.moveHandle.getColor());
       model.lastHandle.setScale1(model.moveHandle.getScale1());
+      model.lastHandle.setManipulator(model.manipulator);
 
       if (!model.firstHandle) {
         model.firstHandle = model.lastHandle;
@@ -291,17 +292,17 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleMouseMove = (callData) => {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
+      !manipulator ||
       !model.activeState ||
       !model.activeState.getActive() ||
-      !model.pickable ||
-      !model.manipulator
+      !model.pickable
     ) {
       return macro.VOID;
     }
-    model.manipulator.setNormal(model._camera.getDirectionOfProjection());
-
-    const worldCoords = model.manipulator.handleEvent(
+    const worldCoords = manipulator.handleEvent(
       callData,
       model._apiSpecificRenderWindow
     );

--- a/Sources/Widgets/Widgets3D/SplineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/index.js
@@ -16,6 +16,8 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkSplineWidget(publicAPI, model) {
   model.classHierarchy.push('vtkSplineWidget');
 
+  const superClass = { ...publicAPI };
+
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
@@ -50,17 +52,31 @@ function vtkSplineWidget(publicAPI, model) {
     }
   };
 
+  // --- Public methods -------------------------------------------------------
+  publicAPI.setManipulator = (manipulator) => {
+    superClass.setManipulator(manipulator);
+    model.widgetState.getMoveHandle().setManipulator(manipulator);
+    model.widgetState.getHandleList().forEach((handle) => {
+      handle.setManipulator(manipulator);
+    });
+  };
+
   // --------------------------------------------------------------------------
   // initialization
   // --------------------------------------------------------------------------
 
   // Default manipulator
-  model.manipulator = vtkPlanePointManipulator.newInstance();
+  publicAPI.setManipulator(
+    model.manipulator ||
+      model.manipulator ||
+      vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
+  );
 }
 
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
+  // manipulator: null,
   freehandMinDistance: 0.1,
   allowFreehand: true,
   resolution: 32, // propagates to SplineContextRepresentation

--- a/Sources/Widgets/Widgets3D/SplineWidget/state.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/state.js
@@ -11,7 +11,7 @@ export default function generateState() {
     .addField({ name: 'splineBias', initialValue: 0 })
     .addStateFromMixin({
       labels: ['moveHandle'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'moveHandle',
       initialValues: {
         scale1: 0.05,
@@ -20,7 +20,7 @@ export default function generateState() {
     })
     .addDynamicMixinState({
       labels: ['handles'],
-      mixins: ['origin', 'color', 'scale1', 'visible'],
+      mixins: ['origin', 'color', 'scale1', 'visible', 'manipulator'],
       name: 'handle',
       initialValues: {
         scale1: 0.05,


### PR DESCRIPTION
Harmonizes the way manipulators are used in widgets so its more consistent. 

Improves the manipulators so they can use 3 different origins: `userOrigin` (set by the user outside of the
widget code), `handleOrigin` (automatically set if the handle have a manipulator mixin) and
`widgetOrigin` (occasionally set in the widget code to give a "global" origin to the manipulator).
The manipulator normal is handled the same way, but can also use camera normal if the property
`useCameraNormal` is set to true.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Widget manipulator are now more customizable. It is possible to set a manipulator for each handle (ex: `widget.getWidgetState().getHandle().setManipulator(manipulator)`) or for the whole widget (ex: `widget.setManipulator(manipulator)`). In this case, the manipulator will be shared between each handle.

Manipulators will try to set their origin using the following order:
- userOrigin > handleOrigin > widgetOrigin

Manipulators will try to set their normal using the following order:
- userNormal > cameraNormal (*if useCameraNormal is true*) > handleNormal > widgetNormal

This allow to redefine the origin/normal of a manipulator (ex: to force a handle to move along a plane) without creating a custom widgets and override methods.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
In `LineManipulator`, `PlaneManipulator` and `TrackballManipulator`, added the following APIs:
  - `getUserNormal` / `setUserNormal`
  - `getHandleNormal` / `setHandleNormal`
  - `getWidgetNormal` / `setWidgetNormal`
  - `getUserOrigin` / `setUserOrigin`
  - `getHandleOrigin` / `setHandleOrigin`
  - `getWidgetOrigin` / `setWidgetOrigin`
  - `getUseCameraNormal` / `setUseCameraNormal`
 
`setOrigin` and `setNormal` APIs have been removed
- [x] Documentation and TypeScript definitions were updated to match those changes (todo)

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: v24.3.0
  - **OS**: Ubuntu 20.04 LTS
  - **Browser**: Chromium 98.0.4697.0
