### PR TITLE
fix(WebGPU): fix to caching and minor fix to stick mapper

### DIFF
--- a/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
+++ b/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
@@ -130,6 +130,7 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
 
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
+      model.WebGPUActor = publicAPI.getFirstAncestorOfType('vtkWebGPUActor');
       if (!model.renderable.getStatic()) {
         model.renderable.update();
       }

--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -336,11 +336,9 @@ function vtkWebGPUImageMapper(publicAPI, model) {
   const superClassUpdateBuffers = publicAPI.updateBuffers;
   publicAPI.updateBuffers = () => {
     superClassUpdateBuffers();
-    const treq = {
-      imageData: model.currentInput,
-      owner: model.currentInput.getPointData().getScalars(),
-    };
-    const newTex = model.device.getTextureManager().getTexture(treq);
+    const newTex = model.device
+      .getTextureManager()
+      .getTextureForImageData(model.currentInput);
     const tViews = model.textureViews;
 
     if (!tViews[0] || tViews[0].getTexture() !== newTex) {

--- a/Sources/Rendering/WebGPU/SphereMapper/index.js
+++ b/Sources/Rendering/WebGPU/SphereMapper/index.js
@@ -178,14 +178,13 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
 
     const vertexInput = model.vertexInput;
 
-    let buffRequest = {
-      owner: points,
-      hash: 'spm',
-      time: points.getMTime(),
-      usage: BufferUsage.RawVertex,
-      format: 'float32x3',
-    };
-    if (!model.device.getBufferManager().hasBuffer(buffRequest)) {
+    let hash = `spm${points.getMTime()}float32x3`;
+    if (!model.device.getBufferManager().hasBuffer(hash)) {
+      const buffRequest = {
+        hash,
+        usage: BufferUsage.RawVertex,
+        format: 'float32x3',
+      };
       // xyz v1 v2 v3
       const tmpVBO = new Float32Array(3 * numPoints * 3);
 
@@ -220,16 +219,17 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
 
     const defaultRadius = model.renderable.getRadius();
     if (scales || defaultRadius !== model._lastRadius) {
-      buffRequest = {
-        owner: scales,
-        hash: 'spm',
-        time: scales
+      hash = `spm${
+        scales
           ? pointData.getArray(model.renderable.getScaleArray()).getMTime()
-          : 0,
-        usage: BufferUsage.RawVertex,
-        format: 'float32x2',
-      };
-      if (!model.device.getBufferManager().hasBuffer(buffRequest)) {
+          : defaultRadius
+      }float32x2`;
+      if (!model.device.getBufferManager().hasBuffer(hash)) {
+        const buffRequest = {
+          hash,
+          usage: BufferUsage.RawVertex,
+          format: 'float32x2',
+        };
         const tmpVBO = new Float32Array(3 * numPoints * 2);
 
         const cos30 = Math.cos(vtkMath.radiansFromDegrees(30.0));
@@ -258,14 +258,13 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
     if (model.renderable.getScalarVisibility()) {
       const c = model.renderable.getColorMapColors();
       if (c) {
-        buffRequest = {
-          owner: c,
-          hash: 'spm',
-          time: c.getMTime(),
-          usage: BufferUsage.RawVertex,
-          format: 'unorm8x4',
-        };
-        if (!model.device.getBufferManager().hasBuffer(buffRequest)) {
+        hash = `spm${c.getMTime()}unorm8x4`;
+        if (!model.device.getBufferManager().hasBuffer(hash)) {
+          const buffRequest = {
+            hash,
+            usage: BufferUsage.RawVertex,
+            format: 'unorm8x4',
+          };
           const colorComponents = c.getNumberOfComponents();
           if (colorComponents !== 4) {
             vtkErrorMacro('this should be 4');

--- a/Sources/Rendering/WebGPU/StorageBuffer/index.js
+++ b/Sources/Rendering/WebGPU/StorageBuffer/index.js
@@ -42,7 +42,6 @@ function vtkWebGPUStorageBuffer(publicAPI, model) {
     if (!model._buffer) {
       const req = {
         nativeArray: model.Float32Array,
-        time: 0,
         usage: BufferUsage.Storage,
         label: model.label,
       };

--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -93,7 +93,6 @@ function vtkWebGPUTexture(publicAPI, model) {
 
       if (req.dataArray) {
         buffRequest.dataArray = req.dataArray;
-        buffRequest.time = req.dataArray.getMTime();
       }
       buffRequest.nativeArray = req.nativeArray;
 
@@ -172,7 +171,6 @@ function vtkWebGPUTexture(publicAPI, model) {
       // create and write the buffer
       const buffRequest = {
         nativeArray: imageData.data,
-        time: 0,
         /* eslint-disable no-undef */
         usage: BufferUsage.Texture,
         /* eslint-enable no-undef */

--- a/Sources/Rendering/WebGPU/TextureManager/index.js
+++ b/Sources/Rendering/WebGPU/TextureManager/index.js
@@ -120,15 +120,38 @@ function vtkWebGPUTextureManager(publicAPI, model) {
   // this is the main entry point
   publicAPI.getTexture = (req) => {
     // if we have a source the get/create/cache the texture
-    if (req.owner) {
-      // fill out the req time and format based on imageData/image
-      _fillRequest(req);
+    if (req.hash) {
       // if a matching texture already exists then return it
-      const hash = req.time + req.format;
-      return model.device.getCachedObject(req.owner, hash, _createTexture, req);
+      return model.device.getCachedObject(req.hash, _createTexture, req);
     }
 
     return _createTexture(req);
+  };
+
+  publicAPI.getTextureForImageData = (imgData) => {
+    const treq = { time: imgData.getMTime() };
+    treq.imageData = imgData;
+    // fill out the req time and format based on imageData/image
+    _fillRequest(treq);
+    treq.hash = treq.time + treq.format;
+    return model.device.getTextureManager().getTexture(treq);
+  };
+
+  publicAPI.getTextureForVTKTexture = (srcTexture) => {
+    const treq = { time: srcTexture.getMTime() };
+    if (srcTexture.getInputData()) {
+      treq.imageData = srcTexture.getInputData();
+    } else if (srcTexture.getImage()) {
+      treq.image = srcTexture.getImage();
+    } else if (srcTexture.getJsImageData()) {
+      treq.jsImageData = srcTexture.getJsImageData();
+    } else if (srcTexture.getCanvas()) {
+      treq.canvas = srcTexture.getCanvas();
+    }
+    // fill out the req time and format based on imageData/image
+    _fillRequest(treq);
+    treq.hash = treq.time + treq.format;
+    return model.device.getTextureManager().getTexture(treq);
   };
 }
 

--- a/Sources/Rendering/WebGPU/UniformBuffer/index.js
+++ b/Sources/Rendering/WebGPU/UniformBuffer/index.js
@@ -191,7 +191,6 @@ function vtkWebGPUUniformBuffer(publicAPI, model) {
     if (!model.UBO) {
       const req = {
         nativeArray: model.Float32Array,
-        time: 0,
         usage: BufferUsage.UniformArray,
         label: model.label,
       };

--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -347,11 +347,9 @@ function vtkWebGPUVolumePass(publicAPI, model) {
     // points
     const points = pd.getPoints();
     const buffRequest = {
-      owner: points,
       usage: BufferUsage.PointArray,
       format: 'float32x4',
-      time: Math.max(points.getMTime(), cells.getMTime()),
-      hash: 'vp',
+      hash: `vp${points.getMTime()}${cells.getMTime()}`,
       dataArray: points,
       cells,
       primitiveType: PrimitiveTypes.Triangles,

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -870,11 +870,9 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
       const volMapr = actor.getMapper();
       const image = volMapr.getInputData();
 
-      const treq = {
-        imageData: image,
-        owner: image.getPointData().getScalars(),
-      };
-      const newTex = model.device.getTextureManager().getTexture(treq);
+      const newTex = model.device
+        .getTextureManager()
+        .getTextureForImageData(image);
       if (
         !model.textureViews[vidx + 4] ||
         model.textureViews[vidx + 4].getTexture() !== newTex


### PR DESCRIPTION
Stick mapper was setting frag_depth inside an if statement and
that was not working. Moved it outside the if statement.

Updated the device cache to use a map of weakrefs instead
of a weakmap. The old approach had issues keeping objects
too long if their sources never were freed. Such as if an
array just changes mtime but not source (not the best approach
but it happens)  The new cache approach just uses a WeakRef to
avoid the issue with sources/owner and so that concept was removed.

Now it is just a hash -> weakRef(object) map approach and when the
object finalizes we remove the entry in the map.