### PR TITLE
refactor(splinewidget, splinecontextrepresentation): update represent…

### DIFF
--- a/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/example/index.js
@@ -81,9 +81,9 @@ const boundaryCondition = document.querySelector('.boundaryCondition');
 const onBoundaryCondition = () => {
   const isDefault = boundaryCondition.selectedIndex === 0;
   boundaryConditionValueXInput.disabled =
-    widgetRepresentation.getClose() || isDefault;
+    widget.getWidgetState().getSplineClosed() || isDefault;
   boundaryConditionValueYInput.disabled =
-    widgetRepresentation.getClose() || isDefault;
+    widget.getWidgetState().getSplineClosed() || isDefault;
   widget
     .getWidgetState()
     .setSplineBoundaryCondition(boundaryCondition.selectedIndex);
@@ -99,8 +99,7 @@ const onClosedChange = () => {
     isClosed.checked || boundaryCondition.selectedIndex === 0;
   boundaryConditionValueYInput.disabled =
     isClosed.checked || boundaryCondition.selectedIndex === 0;
-  widget.getWidgetState().setSplineClose(isClosed.checked);
-  widgetRepresentation.setClose(isClosed.checked);
+  widget.getWidgetState().setSplineClosed(isClosed.checked);
   renderWindow.render();
 };
 isClosed.addEventListener('click', onClosedChange);

--- a/Sources/Widgets/Widgets3D/SplineWidget/state.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/state.js
@@ -8,7 +8,7 @@ export default function generateState() {
   return vtkStateBuilder
     .createBuilder()
     .addField({ name: 'splineKind', initialValue: splineKind.KOCHANEK_SPLINE })
-    .addField({ name: 'splineClose', initialValue: true })
+    .addField({ name: 'splineClosed', initialValue: true })
     .addField({
       name: 'splineBoundaryCondition',
       initialValue: BoundaryCondition.DEFAULT,


### PR DESCRIPTION
In the spline example, update representation on widget state changes instead of directly in the example.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
Remove the setting on the representation from the example. Updating that property in the `requestData` function according to the state instead.
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: 24.10.0
  - **OS**: Windows 10
  - **Browser**: ex: Chrome 101.0.4951.54

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
