### PR TITLE
fix(scalarbaractor): check for renderable mtime when deciding if we should update the actor

### DIFF
--- a/Sources/Rendering/Core/ScalarBarActor/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/index.js
@@ -221,8 +221,11 @@ function vtkScalarBarActorHelper(publicAPI, model) {
     // did something significant change? If so rebuild a lot of things
     if (
       model.forceUpdate ||
-      Math.max(scalarsToColors.getMTime(), publicAPI.getMTime()) >
-        model.lastRebuildTime.getMTime()
+      Math.max(
+        scalarsToColors.getMTime(),
+        publicAPI.getMTime(),
+        model.renderable.getMTime()
+      ) > model.lastRebuildTime.getMTime()
     ) {
       const range = scalarsToColors.getMappingRange();
       model.lastTickBounds = [...range];


### PR DESCRIPTION
### Context
Say you have a `scalarBarActor` instance and you want to sometimes update its styling; doing something like that:
```js
const newOverlayColor = "green";
scalarBarActor.setAxisTextStyle({ fontColor: newOverlayColor });
scalarBarActor.setTickTextStyle({ fontColor: newOverlayColor });
renderWindow.render();
```
Currently this code does not work.

### Results
This PR makes it so any changes done using the `vtkScalarBarActor` public API triggers a redraw of the actor.

### Changes
Check for the renderable modified time.
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: v19.4.0
  - **OS**: Archlinux
  - **Browser**: Firefox 100.0 (64-bit)
