### PR TITLE
Fix TS definitions in LookupTable

### DIFF
--- a/Sources/Common/Core/LookupTable/index.d.ts
+++ b/Sources/Common/Core/LookupTable/index.d.ts
@@ -22,12 +22,12 @@ export interface vtkLookupTable extends vtkScalarsToColors {
 	/**
 	 * 
 	 */
-	getAboveRangeColor(): Range;
+	getAboveRangeColor(): RGBAColor;
 
 	/**
 	 * 
 	 */
-	getAboveRangeColorByReference(): Range;
+	getAboveRangeColorByReference(): RGBAColor;
 
 	/**
 	 * 
@@ -153,13 +153,13 @@ export interface vtkLookupTable extends vtkScalarsToColors {
 	 * 
 	 * @param aboveRangeColor 
 	 */
-	setAboveRangeColor(aboveRangeColor: Range): boolean;
+	setAboveRangeColor(aboveRangeColor: RGBAColor): boolean;
 
 	/**
 	 * 
 	 * @param aboveRangeColor 
 	 */
-	setAboveRangeColorFrom(aboveRangeColor: Range): boolean;
+	setAboveRangeColorFrom(aboveRangeColor: RGBAColor): boolean;
 
 	/**
 	 * 
@@ -177,13 +177,13 @@ export interface vtkLookupTable extends vtkScalarsToColors {
 	 * 
 	 * @param belowRangeColor 
 	 */
-	setBelowRangeColor(belowRangeColor: Range): boolean;
+	setBelowRangeColor(belowRangeColor: RGBAColor): boolean;
 
 	/**
 	 * 
 	 * @param belowRangeColor 
 	 */
-	setBelowRangeColorFrom(belowRangeColor: Range): boolean;
+	setBelowRangeColorFrom(belowRangeColor: RGBAColor): boolean;
 
 	/**
 	 * 


### PR DESCRIPTION
Fixes #2413

### Context
Some methods arguments (and return types) are typed `Range` when they should be `RGBAColor`

### Results
The TS compiler is happier.

### Changes
Updated a few TS definitions in methods I use.

### PR and Code Checklist
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests
- [ ] Tested environment: the typescript compiler that the vue-cli boilerplate sets up.
