### PR TITLE
fix(RenderWindowInteractor): trigger mousemove

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -384,17 +384,17 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     if (pointerCache.has(event.pointerId)) {
       const pointer = pointerCache.get(event.pointerId);
       pointer.position = getScreenEventPositionFor(event);
+    }
 
-      switch (event.pointerType) {
-        case 'pen':
-        case 'touch':
-          publicAPI.handleTouchMove(event);
-          break;
-        case 'mouse':
-        default:
-          publicAPI.handleMouseMove(event);
-          break;
-      }
+    switch (event.pointerType) {
+      case 'pen':
+      case 'touch':
+        publicAPI.handleTouchMove(event);
+        break;
+      case 'mouse':
+      default:
+        publicAPI.handleMouseMove(event);
+        break;
     }
   };
 
@@ -728,7 +728,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       }
       // handle the gesture
       publicAPI.recognizeGesture('TouchStart', positions);
-    } else {
+    } else if (pointers.length === 1) {
       const callData = {
         ...getModifierKeysFor(EMPTY_MOUSE_EVENT),
         position: getScreenEventPositionFor(event),
@@ -743,7 +743,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     if (model.recognizeGestures && pointers.length > 1) {
       const positions = pointerCacheToPositions(pointerCache);
       publicAPI.recognizeGesture('TouchMove', positions);
-    } else {
+    } else if (pointers.length === 1) {
       const callData = {
         ...getModifierKeysFor(EMPTY_MOUSE_EVENT),
         position: pointers[0].position,
@@ -780,7 +780,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
         const positions = pointerCacheToPositions(pointerCache);
         publicAPI.recognizeGesture('TouchMove', positions);
       }
-    } else {
+    } else if (pointers.length === 1) {
       const callData = {
         ...getModifierKeysFor(EMPTY_MOUSE_EVENT),
         position: pointers[0].position,


### PR DESCRIPTION
Movement should be triggered regardless of if we've tracked the pointer.
For touch, events will only be triggered if there is at least one
tracked pointer.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Fixes #2450 
### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
- Fix RenderWindowInteractor

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Manually tested PolyLineWidget with a mouse. Touch with widgets is still a bit broken, but I should be able to fix that once I address #2435. 

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
