### PR TITLE
chore(WebGPU): cleanup webgpu mappers

### DIFF
--- a/Sources/Rendering/Core/ScalarBarActor/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/index.js
@@ -202,7 +202,6 @@ function vtkScalarBarActorHelper(publicAPI, model) {
     ) {
       const range = scalarsToColors.getMappingRange();
       model.lastTickBounds = [...range];
-      model.barMapper.setScalarRange(model.lastTickBounds);
 
       // compute tick marks for axes (update for log scale)
       const scale = d3
@@ -847,6 +846,7 @@ const newScalarBarActorHelper = macro.newInstance(
 
     model.barMapper = vtkMapper.newInstance();
     model.barMapper.setInterpolateScalarsBeforeMapping(true);
+    model.barMapper.setUseLookupTableScalarRange(true);
     model.polyData = vtkPolyData.newInstance();
     model.barMapper.setInputData(model.polyData);
     model.barActor = vtkActor.newInstance();

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -70,6 +70,8 @@ function vtkViewNode(publicAPI, model) {
     return model._parent.getFirstAncestorOfType(type);
   };
 
+  // add a missing node/child for the passed in renderables. This should
+  // be called only in between prepareNodes and removeUnusedNodes
   publicAPI.addMissingNode = (dobj) => {
     if (!dobj) {
       return;
@@ -90,6 +92,8 @@ function vtkViewNode(publicAPI, model) {
     }
   };
 
+  // add missing nodes/children for the passed in renderables. This should
+  // be called only in between prepareNodes and removeUnusedNodes
   publicAPI.addMissingNodes = (dataObjs) => {
     if (!dataObjs || !dataObjs.length) {
       return;
@@ -111,6 +115,26 @@ function vtkViewNode(publicAPI, model) {
           model.children.push(newNode);
         }
       }
+    }
+  };
+
+  // ability to add children that have no renderable use in the same manner
+  // as addMissingNodes This case is when a normal viewnode wants to
+  // delegate passes to a helper or child that doeasn't map to a clear
+  // renderable or any renderable
+  publicAPI.addMissingChildren = (children) => {
+    if (!children || !children.length) {
+      return;
+    }
+
+    for (let index = 0; index < children.length; ++index) {
+      const child = children[index];
+      const cindex = model.children.indexOf(child);
+      if (cindex === -1) {
+        child.setParent(publicAPI);
+        model.children.push(child);
+      }
+      child.setVisited(true);
     }
   };
 

--- a/Sources/Rendering/WebGPU/CellArrayMapper/index.js
+++ b/Sources/Rendering/WebGPU/CellArrayMapper/index.js
@@ -1,0 +1,798 @@
+import { mat3, mat4 } from 'gl-matrix';
+
+import * as macro from 'vtk.js/Sources/macros';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
+import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+import vtkWebGPUBufferManager from 'vtk.js/Sources/Rendering/WebGPU/BufferManager';
+import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
+import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
+import vtkWebGPUSimpleMapper from 'vtk.js/Sources/Rendering/WebGPU/SimpleMapper';
+
+const { BufferUsage, PrimitiveTypes } = vtkWebGPUBufferManager;
+const { Representation } = vtkProperty;
+const { ScalarMode } = vtkMapper;
+
+const vtkWebGPUPolyDataVS = `
+//VTK::Renderer::Dec
+
+//VTK::Color::Dec
+
+//VTK::Normal::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::Select::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::IOStructs::Dec
+
+@stage(vertex)
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output : vertexOutput;
+
+  var vertex: vec4<f32> = vertexBC;
+
+  //VTK::Color::Impl
+
+  //VTK::Normal::Impl
+
+  //VTK::TCoord::Impl
+
+  //VTK::Select::Impl
+
+  //VTK::Position::Impl
+
+  return output;
+}
+`;
+
+const vtkWebGPUPolyDataFS = `
+//VTK::Renderer::Dec
+
+//VTK::Color::Dec
+
+// optional surface normal declaration
+//VTK::Normal::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::Select::Dec
+
+//VTK::RenderEncoder::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::IOStructs::Dec
+
+@stage(fragment)
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output : fragmentOutput;
+
+  var ambientColor: vec4<f32> = mapperUBO.AmbientColor;
+  var diffuseColor: vec4<f32> = mapperUBO.DiffuseColor;
+  var opacity: f32 = mapperUBO.Opacity;
+
+  //VTK::Color::Impl
+
+  //VTK::Normal::Impl
+
+  //VTK::Light::Impl
+
+  var computedColor: vec4<f32> = vec4<f32>(ambientColor.rgb * mapperUBO.AmbientIntensity
+     + diffuse * mapperUBO.DiffuseIntensity
+     + specular * mapperUBO.SpecularIntensity,
+     opacity);
+
+  //VTK::TCoord::Impl
+
+  //VTK::Select::Impl
+
+  if (computedColor.a == 0.0) { discard; };
+
+  //VTK::Position::Impl
+
+  //VTK::RenderEncoder::Impl
+  return output;
+}
+`;
+
+function isEdges(hash) {
+  // edge pipelines have "edge" in them
+  return hash.indexOf('edge') >= 0;
+}
+
+// ----------------------------------------------------------------------------
+// vtkWebGPUCellArrayMapper methods
+// ----------------------------------------------------------------------------
+
+function vtkWebGPUCellArrayMapper(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkWebGPUCellArrayMapper');
+
+  publicAPI.buildPass = (prepass) => {
+    if (prepass) {
+      model.WebGPUActor = publicAPI.getFirstAncestorOfType('vtkWebGPUActor');
+      model.WebGPURenderer =
+        model.WebGPUActor.getFirstAncestorOfType('vtkWebGPURenderer');
+      model.WebGPURenderWindow = model.WebGPURenderer.getParent();
+      model.device = model.WebGPURenderWindow.getDevice();
+    }
+  };
+
+  // Renders myself
+  publicAPI.translucentPass = (prepass) => {
+    if (prepass) {
+      publicAPI.prepareToDraw(model.WebGPURenderer.getRenderEncoder());
+      model.renderEncoder.registerDrawCallback(model.pipeline, publicAPI.draw);
+    }
+  };
+
+  publicAPI.opaquePass = (prepass) => {
+    if (prepass) {
+      publicAPI.prepareToDraw(model.WebGPURenderer.getRenderEncoder());
+      model.renderEncoder.registerDrawCallback(model.pipeline, publicAPI.draw);
+    }
+  };
+
+  publicAPI.updateUBO = () => {
+    // make sure the data is up to date
+    const actor = model.WebGPUActor.getRenderable();
+    const ppty = actor.getProperty();
+    const utime = model.UBO.getSendTime();
+    if (
+      publicAPI.getMTime() > utime ||
+      ppty.getMTime() > utime ||
+      model.renderable.getMTime() > utime
+    ) {
+      const keyMats = model.WebGPUActor.getKeyMatrices(model.WebGPURenderer);
+      model.UBO.setArray('BCWCMatrix', keyMats.bcwc);
+      model.UBO.setArray('BCSCMatrix', keyMats.bcsc);
+      model.UBO.setArray('MCWCNormals', keyMats.normalMatrix);
+
+      let aColor = ppty.getAmbientColorByReference();
+      model.UBO.setValue('AmbientIntensity', ppty.getAmbient());
+      model.UBO.setArray('AmbientColor', [
+        aColor[0],
+        aColor[1],
+        aColor[2],
+        1.0,
+      ]);
+      model.UBO.setValue('DiffuseIntensity', ppty.getDiffuse());
+      aColor = ppty.getDiffuseColorByReference();
+      model.UBO.setArray('DiffuseColor', [
+        aColor[0],
+        aColor[1],
+        aColor[2],
+        1.0,
+      ]);
+      model.UBO.setValue('SpecularIntensity', ppty.getSpecular());
+      model.UBO.setValue('SpecularPower', ppty.getSpecularPower());
+      aColor = ppty.getSpecularColorByReference();
+      model.UBO.setArray('SpecularColor', [
+        aColor[0],
+        aColor[1],
+        aColor[2],
+        1.0,
+      ]);
+      model.UBO.setValue('LineWidth', ppty.getLineWidth());
+      aColor = ppty.getEdgeColorByReference();
+      model.UBO.setArray('EdgeColor', [aColor[0], aColor[1], aColor[2], 1.0]);
+      model.UBO.setValue('Opacity', ppty.getOpacity());
+      model.UBO.setValue('PropID', model.WebGPUActor.getPropID());
+      const device = model.WebGPURenderWindow.getDevice();
+      model.UBO.sendIfNeeded(device);
+    }
+  };
+
+  publicAPI.haveWideLines = () => {
+    const actor = model.WebGPUActor.getRenderable();
+    const representation = actor.getProperty().getRepresentation();
+    if (actor.getProperty().getLineWidth() <= 1.0) {
+      return false;
+    }
+    if (model.primitiveType === PrimitiveTypes.Verts) {
+      return false;
+    }
+    if (
+      model.primitiveType === PrimitiveTypes.Triangles ||
+      model.primitiveType === PrimitiveTypes.TriangleStrips
+    ) {
+      return representation === Representation.WIREFRAME;
+    }
+    return true;
+  };
+
+  publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
+    const vDesc = pipeline.getShaderDescription('vertex');
+    vDesc.addBuiltinOutput('vec4<f32>', '@builtin(position) Position');
+    let code = vDesc.getCode();
+    if (publicAPI.haveWideLines()) {
+      vDesc.addBuiltinInput('u32', '@builtin(instance_index) instanceIndex');
+      // widen the edge
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+        '    var tmpPos: vec4<f32> = rendererUBO.SCPCMatrix*mapperUBO.BCSCMatrix*vertexBC;',
+        '    var numSteps: f32 = ceil(mapperUBO.LineWidth - 1.0);',
+        '    var offset: f32 = (mapperUBO.LineWidth - 1.0) * (f32(input.instanceIndex / 2u) - numSteps/2.0) / numSteps;',
+        '    var tmpPos2: vec3<f32> = tmpPos.xyz / tmpPos.w;',
+        '    tmpPos2.x = tmpPos2.x + 2.0 * (f32(input.instanceIndex) % 2.0) * offset / rendererUBO.viewportSize.x;',
+        '    tmpPos2.y = tmpPos2.y + 2.0 * (f32(input.instanceIndex + 1u) % 2.0) * offset / rendererUBO.viewportSize.y;',
+        '    tmpPos2.z = tmpPos2.z + 0.00001;', // could become a setting
+        '    output.Position = vec4<f32>(tmpPos2.xyz * tmpPos.w, tmpPos.w);',
+      ]).result;
+    } else {
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+        '    output.Position = rendererUBO.SCPCMatrix*mapperUBO.BCSCMatrix*vertexBC;',
+      ]).result;
+    }
+
+    vDesc.setCode(code);
+  };
+  model.shaderReplacements.set(
+    'replaceShaderPosition',
+    publicAPI.replaceShaderPosition
+  );
+
+  publicAPI.replaceShaderNormal = (hash, pipeline, vertexInput) => {
+    if (vertexInput.hasAttribute('normalMC')) {
+      const vDesc = pipeline.getShaderDescription('vertex');
+      vDesc.addOutput('vec3<f32>', 'normalVC');
+      let code = vDesc.getCode();
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Normal::Impl', [
+        '  output.normalVC = normalize((rendererUBO.WCVCNormals * mapperUBO.MCWCNormals * normalMC).xyz);',
+      ]).result;
+      vDesc.setCode(code);
+
+      const fDesc = pipeline.getShaderDescription('fragment');
+      code = fDesc.getCode();
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Normal::Impl', [
+        '  var normal: vec3<f32> = input.normalVC;',
+        '  if (!input.frontFacing) { normal = -normal; }',
+      ]).result;
+      fDesc.setCode(code);
+    }
+  };
+  model.shaderReplacements.set(
+    'replaceShaderNormal',
+    publicAPI.replaceShaderNormal
+  );
+
+  // we only apply lighting when there is a "var normal" declaration in the
+  // fragment shader code. That is the lighting trigger.
+  publicAPI.replaceShaderLight = (hash, pipeline, vertexInput) => {
+    const fDesc = pipeline.getShaderDescription('fragment');
+    let code = fDesc.getCode();
+    if (code.includes('var normal')) {
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Light::Impl', [
+        '  var df: f32  = max(0.0, normal.z);',
+        '  var sf: f32 = pow(df, mapperUBO.SpecularPower);',
+        '  var diffuse: vec3<f32> = df * diffuseColor.rgb;',
+        '  var specular: vec3<f32> = sf * mapperUBO.SpecularColor.rgb * mapperUBO.SpecularColor.a;',
+      ]).result;
+      fDesc.setCode(code);
+    } else {
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Light::Impl', [
+        '  var diffuse: vec3<f32> = diffuseColor.rgb;',
+        '  var specular: vec3<f32> = mapperUBO.SpecularColor.rgb * mapperUBO.SpecularColor.a;',
+      ]).result;
+      fDesc.setCode(code);
+    }
+  };
+  model.shaderReplacements.set(
+    'replaceShaderLight',
+    publicAPI.replaceShaderLight
+  );
+
+  publicAPI.replaceShaderColor = (hash, pipeline, vertexInput) => {
+    if (isEdges(hash)) {
+      const fDesc = pipeline.getShaderDescription('fragment');
+      let code = fDesc.getCode();
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Color::Impl', [
+        'ambientColor = mapperUBO.EdgeColor;',
+        'diffuseColor = mapperUBO.EdgeColor;',
+      ]).result;
+      fDesc.setCode(code);
+      return;
+    }
+
+    if (!vertexInput.hasAttribute('colorVI')) return;
+
+    const vDesc = pipeline.getShaderDescription('vertex');
+    vDesc.addOutput('vec4<f32>', 'color');
+    let code = vDesc.getCode();
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Color::Impl', [
+      '  output.color = colorVI;',
+    ]).result;
+    vDesc.setCode(code);
+
+    const fDesc = pipeline.getShaderDescription('fragment');
+    code = fDesc.getCode();
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Color::Impl', [
+      'ambientColor = input.color;',
+      'diffuseColor = input.color;',
+      'opacity = mapperUBO.Opacity * input.color.a;',
+    ]).result;
+    fDesc.setCode(code);
+  };
+  model.shaderReplacements.set(
+    'replaceShaderColor',
+    publicAPI.replaceShaderColor
+  );
+
+  publicAPI.replaceShaderTCoord = (hash, pipeline, vertexInput) => {
+    if (!vertexInput.hasAttribute('tcoord')) return;
+
+    const vDesc = pipeline.getShaderDescription('vertex');
+    vDesc.addOutput('vec2<f32>', 'tcoordVS');
+    let code = vDesc.getCode();
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::TCoord::Impl', [
+      '  output.tcoordVS = tcoord;',
+    ]).result;
+    vDesc.setCode(code);
+
+    const fDesc = pipeline.getShaderDescription('fragment');
+    code = fDesc.getCode();
+
+    // todo handle multiple textures? Blend multiply ?
+    if (model.textures.length) {
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::TCoord::Impl', [
+        'var tcolor: vec4<f32> = textureSample(Texture0, Texture0Sampler, input.tcoordVS);',
+        'computedColor = computedColor*tcolor;',
+      ]).result;
+    }
+    fDesc.setCode(code);
+  };
+  model.shaderReplacements.set(
+    'replaceShaderTCoord',
+    publicAPI.replaceShaderTCoord
+  );
+
+  publicAPI.replaceShaderSelect = (hash, pipeline, vertexInput) => {
+    if (hash.includes('sel')) {
+      const fDesc = pipeline.getShaderDescription('fragment');
+      let code = fDesc.getCode();
+      // by default there are no composites, so just 0
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Select::Impl', [
+        '  var compositeID: u32 = 0u;',
+      ]).result;
+      fDesc.setCode(code);
+    }
+  };
+  model.shaderReplacements.set(
+    'replaceShaderSelect',
+    publicAPI.replaceShaderSelect
+  );
+
+  publicAPI.getUsage = (rep, i) => {
+    if (rep === Representation.POINTS || i === PrimitiveTypes.Points) {
+      return BufferUsage.Verts;
+    }
+
+    if (i === PrimitiveTypes.Lines) {
+      return BufferUsage.Lines;
+    }
+
+    if (rep === Representation.WIREFRAME) {
+      if (i === PrimitiveTypes.Triangles) {
+        return BufferUsage.LinesFromTriangles;
+      }
+      return BufferUsage.LinesFromStrips;
+    }
+
+    if (i === PrimitiveTypes.Triangles) {
+      return BufferUsage.Triangles;
+    }
+
+    if (i === PrimitiveTypes.TriangleStrips) {
+      return BufferUsage.Strips;
+    }
+
+    if (i === PrimitiveTypes.TriangleEdges) {
+      return BufferUsage.LinesFromTriangles;
+    }
+
+    // only strip edges left which are lines
+    return BufferUsage.LinesFromStrips;
+  };
+
+  publicAPI.getHashFromUsage = (usage) => `pt${usage}`;
+
+  publicAPI.getTopologyFromUsage = (usage) => {
+    switch (usage) {
+      case BufferUsage.Triangles:
+        return 'triangle-list';
+      case BufferUsage.Verts:
+        return 'point-list';
+      case BufferUsage.Lines:
+      default:
+        return 'line-list';
+    }
+  };
+
+  publicAPI.buildVertexInput = () => {
+    const pd = model.currentInput;
+    const cells = model.cellArray;
+    const primType = model.primitiveType;
+
+    const actor = model.WebGPUActor.getRenderable();
+    let representation = actor.getProperty().getRepresentation();
+    const device = model.WebGPURenderWindow.getDevice();
+    let edges = false;
+    if (primType === PrimitiveTypes.TriangleEdges) {
+      edges = true;
+      representation = Representation.WIREFRAME;
+    }
+
+    const vertexInput = model.vertexInput;
+    const hash = `R${representation}P${primType}`;
+
+    // hash = all things that can change the values on the buffer
+    // since mtimes are unique we can use
+    // - cells mtime - because cells drive how we pack
+    // - rep (point/wireframe/surface) - again because of packing
+    // - relevant dataArray mtime - the source data
+    // - shift - not currently captured
+    // - scale - not currently captured
+    // - format
+    // - usage
+    // - packExtra - covered by format
+    // - prim type (vert/lines/polys/strips) - covered by cells mtime
+
+    // points
+    const points = pd.getPoints();
+    if (points) {
+      const shift = model.WebGPUActor.getBufferShift(model.WebGPURenderer);
+      const buffRequest = {
+        owner: points,
+        usage: BufferUsage.PointArray,
+        format: 'float32x4',
+        time: Math.max(
+          points.getMTime(),
+          cells.getMTime(),
+          model.WebGPUActor.getKeyMatricesTime().getMTime()
+        ),
+        hash,
+        dataArray: points,
+        cells,
+        primitiveType: primType,
+        representation,
+        shift,
+        packExtra: true,
+      };
+      const buff = device.getBufferManager().getBuffer(buffRequest);
+      vertexInput.addBuffer(buff, ['vertexBC']);
+    } else {
+      vertexInput.removeBufferIfPresent('vertexBC');
+    }
+
+    // normals, only used for surface rendering
+    const usage = publicAPI.getUsage(representation, primType);
+    if (usage === BufferUsage.Triangles || usage === BufferUsage.Strips) {
+      const normals = pd.getPointData().getNormals();
+      const buffRequest = {
+        format: 'snorm8x4',
+        hash,
+        cells,
+        representation,
+        primitiveType: primType,
+        packExtra: true,
+        shift: 0,
+        scale: 127,
+      };
+      if (normals) {
+        buffRequest.owner = normals;
+        buffRequest.dataArray = normals;
+        buffRequest.time = Math.max(normals.getMTime(), cells.getMTime());
+        buffRequest.usage = BufferUsage.PointArray;
+        const buff = device.getBufferManager().getBuffer(buffRequest);
+        vertexInput.addBuffer(buff, ['normalMC']);
+      } else if (primType === PrimitiveTypes.Triangles) {
+        buffRequest.owner = points;
+        buffRequest.dataArray = points;
+        buffRequest.time = Math.max(points.getMTime(), cells.getMTime());
+        buffRequest.usage = BufferUsage.NormalsFromPoints;
+        const buff = device.getBufferManager().getBuffer(buffRequest);
+        vertexInput.addBuffer(buff, ['normalMC']);
+      } else {
+        vertexInput.removeBufferIfPresent('normalMC');
+      }
+    } else {
+      vertexInput.removeBufferIfPresent('normalMC');
+    }
+
+    // deal with colors but only if modified
+    let haveColors = false;
+    if (model.renderable.getScalarVisibility()) {
+      const c = model.renderable.getColorMapColors();
+      if (c && !edges) {
+        const scalarMode = model.renderable.getScalarMode();
+        let haveCellScalars = false;
+        // We must figure out how the scalars should be mapped to the polydata.
+        if (
+          (scalarMode === ScalarMode.USE_CELL_DATA ||
+            scalarMode === ScalarMode.USE_CELL_FIELD_DATA ||
+            scalarMode === ScalarMode.USE_FIELD_DATA ||
+            !pd.getPointData().getScalars()) &&
+          scalarMode !== ScalarMode.USE_POINT_FIELD_DATA &&
+          c
+        ) {
+          haveCellScalars = true;
+        }
+        const buffRequest = {
+          owner: c,
+          usage: BufferUsage.PointArray,
+          format: 'unorm8x4',
+          time: Math.max(c.getMTime(), cells.getMTime(), points.getMTime()),
+          hash: hash + haveCellScalars,
+          dataArray: c,
+          cells,
+          primitiveType: primType,
+          representation,
+          cellData: haveCellScalars,
+          cellOffset: 0,
+        };
+        const buff = device.getBufferManager().getBuffer(buffRequest);
+        vertexInput.addBuffer(buff, ['colorVI']);
+        haveColors = true;
+      }
+    }
+    if (!haveColors) {
+      vertexInput.removeBufferIfPresent('colorVI');
+    }
+
+    let tcoords = null;
+    if (
+      model.renderable.getInterpolateScalarsBeforeMapping() &&
+      model.renderable.getColorCoordinates()
+    ) {
+      tcoords = model.renderable.getColorCoordinates();
+    } else {
+      tcoords = pd.getPointData().getTCoords();
+    }
+    if (tcoords && !edges) {
+      // console.log(`tcoords ${tcoords.getMTime()}`);
+      const buffRequest = {
+        owner: tcoords,
+        usage: BufferUsage.PointArray,
+        format: 'float32x2',
+        time: Math.max(tcoords.getMTime(), cells.getMTime()),
+        hash,
+        dataArray: tcoords,
+        cells,
+        primitiveType: primType,
+        representation,
+      };
+      const buff = device.getBufferManager().getBuffer(buffRequest);
+      vertexInput.addBuffer(buff, ['tcoord']);
+    } else {
+      vertexInput.removeBufferIfPresent('tcoord');
+    }
+  };
+
+  publicAPI.updateTextures = () => {
+    // we keep track of new and used textures so
+    // that we can clean up any unused textures so we don't hold onto them
+    const usedTextures = [];
+    const newTextures = [];
+
+    // do we have a scalar color texture
+    const idata = model.renderable.getColorTextureMap(); // returns an imagedata
+    if (idata) {
+      if (!model.colorTexture) {
+        model.colorTexture = vtkTexture.newInstance({ label: 'polyDataColor' });
+      }
+      model.colorTexture.setInputData(idata);
+      newTextures.push(model.colorTexture);
+    }
+
+    // actor textures?
+    const actor = model.WebGPUActor.getRenderable();
+    const textures = actor.getTextures();
+    for (let i = 0; i < textures.length; i++) {
+      if (
+        textures[i].getInputData() ||
+        textures[i].getJsImageData() ||
+        textures[i].getCanvas()
+      ) {
+        newTextures.push(textures[i]);
+      }
+      if (textures[i].getImage() && textures[i].getImageLoaded()) {
+        newTextures.push(textures[i]);
+      }
+    }
+
+    let usedCount = 0;
+    for (let i = 0; i < newTextures.length; i++) {
+      const srcTexture = newTextures[i];
+      const treq = { time: srcTexture.getMTime() };
+      if (srcTexture.getInputData()) {
+        treq.imageData = srcTexture.getInputData();
+        treq.owner = treq.imageData.getPointData().getScalars();
+      } else if (srcTexture.getImage()) {
+        treq.image = srcTexture.getImage();
+        treq.owner = treq.image;
+      } else if (srcTexture.getJsImageData()) {
+        treq.jsImageData = srcTexture.getJsImageData();
+        treq.owner = treq.jsImageData;
+      } else if (srcTexture.getCanvas()) {
+        treq.canvas = srcTexture.getCanvas();
+        treq.owner = treq.canvas;
+      }
+      const newTex = model.device.getTextureManager().getTexture(treq);
+      if (newTex.getReady()) {
+        // is this a new texture
+        let found = false;
+        for (let t = 0; t < model.textures.length; t++) {
+          if (model.textures[t] === newTex) {
+            usedCount++;
+            found = true;
+            usedTextures[t] = true;
+          }
+        }
+        if (!found) {
+          usedTextures[model.textures.length] = true;
+          const tview = newTex.createView(`Texture${usedCount++}`);
+          model.textures.push(newTex);
+          model.textureViews.push(tview);
+          const interpolate = srcTexture.getInterpolate()
+            ? 'linear'
+            : 'nearest';
+          tview.addSampler(model.device, {
+            minFilter: interpolate,
+            magFilter: interpolate,
+          });
+        }
+      }
+    }
+
+    // remove unused textures
+    for (let i = model.textures.length - 1; i >= 0; i--) {
+      if (!usedTextures[i]) {
+        model.textures.splice(i, 1);
+        model.textureViews.splice(i, 1);
+      }
+    }
+  };
+
+  // compute a unique hash for a pipeline, this needs to be unique enough to
+  // capture any pipeline code changes (which includes shader changes)
+  // or vertex input changes/ bind groups/ etc
+  publicAPI.computePipelineHash = () => {
+    let pipelineHash = 'pd';
+    if (
+      model.primitiveType === PrimitiveTypes.TriangleEdges ||
+      model.primitiveType === PrimitiveTypes.TriangleStripEdges
+    ) {
+      pipelineHash += 'edge';
+    } else {
+      if (model.vertexInput.hasAttribute(`normalMC`)) {
+        pipelineHash += `n`;
+      }
+      if (model.vertexInput.hasAttribute(`colorVI`)) {
+        pipelineHash += `c`;
+      }
+      if (model.vertexInput.hasAttribute(`tcoord`)) {
+        pipelineHash += `t`;
+      }
+      if (model.textures.length) {
+        pipelineHash += `tx${model.textures.length}`;
+      }
+    }
+
+    if (model.SSBO) {
+      pipelineHash += `ssbo`;
+    }
+    const uhash = publicAPI.getHashFromUsage(model.usage);
+    pipelineHash += uhash;
+    pipelineHash += model.renderEncoder.getPipelineHash();
+
+    model.pipelineHash = pipelineHash;
+  };
+
+  publicAPI.updateBuffers = () => {
+    // handle textures if not edges
+    if (
+      model.primitiveType !== PrimitiveTypes.TriangleEdges &&
+      model.primitiveType !== PrimitiveTypes.TriangleStripEdges
+    ) {
+      publicAPI.updateTextures();
+    }
+
+    const actor = model.WebGPUActor.getRenderable();
+    const rep = actor.getProperty().getRepresentation();
+
+    // handle per primitive type
+    model.usage = publicAPI.getUsage(rep, model.primitiveType);
+    publicAPI.buildVertexInput();
+
+    const vbo = model.vertexInput.getBuffer('vertexBC');
+    publicAPI.setNumberOfVertices(
+      vbo.getSizeInBytes() / vbo.getStrideInBytes()
+    );
+    publicAPI.setTopology(publicAPI.getTopologyFromUsage(model.usage));
+    publicAPI.updateUBO();
+    if (publicAPI.haveWideLines()) {
+      const ppty = actor.getProperty();
+      publicAPI.setNumberOfInstances(Math.ceil(ppty.getLineWidth() * 2.0));
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  cellArray: null,
+  currentInput: null,
+  cellOffset: 0,
+  primitiveType: 0,
+  colorTexture: null,
+  renderEncoder: null,
+  textures: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkWebGPUSimpleMapper.extend(publicAPI, model, initialValues);
+
+  model.fragmentShaderTemplate = vtkWebGPUPolyDataFS;
+  model.vertexShaderTemplate = vtkWebGPUPolyDataVS;
+
+  model._tmpMat3 = mat3.identity(new Float64Array(9));
+  model._tmpMat4 = mat4.identity(new Float64Array(16));
+
+  model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
+  model.UBO.addEntry('BCWCMatrix', 'mat4x4<f32>');
+  model.UBO.addEntry('BCSCMatrix', 'mat4x4<f32>');
+  model.UBO.addEntry('MCWCNormals', 'mat4x4<f32>');
+  model.UBO.addEntry('AmbientColor', 'vec4<f32>');
+  model.UBO.addEntry('DiffuseColor', 'vec4<f32>');
+  model.UBO.addEntry('EdgeColor', 'vec4<f32>');
+  model.UBO.addEntry('SpecularColor', 'vec4<f32>');
+  model.UBO.addEntry('AmbientIntensity', 'f32');
+  model.UBO.addEntry('DiffuseIntensity', 'f32');
+  model.UBO.addEntry('SpecularIntensity', 'f32');
+  model.UBO.addEntry('LineWidth', 'f32');
+  model.UBO.addEntry('Opacity', 'f32');
+  model.UBO.addEntry('SpecularPower', 'f32');
+  model.UBO.addEntry('PropID', 'u32');
+
+  // Build VTK API
+  macro.setGet(publicAPI, model, [
+    'cellArray',
+    'currentInput',
+    'cellOffset',
+    'primitiveType',
+    'renderEncoder',
+  ]);
+
+  model.textures = [];
+
+  // Object methods
+  vtkWebGPUCellArrayMapper(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(
+  extend,
+  'vtkWebGPUCellArrayMapper'
+);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Rendering/WebGPU/FullScreenQuad/index.js
+++ b/Sources/Rendering/WebGPU/FullScreenQuad/index.js
@@ -1,6 +1,6 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
-import vtkWebGPUMapperHelper from 'vtk.js/Sources/Rendering/WebGPU/MapperHelper';
+import vtkWebGPUSimpleMapper from 'vtk.js/Sources/Rendering/WebGPU/SimpleMapper';
 
 // ----------------------------------------------------------------------------
 // vtkWebGPUFullScreenQuad methods
@@ -25,12 +25,10 @@ function vtkWebGPUFullScreenQuad(publicAPI, model) {
     publicAPI.replaceShaderPosition
   );
 
-  const superclassBuild = publicAPI.build;
-  publicAPI.build = (renderEncoder, device) => {
-    const buff = device.getBufferManager().getFullScreenQuadBuffer();
+  publicAPI.updateBuffers = () => {
+    const buff = model.device.getBufferManager().getFullScreenQuadBuffer();
     model.vertexInput.addBuffer(buff, ['vertexBC']);
     model.numberOfVertices = 6;
-    superclassBuild(renderEncoder, device);
   };
 }
 
@@ -46,7 +44,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Inheritance
-  vtkWebGPUMapperHelper.extend(publicAPI, model, initialValues);
+  vtkWebGPUSimpleMapper.extend(publicAPI, model, initialValues);
 
   // Object methods
   vtkWebGPUFullScreenQuad(publicAPI, model);

--- a/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
+++ b/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
@@ -1,21 +1,14 @@
 import * as macro from 'vtk.js/Sources/macros';
+import vtkWebGPUCellArrayMapper from 'vtk.js/Sources/Rendering/WebGPU/CellArrayMapper';
 import vtkWebGPUPolyDataMapper from 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper';
 import vtkWebGPUStorageBuffer from 'vtk.js/Sources/Rendering/WebGPU/StorageBuffer';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
-import vtkWebGPUBufferManager from 'vtk.js/Sources/Rendering/WebGPU/BufferManager';
 import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
 
-const { PrimitiveTypes } = vtkWebGPUBufferManager;
-
-// ----------------------------------------------------------------------------
-// vtkWebGPUSphereMapper methods
-// ----------------------------------------------------------------------------
-
-function vtkWebGPUGlyph3DMapper(publicAPI, model) {
+function vtkWebGPUGlyph3DCellArrayMapper(publicAPI, model) {
   // Set our className
-  model.classHierarchy.push('vtkWebGPUGlyph3DMapper');
+  model.classHierarchy.push('vtkWebGPUGlyph3DCellArrayMapper');
 
-  // Capture 'parentClass' api for internal use
   const superClass = { ...publicAPI };
 
   publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
@@ -30,6 +23,10 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
     ]).result;
     vDesc.setCode(code);
   };
+  model.shaderReplacements.set(
+    'replaceShaderPosition',
+    publicAPI.replaceShaderPosition
+  );
 
   publicAPI.replaceShaderNormal = (hash, pipeline, vertexInput) => {
     if (vertexInput.hasAttribute('normalMC')) {
@@ -44,9 +41,13 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
     }
     superClass.replaceShaderNormal(hash, pipeline, vertexInput);
   };
+  model.shaderReplacements.set(
+    'replaceShaderNormal',
+    publicAPI.replaceShaderNormal
+  );
 
   publicAPI.replaceShaderColor = (hash, pipeline, vertexInput) => {
-    if (!model.carray) {
+    if (!model.renderable.getColorArray()) {
       superClass.replaceShaderColor(hash, pipeline, vertexInput);
       return;
     }
@@ -67,6 +68,10 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
     ]).result;
     fDesc.setCode(code);
   };
+  model.shaderReplacements.set(
+    'replaceShaderColor',
+    publicAPI.replaceShaderColor
+  );
 
   publicAPI.replaceShaderSelect = (hash, pipeline, vertexInput) => {
     if (hash.includes('sel')) {
@@ -86,8 +91,65 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
       fDesc.setCode(code);
     }
   };
+  model.shaderReplacements.set(
+    'replaceShaderSelect',
+    publicAPI.replaceShaderSelect
+  );
+}
 
-  publicAPI.buildPrimitives = () => {
+// ----------------------------------------------------------------------------
+export function caExtend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, {}, initialValues);
+
+  // Inheritance
+  vtkWebGPUCellArrayMapper.extend(publicAPI, model, initialValues);
+
+  // Object methods
+  vtkWebGPUGlyph3DCellArrayMapper(publicAPI, model);
+}
+
+const caNewInstance = macro.newInstance(
+  caExtend,
+  'vtkWebGPUGlyph3DCellArrayMapper'
+);
+
+// ----------------------------------------------------------------------------
+// vtkWebGPUSphereMapper methods
+// ----------------------------------------------------------------------------
+
+function vtkWebGPUGlyph3DMapper(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkWebGPUGlyph3DMapper');
+
+  publicAPI.createCellArrayMapper = () => {
+    const mpr = caNewInstance();
+    mpr.setSSBO(model.SSBO);
+    mpr.setRenderable(model.renderable);
+    return mpr;
+  };
+
+  publicAPI.buildPass = (prepass) => {
+    if (prepass) {
+      if (!model.renderable.getStatic()) {
+        model.renderable.update();
+      }
+
+      const gpoly = model.renderable.getInputData(1);
+
+      model.renderable.mapScalars(gpoly, 1.0);
+
+      publicAPI.updateSSBO();
+
+      publicAPI.updateCellArrayMappers(gpoly);
+
+      for (let i = 0; i < model.children.length; i++) {
+        const cellMapper = model.children[i];
+        cellMapper.setNumberOfInstances(model.numInstances);
+      }
+    }
+  };
+
+  publicAPI.updateSSBO = () => {
     model.currentInput = model.renderable.getInputData(1);
 
     model.renderable.buildArrays();
@@ -96,7 +158,7 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
     const garray = model.renderable.getMatrixArray();
     const narray = model.renderable.getNormalArray();
     model.carray = model.renderable.getColorArray();
-    const numInstances = garray.length / 16;
+    model.numInstances = garray.length / 16;
 
     if (
       model.renderable.getBuildTime().getMTime() >
@@ -104,10 +166,13 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
     ) {
       // In Core class all arrays are rebuilt when this happens
       // but these arrays can be shared between all primType
+      model.WebGPURenderWindow = publicAPI.getFirstAncestorOfType(
+        'vtkWebGPURenderWindow'
+      );
       const device = model.WebGPURenderWindow.getDevice();
 
       model.SSBO.clearData();
-      model.SSBO.setNumberOfInstances(numInstances);
+      model.SSBO.setNumberOfInstances(model.numInstances);
       model.SSBO.addEntry('matrix', 'mat4x4<f32>');
       model.SSBO.addEntry('normal', 'mat4x4<f32>');
       if (model.carray) {
@@ -125,13 +190,6 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
 
       model.SSBO.send(device);
       model.glyphBOBuildTime.modified();
-    }
-
-    superClass.buildPrimitives();
-
-    for (let i = 0; i < model.primitives.length; i++) {
-      const primHelper = model.primitives[i];
-      primHelper.setNumberOfInstances(numInstances);
     }
   };
 }
@@ -157,15 +215,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Object methods
   vtkWebGPUGlyph3DMapper(publicAPI, model);
-
-  for (let i = PrimitiveTypes.Start; i < PrimitiveTypes.End; i++) {
-    model.primitives[i].setSSBO(model.SSBO);
-    const sr = model.primitives[i].getShaderReplacements();
-    sr.set('replaceShaderPosition', publicAPI.replaceShaderPosition);
-    sr.set('replaceShaderNormal', publicAPI.replaceShaderNormal);
-    sr.set('replaceShaderSelect', publicAPI.replaceShaderSelect);
-    sr.set('replaceShaderColor', publicAPI.replaceShaderColor);
-  }
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -5,12 +5,10 @@ import * as macro from 'vtk.js/Sources/macros';
 // import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 // import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
-import vtkWebGPUStorageBuffer from 'vtk.js/Sources/Rendering/WebGPU/StorageBuffer';
 import vtkWebGPUFullScreenQuad from 'vtk.js/Sources/Rendering/WebGPU/FullScreenQuad';
 import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
 import vtkWebGPUSampler from 'vtk.js/Sources/Rendering/WebGPU/Sampler';
 // import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
-import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
 
 // import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
 import { InterpolationType } from 'vtk.js/Sources/Rendering/Core/ImageProperty/Constants';
@@ -112,12 +110,9 @@ function vtkWebGPUImageMapper(publicAPI, model) {
     model.renderable.update();
 
     model.currentInput = model.renderable.getInputData();
-    model.renderEncoder = model.WebGPURenderer.getRenderEncoder();
 
-    publicAPI.build(model.renderEncoder, model.device);
-
-    // update descriptor sets
-    publicAPI.updateUBO(model.device);
+    publicAPI.prepareToDraw(model.WebGPURenderer.getRenderEncoder());
+    model.renderEncoder.registerDrawCallback(model.pipeline, publicAPI.draw);
   };
 
   publicAPI.computePipelineHash = () => {
@@ -131,7 +126,7 @@ function vtkWebGPUImageMapper(publicAPI, model) {
     }
   };
 
-  publicAPI.updateUBO = (device) => {
+  publicAPI.updateUBO = () => {
     const utime = model.UBO.getSendTime();
     const actor = model.WebGPUImageSlice.getRenderable();
     const volMapr = actor.getMapper();
@@ -231,7 +226,7 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       // for performance in the fragment shader
       const cScale = [1, 1, 1, 1];
       const cShift = [0, 0, 0, 0];
-      const tView = model.helper.getTextureViews()[0];
+      const tView = model.textureViews[0];
       const tScale = tView.getTexture().getScale();
       const numComp = tView.getTexture().getNumberOfComponents();
       const iComps = false; // todo handle independent?
@@ -252,14 +247,14 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       }
       model.UBO.setArray('cScale', cScale);
       model.UBO.setArray('cShift', cShift);
-      model.UBO.sendIfNeeded(device);
+      model.UBO.sendIfNeeded(model.device);
     }
   };
 
-  publicAPI.updateLUTImage = (device) => {
+  publicAPI.updateLUTImage = () => {
     const actorProperty = model.WebGPUImageSlice.getRenderable().getProperty();
 
-    const tView = model.helper.getTextureViews()[0];
+    const tView = publicAPI.getTextureViews()[0];
     const numComp = tView.getTexture().getNumberOfComponents();
     const iComps = false; // todo support indepenedent comps?
     const numIComps = iComps ? numComp : 1;
@@ -329,36 +324,32 @@ function vtkWebGPUImageMapper(publicAPI, model) {
           depth: 1,
           format: 'rgba8unorm',
         };
-        const newTex = device.getTextureManager().getTexture(treq);
+        const newTex = model.device.getTextureManager().getTexture(treq);
         const tview = newTex.createView('tfunTexture');
-        const tViews = model.helper.getTextureViews();
-        tViews[1] = tview;
+        model.textureViews[1] = tview;
       }
 
       model.colorTextureString = cfunToString;
     }
   };
 
-  publicAPI.updateBuffers = (device) => {
+  const superClassUpdateBuffers = publicAPI.updateBuffers;
+  publicAPI.updateBuffers = () => {
+    superClassUpdateBuffers();
     const treq = {
       imageData: model.currentInput,
       owner: model.currentInput.getPointData().getScalars(),
     };
-    const newTex = device.getTextureManager().getTexture(treq);
-    const tViews = model.helper.getTextureViews();
+    const newTex = model.device.getTextureManager().getTexture(treq);
+    const tViews = model.textureViews;
 
     if (!tViews[0] || tViews[0].getTexture() !== newTex) {
       const tview = newTex.createView('imgTexture');
       tViews[0] = tview;
     }
 
-    publicAPI.updateLUTImage(device);
-  };
-
-  publicAPI.build = (renderEncoder, device) => {
-    publicAPI.computePipelineHash();
-    model.helper.setPipelineHash(model.pipelineHash);
-    publicAPI.updateBuffers(device);
+    publicAPI.updateLUTImage();
+    publicAPI.updateUBO();
 
     // set interpolation on the texture based on property setting
     const actorProperty = model.WebGPUImageSlice.getRenderable().getProperty();
@@ -374,26 +365,15 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       model.clampSampler = vtkWebGPUSampler.newInstance({
         label: 'clampSampler',
       });
-      model.clampSampler.create(device, {
+      model.clampSampler.create(model.device, {
         minFilter: iType,
         magFilter: iType,
       });
+      model.additionalBindables = [model.clampSampler];
     }
-
-    model.helper.setAdditionalBindables(publicAPI.getBindables());
-    model.helper.setWebGPURenderer(model.WebGPURenderer);
-    model.helper.build(renderEncoder, device);
-    model.helper.registerToDraw();
   };
 
-  publicAPI.getBindables = () => {
-    const bindables = [];
-    // bindables.push(model.componentSSBO);
-    bindables.push(model.clampSampler);
-    return bindables;
-  };
-
-  const sr = model.helper.getShaderReplacements();
+  const sr = publicAPI.getShaderReplacements();
 
   publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
     const vDesc = pipeline.getShaderDescription('vertex');
@@ -467,17 +447,6 @@ function vtkWebGPUImageMapper(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   rowLength: 1024,
-  // VBOBuildTime: 0,
-  // VBOBuildString: null,
-  // webGPUTexture: null,
-  // tris: null,
-  // imagemat: null,
-  // imagematinv: null,
-  // colorTexture: null,
-  // pwfTexture: null,
-  // lastHaveSeenDepthRequest: false,
-  // haveSeenDepthRequest: false,
-  // lastTextureComponents: 0,
 };
 
 // ----------------------------------------------------------------------------
@@ -486,10 +455,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Inheritance
-  vtkViewNode.extend(publicAPI, model, initialValues);
+  vtkWebGPUFullScreenQuad.extend(publicAPI, model, initialValues);
 
-  model.helper = vtkWebGPUFullScreenQuad.newInstance();
-  model.helper.setFragmentShaderTemplate(imgFragTemplate);
+  publicAPI.setFragmentShaderTemplate(imgFragTemplate);
 
   model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
   model.UBO.addEntry('SCTCMatrix', 'mat4x4<f32>');
@@ -498,13 +466,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.UBO.addEntry('Axis1', 'vec4<f32>');
   model.UBO.addEntry('cScale', 'vec4<f32>');
   model.UBO.addEntry('cShift', 'vec4<f32>');
-  model.helper.setUBO(model.UBO);
-
-  model.SSBO = vtkWebGPUStorageBuffer.newInstance({ label: 'volumeSSBO' });
-
-  model.componentSSBO = vtkWebGPUStorageBuffer.newInstance({
-    label: 'componentSSBO',
-  });
 
   model.lutBuildTime = {};
   macro.obj(model.lutBuildTime, { mtime: 0 });

--- a/Sources/Rendering/WebGPU/Pipeline/index.js
+++ b/Sources/Rendering/WebGPU/Pipeline/index.js
@@ -79,6 +79,17 @@ function vtkWebGPUPipeline(publicAPI, model) {
   publicAPI.bindVertexInput = (renderEncoder, vInput) => {
     vInput.bindBuffers(renderEncoder);
   };
+
+  publicAPI.addDrawCallback = (cb) => {
+    model._drawCallbacks.push(cb);
+  };
+
+  // handle anything that needs to be done when drawing
+  publicAPI.draw = (encoder) => {
+    for (let cb = 0; cb < model._drawCallbacks.length; cb++) {
+      model._drawCallbacks[cb](encoder, publicAPI);
+    }
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -103,6 +114,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.layouts = [];
   model.shaderDescriptions = [];
+  model._drawCallbacks = [];
 
   macro.get(publicAPI, model, ['handle', 'pipelineDescription']);
   macro.setGet(publicAPI, model, [

--- a/Sources/Rendering/WebGPU/PolyDataMapper/index.js
+++ b/Sources/Rendering/WebGPU/PolyDataMapper/index.js
@@ -1,120 +1,11 @@
-import { mat3, mat4 } from 'gl-matrix';
-
 import * as macro from 'vtk.js/Sources/macros';
-import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
-import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
-import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
 import vtkWebGPUBufferManager from 'vtk.js/Sources/Rendering/WebGPU/BufferManager';
-import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
-import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
-import vtkWebGPUMapperHelper from 'vtk.js/Sources/Rendering/WebGPU/MapperHelper';
+import vtkWebGPUCellArrayMapper from 'vtk.js/Sources/Rendering/WebGPU/CellArrayMapper';
 import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
 
 import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
 
-const { BufferUsage, PrimitiveTypes } = vtkWebGPUBufferManager;
-const { Representation } = vtkProperty;
-const { ScalarMode } = vtkMapper;
-const StartEvent = { type: 'StartEvent' };
-const EndEvent = { type: 'EndEvent' };
-
-const vtkWebGPUPolyDataVS = `
-//VTK::Renderer::Dec
-
-//VTK::Color::Dec
-
-//VTK::Normal::Dec
-
-//VTK::TCoord::Dec
-
-//VTK::Select::Dec
-
-//VTK::Mapper::Dec
-
-//VTK::IOStructs::Dec
-
-@stage(vertex)
-fn main(
-//VTK::IOStructs::Input
-)
-//VTK::IOStructs::Output
-{
-  var output : vertexOutput;
-
-  var vertex: vec4<f32> = vertexBC;
-
-  //VTK::Color::Impl
-
-  //VTK::Normal::Impl
-
-  //VTK::TCoord::Impl
-
-  //VTK::Select::Impl
-
-  //VTK::Position::Impl
-
-  return output;
-}
-`;
-
-const vtkWebGPUPolyDataFS = `
-//VTK::Renderer::Dec
-
-//VTK::Color::Dec
-
-// optional surface normal declaration
-//VTK::Normal::Dec
-
-//VTK::TCoord::Dec
-
-//VTK::Select::Dec
-
-//VTK::RenderEncoder::Dec
-
-//VTK::Mapper::Dec
-
-//VTK::IOStructs::Dec
-
-@stage(fragment)
-fn main(
-//VTK::IOStructs::Input
-)
-//VTK::IOStructs::Output
-{
-  var output : fragmentOutput;
-
-  var ambientColor: vec4<f32> = mapperUBO.AmbientColor;
-  var diffuseColor: vec4<f32> = mapperUBO.DiffuseColor;
-  var opacity: f32 = mapperUBO.Opacity;
-
-  //VTK::Color::Impl
-
-  //VTK::Normal::Impl
-
-  //VTK::Light::Impl
-
-  var computedColor: vec4<f32> = vec4<f32>(ambientColor.rgb * mapperUBO.AmbientIntensity
-     + diffuse * mapperUBO.DiffuseIntensity
-     + specular * mapperUBO.SpecularIntensity,
-     opacity);
-
-  //VTK::TCoord::Impl
-
-  //VTK::Select::Impl
-
-  if (computedColor.a == 0.0) { discard; };
-
-  //VTK::Position::Impl
-
-  //VTK::RenderEncoder::Impl
-  return output;
-}
-`;
-
-function isEdges(hash) {
-  // edge pipelines have "edge" in them
-  return hash.indexOf('edge') >= 0;
-}
+const { PrimitiveTypes } = vtkWebGPUBufferManager;
 
 // ----------------------------------------------------------------------------
 // vtkWebGPUPolyDataMapper methods
@@ -124,549 +15,25 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkWebGPUPolyDataMapper');
 
+  publicAPI.createCellArrayMapper = () =>
+    vtkWebGPUCellArrayMapper.newInstance();
+
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
       model.WebGPUActor = publicAPI.getFirstAncestorOfType('vtkWebGPUActor');
-      model.WebGPURenderer =
-        model.WebGPUActor.getFirstAncestorOfType('vtkWebGPURenderer');
-      model.WebGPURenderWindow = model.WebGPURenderer.getParent();
-      model.device = model.WebGPURenderWindow.getDevice();
-    }
-  };
-
-  // Renders myself
-  publicAPI.translucentPass = (prepass) => {
-    if (prepass) {
-      publicAPI.render();
-    }
-  };
-
-  publicAPI.opaquePass = (prepass) => {
-    if (prepass) {
-      publicAPI.render();
-    }
-  };
-
-  publicAPI.updateUBO = () => {
-    // make sure the data is up to date
-    const actor = model.WebGPUActor.getRenderable();
-    const ppty = actor.getProperty();
-    const utime = model.UBO.getSendTime();
-    if (
-      publicAPI.getMTime() > utime ||
-      ppty.getMTime() > utime ||
-      model.renderable.getMTime() > utime
-    ) {
-      const keyMats = model.WebGPUActor.getKeyMatrices(model.WebGPURenderer);
-      model.UBO.setArray('BCWCMatrix', keyMats.bcwc);
-      model.UBO.setArray('BCSCMatrix', keyMats.bcsc);
-      model.UBO.setArray('MCWCNormals', keyMats.normalMatrix);
-
-      let aColor = ppty.getAmbientColorByReference();
-      model.UBO.setValue('AmbientIntensity', ppty.getAmbient());
-      model.UBO.setArray('AmbientColor', [
-        aColor[0],
-        aColor[1],
-        aColor[2],
-        1.0,
-      ]);
-      model.UBO.setValue('DiffuseIntensity', ppty.getDiffuse());
-      aColor = ppty.getDiffuseColorByReference();
-      model.UBO.setArray('DiffuseColor', [
-        aColor[0],
-        aColor[1],
-        aColor[2],
-        1.0,
-      ]);
-      model.UBO.setValue('SpecularIntensity', ppty.getSpecular());
-      model.UBO.setValue('SpecularPower', ppty.getSpecularPower());
-      aColor = ppty.getSpecularColorByReference();
-      model.UBO.setArray('SpecularColor', [
-        aColor[0],
-        aColor[1],
-        aColor[2],
-        1.0,
-      ]);
-      aColor = ppty.getEdgeColorByReference();
-      model.UBO.setArray('EdgeColor', [aColor[0], aColor[1], aColor[2], 1.0]);
-      model.UBO.setValue('Opacity', ppty.getOpacity());
-      model.UBO.setValue('PropID', model.WebGPUActor.getPropID());
-      const device = model.WebGPURenderWindow.getDevice();
-      model.UBO.sendIfNeeded(device);
-    }
-  };
-
-  publicAPI.render = () => {
-    publicAPI.invokeEvent(StartEvent);
-    if (!model.renderable.getStatic()) {
-      model.renderable.update();
-    }
-    model.currentInput = model.renderable.getInputData();
-    publicAPI.invokeEvent(EndEvent);
-
-    model.renderEncoder = model.WebGPURenderer.getRenderEncoder();
-
-    publicAPI.buildPrimitives();
-
-    // update descriptor sets
-    publicAPI.updateUBO();
-  };
-
-  publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
-    const vDesc = pipeline.getShaderDescription('vertex');
-    vDesc.addBuiltinOutput('vec4<f32>', '@builtin(position) Position');
-    let code = vDesc.getCode();
-    if (isEdges(hash)) {
-      vDesc.addBuiltinInput('u32', '@builtin(instance_index) instanceIndex');
-      // widen the edge
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
-        '    var tmpPos: vec4<f32> = rendererUBO.SCPCMatrix*mapperUBO.BCSCMatrix*vertexBC;',
-        '    var tmpPos2: vec3<f32> = tmpPos.xyz / tmpPos.w;',
-        '    tmpPos2.x = tmpPos2.x + 1.4*(f32(input.instanceIndex % 2u) - 0.5)/rendererUBO.viewportSize.x;',
-        '    tmpPos2.y = tmpPos2.y + 1.4*(f32(input.instanceIndex / 2u) - 0.5)/rendererUBO.viewportSize.y;',
-        '    tmpPos2.z = tmpPos2.z + 0.00001;', // could become a setting
-        '    output.Position = vec4<f32>(tmpPos2.xyz * tmpPos.w, tmpPos.w);',
-      ]).result;
-    } else {
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
-        '    output.Position = rendererUBO.SCPCMatrix*mapperUBO.BCSCMatrix*vertexBC;',
-      ]).result;
-    }
-
-    vDesc.setCode(code);
-  };
-
-  publicAPI.replaceShaderNormal = (hash, pipeline, vertexInput) => {
-    if (vertexInput.hasAttribute('normalMC')) {
-      const vDesc = pipeline.getShaderDescription('vertex');
-      vDesc.addOutput('vec3<f32>', 'normalVC');
-      let code = vDesc.getCode();
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Normal::Impl', [
-        '  output.normalVC = normalize((rendererUBO.WCVCNormals * mapperUBO.MCWCNormals * normalMC).xyz);',
-      ]).result;
-      vDesc.setCode(code);
-
-      const fDesc = pipeline.getShaderDescription('fragment');
-      code = fDesc.getCode();
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Normal::Impl', [
-        '  var normal: vec3<f32> = input.normalVC;',
-        '  if (!input.frontFacing) { normal = -normal; }',
-      ]).result;
-      fDesc.setCode(code);
-    }
-  };
-
-  // we only apply lighting when there is a "var normal" declaration in the
-  // fragment shader code. That is the lighting trigger.
-  publicAPI.replaceShaderLight = (hash, pipeline, vertexInput) => {
-    const fDesc = pipeline.getShaderDescription('fragment');
-    let code = fDesc.getCode();
-    if (code.includes('var normal')) {
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Light::Impl', [
-        '  var df: f32  = max(0.0, normal.z);',
-        '  var sf: f32 = pow(df, mapperUBO.SpecularPower);',
-        '  var diffuse: vec3<f32> = df * diffuseColor.rgb;',
-        '  var specular: vec3<f32> = sf * mapperUBO.SpecularColor.rgb * mapperUBO.SpecularColor.a;',
-      ]).result;
-      fDesc.setCode(code);
-    } else {
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Light::Impl', [
-        '  var diffuse: vec3<f32> = diffuseColor.rgb;',
-        '  var specular: vec3<f32> = mapperUBO.SpecularColor.rgb * mapperUBO.SpecularColor.a;',
-      ]).result;
-      fDesc.setCode(code);
-    }
-  };
-
-  publicAPI.replaceShaderColor = (hash, pipeline, vertexInput) => {
-    if (isEdges(hash)) {
-      const fDesc = pipeline.getShaderDescription('fragment');
-      let code = fDesc.getCode();
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Color::Impl', [
-        'ambientColor = mapperUBO.EdgeColor;',
-        'diffuseColor = mapperUBO.EdgeColor;',
-      ]).result;
-      fDesc.setCode(code);
-      return;
-    }
-
-    if (!vertexInput.hasAttribute('colorVI')) return;
-
-    const vDesc = pipeline.getShaderDescription('vertex');
-    vDesc.addOutput('vec4<f32>', 'color');
-    let code = vDesc.getCode();
-    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Color::Impl', [
-      '  output.color = colorVI;',
-    ]).result;
-    vDesc.setCode(code);
-
-    const fDesc = pipeline.getShaderDescription('fragment');
-    code = fDesc.getCode();
-    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Color::Impl', [
-      'ambientColor = input.color;',
-      'diffuseColor = input.color;',
-      'opacity = mapperUBO.Opacity * input.color.a;',
-    ]).result;
-    fDesc.setCode(code);
-  };
-
-  publicAPI.replaceShaderTCoord = (hash, pipeline, vertexInput) => {
-    if (!vertexInput.hasAttribute('tcoord')) return;
-
-    const vDesc = pipeline.getShaderDescription('vertex');
-    vDesc.addOutput('vec2<f32>', 'tcoordVS');
-    let code = vDesc.getCode();
-    code = vtkWebGPUShaderCache.substitute(code, '//VTK::TCoord::Impl', [
-      '  output.tcoordVS = tcoord;',
-    ]).result;
-    vDesc.setCode(code);
-
-    const fDesc = pipeline.getShaderDescription('fragment');
-    code = fDesc.getCode();
-
-    // todo handle multiple textures? Blend multiply ?
-    if (model.textures.length) {
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::TCoord::Impl', [
-        'var tcolor: vec4<f32> = textureSample(Texture0, Texture0Sampler, input.tcoordVS);',
-        'computedColor = computedColor*tcolor;',
-      ]).result;
-    }
-    fDesc.setCode(code);
-  };
-
-  publicAPI.replaceShaderSelect = (hash, pipeline, vertexInput) => {
-    if (hash.includes('sel')) {
-      const fDesc = pipeline.getShaderDescription('fragment');
-      let code = fDesc.getCode();
-      // by default there are no composites, so just 0
-      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Select::Impl', [
-        '  var compositeID: u32 = 0u;',
-      ]).result;
-      fDesc.setCode(code);
-    }
-  };
-
-  publicAPI.getUsage = (rep, i) => {
-    if (rep === Representation.POINTS || i === PrimitiveTypes.Points) {
-      return BufferUsage.Verts;
-    }
-
-    if (i === PrimitiveTypes.Lines) {
-      return BufferUsage.Lines;
-    }
-
-    if (rep === Representation.WIREFRAME) {
-      if (i === PrimitiveTypes.Triangles) {
-        return BufferUsage.LinesFromTriangles;
+      if (!model.renderable.getStatic()) {
+        model.renderable.update();
       }
-      return BufferUsage.LinesFromStrips;
-    }
 
-    if (i === PrimitiveTypes.Triangles) {
-      return BufferUsage.Triangles;
-    }
+      const poly = model.renderable.getInputData();
 
-    if (i === PrimitiveTypes.TriangleStrips) {
-      return BufferUsage.Strips;
-    }
+      model.renderable.mapScalars(poly, 1.0);
 
-    if (i === PrimitiveTypes.TriangleEdges) {
-      return BufferUsage.LinesFromTriangles;
-    }
-
-    // only strip edges left which are lines
-    return BufferUsage.LinesFromStrips;
-  };
-
-  publicAPI.getHashFromUsage = (usage) => `pt${usage}`;
-
-  publicAPI.getTopologyFromUsage = (usage) => {
-    switch (usage) {
-      case BufferUsage.Triangles:
-        return 'triangle-list';
-      case BufferUsage.Verts:
-        return 'point-list';
-      case BufferUsage.Lines:
-      default:
-        return 'line-list';
+      publicAPI.updateCellArrayMappers(poly);
     }
   };
 
-  publicAPI.buildVertexInput = (pd, cells, primType) => {
-    const actor = model.WebGPUActor.getRenderable();
-    let representation = actor.getProperty().getRepresentation();
-    const device = model.WebGPURenderWindow.getDevice();
-    let edges = false;
-    if (primType === PrimitiveTypes.TriangleEdges) {
-      edges = true;
-      representation = Representation.WIREFRAME;
-    }
-
-    const vertexInput = model.primitives[primType].getVertexInput();
-    const hash = `R${representation}P${primType}`;
-
-    // hash = all things that can change the values on the buffer
-    // since mtimes are unique we can use
-    // - cells mtime - because cells drive how we pack
-    // - rep (point/wireframe/surface) - again because of packing
-    // - relevant dataArray mtime - the source data
-    // - shift - not currently captured
-    // - scale - not currently captured
-    // - format
-    // - usage
-    // - packExtra - covered by format
-    // - prim type (vert/lines/polys/strips) - covered by cells mtime
-
-    // points
-    const points = pd.getPoints();
-    if (points) {
-      const shift = model.WebGPUActor.getBufferShift(model.WebGPURenderer);
-      const buffRequest = {
-        owner: points,
-        usage: BufferUsage.PointArray,
-        format: 'float32x4',
-        time: Math.max(
-          points.getMTime(),
-          cells.getMTime(),
-          model.WebGPUActor.getKeyMatricesTime().getMTime()
-        ),
-        hash,
-        dataArray: points,
-        cells,
-        primitiveType: primType,
-        representation,
-        shift,
-        packExtra: true,
-      };
-      const buff = device.getBufferManager().getBuffer(buffRequest);
-      vertexInput.addBuffer(buff, ['vertexBC']);
-    } else {
-      vertexInput.removeBufferIfPresent('vertexBC');
-    }
-
-    // normals, only used for surface rendering
-    const usage = publicAPI.getUsage(representation, primType);
-    if (usage === BufferUsage.Triangles || usage === BufferUsage.Strips) {
-      const normals = pd.getPointData().getNormals();
-      const buffRequest = {
-        format: 'snorm8x4',
-        hash,
-        cells,
-        representation,
-        primitiveType: primType,
-        packExtra: true,
-        shift: 0,
-        scale: 127,
-      };
-      if (normals) {
-        buffRequest.owner = normals;
-        buffRequest.dataArray = normals;
-        buffRequest.time = Math.max(normals.getMTime(), cells.getMTime());
-        buffRequest.usage = BufferUsage.PointArray;
-        const buff = device.getBufferManager().getBuffer(buffRequest);
-        vertexInput.addBuffer(buff, ['normalMC']);
-      } else if (primType === PrimitiveTypes.Triangles) {
-        buffRequest.owner = points;
-        buffRequest.dataArray = points;
-        buffRequest.time = Math.max(points.getMTime(), cells.getMTime());
-        buffRequest.usage = BufferUsage.NormalsFromPoints;
-        const buff = device.getBufferManager().getBuffer(buffRequest);
-        vertexInput.addBuffer(buff, ['normalMC']);
-      } else {
-        vertexInput.removeBufferIfPresent('normalMC');
-      }
-    } else {
-      vertexInput.removeBufferIfPresent('normalMC');
-    }
-
-    // deal with colors but only if modified
-    let haveColors = false;
-    if (model.renderable.getScalarVisibility()) {
-      const c = model.renderable.getColorMapColors();
-      if (c && !edges) {
-        const scalarMode = model.renderable.getScalarMode();
-        let haveCellScalars = false;
-        // We must figure out how the scalars should be mapped to the polydata.
-        if (
-          (scalarMode === ScalarMode.USE_CELL_DATA ||
-            scalarMode === ScalarMode.USE_CELL_FIELD_DATA ||
-            scalarMode === ScalarMode.USE_FIELD_DATA ||
-            !pd.getPointData().getScalars()) &&
-          scalarMode !== ScalarMode.USE_POINT_FIELD_DATA &&
-          c
-        ) {
-          haveCellScalars = true;
-        }
-        const buffRequest = {
-          owner: c,
-          usage: BufferUsage.PointArray,
-          format: 'unorm8x4',
-          time: Math.max(c.getMTime(), cells.getMTime(), points.getMTime()),
-          hash: hash + haveCellScalars,
-          dataArray: c,
-          cells,
-          primitiveType: primType,
-          representation,
-          cellData: haveCellScalars,
-          cellOffset: 0,
-        };
-        const buff = device.getBufferManager().getBuffer(buffRequest);
-        vertexInput.addBuffer(buff, ['colorVI']);
-        haveColors = true;
-      }
-    }
-    if (!haveColors) {
-      vertexInput.removeBufferIfPresent('colorVI');
-    }
-
-    let tcoords = null;
-    if (
-      model.renderable.getInterpolateScalarsBeforeMapping() &&
-      model.renderable.getColorCoordinates()
-    ) {
-      tcoords = model.renderable.getColorCoordinates();
-    } else {
-      tcoords = pd.getPointData().getTCoords();
-    }
-    if (tcoords && !edges) {
-      const buffRequest = {
-        owner: tcoords,
-        usage: BufferUsage.PointArray,
-        format: 'float32x2',
-        time: Math.max(tcoords.getMTime(), cells.getMTime()),
-        hash,
-        dataArray: tcoords,
-        cells,
-        primitiveType: primType,
-        representation,
-      };
-      const buff = device.getBufferManager().getBuffer(buffRequest);
-      vertexInput.addBuffer(buff, ['tcoord']);
-    } else {
-      vertexInput.removeBufferIfPresent('tcoord');
-    }
-  };
-
-  publicAPI.updateTextures = () => {
-    // we keep track of new and used textures so
-    // that we can clean up any unused textures so we don't hold onto them
-    const usedTextures = [];
-    const newTextures = [];
-
-    // do we have a scalar color texture
-    const idata = model.renderable.getColorTextureMap(); // returns an imagedata
-    if (idata) {
-      if (!model.colorTexture) {
-        model.colorTexture = vtkTexture.newInstance({ label: 'polyDataColor' });
-      }
-      model.colorTexture.setInputData(idata);
-      newTextures.push(model.colorTexture);
-    }
-
-    // actor textures?
-    const actor = model.WebGPUActor.getRenderable();
-    const textures = actor.getTextures();
-    for (let i = 0; i < textures.length; i++) {
-      if (
-        textures[i].getInputData() ||
-        textures[i].getJsImageData() ||
-        textures[i].getCanvas()
-      ) {
-        newTextures.push(textures[i]);
-      }
-      if (textures[i].getImage() && textures[i].getImageLoaded()) {
-        newTextures.push(textures[i]);
-      }
-    }
-
-    let usedCount = 0;
-    for (let i = 0; i < newTextures.length; i++) {
-      const srcTexture = newTextures[i];
-      const treq = { time: srcTexture.getMTime() };
-      if (srcTexture.getInputData()) {
-        treq.imageData = srcTexture.getInputData();
-        treq.owner = treq.imageData.getPointData().getScalars();
-      } else if (srcTexture.getImage()) {
-        treq.image = srcTexture.getImage();
-        treq.owner = treq.image;
-      } else if (srcTexture.getJsImageData()) {
-        treq.jsImageData = srcTexture.getJsImageData();
-        treq.owner = treq.jsImageData;
-      } else if (srcTexture.getCanvas()) {
-        treq.canvas = srcTexture.getCanvas();
-        treq.owner = treq.canvas;
-      }
-      const newTex = model.device.getTextureManager().getTexture(treq);
-      if (newTex.getReady()) {
-        // is this a new texture
-        let found = false;
-        for (let t = 0; t < model.textures.length; t++) {
-          if (model.textures[t] === newTex) {
-            usedCount++;
-            found = true;
-            usedTextures[t] = true;
-          }
-        }
-        if (!found) {
-          usedTextures[model.textures.length] = true;
-          const tview = newTex.createView(`Texture${usedCount++}`);
-          model.textures.push(newTex);
-          model.textureViews.push(tview);
-          const interpolate = srcTexture.getInterpolate()
-            ? 'linear'
-            : 'nearest';
-          tview.addSampler(model.device, {
-            minFilter: interpolate,
-            magFilter: interpolate,
-          });
-        }
-      }
-    }
-
-    // remove unused textures
-    for (let i = model.textures.length - 1; i >= 0; i--) {
-      if (!usedTextures[i]) {
-        model.textures.splice(i, 1);
-        model.textureViews.splice(i, 1);
-      }
-    }
-  };
-
-  // compute a unique hash for a pipeline, this needs to be unique enough to
-  // capture any pipeline code changes (which includes shader changes)
-  // or vertex input changes/ bind groups/ etc
-  publicAPI.computePipelineHash = (vertexInput, usage, edges) => {
-    let pipelineHash = 'pd';
-    if (edges) {
-      pipelineHash += 'edge';
-    } else {
-      if (vertexInput.hasAttribute(`normalMC`)) {
-        pipelineHash += `n`;
-      }
-      if (vertexInput.hasAttribute(`colorVI`)) {
-        pipelineHash += `c`;
-      }
-      if (vertexInput.hasAttribute(`tcoord`)) {
-        pipelineHash += `t`;
-      }
-      if (model.textures.length) {
-        pipelineHash += `tx${model.textures.length}`;
-      }
-    }
-
-    if (model.SSBO) {
-      pipelineHash += `ssbo`;
-    }
-    const uhash = publicAPI.getHashFromUsage(usage);
-    pipelineHash += uhash;
-    pipelineHash += model.renderEncoder.getPipelineHash();
-
-    return pipelineHash;
-  };
-
-  // was originally buildIBOs() but not using IBOs right now
-  publicAPI.buildPrimitives = () => {
-    const poly = model.currentInput;
+  publicAPI.updateCellArrayMappers = (poly) => {
     const prims = [
       poly.getVerts(),
       poly.getLines(),
@@ -674,100 +41,54 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
       poly.getStrips(),
     ];
 
-    const device = model.WebGPURenderWindow.getDevice();
-
-    model.renderable.mapScalars(poly, 1.0);
-
-    // handle textures
-    publicAPI.updateTextures();
-
-    const actor = model.WebGPUActor.getRenderable();
-    const rep = actor.getProperty().getRepresentation();
-    const edgeVisibility = actor.getProperty().getEdgeVisibility();
-
-    // handle per primitive type
+    // we instantiate a cell array mapper for each cellArray that has cells
+    // and they handle the rendering of that cell array
+    const cellMappers = [];
+    let cellOffset = 0;
     for (let i = PrimitiveTypes.Points; i <= PrimitiveTypes.Triangles; i++) {
       if (prims[i].getNumberOfValues() > 0) {
-        {
-          const usage = publicAPI.getUsage(rep, i);
-          const primHelper = model.primitives[i];
-
-          publicAPI.buildVertexInput(model.currentInput, prims[i], i);
-          primHelper.setPipelineHash(
-            publicAPI.computePipelineHash(
-              primHelper.getVertexInput(),
-              usage,
-              false
-            )
-          );
-
-          primHelper.setTextureViews(model.textureViews);
-          primHelper.setWebGPURenderer(model.WebGPURenderer);
-          primHelper.setNumberOfInstances(1);
-          const vbo = primHelper.getVertexInput().getBuffer('vertexBC');
-          primHelper.setNumberOfVertices(
-            vbo.getSizeInBytes() / vbo.getStrideInBytes()
-          );
-          primHelper.setTopology(publicAPI.getTopologyFromUsage(usage));
-          primHelper.build(model.renderEncoder, device);
-          primHelper.registerToDraw();
+        if (!model.primitives[i]) {
+          model.primitives[i] = publicAPI.createCellArrayMapper();
         }
+        const cellMapper = model.primitives[i];
+        cellMapper.setCellArray(prims[i]);
+        cellMapper.setCurrentInput(poly);
+        cellMapper.setCellOffset(cellOffset);
+        cellMapper.setPrimitiveType(i);
+        cellMapper.setRenderable(model.renderable);
+        cellOffset += prims[i].getNumberOfCells();
+        cellMappers.push(cellMapper);
+      } else {
+        model.primitives[i] = null;
+      }
+    }
 
-        // also handle edge visibility if turned on
-        if (
-          edgeVisibility &&
-          rep === Representation.SURFACE &&
-          i === PrimitiveTypes.Triangles
-        ) {
-          const primHelper = model.primitives[PrimitiveTypes.TriangleEdges];
-          const usage = publicAPI.getUsage(rep, PrimitiveTypes.TriangleEdges);
-
-          publicAPI.buildVertexInput(
-            model.currentInput,
-            prims[PrimitiveTypes.Triangles],
-            PrimitiveTypes.TriangleEdges
-          );
-          primHelper.setPipelineHash(
-            publicAPI.computePipelineHash(
-              primHelper.getVertexInput(),
-              usage,
-              true
-            )
-          );
-
-          primHelper.setWebGPURenderer(model.WebGPURenderer);
-          primHelper.setNumberOfInstances(4);
-          const vbo = primHelper.getVertexInput().getBuffer('vertexBC');
-          primHelper.setNumberOfVertices(
-            vbo.getSizeInBytes() / vbo.getStrideInBytes()
-          );
-          primHelper.setTopology(publicAPI.getTopologyFromUsage(usage));
-          primHelper.build(model.renderEncoder, device);
-          primHelper.registerToDraw();
+    if (model.WebGPUActor.getRenderable().getProperty().getEdgeVisibility()) {
+      for (
+        let i = PrimitiveTypes.TriangleEdges;
+        i <= PrimitiveTypes.TriangleStripEdges;
+        i++
+      ) {
+        if (prims[i - 2].getNumberOfValues() > 0) {
+          if (!model.primitives[i]) {
+            model.primitives[i] = publicAPI.createCellArrayMapper();
+          }
+          const cellMapper = model.primitives[i];
+          cellMapper.setCellArray(prims[i - 2]);
+          cellMapper.setCurrentInput(poly);
+          cellMapper.setCellOffset(model.primitives[i - 2].getCellOffset());
+          cellMapper.setPrimitiveType(i);
+          cellMapper.setRenderable(model.renderable);
+          cellMappers.push(cellMapper);
+        } else {
+          model.primitives[i] = null;
         }
       }
     }
-  };
 
-  publicAPI.setShaderReplacement = (name, func) => {
-    for (let i = PrimitiveTypes.Start; i < PrimitiveTypes.End; i++) {
-      const sr = model.primitives[i].getShaderReplacements();
-      sr.set(name, func);
-    }
-  };
-
-  publicAPI.setFragmentShaderTemplate = (val) => {
-    model.fragmentShaderTemplate = val;
-    for (let i = PrimitiveTypes.Start; i < PrimitiveTypes.End; i++) {
-      model.primitives[i].setFragmentShaderTemplate(val);
-    }
-  };
-
-  publicAPI.setVertexShaderTemplate = (val) => {
-    model.fragmentShaderTemplate = val;
-    for (let i = PrimitiveTypes.Start; i < PrimitiveTypes.End; i++) {
-      model.primitives[i].setVertexShaderTemplate(val);
-    }
+    publicAPI.prepareNodes();
+    publicAPI.addMissingChildren(cellMappers);
+    publicAPI.removeUnusedNodes();
   };
 }
 
@@ -776,14 +97,7 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  colorTexture: null,
-  renderEncoder: null,
-  textures: null,
-  textureViews: null,
   primitives: null,
-  tmpMat4: null,
-  fragmentShaderTemplate: null,
-  vertexShaderTemplate: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -794,79 +108,10 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkViewNode.extend(publicAPI, model, initialValues);
 
-  model.tmpMat3 = mat3.identity(new Float64Array(9));
-  model.tmpMat4 = mat4.identity(new Float64Array(16));
-
-  model.fragmentShaderTemplate =
-    model.fragmentShaderTemplate || vtkWebGPUPolyDataFS;
-  model.vertexShaderTemplate =
-    model.vertexShaderTemplate || vtkWebGPUPolyDataVS;
-
-  model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
-  model.UBO.addEntry('BCWCMatrix', 'mat4x4<f32>');
-  model.UBO.addEntry('BCSCMatrix', 'mat4x4<f32>');
-  model.UBO.addEntry('MCWCNormals', 'mat4x4<f32>');
-  model.UBO.addEntry('AmbientColor', 'vec4<f32>');
-  model.UBO.addEntry('DiffuseColor', 'vec4<f32>');
-  model.UBO.addEntry('EdgeColor', 'vec4<f32>');
-  model.UBO.addEntry('AmbientIntensity', 'f32');
-  model.UBO.addEntry('DiffuseIntensity', 'f32');
-  model.UBO.addEntry('SpecularColor', 'vec4<f32>');
-  model.UBO.addEntry('SpecularIntensity', 'f32');
-  model.UBO.addEntry('Opacity', 'f32');
-  model.UBO.addEntry('SpecularPower', 'f32');
-  model.UBO.addEntry('PropID', 'u32');
-
-  // Build VTK API
-  macro.get(publicAPI, model, [
-    'fragmentShaderTemplate',
-    'vertexShaderTemplate',
-    'UBO',
-  ]);
-  macro.setGet(publicAPI, model, ['renderEncoder']);
-
-  model.textures = [];
-  model.textureViews = [];
   model.primitives = [];
 
   // Object methods
   vtkWebGPUPolyDataMapper(publicAPI, model);
-
-  for (let i = PrimitiveTypes.Start; i < PrimitiveTypes.End; i++) {
-    model.primitives[i] = vtkWebGPUMapperHelper.newInstance();
-    model.primitives[i].setUBO(model.UBO);
-    model.primitives[i].setVertexShaderTemplate(
-      publicAPI.getVertexShaderTemplate()
-    );
-    model.primitives[i].setFragmentShaderTemplate(
-      publicAPI.getFragmentShaderTemplate()
-    );
-  }
-
-  publicAPI.setShaderReplacement(
-    'replaceShaderPosition',
-    publicAPI.replaceShaderPosition
-  );
-  publicAPI.setShaderReplacement(
-    'replaceShaderLight',
-    publicAPI.replaceShaderLight
-  );
-  publicAPI.setShaderReplacement(
-    'replaceShaderTCoord',
-    publicAPI.replaceShaderTCoord
-  );
-  publicAPI.setShaderReplacement(
-    'replaceShaderNormal',
-    publicAPI.replaceShaderNormal
-  );
-  publicAPI.setShaderReplacement(
-    'replaceShaderSelect',
-    publicAPI.replaceShaderSelect
-  );
-  publicAPI.setShaderReplacement(
-    'replaceShaderColor',
-    publicAPI.replaceShaderColor
-  );
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -12,6 +12,7 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
   model.classHierarchy.push('vtkWebGPURenderEncoder');
 
   publicAPI.begin = (encoder) => {
+    model.drawCallbacks = [];
     model.handle = encoder.beginRenderPass(model.description);
     if (model.label) {
       model.handle.pushDebugGroup(model.label);
@@ -19,13 +20,28 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
   };
 
   publicAPI.end = () => {
+    // loop over registered pipelines and their callbacks
+    for (let i = 0; i < model.drawCallbacks.length; i++) {
+      const pStruct = model.drawCallbacks[i];
+      const pl = pStruct.pipeline;
+
+      publicAPI.setPipeline(pl);
+
+      for (let cb = 0; cb < pStruct.callbacks.length; cb++) {
+        pStruct.callbacks[cb](publicAPI);
+      }
+    }
     if (model.label) {
       model.handle.popDebugGroup();
     }
     model.handle.end();
+    model.boundPipeline = null;
   };
 
   publicAPI.setPipeline = (pl) => {
+    if (model.boundPipeline === pl) {
+      return;
+    }
     model.handle.setPipeline(pl.getHandle());
     const pd = pl.getPipelineDescription();
 
@@ -61,6 +77,7 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
       }
     }
     model.boundPipeline = pl;
+    pl.draw(publicAPI);
   };
 
   publicAPI.replaceShaderCode = (pipeline) => {
@@ -109,6 +126,19 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
       model.description.depthStencilAttachment.view =
         model.depthTextureView.getHandle();
     }
+  };
+
+  // register pipeline callbacks from a mapper
+  publicAPI.registerDrawCallback = (pipeline, cb) => {
+    // if there is a matching pipeline just add the cb
+    for (let i = 0; i < model.drawCallbacks.length; i++) {
+      if (model.drawCallbacks[i].pipeline === pipeline) {
+        model.drawCallbacks[i].callbacks.push(cb);
+        return;
+      }
+    }
+
+    model.drawCallbacks.push({ pipeline, callbacks: [cb] });
   };
 
   // simple forwarders

--- a/Sources/Rendering/WebGPU/ShaderDescription/index.js
+++ b/Sources/Rendering/WebGPU/ShaderDescription/index.js
@@ -48,18 +48,18 @@ function vtkWebGPUShaderDescription(publicAPI, model) {
         for (let i = 0; i < inputNames.length; i++) {
           if (inputInterpolations[i] !== undefined) {
             inputStruct.push(
-              `  @location(${i}) @interpolate(${inputInterpolations[i]}) ${inputNames[i]} : ${inputTypes[i]};`
+              `  @location(${i}) @interpolate(${inputInterpolations[i]}) ${inputNames[i]} : ${inputTypes[i]},`
             );
           } else {
             inputStruct.push(
-              `  @location(${i}) ${inputNames[i]} : ${inputTypes[i]};`
+              `  @location(${i}) ${inputNames[i]} : ${inputTypes[i]},`
             );
           }
         }
       }
       for (let i = 0; i < model.builtinInputNames.length; i++) {
         inputStruct.push(
-          `  ${model.builtinInputNames[i]} : ${model.builtinInputTypes[i]};`
+          `  ${model.builtinInputNames[i]} : ${model.builtinInputTypes[i]},`
         );
       }
       if (inputStruct.length > 1) {
@@ -82,17 +82,17 @@ function vtkWebGPUShaderDescription(publicAPI, model) {
       for (let i = 0; i < model.outputNames.length; i++) {
         if (model.outputInterpolations[i] !== undefined) {
           outputStruct.push(
-            `  @location(${i}) @interpolate(${model.outputInterpolations[i]}) ${model.outputNames[i]} : ${model.outputTypes[i]};`
+            `  @location(${i}) @interpolate(${model.outputInterpolations[i]}) ${model.outputNames[i]} : ${model.outputTypes[i]},`
           );
         } else {
           outputStruct.push(
-            `  @location(${i}) ${model.outputNames[i]} : ${model.outputTypes[i]};`
+            `  @location(${i}) ${model.outputNames[i]} : ${model.outputTypes[i]},`
           );
         }
       }
       for (let i = 0; i < model.builtinOutputNames.length; i++) {
         outputStruct.push(
-          `  ${model.builtinOutputNames[i]} : ${model.builtinOutputTypes[i]};`
+          `  ${model.builtinOutputNames[i]} : ${model.builtinOutputTypes[i]},`
         );
       }
       outputStruct.push('};');

--- a/Sources/Rendering/WebGPU/SimpleMapper/index.js
+++ b/Sources/Rendering/WebGPU/SimpleMapper/index.js
@@ -1,11 +1,12 @@
 import macro from 'vtk.js/Sources/macros';
+import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
 import vtkWebGPUBindGroup from 'vtk.js/Sources/Rendering/WebGPU/BindGroup';
 import vtkWebGPUPipeline from 'vtk.js/Sources/Rendering/WebGPU/Pipeline';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
 import vtkWebGPUShaderDescription from 'vtk.js/Sources/Rendering/WebGPU/ShaderDescription';
 import vtkWebGPUVertexInput from 'vtk.js/Sources/Rendering/WebGPU/VertexInput';
 
-const vtkWebGPUMapperHelperVS = `
+const vtkWebGPUSimpleMapperVS = `
 //VTK::Renderer::Dec
 
 //VTK::Color::Dec
@@ -44,7 +45,7 @@ fn main(
 }
 `;
 
-const vtkWebGPUMapperHelperFS = `
+const vtkWebGPUSimpleMapperFS = `
 //VTK::Renderer::Dec
 
 //VTK::Color::Dec
@@ -87,12 +88,12 @@ fn main(
 `;
 
 // ----------------------------------------------------------------------------
-// vtkWebGPUMapperHelper methods
+// vtkWebGPUSimpleMapper methods
 // ----------------------------------------------------------------------------
 
-function vtkWebGPUMapperHelper(publicAPI, model) {
+function vtkWebGPUSimpleMapper(publicAPI, model) {
   // Set our className
-  model.classHierarchy.push('vtkWebGPUMapperHelper');
+  model.classHierarchy.push('vtkWebGPUSimpleMapper');
 
   publicAPI.generateShaderDescriptions = (hash, pipeline, vertexInput) => {
     // create the shader descriptions
@@ -233,7 +234,55 @@ function vtkWebGPUMapperHelper(publicAPI, model) {
     model.textureViews.push(view);
   };
 
-  publicAPI.renderForPipeline = (renderEncoder) => {
+  // do everything required for this mapper to be rerady to draw
+  // but do not bind or do the actual draw commands as the pipeline
+  // is not neccessarily bound yet
+  publicAPI.prepareToDraw = (renderEncoder) => {
+    model.renderEncoder = renderEncoder;
+
+    // do anything needed to get our input data up to date
+    publicAPI.updateInput();
+
+    // make sure buffers are created and up to date
+    publicAPI.updateBuffers();
+
+    // update bindings and bind groups/layouts
+    // does not acutally bind them, that is done in draw(...)
+    publicAPI.updateBindings();
+
+    // update the pipeline, includes computing the hash, and if needed
+    // creating the pipeline, shader code etc
+    publicAPI.updatePipeline();
+  };
+
+  publicAPI.updateInput = () => {};
+
+  publicAPI.updateBuffers = () => {};
+
+  publicAPI.updateBindings = () => {
+    // bindings can change without a pipeline change
+    // as long as their layout remains the same.
+    // That is why this is done even when the pipeline
+    // hash doesn't change.
+    model.bindGroup.setBindables(publicAPI.getBindables());
+  };
+
+  publicAPI.computePipelineHash = () => {};
+
+  publicAPI.registerDrawCallback = (encoder) => {
+    encoder.registerDrawCallback(model.pipeline, publicAPI.draw);
+  };
+
+  publicAPI.prepareAndDraw = (encoder) => {
+    publicAPI.prepareToDraw(encoder);
+    encoder.setPipeline(model.pipeline);
+    publicAPI.draw(encoder);
+  };
+
+  // do the rest of the calls required to draw this mapper
+  // at this point the command encouder and pipeline are
+  // created and bound
+  publicAPI.draw = (renderEncoder) => {
     const pipeline = renderEncoder.getBoundPipeline();
 
     // bind the mapper bind group
@@ -242,24 +291,6 @@ function vtkWebGPUMapperHelper(publicAPI, model) {
     // bind the vertex input
     pipeline.bindVertexInput(renderEncoder, model.vertexInput);
     renderEncoder.draw(model.numberOfVertices, model.numberOfInstances, 0, 0);
-  };
-
-  publicAPI.registerToDraw = () => {
-    if (model.pipeline) {
-      model.WebGPURenderer.registerPipelineCallback(
-        model.pipeline,
-        publicAPI.renderForPipeline
-      );
-    }
-  };
-
-  publicAPI.render = (renderEncoder, device) => {
-    publicAPI.build(renderEncoder, device);
-    renderEncoder.setPipeline(model.pipeline);
-    if (model.WebGPURenderer) {
-      model.WebGPURenderer.bindUBO(renderEncoder);
-    }
-    publicAPI.renderForPipeline(renderEncoder);
   };
 
   publicAPI.getBindables = () => {
@@ -284,22 +315,18 @@ function vtkWebGPUMapperHelper(publicAPI, model) {
     return bindables;
   };
 
-  publicAPI.build = (renderEncoder, device) => {
-    // handle per primitive type
-    model.renderEncoder = renderEncoder;
+  publicAPI.updatePipeline = () => {
+    publicAPI.computePipelineHash();
+    model.pipeline = model.device.getPipeline(model.pipelineHash);
 
-    model.pipeline = device.getPipeline(model.pipelineHash);
-
-    model.bindGroup.setBindables(publicAPI.getBindables());
-
-    // build VBO for this primitive
     // build the pipeline if needed
     if (!model.pipeline) {
       model.pipeline = vtkWebGPUPipeline.newInstance();
-      model.pipeline.setDevice(device);
+      model.pipeline.setDevice(model.device);
 
       if (model.WebGPURenderer) {
         model.pipeline.addBindGroupLayout(model.WebGPURenderer.getBindGroup());
+        model.pipeline.addDrawCallback(model.WebGPURenderer.bindUBO);
       }
 
       model.pipeline.addBindGroupLayout(model.bindGroup);
@@ -310,11 +337,11 @@ function vtkWebGPUMapperHelper(publicAPI, model) {
         model.vertexInput
       );
       model.pipeline.setTopology(model.topology);
-      model.pipeline.setRenderEncoder(renderEncoder);
+      model.pipeline.setRenderEncoder(model.renderEncoder);
       model.pipeline.setVertexState(
         model.vertexInput.getVertexInputInformation()
       );
-      device.createPipeline(model.pipelineHash, model.pipeline);
+      model.device.createPipeline(model.pipelineHash, model.pipeline);
     }
   };
 }
@@ -346,7 +373,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Inheritance
-  macro.obj(publicAPI, model);
+  vtkViewNode.extend(publicAPI, model, initialValues);
 
   model.textureViews = [];
   model.vertexInput = vtkWebGPUVertexInput.newInstance();
@@ -356,14 +383,14 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.additionalBindables = [];
 
   model.fragmentShaderTemplate =
-    model.fragmentShaderTemplate || vtkWebGPUMapperHelperFS;
+    model.fragmentShaderTemplate || vtkWebGPUSimpleMapperFS;
   model.vertexShaderTemplate =
-    model.vertexShaderTemplate || vtkWebGPUMapperHelperVS;
+    model.vertexShaderTemplate || vtkWebGPUSimpleMapperVS;
 
   model.shaderReplacements = new Map();
 
   // Build VTK API
-  macro.get(publicAPI, model, ['vertexInput']);
+  macro.get(publicAPI, model, ['pipeline', 'vertexInput']);
   macro.setGet(publicAPI, model, [
     'additionalBindables',
     'device',
@@ -382,12 +409,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
 
   // Object methods
-  vtkWebGPUMapperHelper(publicAPI, model);
+  vtkWebGPUSimpleMapper(publicAPI, model);
 }
 
 // ----------------------------------------------------------------------------
 
-export const newInstance = macro.newInstance(extend, 'vtkWebGPUMapperHelper');
+export const newInstance = macro.newInstance(extend, 'vtkWebGPUSimpleMapper');
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Rendering/WebGPU/SphereMapper/index.js
+++ b/Sources/Rendering/WebGPU/SphereMapper/index.js
@@ -1,12 +1,12 @@
 import * as macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
-import vtkWebGPUPolyDataMapper from 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper';
+import vtkWebGPUCellArrayMapper from 'vtk.js/Sources/Rendering/WebGPU/CellArrayMapper';
 import vtkWebGPUBufferManager from 'vtk.js/Sources/Rendering/WebGPU/BufferManager';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
 
 import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
 
-const { BufferUsage, PrimitiveTypes } = vtkWebGPUBufferManager;
+const { BufferUsage } = vtkWebGPUBufferManager;
 const { vtkErrorMacro } = macro;
 
 const vtkWebGPUSphereMapperVS = `
@@ -65,6 +65,21 @@ fn main(
 function vtkWebGPUSphereMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkWebGPUSphereMapper');
+
+  const cellMapperBuildPass = publicAPI.buildPass;
+  publicAPI.buildPass = (prepass) => {
+    if (prepass) {
+      if (!model.renderable.getStatic()) {
+        model.renderable.update();
+      }
+
+      const poly = model.renderable.getInputData();
+
+      publicAPI.setCellArray(poly.getVerts());
+      publicAPI.setCurrentInput(poly);
+    }
+    cellMapperBuildPass(prepass);
+  };
 
   publicAPI.replaceShaderNormal = (hash, pipeline, vertexInput) => {
     const vDesc = pipeline.getShaderDescription('vertex');
@@ -140,37 +155,28 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
   // compute a unique hash for a pipeline, this needs to be unique enough to
   // capture any pipeline code changes (which includes shader changes)
   // or vertex input changes/ bind groups/ etc
-  publicAPI.computePipelineHash = (vertexInput) => {
-    let pipelineHash = 'spm';
-    if (vertexInput.hasAttribute(`colorVI`)) {
-      pipelineHash += `c`;
+  publicAPI.computePipelineHash = () => {
+    model.pipelineHash = 'spm';
+    if (model.vertexInput.hasAttribute(`colorVI`)) {
+      model.pipelineHash += `c`;
     }
-    pipelineHash += model.renderEncoder.getPipelineHash();
-
-    return pipelineHash;
+    model.pipelineHash += model.renderEncoder.getPipelineHash();
   };
 
-  // was originally buildIBOs() but not using IBOs right now
-  publicAPI.buildPrimitives = () => {
+  publicAPI.updateBuffers = () => {
     const poly = model.currentInput;
 
-    const device = model.WebGPURenderWindow.getDevice();
-
     model.renderable.mapScalars(poly, 1.0);
-
-    // handle triangles
-    const i = PrimitiveTypes.Triangles;
 
     const points = poly.getPoints();
     const numPoints = points.getNumberOfPoints();
     const pointArray = points.getData();
-    const primHelper = model.primitives[i];
 
     // default to one instance and computed number of verts
-    primHelper.setNumberOfInstances(1);
-    primHelper.setNumberOfVertices(3 * numPoints);
+    publicAPI.setNumberOfInstances(1);
+    publicAPI.setNumberOfVertices(3 * numPoints);
 
-    const vertexInput = model.primitives[i].getVertexInput();
+    const vertexInput = model.vertexInput;
 
     let buffRequest = {
       owner: points,
@@ -179,7 +185,7 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
       usage: BufferUsage.RawVertex,
       format: 'float32x3',
     };
-    if (!device.getBufferManager().hasBuffer(buffRequest)) {
+    if (!model.device.getBufferManager().hasBuffer(buffRequest)) {
       // xyz v1 v2 v3
       const tmpVBO = new Float32Array(3 * numPoints * 3);
 
@@ -198,7 +204,7 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
         tmpVBO[vboIdx++] = pointArray[pointIdx + 2];
       }
       buffRequest.nativeArray = tmpVBO;
-      const buff = device.getBufferManager().getBuffer(buffRequest);
+      const buff = model.device.getBufferManager().getBuffer(buffRequest);
       vertexInput.addBuffer(buff, ['vertexBC']);
     }
 
@@ -223,7 +229,7 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
         usage: BufferUsage.RawVertex,
         format: 'float32x2',
       };
-      if (!device.getBufferManager().hasBuffer(buffRequest)) {
+      if (!model.device.getBufferManager().hasBuffer(buffRequest)) {
         const tmpVBO = new Float32Array(3 * numPoints * 2);
 
         const cos30 = Math.cos(vtkMath.radiansFromDegrees(30.0));
@@ -241,13 +247,11 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
           tmpVBO[vboIdx++] = 2.0 * radius;
         }
         buffRequest.nativeArray = tmpVBO;
-        const buff = device.getBufferManager().getBuffer(buffRequest);
+        const buff = model.device.getBufferManager().getBuffer(buffRequest);
         vertexInput.addBuffer(buff, ['offsetMC']);
       }
       model._lastRadius = defaultRadius;
     }
-
-    model.renderable.mapScalars(poly, 1.0);
 
     // deal with colors but only if modified
     let haveColors = false;
@@ -261,7 +265,7 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
           usage: BufferUsage.RawVertex,
           format: 'unorm8x4',
         };
-        if (!device.getBufferManager().hasBuffer(buffRequest)) {
+        if (!model.device.getBufferManager().hasBuffer(buffRequest)) {
           const colorComponents = c.getNumberOfComponents();
           if (colorComponents !== 4) {
             vtkErrorMacro('this should be 4');
@@ -279,7 +283,7 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
             }
           }
           buffRequest.nativeArray = tmpVBO;
-          const buff = device.getBufferManager().getBuffer(buffRequest);
+          const buff = model.device.getBufferManager().getBuffer(buffRequest);
           vertexInput.addBuffer(buff, ['colorVI']);
         }
         haveColors = true;
@@ -289,11 +293,8 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
       vertexInput.removeBufferIfPresent('colorVI');
     }
 
-    primHelper.setPipelineHash(publicAPI.computePipelineHash(vertexInput));
-    primHelper.setWebGPURenderer(model.WebGPURenderer);
-    primHelper.setTopology('triangle-list');
-    primHelper.build(model.renderEncoder, device);
-    primHelper.registerToDraw();
+    publicAPI.setTopology('triangle-list');
+    publicAPI.updateUBO();
   };
 }
 
@@ -309,16 +310,14 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Inheritance
-  vtkWebGPUPolyDataMapper.extend(publicAPI, model, initialValues);
+  vtkWebGPUCellArrayMapper.extend(publicAPI, model, initialValues);
 
-  model.primitives[PrimitiveTypes.Triangles].setVertexShaderTemplate(
-    vtkWebGPUSphereMapperVS
-  );
+  publicAPI.setVertexShaderTemplate(vtkWebGPUSphereMapperVS);
 
   // Object methods
   vtkWebGPUSphereMapper(publicAPI, model);
 
-  const sr = model.primitives[PrimitiveTypes.Triangles].getShaderReplacements();
+  const sr = model.shaderReplacements;
   sr.set('replaceShaderPosition', publicAPI.replaceShaderPosition);
   sr.set('replaceShaderNormal', publicAPI.replaceShaderNormal);
 }

--- a/Sources/Rendering/WebGPU/StorageBuffer/index.js
+++ b/Sources/Rendering/WebGPU/StorageBuffer/index.js
@@ -169,13 +169,13 @@ function vtkWebGPUStorageBuffer(publicAPI, model) {
     const lines = [`struct ${model.label}StructEntry\n{`];
     for (let i = 0; i < model.bufferEntries.length; i++) {
       const entry = model.bufferEntries[i];
-      lines.push(`  ${entry.name}: ${entry.type};`);
+      lines.push(`  ${entry.name}: ${entry.type},`);
     }
     lines.push(`
 };
 struct ${model.label}Struct
 {
-  values: array<${model.label}StructEntry>;
+  values: array<${model.label}StructEntry>,
 };
 @binding(${binding}) @group(${group}) var<storage, read> ${model.label}: ${model.label}Struct;
 `);

--- a/Sources/Rendering/WebGPU/UniformBuffer/index.js
+++ b/Sources/Rendering/WebGPU/UniformBuffer/index.js
@@ -285,7 +285,7 @@ function vtkWebGPUUniformBuffer(publicAPI, model) {
     const lines = [`struct ${model.label}Struct\n{`];
     for (let i = 0; i < model.bufferEntries.length; i++) {
       const entry = model.bufferEntries[i];
-      lines.push(`  ${entry.name}: ${entry.type};`);
+      lines.push(`  ${entry.name}: ${entry.type},`);
     }
     lines.push(
       `};\n@binding(${binding}) @group(${group}) var<uniform> ${model.label}: ${model.label}Struct;`

--- a/Sources/Rendering/WebGPU/Volume/index.js
+++ b/Sources/Rendering/WebGPU/Volume/index.js
@@ -28,10 +28,7 @@ function vtkWebGPUVolume(publicAPI, model) {
       if (model.propID === undefined) {
         model.propID = model.WebGPURenderWindow.getUniquePropID();
       }
-      publicAPI.prepareNodes();
       model.renderable.getMapper().update();
-      // publicAPI.addMissingNode(model.renderable.getMapper());
-      publicAPI.removeUnusedNodes();
     }
   };
 
@@ -82,23 +79,6 @@ function vtkWebGPUVolume(publicAPI, model) {
         }
       }
     }
-  };
-
-  publicAPI.traverseVolumePass = (renderPass) => {
-    if (
-      !model.renderable ||
-      !model.renderable.getNestedVisibility() ||
-      (model.WebGPURenderer.getSelector() &&
-        !model.renderable.getNestedPickable())
-    ) {
-      return;
-    }
-
-    publicAPI.apply(renderPass, true);
-
-    model.children[0].traverse(renderPass);
-
-    publicAPI.apply(renderPass, false);
   };
 
   publicAPI.getKeyMatrices = (wgpuRen) => {

--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -3,7 +3,7 @@ import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
 import vtkRenderPass from 'vtk.js/Sources/Rendering/SceneGraph/RenderPass';
 import vtkWebGPUBufferManager from 'vtk.js/Sources/Rendering/WebGPU/BufferManager';
-import vtkWebGPUMapperHelper from 'vtk.js/Sources/Rendering/WebGPU/MapperHelper';
+import vtkWebGPUSimpleMapper from 'vtk.js/Sources/Rendering/WebGPU/SimpleMapper';
 import vtkWebGPURenderEncoder from 'vtk.js/Sources/Rendering/WebGPU/RenderEncoder';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
 import vtkWebGPUTexture from 'vtk.js/Sources/Rendering/WebGPU/Texture';
@@ -231,11 +231,6 @@ function vtkWebGPUVolumePass(publicAPI, model) {
     // copy back to the original color buffer
 
     // final composite
-    model._copyEncoder.setColorTextureView(0, model.colorTextureView);
-    model._copyEncoder.attachTextureViews();
-    renNode.setRenderEncoder(model._copyEncoder);
-    model._copyEncoder.begin(viewNode.getCommandEncoder());
-    renNode.scissorAndViewport(model._copyEncoder);
     model._volumeCopyQuad.setWebGPURenderer(renNode);
     if (model._useSmallViewport) {
       const width = model._colorTextureView.getTexture().getWidth();
@@ -248,7 +243,13 @@ function vtkWebGPUVolumePass(publicAPI, model) {
       model._copyUBO.setArray('tscale', [1.0, 1.0]);
     }
     model._copyUBO.sendIfNeeded(device);
-    model._volumeCopyQuad.render(model._copyEncoder, viewNode.getDevice());
+
+    model._copyEncoder.setColorTextureView(0, model.colorTextureView);
+    model._copyEncoder.attachTextureViews();
+
+    model._copyEncoder.begin(viewNode.getCommandEncoder());
+    renNode.scissorAndViewport(model._copyEncoder);
+    model._volumeCopyQuad.prepareAndDraw(model._copyEncoder);
     model._copyEncoder.end();
   };
 
@@ -321,7 +322,6 @@ function vtkWebGPUVolumePass(publicAPI, model) {
       ? model._clearEncoder
       : model._mergeEncoder;
     encoder.attachTextureViews();
-    renNode.setRenderEncoder(encoder);
     encoder.begin(viewNode.getCommandEncoder());
     let width = model._colorTextureView.getTexture().getWidth();
     let height = model._colorTextureView.getTexture().getHeight();
@@ -335,7 +335,7 @@ function vtkWebGPUVolumePass(publicAPI, model) {
 
     model.fullScreenQuad.setWebGPURenderer(renNode);
     model.fullScreenQuad.setVolumes(volumes);
-    model.fullScreenQuad.render(encoder, viewNode.getDevice());
+    model.fullScreenQuad.prepareAndDraw(encoder);
     encoder.end();
   };
 
@@ -427,8 +427,6 @@ function vtkWebGPUVolumePass(publicAPI, model) {
   };
 
   publicAPI.drawDepthRange = (renNode, viewNode) => {
-    const device = viewNode.getDevice();
-
     // copy current depth buffer to
     model._depthRangeTexture.resizeToMatch(model.colorTextureView.getTexture());
     model._depthRangeTexture2.resizeToMatch(
@@ -442,8 +440,8 @@ function vtkWebGPUVolumePass(publicAPI, model) {
     renNode.volumeDepthRangePass(true);
     model._mapper.setWebGPURenderer(renNode);
 
-    model._mapper.build(model._depthRangeEncoder, device);
-    model._mapper.registerToDraw();
+    model._mapper.prepareToDraw(model._depthRangeEncoder);
+    model._mapper.registerDrawCallback(model._depthRangeEncoder);
 
     renNode.volumeDepthRangePass(false);
   };
@@ -715,7 +713,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkRenderPass.extend(publicAPI, model, initialValues);
 
   model._lastScale = 2.0;
-  model._mapper = vtkWebGPUMapperHelper.newInstance();
+  model._mapper = vtkWebGPUSimpleMapper.newInstance();
   model._mapper.setFragmentShaderTemplate(DepthBoundsFS);
   model._mapper
     .getShaderReplacements()

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -841,7 +841,9 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
     model.componentSSBO.send(device);
   };
 
-  publicAPI.updateBuffers = (device) => {
+  const superClassUpdateBuffers = publicAPI.updateBuffers;
+  publicAPI.updateBuffers = () => {
+    superClassUpdateBuffers();
     // compute the min step size
     let sampleDist = model.volumes[0]
       .getRenderable()
@@ -858,7 +860,7 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
     if (model.sampleDist !== sampleDist) {
       model.sampleDist = sampleDist;
       model.UBO.setValue('SampleDistance', sampleDist);
-      model.UBO.sendIfNeeded(device);
+      model.UBO.sendIfNeeded(model.device);
     }
 
     // add in 3d volume textures
@@ -872,7 +874,7 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
         imageData: image,
         owner: image.getPointData().getScalars(),
       };
-      const newTex = device.getTextureManager().getTexture(treq);
+      const newTex = model.device.getTextureManager().getTexture(treq);
       if (
         !model.textureViews[vidx + 4] ||
         model.textureViews[vidx + 4].getTexture() !== newTex
@@ -891,9 +893,19 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
     }
     model.lastVolumeLength = model.volumes.length;
 
-    publicAPI.updateLUTImage(device);
+    publicAPI.updateLUTImage(model.device);
 
-    publicAPI.updateSSBO(device);
+    publicAPI.updateSSBO(model.device);
+
+    if (!model.clampSampler) {
+      model.clampSampler = vtkWebGPUSampler.newInstance({
+        label: 'clampSampler',
+      });
+      model.clampSampler.create(model.device, {
+        minFilter: 'linear',
+        magFilter: 'linear',
+      });
+    }
   };
 
   publicAPI.computePipelineHash = () => {
@@ -921,24 +933,6 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
         return;
       }
     }
-  };
-
-  const superclassBuild = publicAPI.build;
-  publicAPI.build = (renderEncoder, device) => {
-    publicAPI.computePipelineHash();
-    publicAPI.updateBuffers(device);
-
-    if (!model.clampSampler) {
-      model.clampSampler = vtkWebGPUSampler.newInstance({
-        label: 'clampSampler',
-      });
-      model.clampSampler.create(device, {
-        minFilter: 'linear',
-        magFilter: 'linear',
-      });
-    }
-
-    superclassBuild(renderEncoder, device);
   };
 
   const superclassGetBindables = publicAPI.getBindables;


### PR DESCRIPTION
Cleanup and document WebGPU mapper architecture.
This is a first step in trying to make the mappers
for WebGPU cleaner, better documented and more extensible.
The main trust here is to create a CellArrayMapper and update
the polydatamapper to just instantiate and use that. For example
one cellarray mapper for each of verts, lines, polysm, and strips
as opposed to having the polydatamapper try to manage all that
internally.

Also renamed and documented many methods to be more clear, fit better
with WebGPU terminology and have a more clear defined process.

There is more work to be done, the goal being to make mappers both
1) easy to customize - add shader code, add arrays to the VertexInput
2) easy to extend - with data pipelines we can easly add more stages
(filters) to data processing in VTK in a chain but with mappers more
capabilities means a larger and larger bloated mapper, the end goal
would be to enable mappers to be extended without adding to their
base code, but more like adding a filter chain.

Update to latest WebGPU standard
