### PR TITLE
feat(StateBuilder): Allow to set initial values on mixins creation

### DIFF
--- a/Sources/Widgets/Core/StateBuilder/index.js
+++ b/Sources/Widgets/Core/StateBuilder/index.js
@@ -81,8 +81,11 @@ class Builder {
     const listName = `${name}List`;
     this.model[listName] = [];
     // Create new Instance method
-    this.publicAPI[`add${macro.capitalize(name)}`] = () => {
-      const instance = newInstance(mixins, initialValues);
+    this.publicAPI[`add${macro.capitalize(name)}`] = (values) => {
+      const instance = newInstance(mixins, {
+        ...initialValues,
+        ...values,
+      });
       this.publicAPI.bindState(instance, labels);
       this.model[listName].push(instance);
       this.publicAPI.modified();


### PR DESCRIPTION
### Context
When adding a new handle on a widget for example, this is not possible to set properties on the constructor as in other vtk classes.

### Results
Here is the improvement for the `AngleWidget` (for example):
Before:
```
const widgetState = this.widget.getWidgetState();
const newHandle = widgetState.addHandle();
newHandle.setColor(moveHandle.getColor());
newHandle.setScale1(moveHandle.getScale1());
newHandle.setOrigin(pointList[i]);
```
After:
```
const widgetState = this.widget.getWidgetState();
const newHandle = widgetState.addHandle({
  color: moveHandle.getColor(),
  scale1: moveHandle.getScale1(),
  origin: pointList[i]
});

```

### PR and Code Checklist
- [X ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code
