### PR TITLE
feat(WebGPU): add support for index buffers

### DIFF
--- a/Sources/Common/Core/CellArray/index.js
+++ b/Sources/Common/Core/CellArray/index.js
@@ -18,7 +18,12 @@ function extractCellSizes(cellArray) {
 }
 
 function getNumberOfCells(cellArray) {
-  return extractCellSizes(cellArray).length;
+  let cellId = 0;
+  for (let cellArrayIndex = 0; cellArrayIndex < cellArray.length; ) {
+    cellArrayIndex += cellArray[cellArrayIndex] + 1;
+    cellId++;
+  }
+  return cellId;
 }
 
 // ----------------------------------------------------------------------------
@@ -43,8 +48,11 @@ function vtkCellArray(publicAPI, model) {
       return model.numberOfCells;
     }
 
-    model.cellSizes = extractCellSizes(model.values);
-    model.numberOfCells = model.cellSizes.length;
+    if (model.cellSizes) {
+      model.numberOfCells = model.cellSizes.length;
+    } else {
+      model.numberOfCells = getNumberOfCells(model.values);
+    }
     return model.numberOfCells;
   };
 

--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -481,7 +481,7 @@ function vtkMapper(publicAPI, model) {
         2 * input.getLines().getNumberOfCells(),
       triangles:
         input.getPolys().getNumberOfValues() -
-        3 * input.getLines().getNumberOfCells(),
+        3 * input.getPolys().getNumberOfCells(),
     };
     return pcount;
   };

--- a/Sources/Rendering/WebGPU/BindGroup/index.js
+++ b/Sources/Rendering/WebGPU/BindGroup/index.js
@@ -104,12 +104,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'sizeInBytes',
     'usage',
   ]);
-  macro.setGet(publicAPI, model, [
-    'label',
-    'device',
-    'arrayInformation',
-    'sourceTime',
-  ]);
+  macro.setGet(publicAPI, model, ['label', 'device', 'arrayInformation']);
 
   vtkWebGPUBindGroup(publicAPI, model);
 }

--- a/Sources/Rendering/WebGPU/BufferManager/Constants.js
+++ b/Sources/Rendering/WebGPU/BufferManager/Constants.js
@@ -12,7 +12,7 @@ export const BufferUsage = {
   Texture: 10,
   RawVertex: 11,
   Storage: 12,
-  CellIndex: 13,
+  Index: 13,
 };
 
 export const PrimitiveTypes = {

--- a/Sources/Rendering/WebGPU/BufferManager/index.js
+++ b/Sources/Rendering/WebGPU/BufferManager/index.js
@@ -2,15 +2,12 @@ import * as macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import vtkWebGPUBuffer from 'vtk.js/Sources/Rendering/WebGPU/Buffer';
+import vtkWebGPUIndexBuffer from 'vtk.js/Sources/Rendering/WebGPU/IndexBuffer';
 import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
-import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
 import Constants from './Constants';
 
-const { BufferUsage, PrimitiveTypes } = Constants;
-const { Representation } = vtkProperty;
-
-const { vtkDebugMacro, vtkErrorMacro } = macro;
-
+const { BufferUsage } = Constants;
+const { vtkErrorMacro } = macro;
 const { VtkDataTypes } = vtkDataArray;
 
 // the webgpu constants all show up as undefined
@@ -21,43 +18,6 @@ const { VtkDataTypes } = vtkDataArray;
 // ----------------------------------------------------------------------------
 
 export const STATIC = {};
-
-const cellCounters = {
-  // easy, every input point becomes an output point
-  anythingToPoints(numPoints, cellPts) {
-    return numPoints;
-  },
-  linesToWireframe(numPoints, cellPts) {
-    if (numPoints > 1) {
-      return (numPoints - 1) * 2;
-    }
-    return 0;
-  },
-  polysToWireframe(numPoints, cellPts) {
-    if (numPoints > 2) {
-      return numPoints * 2;
-    }
-    return 0;
-  },
-  stripsToWireframe(numPoints, cellPts) {
-    if (numPoints > 2) {
-      return numPoints * 4 - 6;
-    }
-    return 0;
-  },
-  polysToSurface(npts, cellPts) {
-    if (npts > 2) {
-      return (npts - 2) * 3;
-    }
-    return 0;
-  },
-  stripsToSurface(npts, cellPts, offset) {
-    if (numPoints > 2) {
-      return (npts - 2) * 3;
-    }
-    return 0;
-  },
-};
 
 function _getFormatForDataArray(dataArray) {
   let format;
@@ -107,56 +67,10 @@ function _getFormatForDataArray(dataArray) {
   return format;
 }
 
-function getPrimitiveName(primType) {
-  switch (primType) {
-    case PrimitiveTypes.Points:
-      return 'points';
-    case PrimitiveTypes.Lines:
-      return 'lines';
-    case PrimitiveTypes.Triangles:
-    case PrimitiveTypes.TriangleEdges:
-      return 'polys';
-    case PrimitiveTypes.TriangleStripEdges:
-    case PrimitiveTypes.TriangleStrips:
-      return 'strips';
-    default:
-      return '';
-  }
-}
-
-function getOutputSize(cellArray, representation, inRepName) {
-  let countFunc = null;
-  if (representation === Representation.POINTS || inRepName === 'points') {
-    countFunc = cellCounters.anythingToPoints;
-  } else if (
-    representation === Representation.WIREFRAME ||
-    inRepName === 'lines'
-  ) {
-    countFunc = cellCounters[`${inRepName}ToWireframe`];
-  } else {
-    countFunc = cellCounters[`${inRepName}ToSurface`];
-  }
-
-  const array = cellArray.getData();
-  const size = array.length;
-  let caboCount = 0;
-  for (let index = 0; index < size; ) {
-    caboCount += countFunc(array[index], array);
-    index += array[index] + 1;
-  }
-  return caboCount;
-}
-
-function packArray(
-  cellArray,
-  primType,
-  representation,
-  inArray,
-  outputType,
-  options
-) {
-  const result = { elementCount: 0, blockSize: 0, stride: 0 };
-  if (!cellArray.getData() || !cellArray.getData().length) {
+function packArray(indexBuffer, inArrayData, numComp, outputType, options) {
+  const result = {};
+  const flatSize = indexBuffer.getFlatSize();
+  if (!flatSize) {
     return result;
   }
 
@@ -180,143 +94,58 @@ function packArray(
   const packExtra = Object.prototype.hasOwnProperty.call(options, 'packExtra')
     ? options.packExtra
     : false;
-  const pointData = inArray.getData();
 
   let addAPoint;
 
-  const cellBuilders = {
-    // easy, every input point becomes an output point
-    anythingToPoints(numPoints, cellPts, offset, cellId) {
-      for (let i = 0; i < numPoints; ++i) {
-        addAPoint(cellPts[offset + i], cellId);
-      }
-    },
-    linesToWireframe(numPoints, cellPts, offset, cellId) {
-      // for lines we add a bunch of segments
-      for (let i = 0; i < numPoints - 1; ++i) {
-        addAPoint(cellPts[offset + i], cellId);
-        addAPoint(cellPts[offset + i + 1], cellId);
-      }
-    },
-    polysToWireframe(numPoints, cellPts, offset, cellId) {
-      // for polys we add a bunch of segments and close it
-      if (numPoints > 2) {
-        for (let i = 0; i < numPoints; ++i) {
-          addAPoint(cellPts[offset + i], cellId);
-          addAPoint(cellPts[offset + ((i + 1) % numPoints)], cellId);
-        }
-      }
-    },
-    stripsToWireframe(numPoints, cellPts, offset, cellId) {
-      if (numPoints > 2) {
-        // for strips we add a bunch of segments and close it
-        for (let i = 0; i < numPoints - 1; ++i) {
-          addAPoint(cellPts[offset + i], cellId);
-          addAPoint(cellPts[offset + i + 1], cellId);
-        }
-        for (let i = 0; i < numPoints - 2; i++) {
-          addAPoint(cellPts[offset + i], cellId);
-          addAPoint(cellPts[offset + i + 2], cellId);
-        }
-      }
-    },
-    polysToSurface(npts, cellPts, offset, cellId) {
-      for (let i = 0; i < npts - 2; i++) {
-        addAPoint(cellPts[offset + 0], cellId);
-        addAPoint(cellPts[offset + i + 1], cellId);
-        addAPoint(cellPts[offset + i + 2], cellId);
-      }
-    },
-    stripsToSurface(npts, cellPts, offset, cellId) {
-      for (let i = 0; i < npts - 2; i++) {
-        addAPoint(cellPts[offset + i], cellId);
-        addAPoint(cellPts[offset + i + 1 + (i % 2)], cellId);
-        addAPoint(cellPts[offset + i + 1 + ((i + 1) % 2)], cellId);
-      }
-    },
-  };
-
-  const inRepName = getPrimitiveName(primType);
-  let func = null;
-  if (
-    representation === Representation.POINTS ||
-    primType === PrimitiveTypes.Points
-  ) {
-    func = cellBuilders.anythingToPoints;
-  } else if (
-    representation === Representation.WIREFRAME ||
-    primType === PrimitiveTypes.Lines
-  ) {
-    func = cellBuilders[`${inRepName}ToWireframe`];
-  } else {
-    func = cellBuilders[`${inRepName}ToSurface`];
-  }
-
-  const array = cellArray.getData();
-  const size = array.length;
-  const caboCount = getOutputSize(cellArray, representation, inRepName);
   let vboidx = 0;
-
-  const numComp = inArray.getNumberOfComponents();
-  const packedVBO = macro.newTypedArray(
-    outputType,
-    caboCount * (numComp + (packExtra ? 1 : 0))
-  );
+  const stride = numComp + (packExtra ? 1 : 0);
+  const packedVBO = macro.newTypedArray(outputType, flatSize * stride);
 
   // pick the right function based on point versus cell data
-  let getData = (ptId, cellId) => pointData[ptId];
+  let flatIdMap = indexBuffer.getFlatIdToPointId();
   if (options.cellData) {
-    getData = (ptId, cellId) => pointData[cellId];
+    flatIdMap = indexBuffer.getFlatIdToCellId();
   }
 
   // add data based on number of components
   if (numComp === 1) {
-    addAPoint = function addAPointFunc(i, cellid) {
-      packedVBO[vboidx++] = scale[0] * getData(i, cellid) + shift[0];
+    addAPoint = function addAPointFunc(i) {
+      packedVBO[vboidx++] = scale[0] * inArrayData[i] + shift[0];
     };
   } else if (numComp === 2) {
-    addAPoint = function addAPointFunc(i, cellid) {
-      packedVBO[vboidx++] = scale[0] * getData(i * 2, cellid * 2) + shift[0];
-      packedVBO[vboidx++] =
-        scale[1] * getData(i * 2 + 1, cellid * 2 + 1) + shift[1];
+    addAPoint = function addAPointFunc(i) {
+      packedVBO[vboidx++] = scale[0] * inArrayData[i] + shift[0];
+      packedVBO[vboidx++] = scale[1] * inArrayData[i + 1] + shift[1];
     };
   } else if (numComp === 3 && !packExtra) {
-    addAPoint = function addAPointFunc(i, cellid) {
-      packedVBO[vboidx++] = scale[0] * getData(i * 3, cellid * 3) + shift[0];
-      packedVBO[vboidx++] =
-        scale[1] * getData(i * 3 + 1, cellid * 3 + 1) + shift[1];
-      packedVBO[vboidx++] =
-        scale[2] * getData(i * 3 + 2, cellid * 3 + 2) + shift[2];
+    addAPoint = function addAPointFunc(i) {
+      packedVBO[vboidx++] = scale[0] * inArrayData[i] + shift[0];
+      packedVBO[vboidx++] = scale[1] * inArrayData[i + 1] + shift[1];
+      packedVBO[vboidx++] = scale[2] * inArrayData[i + 2] + shift[2];
     };
   } else if (numComp === 3 && packExtra) {
-    addAPoint = function addAPointFunc(i, cellid) {
-      packedVBO[vboidx++] = scale[0] * getData(i * 3, cellid * 3) + shift[0];
-      packedVBO[vboidx++] =
-        scale[1] * getData(i * 3 + 1, cellid * 3 + 1) + shift[1];
-      packedVBO[vboidx++] =
-        scale[2] * getData(i * 3 + 2, cellid * 3 + 2) + shift[2];
+    addAPoint = function addAPointFunc(i) {
+      packedVBO[vboidx++] = scale[0] * inArrayData[i] + shift[0];
+      packedVBO[vboidx++] = scale[1] * inArrayData[i + 1] + shift[1];
+      packedVBO[vboidx++] = scale[2] * inArrayData[i + 2] + shift[2];
       packedVBO[vboidx++] = scale[3] * 1.0 + shift[3];
     };
   } else if (numComp === 4) {
-    addAPoint = function addAPointFunc(i, cellid) {
-      packedVBO[vboidx++] = scale[0] * getData(i * 4, cellid * 4) + shift[0];
-      packedVBO[vboidx++] =
-        scale[1] * getData(i * 4 + 1, cellid * 4 + 1) + shift[1];
-      packedVBO[vboidx++] =
-        scale[2] * getData(i * 4 + 2, cellid * 4 + 2) + shift[2];
-      packedVBO[vboidx++] =
-        scale[3] * getData(i * 4 + 3, cellid * 4 + 3) + shift[3];
+    addAPoint = function addAPointFunc(i) {
+      packedVBO[vboidx++] = scale[0] * inArrayData[i] + shift[0];
+      packedVBO[vboidx++] = scale[1] * inArrayData[i + 1] + shift[1];
+      packedVBO[vboidx++] = scale[2] * inArrayData[i + 2] + shift[2];
+      packedVBO[vboidx++] = scale[3] * inArrayData[i + 3] + shift[3];
     };
   }
 
-  let cellId = options.cellOffset;
-  for (let index = 0; index < size; ) {
-    func(array[index], array, index + 1, cellId);
-    index += array[index] + 1;
-    cellId++;
+  // for each entry in the flat array process it
+  for (let index = 0; index < flatSize; index++) {
+    const inArrayId = numComp * flatIdMap[index];
+    addAPoint(inArrayId);
   }
+
   result.nativeArray = packedVBO;
-  result.elementCount = caboCount;
   return result;
 }
 
@@ -337,91 +166,32 @@ function getNormal(pointData, i0, i1, i2) {
   return result;
 }
 
-function generateNormals(cellArray, primType, representation, inArray) {
-  if (!cellArray.getData() || !cellArray.getData().length) {
+function generateNormals(cellArray, pointArray) {
+  const pointData = pointArray.getData();
+  const cellArrayData = cellArray.getData();
+  if (!cellArrayData || !pointData) {
     return null;
   }
 
-  const pointData = inArray.getData();
-
-  let addAPoint;
-
-  const cellBuilders = {
-    polysToPoints(numPoints, cellPts, offset) {
-      const normal = getNormal(
-        pointData,
-        cellPts[offset],
-        cellPts[offset + 1],
-        cellPts[offset + 2]
-      );
-      for (let i = 0; i < numPoints; ++i) {
-        addAPoint(normal);
-      }
-    },
-    polysToWireframe(numPoints, cellPts, offset) {
-      // for polys we add a bunch of segments and close it
-      // compute the normal
-      const normal = getNormal(
-        pointData,
-        cellPts[offset],
-        cellPts[offset + 1],
-        cellPts[offset + 2]
-      );
-      for (let i = 0; i < numPoints; ++i) {
-        addAPoint(normal);
-        addAPoint(normal);
-      }
-    },
-    polysToSurface(npts, cellPts, offset) {
-      if (npts < 3) {
-        // ignore degenerate triangles
-        vtkDebugMacro('skipping degenerate triangle');
-      } else {
-        // compute the normal
-        const normal = getNormal(
-          pointData,
-          cellPts[offset],
-          cellPts[offset + 1],
-          cellPts[offset + 2]
-        );
-        for (let i = 0; i < npts - 2; i++) {
-          addAPoint(normal);
-          addAPoint(normal);
-          addAPoint(normal);
-        }
-      }
-    },
-  };
-
-  const primName = getPrimitiveName(primType);
-
-  let func = null;
-  if (representation === Representation.POINTS) {
-    func = cellBuilders[`${primName}ToPoints`];
-  } else if (representation === Representation.WIREFRAME) {
-    func = cellBuilders[`${primName}ToWireframe`];
-  } else {
-    func = cellBuilders[`${primName}ToSurface`];
-  }
-
-  const caboCount = getOutputSize(cellArray, representation, primName);
+  // return a cellArray of normals
+  const packedVBO = new Int8Array(cellArray.getNumberOfCells() * 4);
+  const size = cellArrayData.length;
   let vboidx = 0;
 
-  const packedVBO = new Int8Array(caboCount * 4);
-
-  addAPoint = function addAPointFunc(normal) {
+  for (let index = 0; index < size; ) {
+    const normal = getNormal(
+      pointData,
+      cellArrayData[index + 1],
+      cellArrayData[index + 2],
+      cellArrayData[index + 3]
+    );
     packedVBO[vboidx++] = 127 * normal[0];
     packedVBO[vboidx++] = 127 * normal[1];
     packedVBO[vboidx++] = 127 * normal[2];
     packedVBO[vboidx++] = 127;
-  };
-
-  const array = cellArray.getData();
-  const size = array.length;
-  for (let index = 0; index < size; ) {
-    func(array[index], array, index + 1);
-    index += array[index] + 1;
+    index += cellArrayData[index] + 1;
   }
+
   return packedVBO;
 }
 
@@ -439,11 +209,27 @@ function vtkWebGPUBufferManager(publicAPI, model) {
       req.nativeArray = req.dataArray.getData();
     }
 
-    // create one
-    const buffer = vtkWebGPUBuffer.newInstance({ label: req.label });
-    buffer.setDevice(model.device);
+    let buffer;
+    let gpuUsage;
 
-    let gpuUsage = null;
+    // handle index buffers
+    if (req.usage === BufferUsage.Index) {
+      // todo change to FlattenedIndex to be more clear
+      buffer = vtkWebGPUIndexBuffer.newInstance({ label: req.label });
+      buffer.setDevice(model.device);
+      /* eslint-disable no-bitwise */
+      gpuUsage = GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST;
+      /* eslint-enable no-bitwise */
+      buffer.buildIndexBuffer(req);
+      buffer.createAndWrite(req.nativeArray, gpuUsage);
+      buffer.setArrayInformation([{ format: req.format }]);
+    }
+
+    // create one if not done already
+    if (!buffer) {
+      buffer = vtkWebGPUBuffer.newInstance({ label: req.label });
+      buffer.setDevice(model.device);
+    }
 
     // handle uniform buffers
     if (req.usage === BufferUsage.UniformArray) {
@@ -479,10 +265,9 @@ function vtkWebGPUBufferManager(publicAPI, model) {
         req.format
       );
       const result = packArray(
-        req.cells,
-        req.primitiveType,
-        req.representation,
-        req.dataArray,
+        req.indexBuffer,
+        req.dataArray.getData(),
+        req.dataArray.getNumberOfComponents(),
         arrayType,
         {
           packExtra: req.packExtra,
@@ -496,23 +281,32 @@ function vtkWebGPUBufferManager(publicAPI, model) {
       buffer.setStrideInBytes(
         vtkWebGPUTypes.getByteStrideFromBufferFormat(req.format)
       );
-      buffer.setArrayInformation([{ offset: 0, format: req.format }]);
+      buffer.setArrayInformation([
+        {
+          offset: 0,
+          format: req.format,
+          interpolation: req.cellData ? 'flat' : 'perspective',
+        },
+      ]);
     }
 
     // handle normals from points, snorm8x4
     if (req.usage === BufferUsage.NormalsFromPoints) {
       gpuUsage = GPUBufferUsage.VERTEX;
-      const normals = generateNormals(
-        req.cells,
-        req.primitiveType,
-        req.representation,
-        req.dataArray
+      const arrayType = vtkWebGPUTypes.getNativeTypeFromBufferFormat(
+        req.format
       );
-      buffer.createAndWrite(normals, gpuUsage);
+      const normals = generateNormals(req.cells, req.dataArray);
+      const result = packArray(req.indexBuffer, normals, 4, arrayType, {
+        cellData: true,
+      });
+      buffer.createAndWrite(result.nativeArray, gpuUsage);
       buffer.setStrideInBytes(
         vtkWebGPUTypes.getByteStrideFromBufferFormat(req.format)
       );
-      buffer.setArrayInformation([{ offset: 0, format: req.format }]);
+      buffer.setArrayInformation([
+        { offset: 0, format: req.format, interpolation: 'flat' },
+      ]);
     }
 
     if (req.usage === BufferUsage.RawVertex) {
@@ -541,21 +335,14 @@ function vtkWebGPUBufferManager(publicAPI, model) {
     return _createBuffer(req);
   };
 
-  publicAPI.getBufferForPointArray = (
-    dataArray,
-    cells,
-    primitiveType,
-    representation
-  ) => {
+  publicAPI.getBufferForPointArray = (dataArray, indexBuffer) => {
     const format = _getFormatForDataArray(dataArray);
     const buffRequest = {
-      hash: `PA${representation}P${primitiveType}D${dataArray.getMTime()}C${cells.getMTime()}${format}`,
+      hash: `${dataArray.getMTime()}I${indexBuffer.getMTime()}${format}`,
       usage: BufferUsage.PointArray,
       format,
       dataArray,
-      cells,
-      primitiveType,
-      representation,
+      indexBuffer,
     };
     return publicAPI.getBuffer(buffRequest);
   };

--- a/Sources/Rendering/WebGPU/IndexBuffer/index.js
+++ b/Sources/Rendering/WebGPU/IndexBuffer/index.js
@@ -1,0 +1,380 @@
+import macro from 'vtk.js/Sources/macros';
+import Constants from 'vtk.js/Sources/Rendering/WebGPU/BufferManager/Constants';
+import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
+import vtkWebGPUBuffer from 'vtk.js/Sources/Rendering/WebGPU/Buffer';
+
+const { Representation } = vtkProperty;
+const { PrimitiveTypes } = Constants;
+
+// Simulate a small map of pointId to flatId for a cell. The original code
+// used a map and was 2.6x slower (4.7 to 1.9 seconds). Using two fixed
+// length arrays with a count is so much faster even with the required for
+// loops and if statements. This only works as we know the usage is
+// restricted to clear(), set() get() and has() so the count is always
+// incrmenting except for clear where it goes back to 0. Performance
+// improvement is probably due to this appoach not hitting the heap but wow
+// it is so much faster. Code that adds to these vectors checks against 9 to
+// make sure there is room. Switching to test against vec.length -1 results
+// in a small performance hit, so if you change 10, search for 9 in this
+// small class and change those as well.
+class _LimitedMap {
+  constructor() {
+    this.keys = new Uint32Array(10);
+    this.values = new Uint32Array(10);
+    this.count = 0;
+  }
+
+  clear() {
+    this.count = 0;
+  }
+
+  has(key) {
+    for (let i = 0; i < this.count; i++) {
+      if (this.keys[i] === key) {
+        return true;
+      }
+    }
+    return undefined;
+  }
+
+  get(key) {
+    for (let i = 0; i < this.count; i++) {
+      if (this.keys[i] === key) {
+        return this.values[i];
+      }
+    }
+    return undefined;
+  }
+
+  set(key, value) {
+    if (this.count < 9) {
+      this.keys[this.count] = key;
+      this.values[this.count++] = value;
+    }
+  }
+}
+
+function getPrimitiveName(primType) {
+  switch (primType) {
+    case PrimitiveTypes.Points:
+      return 'points';
+    case PrimitiveTypes.Lines:
+      return 'lines';
+    case PrimitiveTypes.Triangles:
+    case PrimitiveTypes.TriangleEdges:
+      return 'polys';
+    case PrimitiveTypes.TriangleStripEdges:
+    case PrimitiveTypes.TriangleStrips:
+      return 'strips';
+    default:
+      return '';
+  }
+}
+
+function _getOrAddFlatId(state, ptId, cellId) {
+  let flatId = state.pointIdToFlatId[ptId];
+  if (flatId < 0) {
+    flatId = state.flatId;
+    state.pointIdToFlatId[ptId] = flatId;
+    state.flatIdToPointId[state.flatId] = ptId;
+    state.flatIdToCellId[state.flatId] = cellId;
+    state.flatId++;
+  }
+  return flatId;
+}
+
+function fillCell(ptIds, cellId, state) {
+  const numPtIds = ptIds.length;
+  // are any points already marked for this cell? If so use that as the provoking point
+  for (let ptIdx = 0; ptIdx < numPtIds; ptIdx++) {
+    let ptId = ptIds[ptIdx];
+    if (state.cellProvokedMap.has(ptId)) {
+      state.ibo[state.iboId++] = state.cellProvokedMap.get(ptId);
+
+      // insert remaining ptIds (they do not need to provoke)
+      for (let ptIdx2 = ptIdx + 1; ptIdx2 < ptIdx + numPtIds; ptIdx2++) {
+        ptId = ptIds[ptIdx2 % numPtIds];
+        const flatId = _getOrAddFlatId(state, ptId, cellId);
+        // add to ibo
+        state.ibo[state.iboId++] = flatId;
+      }
+      // all done now
+      return;
+    }
+  }
+
+  // else have any of the points not been used yet? (not in provokedPointIds)
+  for (let ptIdx = 0; ptIdx < numPtIds; ptIdx++) {
+    let ptId = ptIds[ptIdx];
+    if (!state.provokedPointIds[ptId]) {
+      let flatId = _getOrAddFlatId(state, ptId, cellId);
+      // mark provoking and add to ibo
+      state.provokedPointIds[ptId] = 1;
+      state.cellProvokedMap.set(ptId, flatId);
+      // when provoking always set the cellId as an original non-provoking value
+      // will have been stored and we need to overwrite that
+      state.flatIdToCellId[flatId] = cellId;
+      state.ibo[state.iboId++] = flatId;
+
+      // insert remaining ptIds (they do not need to provoke)
+      for (let ptIdx2 = ptIdx + 1; ptIdx2 < ptIdx + numPtIds; ptIdx2++) {
+        ptId = ptIds[ptIdx2 % numPtIds];
+        flatId = _getOrAddFlatId(state, ptId, cellId);
+        // add to ibo
+        state.ibo[state.iboId++] = flatId;
+      }
+      // all done now
+      return;
+    }
+  }
+
+  // if we got here then none of the ptIds could be used to provoke
+  // so just duplicate the first one
+  let ptId = ptIds[0];
+  let flatId = state.flatId;
+  state.cellProvokedMap.set(ptId, flatId);
+  state.flatIdToPointId[state.flatId] = ptId;
+  state.flatIdToCellId[state.flatId] = cellId;
+  state.flatId++;
+
+  // add to ibo
+  state.ibo[state.iboId++] = flatId;
+
+  // insert remaining ptIds (they do not need to provoke)
+  for (let ptIdx2 = 1; ptIdx2 < numPtIds; ptIdx2++) {
+    ptId = ptIds[ptIdx2];
+    flatId = _getOrAddFlatId(state, ptId, cellId);
+    // add to ibo
+    state.ibo[state.iboId++] = flatId;
+  }
+}
+
+function countCell(ptIds, cellId, state) {
+  const numPtIds = ptIds.length;
+  state.iboSize += numPtIds;
+
+  // are any points already marked for this cell? If so use that as the provoking point
+  for (let ptIdx = 0; ptIdx < numPtIds; ptIdx++) {
+    const ptId = ptIds[ptIdx];
+    if (state.cellProvokedMap.has(ptId)) {
+      return;
+    }
+  }
+
+  // else have any of the points not been used yet? (not in provokedPointIds)
+  for (let ptIdx = 0; ptIdx < numPtIds; ptIdx++) {
+    const ptId = ptIds[ptIdx];
+    if (!state.provokedPointIds[ptId]) {
+      state.provokedPointIds[ptId] = 1;
+      state.cellProvokedMap.set(ptId, 1);
+      return;
+    }
+  }
+  // if we got here then none of the ptIds could be used to provoke
+  state.cellProvokedMap.set(ptIds[0], 1);
+  state.extraPoints++;
+}
+
+let processCell;
+
+const _single = new Uint32Array(1);
+const _double = new Uint32Array(2);
+const _triple = new Uint32Array(3);
+const _indexCellBuilders = {
+  // easy, every input point becomes an output point
+  anythingToPoints(numPoints, cellPts, offset, cellId, state) {
+    for (let i = 0; i < numPoints; ++i) {
+      _single[0] = cellPts[offset + i];
+      processCell(_single, cellId, state);
+    }
+  },
+  linesToWireframe(numPoints, cellPts, offset, cellId, state) {
+    // for lines we add a bunch of segments
+    for (let i = 0; i < numPoints - 1; ++i) {
+      _double[0] = cellPts[offset + i];
+      _double[1] = cellPts[offset + i + 1];
+      processCell(_double, cellId, state);
+    }
+  },
+  polysToWireframe(numPoints, cellPts, offset, cellId, state) {
+    // for polys we add a bunch of segments and close it
+    if (numPoints > 2) {
+      for (let i = 0; i < numPoints; ++i) {
+        _double[0] = cellPts[offset + i];
+        _double[1] = cellPts[offset + ((i + 1) % numPoints)];
+        processCell(_double, cellId, state);
+      }
+    }
+  },
+  stripsToWireframe(numPoints, cellPts, offset, cellId, state) {
+    if (numPoints > 2) {
+      // for strips we add a bunch of segments and close it
+      for (let i = 0; i < numPoints - 1; ++i) {
+        _double[0] = cellPts[offset + i];
+        _double[1] = cellPts[offset + i + 1];
+        processCell(_double, cellId, state);
+      }
+      for (let i = 0; i < numPoints - 2; i++) {
+        _double[0] = cellPts[offset + i];
+        _double[1] = cellPts[offset + i + 2];
+        processCell(_double, cellId, state);
+      }
+    }
+  },
+  polysToSurface(npts, cellPts, offset, cellId, state) {
+    for (let i = 0; i < npts - 2; i++) {
+      _triple[0] = cellPts[offset];
+      _triple[1] = cellPts[offset + i + 1];
+      _triple[2] = cellPts[offset + i + 2];
+      processCell(_triple, cellId, state);
+    }
+  },
+  stripsToSurface(npts, cellPts, offset, cellId, state) {
+    for (let i = 0; i < npts - 2; i++) {
+      _triple[0] = cellPts[offset + i];
+      _triple[1] = cellPts[offset + i + 1 + (i % 2)];
+      _triple[2] = cellPts[offset + i + 1 + ((i + 1) % 2)];
+      processCell(_triple, cellId, state);
+    }
+  },
+};
+
+// ----------------------------------------------------------------------------
+// vtkWebGPUIndexBufferManager methods
+// ----------------------------------------------------------------------------
+
+function vtkWebGPUIndexBuffer(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkWebGPUIndexBuffer');
+
+  publicAPI.buildIndexBuffer = (req) => {
+    const cellArray = req.cells;
+    const primitiveType = req.primitiveType;
+    const representation = req.representation;
+    const cellOffset = req.cellOffset;
+
+    const array = cellArray.getData();
+    const cellArraySize = array.length;
+
+    const inRepName = getPrimitiveName(primitiveType);
+
+    const numPts = req.numberOfPoints;
+    const state = {
+      provokedPointIds: new Uint8Array(numPts), // size is good
+      extraPoints: 0,
+      iboSize: 0,
+      flatId: 0,
+      iboId: 0,
+      cellProvokedMap: new _LimitedMap(),
+    };
+
+    let func = null;
+    if (
+      representation === Representation.POINTS ||
+      primitiveType === PrimitiveTypes.Points
+    ) {
+      func = _indexCellBuilders.anythingToPoints;
+    } else if (
+      representation === Representation.WIREFRAME ||
+      primitiveType === PrimitiveTypes.Lines
+    ) {
+      func = _indexCellBuilders[`${inRepName}ToWireframe`];
+    } else {
+      func = _indexCellBuilders[`${inRepName}ToSurface`];
+    }
+
+    // first we count how many extra provoking points we need
+    processCell = countCell;
+    let cellId = cellOffset || 0;
+    for (let cellArrayIndex = 0; cellArrayIndex < cellArraySize; ) {
+      state.cellProvokedMap.clear();
+      func(array[cellArrayIndex], array, cellArrayIndex + 1, cellId, state);
+      cellArrayIndex += array[cellArrayIndex] + 1;
+      cellId++;
+    }
+
+    // then we allocate the remaining structures
+    // (we pick the best size to save space and transfer costs)
+    if (numPts <= 0xffff) {
+      state.flatIdToPointId = new Uint16Array(numPts + state.extraPoints);
+    } else {
+      state.flatIdToPointId = new Uint32Array(numPts + state.extraPoints);
+    }
+    if (numPts + state.extraPoints < 0x8fff) {
+      state.pointIdToFlatId = new Int16Array(numPts);
+    } else {
+      state.pointIdToFlatId = new Int32Array(numPts);
+    }
+    if (numPts + state.extraPoints <= 0xffff) {
+      state.ibo = new Uint16Array(state.iboSize);
+      req.format = 'uint16';
+    } else {
+      state.ibo = new Uint32Array(state.iboSize);
+      req.format = 'uint32';
+    }
+    if (cellId <= 0xffff) {
+      state.flatIdToCellId = new Uint16Array(numPts + state.extraPoints);
+    } else {
+      state.flatIdToCellId = new Uint32Array(numPts + state.extraPoints);
+    }
+    state.pointIdToFlatId.fill(-1);
+    state.provokedPointIds.fill(0);
+
+    // and fill them in
+    processCell = fillCell;
+    cellId = cellOffset || 0;
+    for (let cellArrayIndex = 0; cellArrayIndex < cellArraySize; ) {
+      state.cellProvokedMap.clear();
+      func(array[cellArrayIndex], array, cellArrayIndex + 1, cellId, state);
+      cellArrayIndex += array[cellArrayIndex] + 1;
+      cellId++;
+    }
+
+    delete state.provokedPointIds;
+    delete state.pointIdToFlatId;
+
+    // store the results we need
+    req.nativeArray = state.ibo;
+    model.flatIdToPointId = state.flatIdToPointId;
+    model.flatIdToCellId = state.flatIdToCellId;
+    model.flatSize = state.flatId;
+    model.indexCount = state.iboId;
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  flatIdToPointId: null,
+  flatIdToCellId: null,
+  flatSize: 0,
+  indexCount: 0,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkWebGPUBuffer.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, [
+    'flatIdToPointId',
+    'flatIdToCellId',
+    'flatSize',
+    'indexCount',
+  ]);
+
+  vtkWebGPUIndexBuffer(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend, ...Constants };

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -2,7 +2,13 @@ import * as macro from 'vtk.js/Sources/macros';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
 
 // methods we forward to the handle
-const forwarded = ['setBindGroup', 'setVertexBuffer', 'draw'];
+const forwarded = [
+  'setBindGroup',
+  'setIndexBuffer',
+  'setVertexBuffer',
+  'draw',
+  'drawIndexed',
+];
 
 // ----------------------------------------------------------------------------
 // vtkWebGPURenderEncoder methods

--- a/Sources/Rendering/WebGPU/SimpleMapper/index.js
+++ b/Sources/Rendering/WebGPU/SimpleMapper/index.js
@@ -290,7 +290,18 @@ function vtkWebGPUSimpleMapper(publicAPI, model) {
 
     // bind the vertex input
     pipeline.bindVertexInput(renderEncoder, model.vertexInput);
-    renderEncoder.draw(model.numberOfVertices, model.numberOfInstances, 0, 0);
+    const indexBuffer = model.vertexInput.getIndexBuffer();
+    if (indexBuffer) {
+      renderEncoder.drawIndexed(
+        indexBuffer.getIndexCount(),
+        model.numberOfInstances,
+        0,
+        0,
+        0
+      );
+    } else {
+      renderEncoder.draw(model.numberOfVertices, model.numberOfInstances, 0, 0);
+    }
   };
 
   publicAPI.getBindables = () => {

--- a/Sources/Rendering/WebGPU/VertexInput/index.js
+++ b/Sources/Rendering/WebGPU/VertexInput/index.js
@@ -137,6 +137,12 @@ function vtkWebGPUVertexInput(publicAPI, model) {
     for (let i = 0; i < model.inputs.length; i++) {
       renderEncoder.setVertexBuffer(i, model.inputs[i].buffer.getHandle());
     }
+    if (model.indexBuffer) {
+      renderEncoder.setIndexBuffer(
+        model.indexBuffer.getHandle(),
+        model.indexBuffer.getArrayInformation()[0].format
+      );
+    }
   };
 
   publicAPI.getReady = () => {};
@@ -157,6 +163,7 @@ const DEFAULT_VALUES = {
   inputs: null,
   bindingDescriptions: false,
   attributeDescriptions: null,
+  indexBuffer: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -170,7 +177,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.attributeDescriptions = [];
   model.inputs = [];
 
-  macro.setGet(publicAPI, model, ['created', 'device', 'handle']);
+  macro.setGet(publicAPI, model, [
+    'created',
+    'device',
+    'handle',
+    'indexBuffer',
+  ]);
 
   // For more macro methods, see "Sources/macros.js"
   // Object specific methods

--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -343,17 +343,30 @@ function vtkWebGPUVolumePass(publicAPI, model) {
     publicAPI.updateDepthPolyData(renNode);
 
     const pd = model._boundsPoly;
-    const cells = pd.getPolys();
-    // points
     const points = pd.getPoints();
-    const buffRequest = {
+    const cells = pd.getPolys();
+
+    let buffRequest = {
+      hash: `vp${cells.getMTime()}`,
+      usage: BufferUsage.Index,
+      cells,
+      numberOfPoints: points.getNumberOfPoints(),
+      primitiveType: PrimitiveTypes.Triangles,
+      representation: Representation.SURFACE,
+    };
+    const indexBuffer = viewNode
+      .getDevice()
+      .getBufferManager()
+      .getBuffer(buffRequest);
+    model._mapper.getVertexInput().setIndexBuffer(indexBuffer);
+
+    // points
+    buffRequest = {
       usage: BufferUsage.PointArray,
       format: 'float32x4',
       hash: `vp${points.getMTime()}${cells.getMTime()}`,
       dataArray: points,
-      cells,
-      primitiveType: PrimitiveTypes.Triangles,
-      representation: Representation.SURFACE,
+      indexBuffer,
       packExtra: true,
     };
     const buff = viewNode.getDevice().getBufferManager().getBuffer(buffRequest);


### PR DESCRIPTION
Add support for index buffers to the webgpu backend and use them in the
CellArrayMapper by default.

This approach uses a flat interpolation approach to support celldata. In
that each primitive must start with a provoking vertex that is only used
for that cell (not primitive). The flat ibo building code handles this
and sets up maps from flatIds to source point and cell IDs. These
mappings can be used to build flat array buffers for point or cell data
to go along with the index buffer.

Note that this flat packing is typically larger than the original point
array as we have to be careful not to use the same point to provoke
multiple cells. In a fully connected triangle mesh each point is shared
by 6 triangles. The old code would explode the point array by 6 as a
brute force solution. This flat packing would theoretically achieve a 2x
size, significantly smaller that the old 6x.

Also includes a fix to getStatistics for RenderWindow

Includes a performance/memory improvement to GetNumberOfCells
