### PR TITLE
fix(widget): fix widget picking when substates are invisible

### DIFF
--- a/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
@@ -251,17 +251,15 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
     return orientationRotation;
   }
 
+  const superGetRepresentationStates = publicAPI.getRepresentationStates;
+  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
+    superGetRepresentationStates(input).filter(
+      (state) => state.getOrigin?.() && state.isVisible?.()
+    );
+
   publicAPI.requestDataInternal = (inData, outData) => {
     const { points, scale, color, direction } = model.internalArrays;
-    const list = publicAPI
-      .getRepresentationStates(inData[0])
-      .filter(
-        (state) =>
-          state.getOrigin &&
-          state.getOrigin() &&
-          state.isVisible &&
-          state.isVisible()
-      );
+    const list = publicAPI.getRepresentationStates(inData[0]);
     const totalCount = list.length;
 
     if (color.getNumberOfValues() !== totalCount) {

--- a/Sources/Widgets/Representations/CircleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/CircleContextRepresentation/index.js
@@ -111,19 +111,16 @@ function vtkCircleContextRepresentation(publicAPI, model) {
     model.pipelines.circle.actor.getProperty().setOpacity(opacity);
   };
 
+  const superGetRepresentationStates = publicAPI.getRepresentationStates;
+  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
+    superGetRepresentationStates(input).filter(
+      (state) => state.getOrigin?.() && state.isVisible?.()
+    );
   // --------------------------------------------------------------------------
 
   publicAPI.requestData = (inData, outData) => {
     const { points, scale, color, direction } = model.internalArrays;
-    const list = publicAPI
-      .getRepresentationStates(inData[0])
-      .filter(
-        (state) =>
-          state.getOrigin &&
-          state.getOrigin() &&
-          state.isVisible &&
-          state.isVisible()
-      );
+    const list = publicAPI.getRepresentationStates(inData[0]);
     const totalCount = list.length;
 
     if (color.getNumberOfValues() !== totalCount) {

--- a/Sources/Widgets/Representations/CubeHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/CubeHandleRepresentation/index.js
@@ -55,19 +55,16 @@ function vtkCubeHandleRepresentation(publicAPI, model) {
 
   publicAPI.addActor(model.actor);
 
+  const superGetRepresentationStates = publicAPI.getRepresentationStates;
+  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
+    superGetRepresentationStates(input).filter(
+      (state) => state.getOrigin?.() && state.isVisible?.()
+    );
   // --------------------------------------------------------------------------
 
   publicAPI.requestData = (inData, outData) => {
     const { points, scale, color } = model.internalArrays;
-    const list = publicAPI
-      .getRepresentationStates(inData[0])
-      .filter(
-        (state) =>
-          state.getOrigin &&
-          state.getOrigin() &&
-          state.isVisible &&
-          state.isVisible()
-      );
+    const list = publicAPI.getRepresentationStates(inData[0]);
     const totalCount = list.length;
 
     if (color.getNumberOfValues() !== totalCount) {

--- a/Sources/Widgets/Representations/SphereContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/SphereContextRepresentation/index.js
@@ -63,17 +63,14 @@ function vtkSphereContextRepresentation(publicAPI, model) {
   publicAPI.setOpacity = (opacity) => {
     model.pipelines.circle.actor.getProperty().setOpacity(opacity);
   };
+  const superGetRepresentationStates = publicAPI.getRepresentationStates;
+  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
+    superGetRepresentationStates(input).filter(
+      (state) => state.getOrigin?.() && state.isVisible?.()
+    );
   publicAPI.requestData = (inData, outData) => {
     const { points, scale, color } = model.internalArrays;
-    const list = publicAPI
-      .getRepresentationStates(inData[0])
-      .filter(
-        (state) =>
-          state.getOrigin &&
-          state.getOrigin() &&
-          state.isVisible &&
-          state.isVisible()
-      );
+    const list = publicAPI.getRepresentationStates(inData[0]);
     const totalCount = list.length;
 
     if (color.getNumberOfValues() !== totalCount) {

--- a/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
@@ -104,19 +104,17 @@ function vtkSphereHandleRepresentation(publicAPI, model) {
     model.displayMapper.setCallback(callback ? callbackProxy : null);
   };
 
+  const superGetRepresentationStates = publicAPI.getRepresentationStates;
+  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
+    superGetRepresentationStates(input).filter(
+      (state) => state.getOrigin?.() && state.isVisible?.()
+    );
+
   // --------------------------------------------------------------------------
 
   publicAPI.requestData = (inData, outData) => {
     const { points, scale, color } = model.internalArrays;
-    const list = publicAPI
-      .getRepresentationStates(inData[0])
-      .filter(
-        (state) =>
-          state.getOrigin &&
-          state.getOrigin() &&
-          state.isVisible &&
-          state.isVisible()
-      );
+    const list = publicAPI.getRepresentationStates(inData[0]);
     const totalCount = list.length;
 
     if (color.getNumberOfValues() !== totalCount) {


### PR DESCRIPTION
getSelectedState() is calling getRepresentationStates(). When hiding a handle, the compositeID of
the visible handles change because of the invisible handle not being rendered.
WidgetRepresentation.getRepresentationStates() returns all handle substates, visible or not.

fix #2374


### Context
Hiding widget handles (i.e. setVisible(false)) disrupts the handle selection. 
When a sphere handle gets invisible, it does not get rendered.
However, an invisible handle could still get selected. 

### Results
Invisible handles no longer disrupt visible handle picking.

### Changes
Synchronize handle state between rendering (requestData) and selecting (getSelectedState)

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
