### PR TITLE
revert(testobbtree): delete obbtree box test

### DIFF
--- a/Sources/Filters/General/OBBTree/test/testOBBTree.js
+++ b/Sources/Filters/General/OBBTree/test/testOBBTree.js
@@ -1,6 +1,5 @@
 import test from 'tape-catch';
 
-import vtkArrowSource from 'vtk.js/Sources/Filters/Sources/ArrowSource';
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkOBBTree from 'vtk.js/Sources/Filters/General/OBBTree';
@@ -8,7 +7,7 @@ import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkTriangleFilter from 'vtk.js/Sources/Filters/General/TriangleFilter';
 
-const epsilon = 0.1;
+const epsilon = 0.0001;
 
 function getAllCorners(startCorner, min, mid, max) {
   const start2min = vtkMath.add(startCorner, min, []);
@@ -34,45 +33,6 @@ function getAllCorners(startCorner, min, mid, max) {
 function hasMatchingPoint(point, points, eps) {
   return !!points.find((pt) => vtkMath.areEquals(point, pt, eps));
 }
-
-test('Test OBB tree constructor', (t) => {
-  const source = vtkArrowSource.newInstance();
-  source.update();
-  const mesh = source.getOutputData();
-
-  const obbTree = vtkOBBTree.newInstance();
-  obbTree.setDataset(mesh);
-  obbTree.setMaxLevel(2);
-  obbTree.buildLocator();
-
-  const corner = [0, 0, 0];
-  const max = [0, 0, 0];
-  const mid = [0, 0, 0];
-  const min = [0, 0, 0];
-  const size = [0, 0, 0];
-
-  const expectedSize = [0.0658262, 0.00126738, 0.00126738];
-  const expectedCorners = [
-    [-0.32499999999999996, -0.13660254037844385, -1.522196077276375e-17],
-    [-0.32499999999999996, 0, -0.13660254037844385],
-    [-0.32499999999999996, 2.04473419971054e-17, 0.13660254037844388],
-    [-0.32499999999999996, 0.13660254037844388, 6.804476607412299e-17],
-    [0.675, -0.13660254037844388, -2.7755575615628914e-17],
-    [0.675, -2.7755575615628914e-17, -0.13660254037844385],
-    [0.675, 0, 0.13660254037844388],
-    [0.675, 0.13660254037844385, 5.551115123125783e-17],
-  ];
-
-  obbTree.computeOBBFromDataset(mesh, corner, max, mid, min, size);
-  const allCorners = getAllCorners(corner, min, mid, max);
-
-  allCorners.forEach((actual, index) => {
-    t.ok(hasMatchingPoint(actual, expectedCorners, epsilon), `Corner ${index}`);
-  });
-  t.ok(vtkMath.areEquals(size, expectedSize, epsilon), 'size');
-
-  t.end();
-});
 
 test('Test OBB tree transform', (t) => {
   const source = vtkCubeSource.newInstance();


### PR DESCRIPTION
As explained [here](https://github.com/Kitware/vtk-js/pull/2339#issuecomment-1143758856), testing the bounding box on itself is not relevant since several bounding boxes could be computed while still being correct.

### Changes
First test on OBBTree have been removed. Epsilon have been put back to 0.0001 to have more precise tests for the other tests.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - Chromium: 99.0.4844.88 for Ubuntu 18.04
  - Chromium: 100.0.4852.0 for Windows 10
  - Firefox: 98.0.2 (64-bit) for Windows 10 
  - Firefox: 91.0 (64-bit) on Ubuntu 18.04
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
