### PR TITLE
fix(WebGL): fix warning on empty gl.clear call

### DIFF
--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -68,8 +68,9 @@ function vtkOpenGLRenderer(publicAPI, model) {
       gl.viewport(ts.lowerLeftU, ts.lowerLeftV, ts.usize, ts.vsize);
 
       gl.colorMask(true, true, true, true);
-      gl.clear(clearMask);
-
+      if (clearMask) {
+        gl.clear(clearMask);
+      }
       gl.enable(gl.DEPTH_TEST);
     }
   };
@@ -156,7 +157,9 @@ function vtkOpenGLRenderer(publicAPI, model) {
     gl.scissor(ts.lowerLeftU, ts.lowerLeftV, ts.usize, ts.vsize);
     gl.viewport(ts.lowerLeftU, ts.lowerLeftV, ts.usize, ts.vsize);
 
-    gl.clear(clearMask);
+    if (clearMask) {
+      gl.clear(clearMask);
+    }
 
     gl.enable(gl.DEPTH_TEST);
     /* eslint-enable no-bitwise */


### PR DESCRIPTION
It was possible for some code paths to end up calling
gl.clear() with no buffers to be cleared which produced a
warning. Add a conditional to catch those two cases.

