### PR TITLE
fix(arrowhandlerepresentation): fix crash in ArrowHandleRepresentation

### DIFF
--- a/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/ArrowHandleRepresentation/index.js
@@ -314,13 +314,13 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
   };
 
   publicAPI.requestData = (inData, outData) => {
-    const shape = publicAPI.getRepresentationStates(inData[0])[0].getShape();
+    const shape = publicAPI.getRepresentationStates(inData[0])[0]?.getShape();
     let shouldCreateGlyph = model.glyph == null;
     if (model.shape !== shape && Object.values(ShapeType).includes(shape)) {
       model.shape = shape;
       shouldCreateGlyph = true;
     }
-    if (shouldCreateGlyph) {
+    if (shouldCreateGlyph && model.shape) {
       model.glyph = createGlyph(model.shape);
       model.mapper.setInputConnection(model.glyph.getOutputPort(), 1);
     }
@@ -332,11 +332,11 @@ function vtkArrowHandleRepresentation(publicAPI, model) {
     ctxVisible = true,
     handleVisible = true
   ) => {
-    const state = publicAPI.getRepresentationStates()[0];
+    const hasValidState = publicAPI.getRepresentationStates().length > 0;
     superClass.updateActorVisibility(
       renderingType,
       ctxVisible,
-      handleVisible && state.isVisible()
+      handleVisible && hasValidState
     );
   };
 }


### PR DESCRIPTION
With #2381, getRepresentationStates() can be an empty array, hence a crash when getShape() is called
on a non-existant first element.

fix #2416

### Context
LineWidget example was crashing

### Results
LineWidget is no longer crashing

### Changes
Support when getRepresentationStates() returns an empty array (no origin and visible sub states)

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
