### PR TITLE
fix(WebGL): fix viewport issue with translucency

### DIFF
--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -252,6 +252,12 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
 
     gl.colorMask(true, true, true, true);
     gl.drawBuffers([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1]);
+
+    // make sure to clear the entire framebuffer as we will
+    // be blitting the entire thing all of it needs good initial values
+    gl.viewport(0, 0, size[0], size[1]);
+    gl.scissor(0, 0, size[0], size[1]);
+
     gl.clearBufferfv(gl.COLOR, 0, [0.0, 0.0, 0.0, 1.0]);
     gl.clearBufferfv(gl.COLOR, 1, [0.0, 0.0, 0.0, 0.0]);
 


### PR DESCRIPTION
Order independent tranlucent pass had an issue were
when there were multiple viewports with translucent actors
the framebuffer was being cleared for only the active viewport
when it needs to be entirely cleared.

Fixes issue: https://github.com/Kitware/vtk-js/issues/2377