### PR TITLE
docs(RemoteView): improve sample viewStream creation

### DIFF
--- a/Sources/IO/Core/WSLinkClient/index.d.ts
+++ b/Sources/IO/Core/WSLinkClient/index.d.ts
@@ -1,4 +1,5 @@
 import { vtkObject, vtkSubscription } from '../../../interfaces';
+import vtkImageStream from '../ImageStream';
 
 /**
  * Bind optional dependency from WSLink to our current class.
@@ -134,7 +135,7 @@ export interface vtkWSLinkClient extends vtkObject {
   /**
    *
    */
-  getImageStream(): object;
+  getImageStream(): vtkImageStream;
 
   /**
    *

--- a/Sources/Rendering/Misc/RemoteView/index.d.ts
+++ b/Sources/Rendering/Misc/RemoteView/index.d.ts
@@ -11,6 +11,7 @@ interface IRemoteViewInitialValues {
   rpcMouseEvent?: string;
   rpcGestureEvent?: any;
   rpcWheelEvent?: any;
+  viewStream?: vtkViewStream;
 }
 
 export interface vtkRemoteView extends vtkObject {


### PR DESCRIPTION
Update sample to pass viewStream on vtkRemoteView creation,
rather than connecting it with the static connectImageStream,
allowing better lifecycle management.
Also update a couple of typescript definitions.