### PR TITLE
fix(WebGL): fix translucent selection on WebGL

### DIFF
--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -205,6 +205,7 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
     // basic alpha blending
     model._supported = false;
     if (
+      renNode.getSelector() ||
       !gl ||
       !viewNode.getWebgl2() ||
       (!gl.getExtension('EXT_color_buffer_half_float') &&


### PR DESCRIPTION
The new order independent translucent pass was not
being bypassed during selection.
