### PR TITLE
perf(vtktexture): speedup array data type conversion

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -610,11 +610,11 @@ function vtkOpenGLTexture(publicAPI, model) {
     ) {
       for (let idx = 0; idx < data.length; idx++) {
         if (data[idx]) {
-          const newArray = new Float32Array(pixCount);
-          for (let i = 0; i < pixCount; i++) {
-            newArray[i] = data[idx][i];
-          }
-          pixData.push(newArray);
+          const dataArrayToCopy =
+            data[idx].length > pixCount
+              ? data[idx].subarray(0, pixCount)
+              : data[idx];
+          pixData.push(new Float32Array(dataArrayToCopy));
         } else {
           pixData.push(null);
         }
@@ -629,11 +629,11 @@ function vtkOpenGLTexture(publicAPI, model) {
     ) {
       for (let idx = 0; idx < data.length; idx++) {
         if (data[idx]) {
-          const newArray = new Uint8Array(pixCount);
-          for (let i = 0; i < pixCount; i++) {
-            newArray[i] = data[idx][i];
-          }
-          pixData.push(newArray);
+          const dataArrayToCopy =
+            data[idx].length > pixCount
+              ? data[idx].subarray(0, pixCount)
+              : data[idx];
+          pixData.push(new Uint8Array(dataArrayToCopy));
         } else {
           pixData.push(null);
         }


### PR DESCRIPTION
### Context
I identified some potential performance hit in vtkTexture.

### Results
Should be faster to copy arrays.

### Changes
Rely on built-in copy function instead of a manual for loop

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <master
  - **OS**: Windows 10
  - **Browser**: Chrome
