### PR TITLE
fix: prevent unsafe model.previousPosition property access

### DIFF
--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
@@ -225,6 +225,10 @@ function vtkMouseRangeManipulator(publicAPI, model) {
     // get a `onMouseMove` call after the pointer has been unlocked.
     if (!interactor.isPointerLocked()) return;
 
+    // previousPosition could be undefined if for some reason the
+    // `startPointerLockEvent` method is called before the `onButtonDown` one.
+    if (model.previousPosition == null) return;
+
     model.previousPosition.x += event.movementX;
     model.previousPosition.y += event.movementY;
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Race conditions can lead to the `onButtonDown` method to be called after `onPointerLockMove`, this means that `previousPosition` will be set to `undefined` while `onPointerLockMove` tries to access its `x` and `y` properties.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

### Funding
This contribution is funded by [Sirona Medical](https://sironamedical.com).

