### PR TITLE
fix(web-worker-loader): patch/fix vite prod build

### DIFF
--- a/Utilities/build/patches/rollup-plugin-web-worker-loader+1.6.1.patch
+++ b/Utilities/build/patches/rollup-plugin-web-worker-loader+1.6.1.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/rollup-plugin-web-worker-loader/src/helper/funcToSource.js b/node_modules/rollup-plugin-web-worker-loader/src/helper/funcToSource.js
+index 6b40a32..e3d9f12 100644
+--- a/node_modules/rollup-plugin-web-worker-loader/src/helper/funcToSource.js
++++ b/node_modules/rollup-plugin-web-worker-loader/src/helper/funcToSource.js
+@@ -1,14 +1,14 @@
+ export function funcToSource(fn, sourcemapArg) {
+     var sourcemap = sourcemapArg === undefined ? null : sourcemapArg;
+-    var source = fn.toString();
+-    var lines = source.split('\n');
+-    lines.pop();
+-    lines.shift();
+-    var blankPrefixLength = lines[0].search(/\S/);
+     var regex = /(['"])__worker_loader_strict__(['"])/g;
+-    for (var i = 0, n = lines.length; i < n; ++i) {
+-        lines[i] = lines[i].substring(blankPrefixLength).replace(regex, '$1use strict$2') + '\n';
+-    }
++    var lines = [];
++
++    // instead of extracting the function source code, just return the function as if it's being evaluated
++    // by the caller.
++    var source = fn.toString();
++    source = source.replace(regex, '$1use strict$2');
++    lines.push('(' + source + ')()');
++
+     if (sourcemap) {
+         lines.push('\/\/# sourceMappingURL=' + sourcemap + '\n');
+     }


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
- https://discourse.vtk.org/t/error-in-production-mode-using-vite-vuejs/8010/5

rollup-plugin-web-worker-loader funcToSource does not work with minified
functions, which gets it into trouble when a minifier does a pass over
the webworker code. This patch is intended to work around this issue by
wrapping the function in a function call, since the results of
funcToSource are evaluated in a worker context in the end.

### Results
- vite prod build works

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Added patch to rollup-plugin-web-worker-loader
- [x] Notify upstream issue of the work around

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- Tested manually using vite, vtk.js, and a volume rendering example and building for prod.

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
