### PR TITLE
fix(cellpicker): return the correct cell id

### DIFF
--- a/Sources/Rendering/Core/CellPicker/index.js
+++ b/Sources/Rendering/Core/CellPicker/index.js
@@ -267,7 +267,7 @@ function vtkCellPicker(publicAPI, model) {
       const cellObject = data.getPolys();
       const points = data.getPoints();
       const cellData = cellObject.getData();
-      let cellId = 0;
+      let cellId = data.getNumberOfLines() + data.getNumberOfVerts();
       const pointsIdList = [-1, -1, -1];
       const cell = vtkTriangle.newInstance();
       const cellPoints = vtkPoints.newInstance();


### PR DESCRIPTION
CellPicker used to return a wrong cell id if having lines and verts in the dataset. This change
makes it so we return a consistent cell id.

### Context
bad cell id value in CellPicker

### Results
We now return a consistent cell id if we have vertices and lines in the dataset.
### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: master<!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: Archlinux<!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: Firefox <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
