### PR TITLE
docs(ts): fix typescript definitions

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/Constants.d.ts
+++ b/Sources/Rendering/Core/ColorTransferFunction/Constants.d.ts
@@ -1,0 +1,17 @@
+export declare enum ColorSpace {
+  RGB = 0,
+  HSV = 1,
+  LAB = 2,
+  DIVERGING = 3,
+}
+
+export declare enum Scale {
+  LINEAR = 0,
+  LOG10 = 1,
+}
+
+declare const _default: {
+	ColorSpace: typeof ColorSpace;
+	Scale: typeof Scale;
+};
+export default _default;

--- a/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
@@ -1,16 +1,6 @@
 import { vtkObject } from '../../../interfaces';
+import { ColorSpace, Scale } from "./Constants";
 
-export enum ColorSpace {
-  RGB,
-  HSV,
-  LAB,
-  DIVERGING,
-}
-
-export enum Scale {
-  LINEAR,
-  LOG10,
-}
 
 /* TODO: use VtkScalarsToColors instead of VtkObject */
 export interface vtkColorTransferFunction extends vtkObject {
@@ -358,5 +348,7 @@ export function newInstance(initialValues?: object): vtkColorTransferFunction;
 export declare const vtkColorTransferFunction: {
   newInstance: typeof newInstance;
   extend: typeof extend;
+  ColorSpace: typeof ColorSpace;
+  Scale: typeof Scale;
 };
 export default vtkColorTransferFunction;

--- a/Sources/Rendering/Core/Coordinate/Constants.d.ts
+++ b/Sources/Rendering/Core/Coordinate/Constants.d.ts
@@ -1,0 +1,14 @@
+export declare enum Coordinate {
+  DISPLAY = 0,
+  NORMALIZED_DISPLAY = 1,
+  VIEWPORT = 2,
+  NORMALIZED_VIEWPORT = 3,
+  PROJECTION = 4,
+  VIEW = 5,
+  WORLD = 6,
+}
+
+declare const _default: {
+	Coordinate: typeof Coordinate;
+};
+export default _default;

--- a/Sources/Rendering/Core/Coordinate/index.d.ts
+++ b/Sources/Rendering/Core/Coordinate/index.d.ts
@@ -1,15 +1,7 @@
 import { vtkObject, vtkProperty } from "../../../interfaces";
 import vtkRenderer from '../Renderer';
+import { Coordinate } from "./Constants";
 
-export enum Coordinate {
-	DISPLAY,
-	NORMALIZED_DISPLAY,
-	VIEWPORT,
-	NORMALIZED_VIEWPORT,
-	PROJECTION,
-	VIEW,
-	WORLD,
-}
 
 /**
  *
@@ -73,7 +65,7 @@ export interface vtkCoordinate extends vtkObject {
 	 * options are Display, Normalized Display, Viewport, Normalized Viewport,
 	 * View, and World.
 	 */
-	getCoordinateSystem(): number;
+	getCoordinateSystem(): Coordinate;
 
 	/**
 	 * Get the coordinate system which this coordinate is defined in as string.
@@ -251,7 +243,8 @@ export function newInstance(initialValues?: ICoordinateInitialValues): vtkCoordi
  * @see [vtkActor](./Rendering_Core_Actor.html)2D
  */
 export declare const vtkCoordinate: {
-	newInstance: typeof newInstance,
-	extend: typeof extend,
+	newInstance: typeof newInstance;
+	extend: typeof extend;
+	Coordinate: typeof Coordinate;
 };
 export default vtkCoordinate;

--- a/Sources/Rendering/Core/Glyph3DMapper/Constants.d.ts
+++ b/Sources/Rendering/Core/Glyph3DMapper/Constants.d.ts
@@ -1,0 +1,17 @@
+export declare enum OrientationModes {
+	DIRECTION = 0,
+	ROTATION = 1,
+	MATRIX = 2,
+}
+
+export declare enum ScaleModes {
+	SCALE_BY_CONSTANT = 0,
+	SCALE_BY_MAGNITUDE = 1,
+	SCALE_BY_COMPONENTS = 2,
+}
+
+declare const _default: {
+	OrientationModes: typeof OrientationModes;
+	ScaleModes: typeof ScaleModes;
+};
+export default _default;

--- a/Sources/Rendering/Core/Glyph3DMapper/index.d.ts
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.d.ts
@@ -1,17 +1,7 @@
 import { Bounds } from "../../../types";
 import vtkMapper, { IMapperInitialValues } from "../Mapper";
+import { OrientationModes, ScaleModes } from "./Constants";
 
-export enum OrientationModes {
-	DIRECTION,
-	ROTATION,
-	MATRIX,
-}
-
-export enum ScaleModes {
-	SCALE_BY_CONSTANT,
-	SCALE_BY_MAGNITUDE,
-	SCALE_BY_COMPONENTS,
-}
 
 interface IPrimitiveCount {
 	points: number;
@@ -168,5 +158,7 @@ export function newInstance(initialValues?: IGlyph3DMapperInitialValues): vtkGly
 export declare const vtkGlyph3DMapper: {
 	newInstance: typeof newInstance;
 	extend: typeof extend;
+	OrientationModes: typeof OrientationModes;
+	ScaleModes: typeof ScaleModes;
 }
 export default vtkGlyph3DMapper;

--- a/Sources/Rendering/Core/ImageMapper/Constants.d.ts
+++ b/Sources/Rendering/Core/ImageMapper/Constants.d.ts
@@ -1,0 +1,14 @@
+export declare enum SlicingMode {
+	NONE = -1,
+	I = 0,
+	J = 1,
+	K = 2,
+	X = 3,
+	Y = 4,
+	Z = 5,
+}
+
+declare const _default: {
+	SlicingMode: typeof SlicingMode;
+};
+export default _default;

--- a/Sources/Rendering/Core/ImageMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageMapper/index.d.ts
@@ -1,16 +1,8 @@
 import vtkCamera from "../Camera";
 import vtkAbstractMapper, { IAbstractMapperInitialValues } from "../AbstractMapper";
 import { Bounds, Vector3 } from "../../../types";
+import { SlicingMode } from "./Constants";
 
-export enum SlicingMode {
-	NONE,
-	I,
-	J,
-	K,
-	X,
-	Y,
-	Z,
-}
 
 interface IClosestIJKAxis {
 	ijkMode: SlicingMode,
@@ -325,5 +317,6 @@ export function newInstance(initialValues?: IImageMapperInitialValues): vtkImage
 export declare const vtkImageMapper: {
 	newInstance: typeof newInstance;
 	extend: typeof extend;
+	SlicingMode: typeof SlicingMode;
 }
 export default vtkImageMapper;

--- a/Sources/Rendering/Core/ImageProperty/Constants.d.ts
+++ b/Sources/Rendering/Core/ImageProperty/Constants.d.ts
@@ -1,0 +1,9 @@
+export declare enum InterpolationType {
+	NEAREST = 0,
+	LINEAR = 1,
+}
+
+declare const _default: {
+	InterpolationType: typeof InterpolationType;
+};
+export default _default;

--- a/Sources/Rendering/Core/ImageProperty/index.d.ts
+++ b/Sources/Rendering/Core/ImageProperty/index.d.ts
@@ -1,17 +1,14 @@
 import { vtkObject } from "../../../interfaces";
 import vtkColorTransferFunction from "../ColorTransferFunction";
-
-export enum InterpolationType {
-	NEAREST,
-	LINEAR,
-}
+import vtkPiecewiseFunction from "../../../Common/DataModel/PiecewiseFunction";
+import { InterpolationType } from "./Constants";
 
 interface IComponentData {
 	piecewiseFunction: number;
 	componentWeight: number;
 }
 
-export interface IImageMapperInitialValues {
+export interface IImagePropertyInitialValues {
 	independentComponents?: boolean;
 	interpolationType?: InterpolationType;
 	colorWindow?: number;
@@ -20,13 +17,13 @@ export interface IImageMapperInitialValues {
 	diffuse?: number;
 	opacity?: number;
 	componentData?: IComponentData[];
-        useLookupTableScalarRange?: boolean;
+	useLookupTableScalarRange?: boolean;
 }
 
 export interface vtkImageProperty extends vtkObject {
 
 	/**
-     * Get the lighting coefficient.
+	 * Get the lighting coefficient.
 	 * @default 1.0
 	 */
 	getAmbient(): number;
@@ -50,7 +47,7 @@ export interface vtkImageProperty extends vtkObject {
 	getComponentWeight(index: number): number;
 
 	/**
-     * Get the diffuse lighting coefficient.
+	 * Get the diffuse lighting coefficient.
 	 * @default 1.0
 	 */
 	getDiffuse(): number;
@@ -72,7 +69,7 @@ export interface vtkImageProperty extends vtkObject {
 	getInterpolationTypeAsString(): string;
 
 	/**
-     * Get the opacity of the object.
+	 * Get the opacity of the object.
 	 * @default 1.0
 	 */
 	getOpacity(): number;
@@ -81,25 +78,25 @@ export interface vtkImageProperty extends vtkObject {
 	 * Get the component weighting function.
 	 * @param {Number} [idx]
 	 */
-	getPiecewiseFunction(idx?: number): any;
+	getPiecewiseFunction(idx?: number): vtkPiecewiseFunction;
 
 	/**
 	 * Get the currently set RGB transfer function.
 	 * @param {Number} [idx]
 	 */
-	getRGBTransferFunction(idx?: number): any;
+	getRGBTransferFunction(idx?: number): vtkColorTransferFunction;
 
 	/**
 	 * Alias to get the piecewise function (backwards compatibility)
 	 * @param {Number} [idx]
 	 */
-	getScalarOpacity(idx: number): number;
+	getScalarOpacity(idx?: number): vtkPiecewiseFunction;
 
-    /**
+	/**
 	 * Set the ambient lighting coefficient.
-     * @param {Number} ambient The ambient lighting coefficient.
-     */
-    setAmbient(ambient: number): boolean;
+	 * @param {Number} ambient The ambient lighting coefficient.
+	 */
+	setAmbient(ambient: number): boolean;
 
 	/**
 	 * Set the level value for window/level.
@@ -120,11 +117,11 @@ export interface vtkImageProperty extends vtkObject {
 	 */
 	setComponentWeight(index: number, value: number): boolean;
 
-    /**
-     * Set the diffuse lighting coefficient.
-     * @param {Number} diffuse  The diffuse lighting coefficient.
-     */
-    setDiffuse(diffuse: number): boolean;
+	/**
+	 * Set the diffuse lighting coefficient.
+	 * @param {Number} diffuse  The diffuse lighting coefficient.
+	 */
+	setDiffuse(diffuse: number): boolean;
 
 	/**
 	 * 
@@ -149,7 +146,7 @@ export interface vtkImageProperty extends vtkObject {
 	setInterpolationTypeToNearest(): boolean;
 
 	/**
-     * Set the opacity of the object
+	 * Set the opacity of the object
 	 * @param {Number} opacity The opacity value.
 	 */
 	setOpacity(opacity: number): boolean;
@@ -157,9 +154,9 @@ export interface vtkImageProperty extends vtkObject {
 	/**
 	 * Set the piecewise function
 	 * @param {Number} index 
-	 * @param func 
+	 * @param {vtkPiecewiseFunction} func 
 	 */
-	setPiecewiseFunction(index: number, func: any): boolean;
+	setPiecewiseFunction(index: number, func: vtkPiecewiseFunction): boolean;
 
 	/**
 	 * Set the color of a volume to an RGB transfer function
@@ -171,14 +168,14 @@ export interface vtkImageProperty extends vtkObject {
 	/**
 	 * Alias to set the piecewise function
 	 * @param {Number} index 
-	 * @param func 
+	 * @param {vtkPiecewiseFunction} func 
 	 */
-	setScalarOpacity(index: any, func: any): boolean;
+	setScalarOpacity(index: number, func: vtkPiecewiseFunction): boolean;
 
 	/**
 	 * Use the range that is set on the lookup table, instead of setting the range from the
-         * ColorWindow/ColorLevel settings
-         * @default false
+		 * ColorWindow/ColorLevel settings
+		 * @default false
 	 * @param {Boolean} useLookupTableScalarRange
 	 */
 	setUseLookupTableScalarRange(useLookupTableScalarRange: boolean): boolean;
@@ -189,15 +186,15 @@ export interface vtkImageProperty extends vtkObject {
  *
  * @param publicAPI object on which methods will be bounds (public)
  * @param model object on which data structure will be bounds (protected)
- * @param {IImageMapperInitialValues} [initialValues] (default: {})
+ * @param {IImagePropertyInitialValues} [initialValues] (default: {})
  */
-export function extend(publicAPI: object, model: object, initialValues?: IImageMapperInitialValues): void;
+export function extend(publicAPI: object, model: object, initialValues?: IImagePropertyInitialValues): void;
 
 /**
  * Method use to create a new instance of vtkImageProperty
- * @param {IImageMapperInitialValues} [initialValues] for pre-setting some of its content
+ * @param {IImagePropertyInitialValues} [initialValues] for pre-setting some of its content
  */
-export function newInstance(initialValues?: IImageMapperInitialValues): vtkImageProperty;
+export function newInstance(initialValues?: IImagePropertyInitialValues): vtkImageProperty;
 
 /**
  * vtkImageProperty provides 2D image display support for vtk.

--- a/Sources/Rendering/Core/Property2D/Constants.d.ts
+++ b/Sources/Rendering/Core/Property2D/Constants.d.ts
@@ -1,0 +1,9 @@
+export declare enum DisplayLocation {
+  BACKGROUND = 0,
+  FOREGROUND = 1,
+}
+
+declare const _default: {
+	DisplayLocation: typeof DisplayLocation;
+};
+export default _default;

--- a/Sources/Rendering/Core/Property2D/index.d.ts
+++ b/Sources/Rendering/Core/Property2D/index.d.ts
@@ -1,12 +1,13 @@
 import { vtkObject } from "../../../interfaces";
 import { RGBColor } from "../../../types";
+import { DisplayLocation } from "./Constants";
 
 interface IProperty2DInitialValues{
 	color?: RGBColor;
 	opacity?: number;
 	pointSize?: number;
 	lineWidth?: number;
-	displayLocation?: string;
+	displayLocation?: DisplayLocation;
 }
 
 export interface vtkProperty2D extends vtkObject {
@@ -25,7 +26,7 @@ export interface vtkProperty2D extends vtkObject {
 	 * Get the display location of the object.
 	 * @default 'Foreground'
 	 */
-	getDisplayLocation(): string;
+	getDisplayLocation(): DisplayLocation;
 
 	/**
 	 * Get the width of a Line. 
@@ -84,7 +85,7 @@ export interface vtkProperty2D extends vtkObject {
 	 * Set the display location of the object.
 	 * @param {String} displayLocation
 	 */
-	setDisplayLocation(displayLocation: string): boolean;
+	setDisplayLocation(displayLocation: DisplayLocation): boolean;
 
 	/**
 	 * Set the width of a Line. The width is expressed in screen units.
@@ -138,7 +139,7 @@ export function newInstance(initialValues?: IProperty2DInitialValues): vtkProper
  * like backface properties can be set and manipulated with this object.
  */
 export declare const vtkProperty2D: {
-	newInstance: typeof newInstance,
-	extend: typeof extend,
+	newInstance: typeof newInstance;
+	extend: typeof extend;
 };
 export default vtkProperty2D;

--- a/Sources/Rendering/Core/ScalarBarActor/index.d.ts
+++ b/Sources/Rendering/Core/ScalarBarActor/index.d.ts
@@ -27,22 +27,22 @@ export interface IStyle {
  *
  */
 export interface IScalarBarActorInitialValues extends IActorInitialValues {
-  automated?: boolean,
-  autoLayout?: (publicAPI: object, model: object) => void,
-  axisLabel?: string,
-  barPosition?: Vector2,
-  barSize?: Size,
-  boxPosition?: Vector2,
-  boxSize?: Size,
-  scalarToColors?: null,
-  axisTitlePixelOffset?: number,
-  axisTextStyle?: IStyle,
-  tickLabelPixelOffset?: number,
-  tickTextStyle?: IStyle,
-  generateTicks?: (helper: any) => void,
-  drawBelowRangeSwatch?: boolean,
-  drawAboveRangeSwatch?: boolean,
-  drawNanAnnotation?: boolean,
+	automated?: boolean,
+	autoLayout?: (publicAPI: object, model: object) => void,
+	axisLabel?: string,
+	barPosition?: Vector2,
+	barSize?: Size,
+	boxPosition?: Vector2,
+	boxSize?: Size,
+	scalarToColors?: null,
+	axisTitlePixelOffset?: number,
+	axisTextStyle?: IStyle,
+	tickLabelPixelOffset?: number,
+	tickTextStyle?: IStyle,
+	generateTicks?: (helper: any) => void,
+	drawBelowRangeSwatch?: boolean,
+	drawAboveRangeSwatch?: boolean,
+	drawNanAnnotation?: boolean,
 }
 
 export interface vtkScalarBarActor extends vtkActor {
@@ -88,10 +88,11 @@ export interface vtkScalarBarActor extends vtkActor {
 	 */
 	getAutoLayout(): any;
 
-  /**
-   * 
-   */
-  getGenerateTicks(): any;
+	/**
+	 * 
+	 */
+	getGenerateTicks(): any;
+
 	/**
 	 * 
 	 */
@@ -121,7 +122,6 @@ export interface vtkScalarBarActor extends vtkActor {
 	 * 
 	 */
 	getBoxPositionByReference(): Vector2;
-
 
 	/**
 	 * 
@@ -180,23 +180,24 @@ export interface vtkScalarBarActor extends vtkActor {
 	 */
 	setAutoLayout(autoLayout: any): boolean;
 
-  /**
-   * Sets the function used to generate legend ticks. 
-   * 
-   * This function takes a vtkScalarBarActorHelper and returns true on success. 
-   * To have the desired effect, the function must call: `helper.setTicks(ticks: num[])` and `helper.setTickStrings(tickStrings: string[])`.
-   * 
-   * After setting the generateTicks function you must regenerate the vtkScalarBarActor for your changes to take effect. 
-   * One way to do that is:
-   * ```
-   *  const mapper = scalarBarActor.getMapper()
-   *  if (mapper) {
-   *    mapper.getLookupTable().resetAnnotations()
-   *  }
-   * ```
-   * @param {(helper: any) => void} generateTicks 
-   */
-  setGenerateTicks(generateTicks: (helper: any) => void): boolean;
+	/**
+	 * Sets the function used to generate legend ticks. 
+	 * 
+	 * This function takes a vtkScalarBarActorHelper and returns true on success. 
+	 * To have the desired effect, the function must call: `helper.setTicks(ticks: num[])` and `helper.setTickStrings(tickStrings: string[])`.
+	 * 
+	 * After setting the generateTicks function you must regenerate the vtkScalarBarActor for your changes to take effect. 
+	 * One way to do that is:
+	 * ```
+	 *  const mapper = scalarBarActor.getMapper()
+	 *  if (mapper) {
+	 *    mapper.getLookupTable().resetAnnotations()
+	 *  }
+	 * ```
+	 * @param generateTicks 
+	 */
+	setGenerateTicks(generateTicks: (helper: any) => void): boolean;
+
 	/**
 	 * 
 	 * @param {Boolean} automated 
@@ -279,7 +280,7 @@ export interface vtkScalarBarActor extends vtkActor {
 	 * Set whether the NaN annotation should be rendered or not.
 	 * @param {Boolean} drawNanAnnotation
 	 */
-	 setDrawNanAnnotation(drawNanAnnotation: boolean): boolean;
+	setDrawNanAnnotation(drawNanAnnotation: boolean): boolean;
 
 	/**
 	 * Set whether the Below range swatch should be rendered or not
@@ -360,7 +361,7 @@ export function newInstance(initialValues?: IScalarBarActorInitialValues): vtkSc
  * (i.e., in the renderer's viewport) on top of the 3D graphics window.
  */
 export declare const vtkScalarBarActor: {
-	newInstance: typeof newInstance,
-	extend: typeof extend,
+	newInstance: typeof newInstance;
+	extend: typeof extend;
 };
 export default vtkScalarBarActor;

--- a/Sources/Rendering/Core/VolumeProperty/Constants.d.ts
+++ b/Sources/Rendering/Core/VolumeProperty/Constants.d.ts
@@ -1,0 +1,16 @@
+export declare enum InterpolationType {
+	NEAREST = 0,
+	LINEAR = 1,
+	FAST_LINEAR = 2
+}
+
+export declare enum OpacityMode {
+	FRACTIONAL = 0,
+	PROPORTIONAL = 1,
+}
+
+declare const _default: {
+	InterpolationType: typeof InterpolationType;
+	OpacityMode: typeof OpacityMode;
+};
+export default _default;


### PR DESCRIPTION
fix #2423

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
