### PR TITLE
Open spline 1 d

### DIFF
--- a/Sources/Common/DataModel/CardinalSpline1D/index.d.ts
+++ b/Sources/Common/DataModel/CardinalSpline1D/index.d.ts
@@ -1,6 +1,5 @@
 import { Vector3 } from '../../../types';
-import vtkSpline1D, { ISpline1DInitialValues } from '../Spline1D';
-
+import vtkSpline1D, { ISpline1DInitialValues, BoundaryCondition } from '../Spline1D';
 
 export interface ICardinalSpline1DInitialValues extends ISpline1DInitialValues {}
 
@@ -20,9 +19,14 @@ export interface vtkCardinalSpline1D extends vtkSpline1D {
 	 * @param {Number} size 
 	 * @param {Float32Array} work 
 	 * @param {Vector3} x 
-	 * @param {Vector3} y 
+	 * @param {Vector3} y
+	 * @param {Object} options
+	 * @param {BoundaryCondition} options.leftConstraint
+	 * @param {Number} options.leftValue
+	 * @param {BoundaryCondition} options.rightConstraint
+	 * @param {Number} options.rightValue
 	 */
-	computeOpenCoefficients(size: number, work: Float32Array, x: Vector3, y: Vector3): void;
+	computeOpenCoefficients(size: number, work: Float32Array, x: Vector3, y: Vector3, options: { leftConstraint: BoundaryCondition, leftValue: number, rightConstraint: BoundaryCondition, rightValue: Number }): void;
 
 	/**
 	 * 

--- a/Sources/Common/DataModel/CardinalSpline1D/index.js
+++ b/Sources/Common/DataModel/CardinalSpline1D/index.js
@@ -1,7 +1,9 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkSpline1D from 'vtk.js/Sources/Common/DataModel/Spline1D';
 
-const { vtkErrorMacro } = macro;
+import { BoundaryCondition } from 'vtk.js/Sources/Common/DataModel/Spline1D/Constants';
+
+const VTK_EPSILON = 0.0001;
 
 // ----------------------------------------------------------------------------
 // vtkCardinalSpline1D methods
@@ -46,9 +48,9 @@ function vtkCardinalSpline1D(publicAPI, model) {
     const dN = work[N];
 
     // solve resulting set of equations.
-    model.coefficients[0 * 4 + 2] = 0;
+    model.coefficients[4 * 0 + 2] = 0;
     work[0] = 0;
-    model.coefficients[0 * 4 + 3] = 1;
+    model.coefficients[4 * 0 + 3] = 1;
 
     for (let k = 1; k <= N; k++) {
       model.coefficients[4 * k + 1] -=
@@ -114,8 +116,145 @@ function vtkCardinalSpline1D(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
-  publicAPI.computeOpenCoefficients = (size, work, x, y) => {
-    vtkErrorMacro('Open splines are not implemented yet!');
+  publicAPI.computeOpenCoefficients = (size, work, x, y, options = {}) => {
+    if (!model.coefficients || model.coefficients.length !== 4 * size) {
+      model.coefficients = new Float32Array(4 * size);
+    }
+    const N = size - 1;
+    // develop constraint at leftmost point.
+    switch (options.leftConstraint) {
+      case BoundaryCondition.DERIVATIVE:
+        // desired slope at leftmost point is leftValue.
+        model.coefficients[4 * 0 + 1] = 1.0;
+        model.coefficients[4 * 0 + 2] = 0.0;
+        work[0] = options.leftValue;
+        break;
+      case BoundaryCondition.SECOND_DERIVATIVE:
+        // desired second derivative at leftmost point is leftValue.
+        model.coefficients[4 * 0 + 1] = 2.0;
+        model.coefficients[4 * 0 + 2] = 1.0;
+        work[0] =
+          3.0 * ((y[1] - y[0]) / (x[1] - x[0])) -
+          0.5 * (x[1] - x[0]) * options.leftValue;
+        break;
+      case BoundaryCondition.SECOND_DERIVATIVE_INTERIOR_POINT:
+        // desired second derivative at leftmost point is
+        // leftValue times second derivative at first interior point.
+        model.coefficients[4 * 0 + 1] = 2.0;
+
+        if (Math.abs(options.leftValue + 2) > VTK_EPSILON) {
+          model.coefficients[4 * 0 + 2] =
+            4.0 * ((0.5 + options.leftValue) / (2.0 + options.leftValue));
+          work[0] =
+            6.0 *
+            ((1.0 + options.leftValue) / (2.0 + options.leftValue)) *
+            ((y[1] - y[0]) / (x[1] - x[0]));
+        } else {
+          model.coefficients[4 * 0 + 2] = 0;
+          work[0] = 0;
+        }
+        break;
+      case BoundaryCondition.DEFAULT:
+      default:
+        // desired slope at leftmost point is derivative from two points
+        model.coefficients[4 * 0 + 1] = 1.0;
+        model.coefficients[4 * 0 + 2] = 0.0;
+        work[0] = y[2] - y[0];
+        break;
+    }
+
+    for (let k = 1; k < N; k++) {
+      const xlk = x[k] - x[k - 1];
+      const xlkp = x[k + 1] - x[k];
+
+      model.coefficients[4 * k + 0] = xlkp;
+      model.coefficients[4 * k + 1] = 2 * (xlkp + xlk);
+      model.coefficients[4 * k + 2] = xlk;
+      work[k] =
+        3.0 *
+        ((xlkp * (y[k] - y[k - 1])) / xlk + (xlk * (y[k + 1] - y[k])) / xlkp);
+    }
+
+    // develop constraint at rightmost point.
+    switch (options.rightConstraint) {
+      case BoundaryCondition.DERIVATIVE:
+        // desired slope at rightmost point is rightValue
+        model.coefficients[4 * N + 0] = 0.0;
+        model.coefficients[4 * N + 1] = 1.0;
+        work[N] = options.rightValue;
+        break;
+      case BoundaryCondition.SECOND_DERIVATIVE:
+        // desired second derivative at rightmost point is rightValue.
+        model.coefficients[4 * N + 0] = 1.0;
+        model.coefficients[4 * N + 1] = 2.0;
+        work[N] =
+          3.0 * ((y[N] - y[N - 1]) / (x[N] - x[N - 1])) +
+          0.5 * (x[N] - x[N - 1]) * options.rightValue;
+        break;
+      case BoundaryCondition.SECOND_DERIVATIVE_INTERIOR_POINT:
+        // desired second derivative at rightmost point is
+        // rightValue times second derivative at last interior point.
+        model.coefficients[4 * N + 1] = 2.0;
+        if (Math.abs(options.rightValue + 2) > VTK_EPSILON) {
+          model.coefficients[4 * N + 0] =
+            4.0 * ((0.5 + options.rightValue) / (2.0 + options.rightValue));
+          work[N] =
+            6.0 *
+            ((1.0 + options.rightValue) / (2.0 + options.rightValue)) *
+            ((y[N] - y[size - 2]) / (x[N] - x[size - 2]));
+        } else {
+          model.coefficients[4 * N + 0] = 0;
+          work[N] = 0;
+        }
+        break;
+      case BoundaryCondition.DEFAULT:
+      default:
+        // desired slope at rightmost point is derivative from two points
+        model.coefficients[4 * N + 0] = 0.0;
+        model.coefficients[4 * N + 1] = 1.0;
+        work[N] = y[N] - y[N - 2];
+        break;
+    }
+
+    // solve resulting set of equations.
+    model.coefficients[4 * 0 + 2] /= model.coefficients[4 * 0 + 1];
+    work[0] /= model.coefficients[4 * N + 1];
+    model.coefficients[4 * N + 3] = 1;
+
+    for (let k = 1; k <= N; k++) {
+      model.coefficients[4 * k + 1] -=
+        model.coefficients[4 * k + 0] * model.coefficients[4 * (k - 1) + 2];
+      model.coefficients[4 * k + 2] /= model.coefficients[4 * k + 1];
+      work[k] =
+        (work[k] - model.coefficients[4 * k + 0] * work[k - 1]) /
+        model.coefficients[4 * k + 1];
+    }
+
+    for (let k = N - 1; k >= 0; k--) {
+      work[k] -= model.coefficients[4 * k + 2] * work[k + 1];
+    }
+
+    // the column vector work now contains the first
+    // derivative of the spline function at each joint.
+    // compute the coefficients of the cubic between
+    // each pair of joints.
+    for (let k = 0; k < N; k++) {
+      const b = x[k + 1] - x[k];
+      model.coefficients[4 * k + 0] = y[k];
+      model.coefficients[4 * k + 1] = work[k];
+      model.coefficients[4 * k + 2] =
+        (3 * (y[k + 1] - y[k])) / (b * b) - (work[k + 1] + 2 * work[k]) / b;
+      model.coefficients[4 * k + 3] =
+        (2 * (y[k] - y[k + 1])) / (b * b * b) +
+        (work[k + 1] + work[k]) / (b * b);
+    }
+
+    // the coefficients of a fictitious nth cubic
+    // are the same as the coefficients in the first interval
+    model.coefficients[4 * N + 0] = y[N];
+    model.coefficients[4 * N + 1] = work[N];
+    model.coefficients[4 * N + 2] = model.coefficients[4 * 0 + 2];
+    model.coefficients[4 * N + 3] = model.coefficients[4 * 0 + 3];
   };
 
   // --------------------------------------------------------------------------

--- a/Sources/Common/DataModel/KochanekSpline1D/index.d.ts
+++ b/Sources/Common/DataModel/KochanekSpline1D/index.d.ts
@@ -1,5 +1,4 @@
-import vtkSpline1D, { ISpline1DInitialValues } from '../Spline1D';
-
+import vtkSpline1D, { ISpline1DInitialValues, BoundaryCondition } from '../Spline1D';
 
 export interface IKochanekSpline1DInitialValues extends ISpline1DInitialValues {
 	tension?: number;
@@ -23,9 +22,14 @@ export interface vtkKochanekSpline1D extends vtkSpline1D {
 	 * @param {Number} size 
 	 * @param {Float32Array} work 
 	 * @param {Number[]} x 
-	 * @param {Number[]} y 
+	 * @param {Number[]} y
+	 * @param {Object} options
+	 * @param {BoundaryCondition} options.leftConstraint
+	 * @param {Number} options.leftValue
+	 * @param {BoundaryCondition} options.rightConstraint
+	 * @param {Number} options.rightValue
 	 */
-	computeOpenCoefficients(size: number, work: Float32Array, x: number[], y: number[]): void;
+	computeOpenCoefficients(size: number, work: Float32Array, x: number[], y: number[], options: { leftConstraint: BoundaryCondition, leftValue: number, rightConstraint: BoundaryCondition, rightValue: Number }): void;
 
 	/**
 	 * 

--- a/Sources/Common/DataModel/KochanekSpline1D/index.js
+++ b/Sources/Common/DataModel/KochanekSpline1D/index.js
@@ -1,7 +1,9 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkSpline1D from 'vtk.js/Sources/Common/DataModel/Spline1D';
 
-const { vtkErrorMacro } = macro;
+import { BoundaryCondition } from 'vtk.js/Sources/Common/DataModel/Spline1D/Constants';
+
+const VTK_EPSILON = 0.0001;
 
 // ----------------------------------------------------------------------------
 // vtkKochanekSpline1D methods
@@ -103,8 +105,132 @@ function vtkKochanekSpline1D(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
-  publicAPI.computeOpenCoefficients = (size, work, x, y) => {
-    vtkErrorMacro('Open splines are not implemented yet!');
+  publicAPI.computeOpenCoefficients = (size, work, x, y, options = {}) => {
+    if (!model.coefficients || model.coefficients.length !== 4 * size) {
+      model.coefficients = new Float32Array(4 * size);
+    }
+    const N = size - 1;
+
+    for (let i = 1; i < N; i++) {
+      const cs = y[i] - y[i - 1];
+      const cd = y[i + 1] - y[i];
+
+      let ds =
+        cs * ((1 - model.tension) * (1 - model.continuity) * (1 + model.bias)) +
+        cd * ((1 - model.tension) * (1 + model.continuity) * (1 - model.bias));
+
+      let dd =
+        cs * ((1 - model.tension) * (1 + model.continuity) * (1 + model.bias)) +
+        cd * ((1 - model.tension) * (1 - model.continuity) * (1 - model.bias));
+
+      // adjust deriviatives for non uniform spacing between nodes
+      const n1 = x[i + 1] - x[i];
+      const n0 = x[i] - x[i - 1];
+
+      ds *= n0 / (n0 + n1);
+      dd *= n1 / (n0 + n1);
+
+      model.coefficients[4 * i + 0] = y[i];
+      model.coefficients[4 * i + 1] = dd;
+      model.coefficients[4 * i + 2] = ds;
+    }
+
+    model.coefficients[4 * 0 + 0] = y[0];
+    model.coefficients[4 * N + 0] = y[N];
+
+    // Calculate the deriviatives at the end points
+
+    switch (options.leftConstraint) {
+      // desired slope at leftmost point is leftValue
+      case BoundaryCondition.DERIVATIVE:
+        model.coefficients[4 * 0 + 1] = options.leftValue;
+        break;
+      case BoundaryCondition.SECOND_DERIVATIVE:
+        // desired second derivative at leftmost point is leftValue
+        model.coefficients[4 * 0 + 1] =
+          (6 * (y[1] - y[0]) -
+            2 * model.coefficients[4 * 1 + 2] -
+            options.leftValue) /
+          4;
+        break;
+      case BoundaryCondition.SECOND_DERIVATIVE_INTERIOR_POINT:
+        // desired second derivative at leftmost point is leftValue
+        // times second derivative at first interior point
+        if (Math.abs(options.leftValue + 2) > VTK_EPSILON) {
+          model.coefficients[4 * 0 + 1] =
+            (3 * (1 + options.leftValue) * (y[1] - y[0]) -
+              (1 + 2 * options.leftValue) * model.coefficients[4 * 1 + 2]) /
+            (2 + options.leftValue);
+        } else {
+          model.coefficients[4 * 0 + 1] = 0.0;
+        }
+        break;
+      case BoundaryCondition.DEFAULT:
+      default:
+        // desired slope at leftmost point is derivative from two points
+        model.coefficients[4 * 0 + 1] = y[2] - y[0];
+        break;
+    }
+    switch (options.rightConstraint) {
+      case BoundaryCondition.DERIVATIVE:
+        // desired slope at rightmost point is leftValue
+        model.coefficients[4 * N + 2] = options.leftValue;
+        break;
+
+      case BoundaryCondition.SECOND_DERIVATIVE:
+        // desired second derivative at rightmost point is leftValue
+        model.coefficients[4 * N + 2] =
+          (6 * (y[N] - y[N - 1]) -
+            2 * model.coefficients[4 * (N - 1) + 1] +
+            options.leftValue) /
+          4.0;
+        break;
+
+      case BoundaryCondition.SECOND_DERIVATIVE_INTERIOR_POINT:
+        // desired second derivative at rightmost point is leftValue
+        // times second derivative at last interior point
+        if (Math.abs(options.leftValue + 2) > VTK_EPSILON) {
+          model.coefficients[4 * N + 2] =
+            (3 * (1 + options.leftValue) * (y[N] - y[N - 1]) -
+              (1 + 2 * options.leftValue) *
+                model.coefficients[4 * (N - 1) + 1]) /
+            (2 + options.leftValue);
+        } else {
+          model.coefficients[4 * N + 2] = 0.0;
+        }
+        break;
+      case BoundaryCondition.DEFAULT:
+      default:
+        // desired slope at rightmost point is rightValue
+        model.coefficients[4 * N + 2] = y[N] - y[N - 2];
+        break;
+    }
+
+    for (let i = 0; i < N; i++) {
+      //
+      // c0    = P ;    c1    = DD ;
+      //   i      i       i       i
+      //
+      // c1    = P   ;  c2    = DS   ;
+      //   i+1    i+1     i+1     i+1
+      //
+      // c2  = -3P  + 3P    - 2DD  - DS   ;
+      //   i      i     i+1      i     i+1
+      //
+      // c3  =  2P  - 2P    +  DD  + DS   ;
+      //   i      i     i+1      i     i+1
+      //
+      model.coefficients[4 * i + 2] =
+        -3 * y[i] +
+        3 * y[i + 1] +
+        -2 * model.coefficients[4 * i + 1] +
+        -1 * model.coefficients[4 * (i + 1) + 2];
+      model.coefficients[4 * i + 3] =
+        2 * y[i] +
+        -2 * y[i + 1] +
+        1 * model.coefficients[4 * i + 1] +
+        1 * model.coefficients[4 * (i + 1) + 2];
+    }
   };
 
   // --------------------------------------------------------------------------

--- a/Sources/Common/DataModel/Spline1D/Constants.js
+++ b/Sources/Common/DataModel/Spline1D/Constants.js
@@ -1,0 +1,17 @@
+// Boundary conditions available to compute open splines
+// DEFAULT : desired slope at boundary point is derivative from two points (boundary and second interior)
+// DERIVATIVE : desired slope at boundary point is the boundary value given.
+// SECOND_DERIVATIVE : second derivative at boundary point is the boundary value given.
+// SECOND_DERIVATIVE_INTERIOR_POINT : desired second derivative at boundary point is the boundary value given times second derivative
+// at first interior point.
+
+export const BoundaryCondition = {
+  DEFAULT: 0,
+  DERIVATIVE: 1,
+  SECOND_DERIVATIVE: 2,
+  SECOND_DERIVATIVE_INTERIOR_POINT: 3,
+};
+
+export default {
+  BoundaryCondition,
+};

--- a/Sources/Common/DataModel/Spline1D/index.d.ts
+++ b/Sources/Common/DataModel/Spline1D/index.d.ts
@@ -3,6 +3,19 @@ import { vtkObject } from "../../../interfaces" ;
 
 export interface ISpline1DInitialValues {}
 
+// Boundary conditions available to compute open splines
+// DEFAULT : desired slope at boundary point is derivative from two points (boundary and second interior)
+// DERIVATIVE : desired slope at boundary point is the boundary value given.
+// SECOND_DERIVATIVE : second derivative at boundary point is the boundary value given.
+// SECOND_DERIVATIVE_INTERIOR_POINT : desired second derivative at boundary point is the boundary value given times second derivative
+// at first interior point.
+export enum BoundaryCondition {
+	DEFAULT,
+	DERIVATIVE,
+	SECOND_DERIVATIVE,
+	SECOND_DERIVATIVE_INTERIOR_POINT,
+  }
+
 export interface vtkSpline1D extends vtkObject {
 
 	/**
@@ -19,9 +32,14 @@ export interface vtkSpline1D extends vtkObject {
 	 * @param {Number} size 
 	 * @param {Float32Array} work 
 	 * @param {Number[]} x 
-	 * @param {Number[]} y 
+	 * @param {Number[]} y
+	 * @param {Object} options
+	 * @param {BoundaryCondition} options.leftConstraint
+	 * @param {Number} options.leftValue
+	 * @param {BoundaryCondition} options.rightConstraint
+	 * @param {Number} options.rightValue
 	 */
-	computeOpenCoefficients(size: number, work: Float32Array, x: number[], y: number[]): void;
+	computeOpenCoefficients(size: number, work: Float32Array, x: number[], y: number[], options: { leftConstraint: BoundaryCondition, leftValue: number, rightConstraint: BoundaryCondition, rightValue: Number }): void;
 		
 	/**
 	 * 

--- a/Sources/Common/DataModel/Spline1D/index.js
+++ b/Sources/Common/DataModel/Spline1D/index.js
@@ -22,7 +22,7 @@ function vtkSpline1D(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
-  publicAPI.computeOpenCoefficients = (size, work, x, y) => {
+  publicAPI.computeOpenCoefficients = (size, work, x, y, options = {}) => {
     vtkErrorMacro(
       `${
         model.classHierarchy.slice(-1)[0]

--- a/Sources/Widgets/Widgets3D/SplineWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/SplineWidget/example/controlPanel.html
@@ -55,6 +55,48 @@
     </td>
   </tr>
   <tr>
+    <td>Closed spline</td>
+    <td></td>
+    <td>
+      <input class="close" type="checkbox" checked />
+    </td>
+  </tr>
+  <tr>
+  <td>Boundary conditions</td>
+  <td></td>
+  <td>
+    <select class="boundaryCondition">
+      <option value="0">default</option>
+      <option value="1">derivative</option>
+      <option value="2">2nd derivative</option>
+      <option value="3">2nd derivative interior point</option>
+    </select>
+  </td>
+  </tr>
+  <tr>
+    <td>Boundary Condition value X</td>
+    <td></td>
+    <td>
+      <input class="boundaryConditionValueX" type="range" min="-2" max="2" step="0.1" value="0">
+    </td>
+  </tr>
+  <tr>
+    <td>Boundary Condition value Y</td>
+    <td></td>
+    <td>
+      <input class="boundaryConditionValueY" type="range" min="-2" max="2" step="0.1" value="0">
+    </td>
+  </tr>
+</tr>
+<tr>
+  <tr>
+    <td>Border</td>
+    <td></td>
+    <td>
+      <input class="border" type="checkbox" checked>
+    </td>
+  </tr>
+  <tr>
     <td>
       <button class="placeWidget" >Place Widget</button>
     </td>

--- a/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
@@ -43,6 +43,69 @@ renderer.resetCamera();
 
 fullScreenRenderer.addController(controlPanel);
 
+const borderCheckBox = document.querySelector('.border');
+const onBorderChanged = () => {
+  widgetRepresentation.setOutputBorder(borderCheckBox.checked);
+  renderWindow.render();
+};
+borderCheckBox.addEventListener('click', onBorderChanged);
+onBorderChanged();
+
+const boundaryConditionValueXInput = document.querySelector(
+  '.boundaryConditionValueX'
+);
+const boundaryConditionValueYInput = document.querySelector(
+  '.boundaryConditionValueY'
+);
+const onBoundaryConditionValueChanged = () => {
+  const valX = boundaryConditionValueXInput.value;
+  const valY = boundaryConditionValueYInput.value;
+  widget
+    .getWidgetState()
+    .setSplineBoundaryConditionValues([parseFloat(valX), parseFloat(valY), 0]);
+  renderWindow.render();
+};
+boundaryConditionValueXInput.addEventListener(
+  'input',
+  onBoundaryConditionValueChanged
+);
+onBoundaryConditionValueChanged();
+
+boundaryConditionValueYInput.addEventListener(
+  'input',
+  onBoundaryConditionValueChanged
+);
+onBoundaryConditionValueChanged();
+
+const boundaryCondition = document.querySelector('.boundaryCondition');
+const onBoundaryCondition = () => {
+  const isDefault = boundaryCondition.selectedIndex === 0;
+  boundaryConditionValueXInput.disabled =
+    widgetRepresentation.getClose() || isDefault;
+  boundaryConditionValueYInput.disabled =
+    widgetRepresentation.getClose() || isDefault;
+  widget
+    .getWidgetState()
+    .setSplineBoundaryCondition(boundaryCondition.selectedIndex);
+  renderWindow.render();
+};
+boundaryCondition.addEventListener('change', onBoundaryCondition);
+onBoundaryCondition();
+
+const isClosed = document.querySelector('.close');
+const onClosedChange = () => {
+  boundaryCondition.disabled = isClosed.checked;
+  boundaryConditionValueXInput.disabled =
+    isClosed.checked || boundaryCondition.selectedIndex === 0;
+  boundaryConditionValueYInput.disabled =
+    isClosed.checked || boundaryCondition.selectedIndex === 0;
+  widget.getWidgetState().setSplineClose(isClosed.checked);
+  widgetRepresentation.setClose(isClosed.checked);
+  renderWindow.render();
+};
+isClosed.addEventListener('click', onClosedChange);
+onClosedChange();
+
 const tensionInput = document.querySelector('.tension');
 const onTensionChanged = () => {
   widget.getWidgetState().setSplineTension(parseFloat(tensionInput.value));

--- a/Sources/Widgets/Widgets3D/SplineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/index.js
@@ -21,6 +21,8 @@ function vtkSplineWidget(publicAPI, model) {
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
+    'boundaryCondition',
+    'close',
     'outputBorder',
     'fill',
     'borderColor',

--- a/Sources/Widgets/Widgets3D/SplineWidget/state.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/state.js
@@ -2,10 +2,21 @@ import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
 
 import { splineKind } from 'vtk.js/Sources/Common/DataModel/Spline3D/Constants';
 
+import { BoundaryCondition } from 'vtk.js/Sources/Common/DataModel/Spline1D/Constants';
+
 export default function generateState() {
   return vtkStateBuilder
     .createBuilder()
     .addField({ name: 'splineKind', initialValue: splineKind.KOCHANEK_SPLINE })
+    .addField({ name: 'splineClose', initialValue: true })
+    .addField({
+      name: 'splineBoundaryCondition',
+      initialValue: BoundaryCondition.DEFAULT,
+    })
+    .addField({
+      name: 'splineBoundaryConditionValues',
+      initialValue: [0, 0, 0],
+    })
     .addField({ name: 'splineTension', initialValue: 0 })
     .addField({ name: 'splineContinuity', initialValue: 0 })
     .addField({ name: 'splineBias', initialValue: 0 })


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Support open splines.
### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Open splines are supported. The two methods already implemented for closed splines are now implemented for open splines. Different boundary conditions are available (on the derivative, second derivative, or second derivative of first interiror point).

![image](https://user-images.githubusercontent.com/61593541/165085412-e92d3278-3b41-4c19-967d-82e78c3b6b24.png)
Figure 1: Result of example of open spline (computation with Kochanek method). New parameters have been added to example.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
Class changed : SplineWidget, SplineExample, Spline3D, KochanekSpline1D, CardinalSpline1D.

The spline example has been changed (as can be seen on the picture above). The user can choose whether to see opened or closed spline and change the boundary condition. The values related for opened spline computation can also be chosen for the x and y axis.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: 24.5.6
  - **OS**: Windows 10
  - **Browser**: Firefox 99.0.1, Chrome 100.0.4896.127, Microsoft Edge 100.0.1185.50

Opened splines can be tested by running the SplineWidget example (`npm run example SplineWidget`). The value given by the computation in itself is not tested. However, assuming that the closed splines are correctly implemented, one can put the first and last points at the same position in the example and compare the shape of the vertices:  both opened and closed splines should be the same as for closed splines, except for the first and last vertices of opened spline.
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
