### PR TITLE
fix(Shader): fix condition statement for shadingOff

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -316,7 +316,7 @@ void rotateToViewCoord(inout vec3 normalIDX){
 #endif
 //=======================================================================
 // compute the normal and gradient magnitude for a position, uses forward difference
-#if vtkLightComplexity > 0
+#if (vtkLightComplexity > 0) || (defined vtkGradientOpacityOn)
   #ifdef vtkComputeNormalFromOpacity
     #ifdef vtkGradientOpacityOn
       vec4 computeNormalForDensity(vec3 pos, float scalar, vec3 tstep, out mat3 scalarInterp, out vec3 secondaryGradientMag)


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Shader code does not compile when switching `ShadingOn` from `true` to `false`. This is a fix for MR [#2432](https://github.com/Kitware/vtk-js/pull/2432).

### Results
Test on all flags related to shading: shading; opacity gradient; density gradient; parallel projection; two sided lighting. No further bugs found.

### Changes
Added additional condition `#if defined vtkGradientOpacityOn` so normal is computed either when there's lighting or when gradient opacity is on.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [X] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Windows 10
  - **Browser**: Chrome 89.0.4389.128

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
