### PR TITLE
Add edge picking support to the Cellpicker

### DIFF
--- a/Sources/Common/DataModel/Cell/index.js
+++ b/Sources/Common/DataModel/Cell/index.js
@@ -113,7 +113,9 @@ function vtkCell(publicAPI, model) {
     pcoords,
     dist2,
     weights
-  ) => {}; // virtual
+  ) => {
+    macro.vtkErrorMacro('vtkCell.evaluatePosition is not implemented.');
+  }; // virtual
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/CellTypes/index.js
+++ b/Sources/Common/DataModel/CellTypes/index.js
@@ -40,6 +40,14 @@ function isLinear(type) {
   );
 }
 
+function hasSubCells(cellType) {
+  return (
+    cellType === CellType.VTK_TRIANGLE_STRIP ||
+    cellType === CellType.VTK_POLY_LINE ||
+    cellType === CellType.VTK_POLY_VERTEX
+  );
+}
+
 // ----------------------------------------------------------------------------
 // Static API
 // ----------------------------------------------------------------------------
@@ -48,6 +56,7 @@ export const STATIC = {
   getClassNameFromTypeId,
   getTypeIdFromClassName,
   isLinear,
+  hasSubCells,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/Line/index.d.ts
+++ b/Sources/Common/DataModel/Line/index.d.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from '../../../types';
+import { Vector3, Vector2 } from '../../../types';
 import vtkCell from '../Cell';
 
 export enum IntersectionState {
@@ -9,7 +9,7 @@ export enum IntersectionState {
 
 interface ILineInitialValues { }
 
-interface IIntersectWithLine {
+export interface IIntersectWithLine {
 	intersect: number;
 	t: number;
 	subId: number;
@@ -50,6 +50,11 @@ export interface vtkLine extends vtkCell {
 	 * @param {Vector3} pcoords The parametric coordinates.
 	 */
 	intersectWithLine(p1: Vector3, p2: Vector3, tol: number, x: Vector3, pcoords: Vector3): IIntersectWithLine;
+
+	/**
+	 * Determine the global coordinates `x' and parametric coordinates `pcoords' in the cell.
+	 */
+	evaluateLocation(pcoords: Vector3, x: Vector3, weights: Vector2): void
 }
 
 /**

--- a/Sources/Common/DataModel/Line/index.js
+++ b/Sources/Common/DataModel/Line/index.js
@@ -63,15 +63,9 @@ function intersection(a1, a2, b1, b2, u, v) {
   v[0] = 0.0;
 
   // Determine line vectors.
-  a21[0] = a2[0] - a1[0];
-  a21[1] = a2[1] - a1[1];
-  a21[2] = a2[2] - a1[2];
-  b21[0] = b2[0] - b1[0];
-  b21[1] = b2[1] - b1[1];
-  b21[2] = b2[2] - b1[2];
-  b1a1[0] = b1[0] - a1[0];
-  b1a1[1] = b1[1] - a1[1];
-  b1a1[2] = b1[2] - a1[2];
+  vtkMath.subtract(a2, a1, a21);
+  vtkMath.subtract(b2, b1, b21);
+  vtkMath.subtract(b1, a1, b1a1);
 
   // Compute the system (least squares) matrix.
   const A = [];
@@ -217,6 +211,7 @@ function vtkLine(publicAPI, model) {
     }
     return outObj;
   };
+
   publicAPI.evaluatePosition = (
     x,
     closestPoint,
@@ -225,6 +220,20 @@ function vtkLine(publicAPI, model) {
     dist2,
     weights
   ) => {}; // virtual
+
+  publicAPI.evaluateLocation = (pcoords, x, weights) => {
+    const a1 = [];
+    const a2 = [];
+    model.points.getPoint(0, a1);
+    model.points.getPoint(1, a2);
+
+    for (let i = 0; i < 3; i++) {
+      x[i] = a1[i] + pcoords[0] * (a2[i] - a1[i]);
+    }
+
+    weights[0] = 1.0 - pcoords[0];
+    weights[1] = pcoords[0];
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/Line/index.js
+++ b/Sources/Common/DataModel/Line/index.js
@@ -212,15 +212,6 @@ function vtkLine(publicAPI, model) {
     return outObj;
   };
 
-  publicAPI.evaluatePosition = (
-    x,
-    closestPoint,
-    subId,
-    pcoords,
-    dist2,
-    weights
-  ) => {}; // virtual
-
   publicAPI.evaluateLocation = (pcoords, x, weights) => {
     const a1 = [];
     const a2 = [];

--- a/Sources/Common/DataModel/PolyLine/index.d.ts
+++ b/Sources/Common/DataModel/PolyLine/index.d.ts
@@ -1,0 +1,63 @@
+import { Vector2, Vector3 } from '../../../types';
+import vtkCell, { ICellInitialValues } from '../Cell';
+import { IIntersectWithLine } from '../Line';
+
+export interface IPolyLineInitialValues extends ICellInitialValues { }
+
+export interface vtkPolyLine extends vtkCell {
+
+	/**
+	 * Get the topological dimensional of the cell (0, 1, 2 or 3).
+	 */
+	getCellDimension(): number;
+
+	/**
+	 * @param {number} t1
+	 * @param {number} t2
+	 * @param {Vector3} p1 The first point coordinate.
+	 * @param {Vector3} p2 The second point coordinate.
+	 * @param {Number} tol The tolerance to use.
+	 * @param {Vector3} x The point which intersect the line.
+	 * @param {Vector3} pcoords The parametric coordinates.
+	 */
+	intersectWithLine(t1: number, t2: number, p1: Vector3, p2: Vector3, tol: number, x: Vector3, pcoords: Vector3): IIntersectWithLine;
+
+  /**
+   * Determine global coordinate (x[3]) from subId and parametric coordinates.
+   * Also returns interpolation weights. (The number of weights is equal to
+   * the number of points in the cell.)
+   * 
+   * @param {number} subId
+   * @param {Vector3} pcoords The parametric coordinates
+   * @param {Vector3} x The global coordinate
+   * @param {Vector2} weights The interpolation weights
+   */
+  evaluateLocation(subId: number, pcoords: Vector3, x: Vector3, weights: Vector2): void
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkPolyLine characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {IPolyLineInitialValues} [initialValues] (default: {})
+ */
+export function extend(publicAPI: object, model: object, initialValues?: IPolyLineInitialValues): void;
+
+/**
+ * Method used to create a new instance of vtkPolyLine.
+ * @param {IPolyLineInitialValues} [initialValues] for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IPolyLineInitialValues): vtkPolyLine;
+
+/** 
+ * vtkPolyLine is a cell which representant a poly line.
+ * 
+ * @see vtkCell
+ */
+export declare const vtkPolyLine: {
+	newInstance: typeof newInstance,
+	extend: typeof extend;
+};
+
+export default vtkPolyLine;

--- a/Sources/Common/DataModel/PolyLine/index.js
+++ b/Sources/Common/DataModel/PolyLine/index.js
@@ -1,0 +1,102 @@
+import macro from 'vtk.js/Sources/macros';
+import vtkCell from 'vtk.js/Sources/Common/DataModel/Cell';
+import vtkLine from 'vtk.js/Sources/Common/DataModel/Line';
+
+function vtkPolyLine(publicAPI, model) {
+  model.classHierarchy.push('vtkPolyLine');
+  const superClass = { ...publicAPI };
+
+  const line = vtkLine.newInstance();
+  line.getPoints().setNumberOfPoints(2);
+
+  publicAPI.getCellDimension = () => 1;
+  publicAPI.intersectWithLine = (t1, t2, p1, p2, tol, x, pcoords) => {
+    const outObj = {
+      intersect: 0,
+      t: Number.MAX_VALUE,
+      subId: 0,
+      betweenPoints: null,
+    };
+
+    const numLines = superClass.getPoints().getNumberOfPoints() - 1;
+    let pDistMin = Number.MAX_VALUE;
+    const minXYZ = [0, 0, 0];
+    const minPCoords = [0, 0, 0];
+    for (let subId = 0; subId < numLines; subId++) {
+      const pCoords = [0, 0, 0];
+
+      line
+        .getPoints()
+        .getData()
+        .set(model.points.getData().subarray(3 * subId, 3 * (subId + 2)));
+
+      const lineIntersected = line.intersectWithLine(p1, p2, tol, x, pcoords);
+
+      if (
+        lineIntersected.intersect === 1 &&
+        lineIntersected.t <= outObj.t + tol &&
+        lineIntersected.t >= t1 &&
+        lineIntersected.t <= t2
+      ) {
+        outObj.intersect = 1;
+        const pDist = line.getParametricDistance(pCoords);
+        if (
+          pDist < pDistMin ||
+          (pDist === pDistMin && lineIntersected.t < outObj.t)
+        ) {
+          outObj.subId = subId;
+          outObj.t = lineIntersected.t;
+          pDistMin = pDist;
+          for (let k = 0; k < 3; k++) {
+            minXYZ[k] = x[k];
+            minPCoords[k] = pCoords[k];
+          }
+        }
+      }
+    }
+
+    return outObj;
+  };
+
+  publicAPI.evaluatePosition = (
+    x,
+    closestPoint,
+    subId,
+    pcoords,
+    dist2,
+    weights
+  ) => {}; // virtual
+
+  publicAPI.evaluateLocation = (subId, pcoords, x, weights) => {
+    line
+      .getPoints()
+      .getData()
+      .set(model.points.getData().subarray(3 * subId, 3 * (subId + 2)));
+
+    return line.evaluateLocation(pcoords, x, weights);
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  vtkCell.extend(publicAPI, model, initialValues);
+
+  vtkPolyLine(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkPolyLine');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Common/DataModel/PolyLine/index.js
+++ b/Sources/Common/DataModel/PolyLine/index.js
@@ -58,15 +58,6 @@ function vtkPolyLine(publicAPI, model) {
     return outObj;
   };
 
-  publicAPI.evaluatePosition = (
-    x,
-    closestPoint,
-    subId,
-    pcoords,
-    dist2,
-    weights
-  ) => {}; // virtual
-
   publicAPI.evaluateLocation = (subId, pcoords, x, weights) => {
     line
       .getPoints()


### PR DESCRIPTION
### Context
Currently, the CellPicker can only pick triangles.

### Results
CellPicker will also try to pick edges.

### Changes
- Added a PolyLine data model class.
- Implemented evaluateLocation in vtkLine
- Changes the picking workflow ; now using `vtkPolyData.getCell` and `vtkPolyData.getCellType`

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: v19.4.0
  - **OS**: ArchLinux
  - **Browser**: Firefox 99.0.1
