### PR TITLE
docs(ts): fix typescript defs

### DIFF
--- a/Sources/Common/Core/ScalarsToColors/Constants.d.ts
+++ b/Sources/Common/Core/ScalarsToColors/Constants.d.ts
@@ -1,0 +1,18 @@
+export declare enum VectorMode {
+	MAGNITUDE = 0,
+	COMPONENT = 1,
+	RGBCOLORS = 2,
+}
+
+export declare enum ScalarMappingTarget {
+	LUMINANCE = 1,
+	LUMINANCE_ALPHA = 2,
+	RGB = 3,
+	RGBA = 4,
+}
+
+declare const _default: {
+	VectorMode: typeof VectorMode;
+	ScalarMappingTarget: typeof ScalarMappingTarget;
+};
+export default _default;

--- a/Sources/Common/Core/ScalarsToColors/index.d.ts
+++ b/Sources/Common/Core/ScalarsToColors/index.d.ts
@@ -1,19 +1,7 @@
-import { vtkObject } from "../../../interfaces" ;
-import { ColorMode } from "../../../Rendering/Core/Mapper";
-import { Range } from "../../../types" ;
-
-export enum VectorMode {
-	MAGNITUDE,
-	COMPONENT,
-	RGBCOLORS
-}
-
-export enum ScalarMappingTarget {
-	LUMINANCE,
-	LUMINANCE_ALPHA,
-	RGB,
-	RGBA
-}
+import { vtkObject } from "../../../interfaces";
+import { ColorMode } from "../../../Rendering/Core/Mapper/Constants";
+import { Range } from "../../../types";
+import { ScalarMappingTarget, VectorMode } from "./Constants";
 
 /**
  *
@@ -370,5 +358,7 @@ export function newInstance(initialValues?: IScalarsToColorsInitialValues): vtkS
 export declare const vtkScalarsToColors: {
 	newInstance: typeof newInstance;
 	extend: typeof extend;
+	VectorMode: typeof VectorMode;
+	ScalarMappingTarget: typeof VectorMode;
 }
 export default vtkScalarsToColors;

--- a/Sources/Common/DataModel/Box/index.d.ts
+++ b/Sources/Common/DataModel/Box/index.d.ts
@@ -1,5 +1,5 @@
-import { vtkObject } from "../../../interfaces" ;
-import { Bounds, Point } from "../../../types";
+import { vtkObject } from "../../../interfaces";
+import { Bounds, Vector3 } from "../../../types";
 
 
 export interface IBoxInitialValues {
@@ -22,9 +22,9 @@ export interface vtkBox extends vtkObject {
 
     /**
      * 
-     * @param {Point} x The point coordinate.
+     * @param {Vector3} x The point coordinate.
      */
-    evaluateFunction(x: Point): number;
+    evaluateFunction(x: Vector3): number;
 
     /**
      * 

--- a/Sources/Common/DataModel/ITKHelper/index.d.ts
+++ b/Sources/Common/DataModel/ITKHelper/index.d.ts
@@ -2,9 +2,9 @@ import vtkPolyData from "../PolyData";
 import vtkImageData from "../ImageData";
 
 export interface IOptions {
-	pointDataName: string;
-	scalarArrayName: string;
-	cellDataName: string;
+	pointDataName?: string;
+	scalarArrayName?: string;
+	cellDataName?: string;
 }
 
 /**

--- a/Sources/Common/DataModel/Line/index.d.ts
+++ b/Sources/Common/DataModel/Line/index.d.ts
@@ -77,7 +77,7 @@ export function newInstance(initialValues?: ILineInitialValues): vtkLine;
  *   t: tolerance of the distance
  *   distance: quared distance between closest point and x
  * }
- * 
+ * ```
  * @static
  * @param {Vector3} x 
  * @param {Vector3} p1 

--- a/Sources/Common/DataModel/PolyData/Constants.d.ts
+++ b/Sources/Common/DataModel/PolyData/Constants.d.ts
@@ -1,0 +1,6 @@
+export declare const POLYDATA_FIELDS : string[];
+
+declare const _default: {
+	POLYDATA_FIELDS: typeof POLYDATA_FIELDS;
+};
+export default _default;

--- a/Sources/Common/DataModel/Spline3D/Constants.d.ts
+++ b/Sources/Common/DataModel/Spline3D/Constants.d.ts
@@ -1,0 +1,9 @@
+export declare enum splineKind {
+	CARDINAL_SPLINE = 'CARDINAL_SPLINE',
+	KOCHANEK_SPLINE = 'KOCHANEK_SPLINE',
+}
+
+declare const _default: {
+	splineKind: typeof splineKind;
+};
+export default _default;

--- a/Sources/Common/DataModel/Spline3D/index.d.ts
+++ b/Sources/Common/DataModel/Spline3D/index.d.ts
@@ -1,10 +1,5 @@
-import { vtkObject } from "../../../interfaces" ;
-
-export enum splineKind {
-	CARDINAL_SPLINE,
-	KOCHANEK_SPLINE,
-}
-
+import { vtkObject } from "../../../interfaces";
+import { splineKind } from "./Constants";
 
 export interface ISpline3DInitialValues {
 	close?: boolean;
@@ -52,7 +47,7 @@ export function newInstance(initialValues?: ISpline3DInitialValues): vtkSpline3D
  * at any given point inside the spline intervals.
  */
 export declare const vtkSpline3D: {
-	newInstance: typeof newInstance,
-	extend: typeof extend
+	newInstance: typeof newInstance;
+	extend: typeof extend;
 };
 export default vtkSpline3D;

--- a/Sources/Filters/General/ImageCropFilter/index.d.ts
+++ b/Sources/Filters/General/ImageCropFilter/index.d.ts
@@ -1,10 +1,12 @@
 import { vtkAlgorithm, vtkObject } from "../../../interfaces";
 
+type CroppingPlanes = number[];
+
 /**
  *
  */
-interface IImageCropFilterInitialValues {
-	croppingPlanes?: any;
+export interface IImageCropFilterInitialValues {
+	croppingPlanes?: CroppingPlanes;
 }
 
 type vtkImageCropFilterBase = vtkObject & vtkAlgorithm;
@@ -15,18 +17,19 @@ export interface vtkImageCropFilter extends vtkImageCropFilterBase {
 	 * Get The cropping planes, in IJK space.
 	 * @default [0, 0, 0, 0, 0, 0].
 	 */
-	getCroppingPlanes(): number[];
+	getCroppingPlanes(): CroppingPlanes;
 
 	/**
 	 * Get The cropping planes, in IJK space.
 	 * @default [0, 0, 0, 0, 0, 0].
 	 */
-	getCroppingPlanesByReference(): number[];
+	getCroppingPlanesByReference(): CroppingPlanes;
 
 	/**
 	 *
 	 */
 	isResetAvailable(): boolean;
+
 	/**
 	 *
 	 */
@@ -43,13 +46,13 @@ export interface vtkImageCropFilter extends vtkImageCropFilterBase {
 	 *
 	 * @param croppingPlanes
 	 */
-	setCroppingPlanes(croppingPlanes: number[]): boolean;
+	setCroppingPlanes(croppingPlanes: CroppingPlanes): boolean;
 
 	/**
 	 *
 	 * @param croppingPlanes
 	 */
-	setCroppingPlanesFrom(croppingPlanes: number[]): boolean;
+	setCroppingPlanesFrom(croppingPlanes: CroppingPlanes): boolean;
 }
 
 /**

--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/Constants.d.ts
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/Constants.d.ts
@@ -1,0 +1,11 @@
+export declare enum Corners {
+	TOP_LEFT = 'TOP_LEFT',
+	TOP_RIGHT = 'TOP_RIGHT',
+	BOTTOM_LEFT = 'BOTTOM_LEFT',
+	BOTTOM_RIGHT = 'BOTTOM_RIGHT',
+}
+
+declare const _default: {
+	Corners: typeof Corners;
+};
+export default _default;

--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.d.ts
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.d.ts
@@ -4,13 +4,8 @@ import vtkAxesActor from "../../../Rendering/Core/AxesActor";
 import vtkRenderer from "../../../Rendering/Core/Renderer";
 import vtkRenderWindowInteractor from "../../../Rendering/Core/RenderWindowInteractor";
 import { Nullable } from "../../../types";
+import { Corners } from "./Constants";
 
-export enum Corners {
-	TOP_LEFT,
-	TOP_RIGHT,
-	BOTTOM_LEFT,
-	BOTTOM_RIGHT,
-}
 
 /**
  * 
@@ -177,5 +172,6 @@ export function newInstance(initialValues?: IOrientationMarkerWidgetInitialValue
 export declare const vtkOrientationMarkerWidget: {
 	newInstance: typeof newInstance;
 	extend: typeof extend;
+	Corners: typeof Corners;
 }
 export default vtkOrientationMarkerWidget;

--- a/Sources/Rendering/Core/Mapper/Constants.d.ts
+++ b/Sources/Rendering/Core/Mapper/Constants.d.ts
@@ -1,0 +1,26 @@
+export declare enum ColorMode {
+	DEFAULT = 0,
+	MAP_SCALARS = 1,
+	DIRECT_SCALARS = 2,
+}
+
+export declare enum ScalarMode {
+	DEFAULT = 0,
+	USE_POINT_DATA = 1,
+	USE_CELL_DATA = 2,
+	USE_POINT_FIELD_DATA = 3,
+	USE_CELL_FIELD_DATA = 4,
+	USE_FIELD_DATA = 5,
+}
+
+export declare enum GetArray {
+	BY_ID = 0,
+	BY_NAME = 1,
+}
+
+declare const _default: {
+	ColorMode: typeof ColorMode;
+	ScalarMode: typeof ScalarMode;
+	GetArray: typeof GetArray;
+};
+export default _default;

--- a/Sources/Rendering/Core/Mapper/index.d.ts
+++ b/Sources/Rendering/Core/Mapper/index.d.ts
@@ -1,25 +1,6 @@
 import { Bounds, Nullable, Range } from "../../../types";
 import vtkAbstractMapper3D, { IAbstractMapper3DInitialValues } from "../AbstractMapper3D";
-
-export enum ColorMode {
-	DEFAULT,
-	MAP_SCALARS,
-	DIRECT_SCALARS,
-}
-
-export enum ScalarMode {
-	DEFAULT,
-	USE_POINT_DATA,
-	USE_CELL_DATA,
-	USE_POINT_FIELD_DATA,
-	USE_CELL_FIELD_DATA,
-	USE_FIELD_DATA,
-}
-
-export enum GetArray {
-	BY_ID,
-	BY_NAME,
-}
+import { ColorMode, GetArray, ScalarMode } from "./Constants";
 
 interface IPrimitiveCount {
 	points: number;
@@ -166,7 +147,7 @@ export interface vtkMapper extends vtkAbstractMapper3D {
 	/**
 	 * Return the method of coloring scalar data.
 	 */
-	getColorMode(): number;
+	getColorMode(): ColorMode;
 
 	/**
 	 * Return the method of coloring scalar data.
@@ -643,5 +624,8 @@ export declare const vtkMapper: {
 	getResolveCoincidentTopologyLineOffsetParameters: typeof getResolveCoincidentTopologyLineOffsetParameters;
 	getResolveCoincidentTopologyPointOffsetParameters: typeof getResolveCoincidentTopologyPointOffsetParameters;
 	getResolveCoincidentTopologyPolygonOffsetParameters: typeof getResolveCoincidentTopologyPolygonOffsetParameters;
+	ColorMode: typeof ColorMode;
+	ScalarMode: typeof ScalarMode;
+	GetArray: typeof GetArray;
 }
 export default vtkMapper;

--- a/Sources/Rendering/Core/Property/Constants.d.ts
+++ b/Sources/Rendering/Core/Property/Constants.d.ts
@@ -1,0 +1,24 @@
+export declare enum Shading {
+	FLAT = 0,
+	GOURAUD = 1,
+	PHONG = 2,
+}
+
+export declare enum Representation {
+	POINTS = 0,
+	WIREFRAME = 1,
+	SURFACE = 2,
+}
+
+export declare enum Interpolation {
+	FLAT = 0,
+	GOURAUD = 1,
+	PHONG = 2,
+}
+
+declare const _default: {
+	Shading: typeof Shading;
+	Representation: typeof Representation;
+	Interpolation: typeof Interpolation;
+};
+export default _default;

--- a/Sources/Rendering/Core/Property/index.d.ts
+++ b/Sources/Rendering/Core/Property/index.d.ts
@@ -1,23 +1,6 @@
 import { vtkObject } from "../../../interfaces";
 import { RGBColor } from "../../../types";
-
-export enum Shading {
-	FLAT,
-	GOURAUD,
-	PHONG,
-}
-
-export enum Representation {
-	POINTS,
-	WIREFRAME,
-	SURFACE,
-}
-
-export enum Interpolation {
-	FLAT,
-	GOURAUD,
-	PHONG,
-}
+import { Interpolation, Representation, Shading } from "./Constants";
 
 export interface IPropertyInitialValues {
 	color?: RGBColor;
@@ -457,7 +440,10 @@ export function newInstance(initialValues?: IPropertyInitialValues): vtkProperty
  * manipulated with this object.
  */
 export declare const vtkProperty: {
-	newInstance: typeof newInstance,
-	extend: typeof extend,
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+	Shading: typeof Shading;
+	Representation: typeof Representation;
+	Interpolation: typeof Interpolation;
 };
 export default vtkProperty;

--- a/Sources/Rendering/Core/RenderWindowInteractor/Constants.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/Constants.d.ts
@@ -1,0 +1,31 @@
+export declare enum Device {
+	Unknown = 0,
+	LeftController = 1,
+	RightController = 2,
+}
+
+export declare enum Input {
+	Unknown = 0,
+	Trigger = 1,
+	TrackPad = 2,
+	Grip = 3,
+	Thumbstick = 4,
+	A = 5,
+	B = 6,
+	ApplicationMenu = 7, // Not exposed in WebXR API
+}
+
+export declare enum Axis {
+	Unknown = 0,
+	TouchpadX = 1,
+	TouchpadY = 2,
+	ThumbstickX = 3,
+	ThumbstickY = 4,
+}
+
+declare const _default: {
+	Device: typeof Device;
+	Input: typeof Input;
+	Axis: typeof Axis;
+};
+export default _default;

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -1,18 +1,45 @@
 import { vtkObject, vtkSubscription } from "../../../interfaces";
 import vtkRenderer from "../Renderer";
+import { Axis, Device, Input } from "./Constants";
 
-export enum Device {
-	Unknown,
-	LeftController,
-	RightController,
-}
-
-export enum Input {
-	Unknown,
-	Trigger,
-	TrackPad,
-	Grip,
-	ApplicationMenu,
+declare enum handledEvents {
+	'StartAnimation',
+	'Animation',
+	'EndAnimation',
+	'MouseEnter',
+	'MouseLeave',
+	'StartMouseMove',
+	'MouseMove',
+	'EndMouseMove',
+	'LeftButtonPress',
+	'LeftButtonRelease',
+	'MiddleButtonPress',
+	'MiddleButtonRelease',
+	'RightButtonPress',
+	'RightButtonRelease',
+	'KeyPress',
+	'KeyDown',
+	'KeyUp',
+	'StartMouseWheel',
+	'MouseWheel',
+	'EndMouseWheel',
+	'StartPinch',
+	'Pinch',
+	'EndPinch',
+	'StartPan',
+	'Pan',
+	'EndPan',
+	'StartRotate',
+	'Rotate',
+	'EndRotate',
+	'Button3D',
+	'Move3D',
+	'StartPointerLock',
+	'EndPointerLock',
+	'StartInteraction',
+	'Interaction',
+	'EndInteraction',
+	'AnimationFrameRateUpdate',
 }
 
 /**
@@ -125,182 +152,218 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 	getStillUpdateRate(): number;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartAnimation(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeAnimation(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndAnimation(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeMouseEnter(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeMouseLeave(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartMouseMove(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeMouseMove(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndMouseMove(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeLeftButtonPress(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeLeftButtonRelease(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeMiddleButtonPress(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeMiddleButtonRelease(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeRightButtonPress(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeRightButtonRelease(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeKeyPress(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeKeyDown(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeKeyUp(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartMouseWheel(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeMouseWheel(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndMouseWheel(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartPinch(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokePinch(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndPinch(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartPan(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokePan(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndPan(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartRotate(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeRotate(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndRotate(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeButton3D(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeMove3D(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartPointerLock(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndPointerLock(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeStartInteractionEvent(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeInteractionEvent(callData: IRenderWindowInteractorEvent): void;
 
 	/**
-	 *
+	 * 
+	 * @param {IRenderWindowInteractorEvent} callData 
 	 */
 	invokeEndInteractionEvent(callData: IRenderWindowInteractorEvent): void;
 
@@ -311,212 +374,247 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 	onStartAnimation(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onAnimation(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndAnimation(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onMouseEnter(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onMouseLeave(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onStartMouseMove(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onMouseMove(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndMouseMove(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onLeftButtonPress(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onLeftButtonRelease(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onMiddleButtonPress(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onMiddleButtonRelease(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onRightButtonPress(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onRightButtonRelease(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onKeyPress(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onKeyDown(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onKeyUp(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onStartMouseWheel(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onMouseWheel(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndMouseWheel(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onStartPinch(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onPinch(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndPinch(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onStartPan(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onPan(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndPan(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onStartRotate(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onRotate(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndRotate(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onButton3D(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onMove3D(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onStartPointerLock(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndPointerLock(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onStartInteractionEvent(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onInteractionEvent(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
 	/**
-	 *
-	 * @param cb The callback to be called
+	 * 
+	 * @param {InteractorEventCallback} cb The callback to be called.
+	 * @param {Number} [priority] The priority of the event.
 	 */
 	onEndInteractionEvent(cb: InteractorEventCallback, priority?: number): Readonly<vtkSubscription>;
 
@@ -1045,7 +1143,11 @@ export function newInstance(initialValues?: IRenderWindowInteractorInitialValues
  * that event are expected to respond appropriately.
  */
 export declare const vtkRenderWindowInteractor: {
-	newInstance: typeof newInstance,
-	extend: typeof extend,
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+	handledEvents: typeof handledEvents;
+	Device: typeof Device;
+	Input: typeof Input;
+	Axis: typeof Axis;
 };
 export default vtkRenderWindowInteractor;

--- a/Sources/Rendering/Core/Viewport/index.d.ts
+++ b/Sources/Rendering/Core/Viewport/index.d.ts
@@ -1,6 +1,6 @@
 
 import { vtkObject } from "../../../interfaces";
-import { RGBColor } from "../../../types";
+import { RGBColor, Size } from "../../../types";
 import vtkActor2D from '../Actor2D';
 import vtkProp from '../Prop';
 
@@ -58,12 +58,10 @@ export interface vtkViewport extends vtkObject {
      */
     getBackgroundByReference(): number[];
 
-
-
     /**
      * 
      */
-    getSize(): any;
+    getSize(): Size;
 
     /**
      * 

--- a/Sources/Rendering/Core/VolumeMapper/Constants.d.ts
+++ b/Sources/Rendering/Core/VolumeMapper/Constants.d.ts
@@ -1,0 +1,19 @@
+export declare enum BlendMode {
+	COMPOSITE_BLEND = 0,
+	MAXIMUM_INTENSITY_BLEND = 1,
+	MINIMUM_INTENSITY_BLEND = 2,
+	AVERAGE_INTENSITY_BLEND = 3,
+	ADDITIVE_INTENSITY_BLEND = 4,
+}
+	
+export declare enum FilterMode {
+	OFF = 0,
+	NORMALIZED = 1,
+	RAW = 2,
+}
+
+declare const _default: {
+	BlendMode: typeof BlendMode;
+	FilterMode: typeof FilterMode;
+};
+export default _default;

--- a/Sources/Rendering/Core/VolumeMapper/index.d.ts
+++ b/Sources/Rendering/Core/VolumeMapper/index.d.ts
@@ -1,12 +1,6 @@
 import { Bounds, Range } from "../../../types";
 import vtkAbstractMapper, { IAbstractMapperInitialValues } from "../AbstractMapper";
-
-export enum BlendMode {
-	COMPOSITE_BLEND,
-	MAXIMUM_INTENSITY_BLEND,
-	MINIMUM_INTENSITY_BLEND,
-	AVERAGE_INTENSITY_BLEND,
-}
+import { BlendMode, FilterMode } from "./Constants";
 
 /**
  * 
@@ -165,7 +159,9 @@ export function newInstance(initialValues?: IVolumeMapperInitialValues): vtkVolu
  * A volume mapper that performs ray casting on the GPU using fragment programs.
  */
 export declare const vtkVolumeMapper: {
-	newInstance: typeof newInstance,
-	extend: typeof extend,
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+	BlendMode: typeof BlendMode;
+	FilterMode: typeof FilterMode;
 };
 export default vtkVolumeMapper;

--- a/Sources/Rendering/Core/VolumeProperty/index.d.ts
+++ b/Sources/Rendering/Core/VolumeProperty/index.d.ts
@@ -1,15 +1,5 @@
 import { vtkObject } from "../../../interfaces";
-
-export enum InterpolationType {
-	NEAREST,
-	LINEAR,
-	FAST_LINEAR,
-}
-
-export enum OpacityMode {
-	FRACTIONAL,
-	PROPORTIONAL,
-}
+import { InterpolationType, OpacityMode } from "./Constants";
 
 interface IVolumePropertyInitialValues  {
 	independentComponents?: boolean;
@@ -412,7 +402,9 @@ export function newInstance(initialValues?: IVolumePropertyInitialValues): vtkVo
  * ```
  */
 export declare const vtkVolumeProperty: {
-	newInstance: typeof newInstance,
-	extend: typeof extend,
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+	InterpolationType: typeof InterpolationType;
+	OpacityMode: typeof OpacityMode;
 };
 export default vtkVolumeProperty;

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
@@ -13,10 +13,11 @@ import vtkRenderWindowInteractor from "../../Core/RenderWindowInteractor";
  */
 export interface IFullScreenRenderWindowInitialValues {
 	background?: RGBColor;
+	container?: HTMLElement
 	containerStyle?: object;
-	controlPanelStyle?: object,
-	listenWindowResize?: boolean;
+	controlPanelStyle?: object;
 	controllerVisibility?: boolean;
+	listenWindowResize?: boolean;
 	resizeCallback?: any;
 }
 

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -1,7 +1,7 @@
 import { vtkAlgorithm, vtkObject } from '../../../interfaces';
 import { Nullable, Size, Vector2, Vector3 } from '../../../types';
-import { vtkRenderer } from '../../../Rendering/Core/Renderer';
 import { VtkDataTypes } from '../../../Common/Core/DataArray';
+import vtkRenderer from '../../Core/Renderer';
 import vtkTexture from '../../Core/Texture';
 import vtkViewStream from '../../../IO/Core/ImageStream/ViewStream';
 
@@ -9,15 +9,33 @@ import vtkViewStream from '../../../IO/Core/ImageStream/ViewStream';
  *
  */
 export interface IOpenGLRenderWindowInitialValues {
-	resolution?: number;
-	point1?: Vector3;
-	point2?: Vector3;
-	pointType?: string;
+	cullFaceEnabled?: boolean;
+	shaderCache?: null;
+	initialized?: boolean;
+	context?: WebGLRenderingContext | WebGL2RenderingContext;
+	canvas?: HTMLCanvasElement;
+	cursorVisibility?: boolean;
+	cursor?: string;
+	textureUnitManager?: null;
+	textureResourceIds?: null;
+	containerSize?: Size;
+	renderPasses?: any[];
+	notifyStartCaptureImage?: boolean;
+	webgl2?: boolean;
+	defaultToWebgl2?: boolean;
+	activeFramebuffer?: any;
+	xrSession?: any;
+	xrSessionIsAR?: boolean;
+	xrReferenceSpace?: any;
+	xrSupported?: boolean;
+	imageFormat?: 'image/png';
+	useOffScreen?: boolean;
+	useBackgroundImage?: boolean;
 }
 
-export interface IOptions {
-	resetCamera: boolean,
-	size: Size,
+export interface ICaptureOptions {
+	resetCamera: boolean;
+	size: Size;
 	scale: number
 }
 
@@ -278,9 +296,9 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * size is assumed.  The default format is "image/png". Returns a promise
 	 * that resolves to the captured screenshot.
 	 * @param {String} format
-	 * @param {IOptions} options
+	 * @param {ICaptureOptions} options
 	 */
-	captureNextImage(format: string, options: IOptions): Nullable<Promise<string>>;
+	captureNextImage(format: string, options: ICaptureOptions): Nullable<Promise<string>>;
 
 	/**
 	 *


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
