### PR TITLE
feat(polydatacellnormals): compute cell normals

### DIFF
--- a/Sources/Filters/Core/PolyDataNormals/example/index.js
+++ b/Sources/Filters/Core/PolyDataNormals/example/index.js
@@ -1,0 +1,94 @@
+import 'vtk.js/Sources/favicon';
+
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import 'vtk.js/Sources/Rendering/Profiles/Geometry';
+
+import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkLineSource from 'vtk.js/Sources/Filters/Sources/LineSource';
+import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+
+import vtkPolyDataNormals from 'vtk.js/Sources/Filters/Core/PolyDataNormals';
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance();
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+
+const computeNormals = vtkPolyDataNormals.newInstance();
+
+const sphere = vtkSphereSource.newInstance({
+  thetaResolution: 4,
+  phiResolution: 4,
+});
+const polydata = sphere.getOutputData();
+
+const mapper = vtkMapper.newInstance();
+const actor = vtkActor.newInstance();
+
+actor.setMapper(mapper);
+mapper.setInputData(polydata);
+
+renderer.addActor(actor);
+
+computeNormals.setInputData(polydata);
+computeNormals.setComputeCellNormals(true);
+computeNormals.update();
+
+const cellNormals = computeNormals.getOutputData().getCellData().getNormals();
+
+const pointsData = polydata.getPoints().getData();
+const polysData = polydata.getPolys().getData();
+
+let numberOfPoints = 0;
+const cellPointIds = [0, 0, 0];
+let normalId = 0;
+
+for (let c = 0; c < polysData.length; c += numberOfPoints + 1) {
+  numberOfPoints = polysData[c];
+
+  if (numberOfPoints < 3) {
+        continue; // eslint-disable-line
+  }
+
+  for (let i = 1; i <= 3; ++i) {
+    cellPointIds[i - 1] = 3 * polysData[c + i];
+  }
+
+  const v1 = pointsData.slice(cellPointIds[0], cellPointIds[0] + 3);
+  const v2 = pointsData.slice(cellPointIds[1], cellPointIds[1] + 3);
+  const v3 = pointsData.slice(cellPointIds[2], cellPointIds[2] + 3);
+
+  const center = [
+    (v1[0] + v2[0] + v3[0]) / 3,
+    (v1[1] + v2[1] + v3[1]) / 3,
+    (v1[2] + v2[2] + v3[2]) / 3,
+  ];
+
+  const line = vtkLineSource.newInstance({
+    point1: center,
+    point2: [
+      center[0] + cellNormals[normalId++],
+      center[1] + cellNormals[normalId++],
+      center[2] + cellNormals[normalId++],
+    ],
+  });
+
+  const lineMapper = vtkMapper.newInstance();
+  const lineActor = vtkActor.newInstance();
+
+  lineActor.setMapper(lineMapper);
+  lineMapper.setInputData(line.getOutputData());
+  renderer.addActor(lineActor);
+}
+
+// Display the resulting STL
+renderer.resetCamera();
+renderWindow.render();
+
+global.renderer = renderer;
+global.renderWindow = renderWindow;


### PR DESCRIPTION
### Context
closes #2434

Gives the option through `setComputeCellNormals` to compute the cell normals for polyData using the `vtkPolyDataNormals` filter.

### Results


### Changes
- Added option to include cell normals. These can be accessed through `polyData.getCellData().getNormals().getData()`
- STATIC method on the `vtkPolyDataNormals` filter to compute the cell normals
- Created an example for the vtkNormals which for now visualizes the cell normals.
<img width="724" alt="image" src="https://user-images.githubusercontent.com/91061248/170271908-0979dee7-9d0b-4407-b359-d543da5010bf.png">

- [ ] Documentation and TypeScript definitions were updated to match those changes
-> Question related to this: can you autogenerate TS-def files? Or should these be created manually?

### PR and Code Checklist
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### TODO
1)
I was thinking it might make sense to either change the `publicAPI.vtkPolyDataNormalsExecute` to accept only one parameter, which would be `vtkPolyData`.

Or to merge `publicAPI.vtkPolyDataNormalsExecute` and `publicAPI.vtkPolyDataCellNormalsExecute` into one method, as there is quite some duplication in both?

I don't know what would be preferred.

2)
Update the example to switch between cell and vertex normals