### PR TITLE
fix(InteractorStyleManipulator): dolly in renderer

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -59,13 +59,16 @@ function dollyToPosition(fact, position, renderer, rwi) {
 
   if (cam.getParallelProjection()) {
     // Zoom relatively to the cursor
-    const aSize = rwi.getView().getViewportSize(renderer);
+    const view = rwi.getView();
+    const aSize = view.getViewportSize(renderer);
+    const viewport = renderer.getViewport();
+    const viewSize = view.getSize();
     const w = aSize[0];
     const h = aSize[1];
     const x0 = w / 2;
     const y0 = h / 2;
-    const x1 = position.x;
-    const y1 = position.y;
+    const x1 = position.x - viewport[0] * viewSize[0];
+    const y1 = position.y - viewport[1] * viewSize[1];
     translateCamera(renderer, rwi, x0, y0, x1, y1);
     cam.setParallelScale(cam.getParallelScale() / fact);
     translateCamera(renderer, rwi, x1, y1, x0, y0);

--- a/Sources/Interaction/Style/InteractorStyleManipulator/test/testDollyToPosition.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/test/testDollyToPosition.js
@@ -1,0 +1,103 @@
+import test from 'tape-catch';
+import { vec3 } from 'gl-matrix';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
+import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/InteractorStyleManipulator';
+
+function setup(t) {
+  // set up environment
+  const gc = testUtils.createGarbageCollector(t);
+  const container = document.querySelector('body');
+  const renderWindowContainer = gc.registerDOMElement(
+    document.createElement('div')
+  );
+  container.appendChild(renderWindowContainer);
+
+  const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+  const renderer = gc.registerResource(vtkRenderer.newInstance());
+  renderWindow.addRenderer(renderer);
+
+  const view = gc.registerResource(renderWindow.newAPISpecificView());
+  view.setContainer(renderWindowContainer);
+  renderWindow.addView(view);
+  view.setSize(400, 400);
+
+  const interactor = gc.registerResource(
+    vtkRenderWindowInteractor.newInstance()
+  );
+  interactor.setView(view);
+  interactor.initialize();
+  interactor.bindEvents(renderWindowContainer);
+
+  const style = vtkInteractorStyleManipulator.newInstance();
+  interactor.setInteractorStyle(style);
+
+  return { gc, renderWindow, renderer, view, interactor, style };
+}
+
+test.onlyIfWebGL('Test dollyToPosition with 2D renderers', (t) => {
+  const { gc, renderer, renderWindow, interactor } = setup(t);
+  const camera = renderer.getActiveCamera();
+  camera.setParallelProjection(true);
+  let baseline = [];
+
+  function resetCamera() {
+    camera.setPosition(0, 0, 0);
+    camera.setDirectionOfProjection(0, 0, 1);
+    camera.setViewUp(0, 1, 0);
+    camera.setFocalPoint(0, 0, 2);
+    renderer.resetCamera([0, 1, 0, 1, 0, 1]);
+  }
+
+  resetCamera();
+  renderWindow.render();
+
+  baseline = camera.getPosition();
+  vtkInteractorStyleManipulator.dollyToPosition(
+    1,
+    { x: 10, y: 20 },
+    renderer,
+    interactor
+  );
+  t.deepEquals(
+    camera.getPosition(),
+    baseline,
+    'Factor=1 does not change position'
+  );
+
+  resetCamera();
+  renderer.setViewport(0, 0, 0.5, 0.5);
+  renderWindow.render();
+
+  vtkInteractorStyleManipulator.dollyToPosition(
+    0.5,
+    { x: 10, y: 10 },
+    renderer,
+    interactor
+  );
+  baseline = camera.getPosition();
+
+  resetCamera();
+  renderer.setViewport(0.5, 0, 1, 0.5);
+  renderWindow.render();
+
+  vtkInteractorStyleManipulator.dollyToPosition(
+    0.5,
+    // adjust mouse position to be in the same spot on the renderer
+    // as before.
+    { x: 210, y: 10 },
+    renderer,
+    interactor
+  );
+
+  t.ok(
+    vec3.equals(camera.getPosition(), baseline),
+    'Factor=0.5, right positioned renderer'
+  );
+
+  gc.releaseResources();
+});


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Dollying in a 2D renderer that doesn't fill the render window requires adjusting the 2D click position relative to where the renderer is. This fixes also fixes the ZoomToMouse functionality on arbitrarily placed 2D renderers.

FYI @WillCMcC 

### Results
- dollyToPosition on 2D renderers works when renderers have non-default viewports

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Fixes dollyToPosition

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
