### PR TITLE
fix(VolumeMapper): Fixed depth test of volume was incorrect in multi-…

### DIFF
--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -565,7 +565,9 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         'zBufferTexture',
         model.zBufferTexture.getTextureUnit()
       );
-      const size = publicAPI.getRenderTargetSize();
+      const size = model._useSmallViewport
+        ? [model._smallViewportWidth, model._smallViewportHeight]
+        : model._openGLRenderWindow.getFramebufferSize();
       program.setUniformf('vpWidth', size[0]);
       program.setUniformf('vpHeight', size[1]);
     }


### PR DESCRIPTION


<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
I think the viewport is an area that scissor the entire frame buffer, and did not change the coordinates of the internal objects, so framebufferSize should be used in depth testing.

### Results
I placed a tube in front of a volume to test depth issues with multiple renderers.

<img src="https://user-images.githubusercontent.com/18617494/164277523-4437e04b-c552-41d7-96dc-e80c5dd97267.png" width=50% height=50%>

#### Before
![image](https://user-images.githubusercontent.com/18617494/164280043-7746d814-5a36-4b9f-b33a-799fdda21658.png)
The graphics display is incomplete, and the volume is always on top of other actors.

#### After
![image](https://user-images.githubusercontent.com/18617494/164280576-03551cb6-1771-42b9-b41d-f9efefbe0aa5.png)
Display and order are normal.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] VolumeMapper

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
