### PR TITLE
docs(breakingchanges): add breaking changes documentation

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,6 +1,6 @@
 ## From 23.x to 24
 
-All old-style widgets except OrientationMarkerWidget and PiecewiseGaussianWidget have been removed.
+- All old-style widgets except OrientationMarkerWidget and PiecewiseGaussianWidget have been removed.
 
 | **Old-style/deprecated widget**   | **New-style widget**            |
 |-----------------------------------|---------------------------------|
@@ -15,6 +15,16 @@ All old-style widgets except OrientationMarkerWidget and PiecewiseGaussianWidget
 | ResliceCursor                     | ResliceCursorWidget             |
 
 - In SVGLandmarkRepresentation: `model.showCircle` is replaced by `model.circleProps.visible`
+- In vtk.js subclasses, prefix with '_' the following "protected" model variables:
+  - vtk*: model.openglRenderWindow -> model._openglRenderWindow
+  - vtk*: model.openglRenderer -> model._openglRenderer
+  - vtkInteractorObserver, vtkOrientationMarkerWidget : model.interactor -> model._interactor
+  - vtkAbstractWidget, vtkViewNode: model.parent -> model._parent
+  - vtkProp: model.parentProp -> model._parentProp
+  - vtkRenderWindowInteractor: model.view -> model._view
+  - vtkRenderer: model.renderWindow -> model._renderWindow
+  - vtkHardwareSelector: model.renderer -> model._renderer
+  - vtkAbstractWidget: model.widgetManager -> model._widgetManager
 
 ## From 22.x to 23
 


### PR DESCRIPTION
between 23 and 24

### Context
Not all breaking changes between 23 and 24 were documented

### Results
Give hints to switch to v24 

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->
