### PR TITLE
refactor(mtlreader): add a boolean to not automatically request and l…

### DIFF
--- a/Sources/IO/Misc/MTLReader/index.js
+++ b/Sources/IO/Misc/MTLReader/index.js
@@ -43,7 +43,7 @@ function vtkMTLReader(publicAPI, model) {
         model.materials[model.currentMaterial] = {};
       }
       model.materials[model.currentMaterial][tokens[0]] = tokens.slice(1);
-      if (tokens[0] === 'map_Kd') {
+      if (model.autoLoadMaterials && tokens[0] === 'map_Kd') {
         const image = new Image();
         image.onload = () => setTimeout(imageReady, 0);
         image.src = [model.baseURL, tokens[1]].join('/');
@@ -165,6 +165,7 @@ const DEFAULT_VALUES = {
   requestCount: 0,
   materials: {},
   interpolateTextures: true,
+  autoLoadMaterials: true,
   // baseURL: null,
   // dataAccessHelper: null,
   // url: null,
@@ -182,6 +183,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'dataAccessHelper',
     'interpolateTextures',
     'splitGroup',
+    'autoLoadMaterials',
   ]);
   macro.event(publicAPI, model, 'busy');
 


### PR DESCRIPTION
…oad materials files

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
