### PR TITLE
fix(ImageCroppingWidget): avoid state reuse

### DIFF
--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/state.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/state.js
@@ -5,71 +5,73 @@ import {
   handleTypeFromName,
 } from 'vtk.js/Sources/Widgets/Widgets3D/ImageCroppingWidget/helpers';
 
-// create our state builder
-const builder = vtkStateBuilder.createBuilder();
+export default function build() {
+  // create our state builder
+  const builder = vtkStateBuilder.createBuilder();
 
-// add image data description fields
-builder
-  .addField({
-    name: 'indexToWorldT',
-    initialValue: Array(16).fill(0),
-  })
-  .addField({
-    name: 'worldToIndexT',
-    initialValue: Array(16).fill(0),
+  // add image data description fields
+  builder
+    .addField({
+      name: 'indexToWorldT',
+      initialValue: Array(16).fill(0),
+    })
+    .addField({
+      name: 'worldToIndexT',
+      initialValue: Array(16).fill(0),
+    });
+
+  // make cropping planes a sub-state so we can listen to it
+  // separately from the rest of the widget state.
+  const croppingState = vtkStateBuilder
+    .createBuilder()
+    .addField({
+      name: 'planes',
+      // index space
+      initialValue: [0, 1, 0, 1, 0, 1],
+    })
+    .build();
+
+  // add cropping planes state to our primary state
+  builder.addStateFromInstance({
+    labels: ['croppingPlanes'],
+    name: 'croppingPlanes',
+    instance: croppingState,
   });
 
-// make cropping planes a sub-state so we can listen to it
-// separately from the rest of the widget state.
-const croppingState = vtkStateBuilder
-  .createBuilder()
-  .addField({
-    name: 'planes',
-    // index space
-    initialValue: [0, 1, 0, 1, 0, 1],
-  })
-  .build();
+  // add all handle states
+  // default bounds is [-1, 1] in all dimensions
+  for (let i = -1; i < 2; i++) {
+    for (let j = -1; j < 2; j++) {
+      for (let k = -1; k < 2; k++) {
+        // skip center of box
+        if (i !== 0 || j !== 0 || k !== 0) {
+          const name = AXES[i + 1] + AXES[j + 1] + AXES[k + 1];
+          const type = handleTypeFromName(name);
 
-// add cropping planes state to our primary state
-builder.addStateFromInstance({
-  labels: ['croppingPlanes'],
-  name: 'croppingPlanes',
-  instance: croppingState,
-});
-
-// add all handle states
-// default bounds is [-1, 1] in all dimensions
-for (let i = -1; i < 2; i++) {
-  for (let j = -1; j < 2; j++) {
-    for (let k = -1; k < 2; k++) {
-      // skip center of box
-      if (i !== 0 || j !== 0 || k !== 0) {
-        const name = AXES[i + 1] + AXES[j + 1] + AXES[k + 1];
-        const type = handleTypeFromName(name);
-
-        // since handle states are rendered via vtkSphereHandleRepresentation,
-        // we can dictate the handle origin, size (scale1), color, and visibility.
-        builder.addStateFromMixin({
-          labels: ['handles', name, type],
-          mixins: [
-            'name',
-            'origin',
-            'color',
-            'scale1',
-            'visible',
-            'manipulator',
-          ],
-          name,
-          initialValues: {
-            scale1: 10,
-            origin: [i, j, k],
-            visible: true,
+          // since handle states are rendered via vtkSphereHandleRepresentation,
+          // we can dictate the handle origin, size (scale1), color, and visibility.
+          builder.addStateFromMixin({
+            labels: ['handles', name, type],
+            mixins: [
+              'name',
+              'origin',
+              'color',
+              'scale1',
+              'visible',
+              'manipulator',
+            ],
             name,
-          },
-        });
+            initialValues: {
+              scale1: 10,
+              origin: [i, j, k],
+              visible: true,
+              name,
+            },
+          });
+        }
       }
     }
   }
-}
 
-export default () => builder.build();
+  return builder.build();
+}


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
- https://discourse.vtk.org/t/deleted-widgets-callback-is-executed/8391
- ImageCroppingWidget state was being reused between factories

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- new states should be entirely isolated from each other

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Fixes image cropping widget state

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
