### PR TITLE
fix(Widgets3D): Allow to place widgets on touchscreen

### DIFF
--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -41,18 +41,25 @@ export default function widgetBehavior(publicAPI, model) {
 
     picker.initializePickList();
     picker.setPickList(publicAPI.getNestedProps());
-
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
       model.activeState === model.widgetState.getMoveHandle() &&
-      model.widgetState.getHandleList().length < MAX_POINTS
+      model.widgetState.getHandleList().length < MAX_POINTS &&
+      manipulator
     ) {
+      const worldCoords = manipulator.handleEvent(
+        e,
+        model._apiSpecificRenderWindow
+      );
       // Commit handle to location
       const moveHandle = model.widgetState.getMoveHandle();
+      moveHandle.setOrigin(...worldCoords);
       const newHandle = model.widgetState.addHandle();
       newHandle.setOrigin(...moveHandle.getOrigin());
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
-      newHandle.setManipulator(model.manipulator);
+      newHandle.setManipulator(manipulator);
     } else {
       isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -34,18 +34,25 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       return macro.VOID;
     }
-
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
       model.activeState === model.widgetState.getMoveHandle() &&
-      model.widgetState.getHandleList().length < MAX_POINTS
+      model.widgetState.getHandleList().length < MAX_POINTS &&
+      manipulator
     ) {
+      const worldCoords = manipulator.handleEvent(
+        e,
+        model._apiSpecificRenderWindow
+      );
       // Commit handle to location
       const moveHandle = model.widgetState.getMoveHandle();
+      moveHandle.setOrigin(...worldCoords);
       const newHandle = model.widgetState.addHandle();
       newHandle.setOrigin(...moveHandle.getOrigin());
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
-      newHandle.setManipulator(model.manipulator);
+      newHandle.setManipulator(manipulator);
     } else {
       isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');

--- a/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
@@ -49,9 +49,19 @@ export default function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
 
-    if (model.activeState === model.widgetState.getMoveHandle()) {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
+    if (
+      model.activeState === model.widgetState.getMoveHandle() &&
+      manipulator
+    ) {
+      const worldCoords = manipulator.handleEvent(
+        e,
+        model._apiSpecificRenderWindow
+      );
       // Commit handle to location
       const moveHandle = model.widgetState.getMoveHandle();
+      moveHandle.setOrigin(worldCoords);
       model.widgetState.getText().setOrigin(moveHandle.getOrigin());
       publicAPI.loseFocus();
     } else {

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -83,16 +83,19 @@ export default function widgetBehavior(publicAPI, model) {
     ) {
       return macro.VOID;
     }
-
-    if (model.activeState === model.widgetState.getMoveHandle()) {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
+    if (
+      model.activeState === model.widgetState.getMoveHandle() &&
+      manipulator
+    ) {
       updateMoveHandle(e);
-      // Commit handle to location
       const moveHandle = model.widgetState.getMoveHandle();
       const newHandle = model.widgetState.addHandle();
-      newHandle.setOrigin(...moveHandle.getOrigin());
+      newHandle.setOrigin(moveHandle.getOrigin());
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
-      newHandle.setManipulator(model.manipulator);
+      newHandle.setManipulator(manipulator);
     } else {
       isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -509,19 +509,28 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleLeftButtonPress = (e) => {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
       !model.activeState ||
       !model.activeState.getActive() ||
-      !model.pickable
+      !model.pickable ||
+      !manipulator
     ) {
       return macro.VOID;
     }
 
     if (model.hasFocus) {
+      const worldCoords = manipulator.handleEvent(
+        e,
+        model._apiSpecificRenderWindow
+      );
       if (!model.point1) {
+        model.point1Handle.setOrigin(worldCoords);
         publicAPI.placePoint1(model.point1Handle.getOrigin());
         publicAPI.invokeStartInteractionEvent();
       } else {
+        model.point2Handle.setOrigin(worldCoords);
         publicAPI.placePoint2(model.point2Handle.getOrigin());
         publicAPI.invokeInteractionEvent();
         publicAPI.invokeEndInteractionEvent();


### PR DESCRIPTION
### Context
Some widgets with a handle links to mouse move don't work with a touchscreen.

### Changes
As the mousemove is not correctly used in touchscreen for widget, we'll have to get the mouse position when user touches instead of getting the move handle position which is set to null.

### PR and Code Checklist
- [x ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x ] Run `npm run reformat` to have correctly formatted code

### Testing
- [ x] Tests passed
