### PR TITLE
fix(WebGPU): update webgpu code to the latest chrome canary

### DIFF
--- a/Sources/Rendering/WebGPU/RenderWindow/index.js
+++ b/Sources/Rendering/WebGPU/RenderWindow/index.js
@@ -68,7 +68,7 @@ function vtkWebGPURenderWindow(publicAPI, model) {
   publicAPI.recreateSwapChain = () => {
     if (model.context) {
       model.context.unconfigure();
-      const presentationFormat = model.context.getPreferredFormat(
+      const presentationFormat = navigator.gpu.getPreferredCanvasFormat(
         model.adapter
       );
 
@@ -77,8 +77,10 @@ function vtkWebGPURenderWindow(publicAPI, model) {
       model.context.configure({
         device: model.device.getHandle(),
         format: presentationFormat,
+        alphaMode: 'premultiplied',
         usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST,
-        size: model.size,
+        width: model.size[0],
+        height: model.size[1],
       });
       model._configured = true;
     }


### PR DESCRIPTION
Fix the canvas creation call to use the new width, height,
alpha mode. Get the preferred format from the gpu now.

