### PR TITLE
fix(cellpicker): skip cells that have the VTK_EMPTY_CELL type

### DIFF
--- a/Sources/Rendering/Core/CellPicker/index.js
+++ b/Sources/Rendering/Core/CellPicker/index.js
@@ -285,14 +285,20 @@ function vtkCellPicker(publicAPI, model) {
 
       const numberOfCells = data.getNumberOfCells();
 
+      /* eslint-disable no-continue */
       for (let cellId = 0; cellId < numberOfCells; cellId++) {
         const pCoords = [0, 0, 0];
 
         minCellType = data.getCellType(cellId);
+
+        // Skip cells that are marked as empty
+        if (minCellType === CellType.VTK_EMPTY_CELL) {
+          continue;
+        }
+
         const cell = tempCellMap[minCellType];
 
         if (cell == null) {
-          // eslint-disable-next-line no-continue
           continue;
         }
 
@@ -344,6 +350,7 @@ function vtkCellPicker(publicAPI, model) {
           }
         }
       }
+      /* eslint-enable no-continue */
     }
 
     if (minCellId >= 0 && tMin < model.globalTMin) {


### PR DESCRIPTION
### Context
Currently there is a `vtkCellTypes.deleteCell(cellId)` public method which set the type of the cell with the given `cellIId` to `VTK_EMPTY_CELL`.
I think the expected behavior from calling such a method is that the cell is simply ignored in most logic within VTK.js, picking included.

### Results
```
const someCellIdIWantToDelete = 5234;
polyData.buildCells();
const cellTypes = polyData.getCells();
cellTypes.deleteCell(someCellIdIWantToDelete)
```
Doing this kind of things and then trying to pick at the position of the cell will ignore the said cell.
### Changes
Add a condition to skip empty cells in vtkCellPicker
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: v19.4.0
  - **OS**: linux
  - **Browser**: firefox 100.0 (64-bit)
