### PR TITLE
feat(hardwareselector): add hardware picking for point and cell ids

### DIFF
--- a/Sources/Rendering/Core/Actor/index.js
+++ b/Sources/Rendering/Core/Actor/index.js
@@ -158,6 +158,12 @@ function vtkActor(publicAPI, model) {
 
   publicAPI.getSupportsSelection = () =>
     model.mapper ? model.mapper.getSupportsSelection() : false;
+
+  publicAPI.processSelectorPixelBuffers = (selector, pixelOffsets) => {
+    if (model.mapper && model.mapper.processSelectorPixelBuffers) {
+      model.mapper.processSelectorPixelBuffers(selector, pixelOffsets);
+    }
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/Core/HardwareSelector/example/index.js
+++ b/Sources/Rendering/Core/HardwareSelector/example/index.js
@@ -53,8 +53,8 @@ document.querySelector('body').appendChild(tooltipElem);
 // Sphere -------------------------------------------------
 
 const sphereSource = vtkSphereSource.newInstance({
-  phiResolution: 500,
-  thetaResolution: 500,
+  phiResolution: 30,
+  thetaResolution: 30,
 });
 
 const sphereMapper = vtkMapper.newInstance();
@@ -253,7 +253,7 @@ function processSelections(selections) {
   }
 
   // Update picture for the user so we can see the green one
-  // updateWorldPosition(worldPosition);
+  updateWorldPosition(worldPosition);
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/Core/HardwareSelector/example/index.js
+++ b/Sources/Rendering/Core/HardwareSelector/example/index.js
@@ -15,7 +15,7 @@ import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenR
 import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import { FieldAssociations } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
 import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
 
@@ -53,9 +53,10 @@ document.querySelector('body').appendChild(tooltipElem);
 // Sphere -------------------------------------------------
 
 const sphereSource = vtkSphereSource.newInstance({
-  phiResolution: 30,
-  thetaResolution: 30,
+  phiResolution: 500,
+  thetaResolution: 500,
 });
+
 const sphereMapper = vtkMapper.newInstance();
 const sphereActor = vtkActor.newInstance();
 sphereActor.setMapper(sphereMapper);
@@ -155,9 +156,7 @@ renderWindow.render();
 
 const hardwareSelector = apiSpecificRenderWindow.getSelector();
 hardwareSelector.setCaptureZValues(true);
-hardwareSelector.setFieldAssociation(
-  FieldAssociations.FIELD_ASSOCIATION_POINTS
-);
+hardwareSelector.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_CELLS);
 
 // ----------------------------------------------------------------------------
 // Create Mouse listener for picking on mouse move
@@ -199,13 +198,42 @@ function processSelections(selections) {
     return;
   }
 
-  const { worldPosition, compositeID, prop } = selections[0].getProperties();
-
-  if (lastProcessedActor === prop) {
+  const { worldPosition, compositeID, prop, attributeID } =
+    selections[0].getProperties();
+  let cursorPosition = [...worldPosition];
+  if (attributeID || attributeID === 0) {
+    const input = prop.getMapper().getInputData();
+    if (!input.getCells()) {
+      input.buildCells();
+    }
+    if (
+      hardwareSelector.getFieldAssociation() ===
+      FieldAssociations.FIELD_ASSOCIATION_POINTS
+    ) {
+      const points = input.getPoints();
+      const point = points.getTuple(attributeID);
+      cursorPosition = [...point];
+    } else {
+      const cellPoints = input.getCellPoints(attributeID);
+      if (cellPoints) {
+        const pointIds = cellPoints.cellPointIds;
+        const points = [];
+        // Find the closest cell point, and use that as cursor position
+        pointIds.forEach((pointId) => {
+          points.push(input.getPoints().getPoint(pointId, []));
+        });
+        const distance = (pA, pB) =>
+          vtkMath.distance2BetweenPoints(pA, worldPosition) -
+          vtkMath.distance2BetweenPoints(pB, worldPosition);
+        const sorted = points.sort(distance);
+        cursorPosition = [...sorted[0]];
+      }
+    }
+  } else if (lastProcessedActor === prop) {
     // Skip render call when nothing change
-    updateWorldPosition(worldPosition);
     return;
   }
+  updateWorldPosition(cursorPosition);
   lastProcessedActor = prop;
 
   // Make the picked actor green
@@ -225,7 +253,7 @@ function processSelections(selections) {
   }
 
   // Update picture for the user so we can see the green one
-  updateWorldPosition(worldPosition);
+  // updateWorldPosition(worldPosition);
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelector.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelector.js
@@ -75,21 +75,62 @@ test('Test HardwareSelector', (tapeContext) => {
   sel.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_POINTS);
   sel.setCaptureZValues(true);
 
-  sel.selectAsync(renderer, 200, 200, 300, 300).then((res) => {
-    // console.log(JSON.stringify(res[0].getProperties()));
-    // console.log(JSON.stringify(res[1].getProperties()));
-    // res[1] should be at 1.0, 1.0, 1.5 in world coords
-    const allGood =
-      res.length === 2 &&
-      res[0].getProperties().prop === actor &&
-      res[1].getProperties().prop === actor3 &&
-      Math.abs(res[1].getProperties().worldPosition[0] - 1.0) < 0.02 &&
-      Math.abs(res[1].getProperties().worldPosition[1] - 1.0) < 0.02 &&
-      Math.abs(res[1].getProperties().worldPosition[2] - 1.5) < 0.02;
+  const promises = [];
+  promises.push(
+    sel.selectAsync(renderer, 200, 200, 300, 300).then((res) => {
+      // res[1] should be at 1.0, 1.0, 1.5 in world coords
+      const allGood =
+        res.length === 2 &&
+        res[0].getProperties().prop === actor &&
+        res[1].getProperties().prop === actor3 &&
+        Math.abs(res[1].getProperties().worldPosition[0] - 1.0) < 0.02 &&
+        Math.abs(res[1].getProperties().worldPosition[1] - 1.0) < 0.02 &&
+        Math.abs(res[1].getProperties().worldPosition[2] - 1.5) < 0.02;
 
-    tapeContext.ok(res.length === 2, 'Two props selected');
-    tapeContext.ok(allGood, 'Correct props were selected');
+      tapeContext.ok(res.length === 2, 'Two props selected');
+      tapeContext.ok(allGood, 'Correct props were selected');
+    })
+  );
 
+  // Test picking points
+  promises.push(
+    sel.selectAsync(renderer, 210, 199, 211, 200).then((res) => {
+      tapeContext.ok(res[0].getProperties().propID === 3);
+      tapeContext.ok(res[0].getProperties().attributeID === 33);
+    })
+  );
+
+  promises.push(
+    sel.selectAsync(renderer, 145, 140, 146, 141).then((res) => {
+      tapeContext.ok(res[0].getProperties().propID === 4);
+      tapeContext.ok(res[0].getProperties().attributeID === 0);
+    })
+  );
+
+  promises.push(
+    sel.selectAsync(renderer, 294, 264, 295, 265).then((res) => {
+      tapeContext.ok(res[0].getProperties().propID === 5);
+      tapeContext.ok(res[0].getProperties().attributeID === 0);
+    })
+  );
+
+  sel.setFieldAssociation(FieldAssociations.FIELD_ASSOCIATION_CELLS);
+
+  // Test picking cells
+  promises.push(
+    sel.selectAsync(renderer, 200, 200, 201, 201).then((res) => {
+      tapeContext.ok(res[0].getProperties().propID === 3);
+      tapeContext.ok(res[0].getProperties().attributeID === 27);
+    })
+  );
+
+  promises.push(
+    sel.selectAsync(renderer, 265, 265, 266, 266).then((res) => {
+      tapeContext.ok(res[0].getProperties().propID === 5);
+      tapeContext.ok(res[0].getProperties().attributeID === 0);
+    })
+  );
+  Promise.all(promises).then(() => {
     gc.releaseResources();
   });
 });

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorSpeed.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorSpeed.js
@@ -77,9 +77,9 @@ test('Test HardwareSelector', (tapeContext) => {
         console.timeEnd('hardware render');
 
         tapeContext.ok(
-          // should take about 3 normal renders but we give it some wiggle room
-          tcTime < tbTime * 6,
-          `Hardware selector takes less than six normal renders (${taTime}, ${tbTime}, ${tcTime})`
+          // should take about 5 normal renders but we give it some wiggle room
+          tcTime < tbTime * 10,
+          `Hardware selector takes less than ten normal renders (${taTime}, ${tbTime}, ${tcTime})`
         );
 
         gc.releaseResources();

--- a/Sources/Rendering/Core/Prop/index.js
+++ b/Sources/Rendering/Core/Prop/index.js
@@ -23,6 +23,8 @@ function vtkProp(publicAPI, model) {
     return m1;
   };
 
+  publicAPI.processSelectorPixelBuffers = (selector, pixeloffsets) => {};
+
   publicAPI.getNestedProps = () => null;
   publicAPI.getActors = () => [];
   publicAPI.getActors2D = () => [];

--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -307,7 +307,6 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
 
     let pointCount = options.vertexOffset;
     addAPoint = function addAPointFunc(i) {
-      // TODO: use a counter to avoid the division
       // Keep track of original point and cell ids, for selection
       if (selectionMaps) {
         selectionMaps.points[pointCount] = i;

--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -47,7 +47,13 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
 
   publicAPI.setType(ObjectType.ARRAY_BUFFER);
 
-  publicAPI.createVBO = (cellArray, inRep, outRep, options) => {
+  publicAPI.createVBO = (
+    cellArray,
+    inRep,
+    outRep,
+    options,
+    selectionMaps = null
+  ) => {
     if (!cellArray.getData() || !cellArray.getData().length) {
       model.elementCount = 0;
       return 0;
@@ -280,7 +286,35 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
       publicAPI.setCoordShiftAndScale(null, null);
     }
 
+    // Initialize the structures used to keep track of point ids and cell ids for selectors
+    if (selectionMaps) {
+      if (!selectionMaps.points && !selectionMaps.cells) {
+        selectionMaps.points = new Int32Array(caboCount);
+        selectionMaps.cells = new Int32Array(caboCount);
+      } else {
+        const newPoints = new Int32Array(
+          caboCount + selectionMaps.points.length
+        );
+        newPoints.set(selectionMaps.points);
+        selectionMaps.points = newPoints;
+        const newCells = new Int32Array(
+          caboCount + selectionMaps.points.length
+        );
+        newCells.set(selectionMaps.cells);
+        selectionMaps.cells = newCells;
+      }
+    }
+
+    let pointCount = options.vertexOffset;
     addAPoint = function addAPointFunc(i) {
+      // TODO: use a counter to avoid the division
+      // Keep track of original point and cell ids, for selection
+      if (selectionMaps) {
+        selectionMaps.points[pointCount] = i;
+        selectionMaps.cells[pointCount] = cellCount;
+      }
+      ++pointCount;
+
       // Vertices
       pointIdx = i * 3;
 

--- a/Sources/Rendering/OpenGL/HardwareSelector/Constants.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/Constants.js
@@ -3,7 +3,8 @@ export const PassTypes = {
   ACTOR_PASS: 0,
   COMPOSITE_INDEX_PASS: 1,
   ID_LOW24: 2,
-  MAX_KNOWN_PASS: 2,
+  ID_HIGH24: 3,
+  MAX_KNOWN_PASS: 3,
 };
 
 export default {


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The WebGL hardware selector currently does not support picking point and cell ids.

### Results
This adds support for picking points and cells with the hardware selector. Currently only implemented for the polydata mapper.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
