### PR TITLE
feat(volume shadow): add volume shadow support for all lighting conditions

### DIFF
--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -77,14 +77,18 @@ function vtkVolumeMapper(publicAPI, model) {
     model.globalIlluminationReach = vtkMath.clampValue(gl, 0.0, 1.0);
     publicAPI.modified();
   };
+
   publicAPI.setVolumetricScatteringBlending = (vsb) => {
     model.volumetricScatteringBlending = vtkMath.clampValue(vsb, 0.0, 1.0);
+
     publicAPI.modified();
   };
+
   publicAPI.setVlumeShadowSamplingDistFactor = (vsdf) => {
     model.volumeShadowSamplingDistFactor = vsdf >= 1.0 ? vsdf : 1.0;
     publicAPI.modified();
   };
+
   publicAPI.setAnisotropy = (at) => {
     model.anisotropy = vtkMath.clampValue(at, -0.99, 0.99);
     publicAPI.modified();
@@ -107,11 +111,11 @@ const DEFAULT_VALUES = {
   filterMode: FilterMode.OFF, // ignored by WebGL so no behavior change
   preferSizeOverAccuracy: false, // Whether to use halfFloat representation of float, when it is inaccurate
   computeNormalFromOpacity: false,
-  //volume shadow parameters
+  // volume shadow parameters
   globalIlluminationReach: 0.0,
   volumetricScatteringBlending: 0.0,
   volumeShadowSamplingDistFactor: 5.0,
-  anisotropy: 0.0,  
+  anisotropy: 0.0,
 };
 
 // ----------------------------------------------------------------------------
@@ -133,7 +137,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'globalIlluminationReach',
     'volumetricScatteringBlending',
     'volumeShadowSamplingDistFactor',
-    'anisotropy',    
+    'anisotropy',
   ]);
 
   macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -90,6 +90,11 @@ const DEFAULT_VALUES = {
   filterMode: FilterMode.OFF, // ignored by WebGL so no behavior change
   preferSizeOverAccuracy: false, // Whether to use halfFloat representation of float, when it is inaccurate
   computeNormalFromOpacity: false,
+  //volume shadow parameters
+  globalIlluminationReach: 0.0,
+  volumetricScatteringBlending: 0.0,
+  volumeShadowSamplingDistFactor: 5.0,
+  anisotropy: 0.0,  
 };
 
 // ----------------------------------------------------------------------------
@@ -108,6 +113,10 @@ export function extend(publicAPI, model, initialValues = {}) {
     'filterMode',
     'preferSizeOverAccuracy',
     'computeNormalFromOpacity',
+    'globalIlluminationReach',
+    'volumetricScatteringBlending',
+    'volumeShadowSamplingDistFactor',
+    'anisotropy',    
   ]);
 
   macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -72,6 +72,23 @@ function vtkVolumeMapper(publicAPI, model) {
   publicAPI.setFilterModeToRaw = () => {
     publicAPI.setFilterMode(FilterMode.RAW);
   };
+
+  publicAPI.setGlobalIlluminationReach = (gl) => {
+    model.globalIlluminationReach = vtkMath.clampValue(gl, 0.0, 1.0);
+    publicAPI.modified();
+  };
+  publicAPI.setVolumetricScatteringBlending = (vsb) => {
+    model.volumetricScatteringBlending = vtkMath.clampValue(vsb, 0.0, 1.0);
+    publicAPI.modified();
+  };
+  publicAPI.setVlumeShadowSamplingDistFactor = (vsdf) => {
+    model.volumeShadowSamplingDistFactor = vsdf >= 1.0 ? vsdf : 1.0;
+    publicAPI.modified();
+  };
+  publicAPI.setAnisotropy = (at) => {
+    model.anisotropy = vtkMath.clampValue(at, -0.99, 0.99);
+    publicAPI.modified();
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -200,6 +200,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           `#define VolumeShadowOn`
         ).result;
       }  
+      if (model.renderable.getVolumetricScatteringBlending() < 1.0){
+        FSSource = vtkShaderProgram.substitute(
+          FSSource,
+          '//VTK::SurfaceShadowOn',
+          `#define SurfaceShadowOn`
+        ).result;
+      }        
     }
 
     // if using gradient opacity define that

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -192,21 +192,21 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     ).result;
 
     // set shadow blending flag
-    if (model.lastLightComplexity > 0){
-      if (model.renderable.getVolumetricScatteringBlending() > 0.0){
+    if (model.lastLightComplexity > 0) {
+      if (model.renderable.getVolumetricScatteringBlending() > 0.0) {
         FSSource = vtkShaderProgram.substitute(
           FSSource,
           '//VTK::VolumeShadowOn',
           `#define VolumeShadowOn`
         ).result;
-      }  
-      if (model.renderable.getVolumetricScatteringBlending() < 1.0){
+      }
+      if (model.renderable.getVolumetricScatteringBlending() < 1.0) {
         FSSource = vtkShaderProgram.substitute(
           FSSource,
           '//VTK::SurfaceShadowOn',
           `#define SurfaceShadowOn`
         ).result;
-      }        
+      }
     }
 
     // if using gradient opacity define that
@@ -309,7 +309,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       ).result;
     }
 
-    if (model.renderable.getVolumetricScatteringBlending() > 0.0){
+    if (model.renderable.getVolumetricScatteringBlending() > 0.0) {
       FSSource = vtkShaderProgram.substitute(
         FSSource,
         '//VTK::VolumeShadow::Dec',
@@ -322,7 +322,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         ],
         false
       ).result;
-    }    
+    }
 
     shaders.Fragment = FSSource;
   };
@@ -864,13 +864,25 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       program.setUniformfv('lightExponent', lightExponent);
       program.setUniformiv('lightPositional', lightPositional);
     }
-    if (model.renderable.getVolumetricScatteringBlending() > 0.0){
-      program.setUniformf('giReach', Math.min(Math.max(model.renderable.getGlobalIlluminationReach(),0.0),1.0));
-      program.setUniformf('volumetricScatteringBlending', model.renderable.getVolumetricScatteringBlending());
-      program.setUniformf('volumeShadowSamplingDistFactor', model.renderable.getVolumeShadowSamplingDistFactor());
+    if (model.renderable.getVolumetricScatteringBlending() > 0.0) {
+      program.setUniformf(
+        'giReach',
+        model.renderable.getGlobalIlluminationReach()
+      );
+      program.setUniformf(
+        'volumetricScatteringBlending',
+        model.renderable.getVolumetricScatteringBlending()
+      );
+      program.setUniformf(
+        'volumeShadowSamplingDistFactor',
+        model.renderable.getVolumeShadowSamplingDistFactor()
+      );
       program.setUniformf('anisotropy', model.renderable.getAnisotropy());
-      program.setUniformf('anisotropy2', model.renderable.getAnisotropy()**2.0);
-    }    
+      program.setUniformf(
+        'anisotropy2',
+        model.renderable.getAnisotropy() ** 2.0
+      );
+    }
   };
 
   publicAPI.setPropertyShaderParameters = (cellBO, ren, actor) => {

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -191,6 +191,17 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       `#define vtkLightComplexity ${model.lastLightComplexity}`
     ).result;
 
+    // set shadow blending flag
+    if (model.lastLightComplexity > 0){
+      if (model.renderable.getVolumetricScatteringBlending() > 0.0){
+        FSSource = vtkShaderProgram.substitute(
+          FSSource,
+          '//VTK::VolumeShadowOn',
+          `#define VolumeShadowOn`
+        ).result;
+      }  
+    }
+
     // if using gradient opacity define that
     model.gopacity = actor.getProperty().getUseGradientOpacity(0);
     for (let nc = 1; iComps && !model.gopacity && nc < numComp; ++nc) {
@@ -290,6 +301,22 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         false
       ).result;
     }
+
+    if (model.renderable.getVolumetricScatteringBlending() > 0.0){
+      FSSource = vtkShaderProgram.substitute(
+        FSSource,
+        '//VTK::VolumeShadow::Dec',
+        [
+          `uniform float volumetricScatteringBlending;`,
+          `uniform float giReach;`,
+          `uniform float volumeShadowSamplingDistFactor;`,
+          `uniform float anisotropy;`,
+          `uniform float anisotropy2;`,
+        ],
+        false
+      ).result;
+    }    
+
     shaders.Fragment = FSSource;
   };
 
@@ -738,26 +765,26 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       // specify the planes in view coordinates
       program.setUniform3f(`vPlaneNormal${i}`, normal[0], normal[1], normal[2]);
       program.setUniformf(`vPlaneDistance${i}`, dist);
+    }
 
-      if (actor.getProperty().getUseLabelOutline()) {
-        const image = model.currentInput;
-        const worldToIndex = image.getWorldToIndex();
+    if (actor.getProperty().getUseLabelOutline()) {
+      const image = model.currentInput;
+      const worldToIndex = image.getWorldToIndex();
 
-        program.setUniformMatrix('vWCtoIDX', worldToIndex);
+      program.setUniformMatrix('vWCtoIDX', worldToIndex);
 
-        // Get the projection coordinate to world coordinate transformation matrix.
-        mat4.invert(model.projectionToWorld, keyMats.wcpc);
-        program.setUniformMatrix('PCWCMatrix', model.projectionToWorld);
+      // Get the projection coordinate to world coordinate transformation matrix.
+      mat4.invert(model.projectionToWorld, keyMats.wcpc);
+      program.setUniformMatrix('PCWCMatrix', model.projectionToWorld);
 
-        const size = publicAPI.getRenderTargetSize();
+      const size = publicAPI.getRenderTargetSize();
 
-        program.setUniformf('vpWidth', size[0]);
-        program.setUniformf('vpHeight', size[1]);
+      program.setUniformf('vpWidth', size[0]);
+      program.setUniformf('vpHeight', size[1]);
 
-        const offset = publicAPI.getRenderTargetOffset();
-        program.setUniformf('vpOffsetX', offset[0] / size[0]);
-        program.setUniformf('vpOffsetY', offset[1] / size[1]);
-      }
+      const offset = publicAPI.getRenderTargetOffset();
+      program.setUniformf('vpOffsetX', offset[0] / size[0]);
+      program.setUniformf('vpOffsetY', offset[1] / size[1]);
     }
 
     mat4.invert(model.projectionToView, keyMats.vcpc);
@@ -830,6 +857,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       program.setUniformfv('lightExponent', lightExponent);
       program.setUniformiv('lightPositional', lightPositional);
     }
+    if (model.renderable.getVolumetricScatteringBlending() > 0.0){
+      program.setUniformf('giReach', Math.min(Math.max(model.renderable.getGlobalIlluminationReach(),0.0),1.0));
+      program.setUniformf('volumetricScatteringBlending', model.renderable.getVolumetricScatteringBlending());
+      program.setUniformf('volumeShadowSamplingDistFactor', model.renderable.getVolumeShadowSamplingDistFactor());
+      program.setUniformf('anisotropy', model.renderable.getAnisotropy());
+      program.setUniformf('anisotropy2', model.renderable.getAnisotropy()**2.0);
+    }    
   };
 
   publicAPI.setPropertyShaderParameters = (cellBO, ren, actor) => {

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -927,29 +927,29 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
         #endif
       #endif
     #else
+      vec4 normalLight;
       #ifdef vtkComputeNormalFromOpacity
         #ifdef vtkGradientOpacityOn
           mat3 scalarInterp;  
           vec3 secondaryGradientMag;  
-          vec4 normalOpacity = vec4(0.0);  
           vec4 normal0 = computeNormalForDensity(posIS, tValue.a, tstep, scalarInterp, secondaryGradientMag);  
-          normalOpacity = computeDensityNormal(tValue.a, normal0.w, scalarInterp,secondaryGradientMag);       
-          if (length(normalOpacity) == 0.0){  
-            normalOpacity = normal0;   
+          normalLight = computeDensityNormal(tValue.a, normal0.w, scalarInterp,secondaryGradientMag);       
+          if (length(normalLight) == 0.0){  
+            normalLight = normal0;   
           }                      
         #else
           vec3 scalarInterp;  
           vec4 normal0 = computeNormalForDensity(posIS, tValue.a, tstep, scalarInterp);  
-          vec4 normalOpacity;          
           if (length(normal0)>0.0){  
-            normalOpacity = computeDensityNormal(tValue.a,scalarInterp);  
-            if (length(normalOpacity)==0.0){  
-              normalOpacity = normal0;  
+            normalLight = computeDensityNormal(tValue.a,scalarInterp);  
+            if (length(normalLight)==0.0){  
+              normalLight = normal0;  
             }  
           }                
         #endif
       #else 
-        vec4 normal0 = computeNormal(posIS, tValue.a, tstep);                
+        vec4 normal0 = computeNormal(posIS, tValue.a, tstep);  
+        normalLight = normal0;             
       #endif
     #endif
   #endif
@@ -1053,18 +1053,9 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
   #if vtkLightComplexity > 0
     #if !defined(vtkComponent0Proportional) && defined(SurfaceShadowOn)
         #if vtkLightComplexity < 3
-          #ifdef vtkComputeNormalFromOpacity
-            applyLightingDirectional(tColor.rgb, normalOpacity);
-          #else
-            applyLightingDirectional(tColor.rgb, normal0);
-          #endif
+            applyLightingDirectional(tColor.rgb, normalLight);
         #else
-          #ifdef vtkComputeNormalFromOpacity
-            applyLightingPositional(tColor.rgb, normalOpacity, IStoVC(posIS));        
-          #else
-            applyLightingPositional(tColor.rgb, normal0, IStoVC(posIS));        
-          #endif
-        #endif
+            applyLightingPositional(tColor.rgb, normalLight, IStoVC(posIS));  
     #endif
 
     #ifdef VolumeShadowOn

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -984,6 +984,9 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
   #if vtkNumComponents == 1
     vec4 tColor = texture2D(ctexture, vec2(tValue.r * cscale0 + cshift0, 0.5));
     tColor.a = goFactor.x*texture2D(otexture, vec2(tValue.r * oscale0 + oshift0, 0.5)).r;
+    if (tColor.a < EPSILON){
+      return vec4(0.0);
+    }    
   #endif
 
   #if defined(vtkIndependentComponentsOn) && vtkNumComponents >= 2
@@ -1056,6 +1059,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
             applyLightingDirectional(tColor.rgb, normalLight);
         #else
             applyLightingPositional(tColor.rgb, normalLight, IStoVC(posIS));  
+        #endif
     #endif
 
     #ifdef VolumeShadowOn
@@ -1186,7 +1190,9 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
       tValue = getTextureValue(posIS);
 
       // now map through opacity and color
-      tColor = getColorForValue(tValue, posIS, tstep);
+      if (texture2D(otexture, vec2(tValue.r * oscale0 + oshift0, 0.5)).r > EPSILON){
+        tColor = getColorForValue(tValue, posIS, tstep);
+      }
 
       float mix = (1.0 - color.a);
 

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -62,6 +62,9 @@ uniform float vSpecular;
 //VTK::Light::Dec
 #endif
 
+//VTK::VolumeShadowOn
+//VTK::VolumeShadow::Dec
+
 // define vtkComputeNormalFromOpacity
 //VTK::vtkComputeNormalFromOpacity
 
@@ -196,6 +199,11 @@ uniform vec4 ipScalarRangeMax;
 //=======================================================================
 // global and custom variables (a temporary section before photorealistics rendering module is complete)
 vec3 rayDirVC;
+float sampleDistanceISVS;
+
+#define SQRT3    1.7321
+#define INV4PI   0.0796
+#define EPSILON  0.001
 
 //=======================================================================
 // Webgl2 specific version of functions
@@ -293,6 +301,50 @@ vec4 getTextureValue(vec3 ijk)
 #endif
 
 //=======================================================================
+// transformation between VC and IS space
+
+// convert vector position from idx to vc
+#if vtkLightComplexity > 0
+vec3 IStoVC(vec3 posIS){
+  vec3 posVC = posIS / vVCToIJK;
+  return posVC.x * vPlaneNormal0 + 
+         posVC.y * vPlaneNormal2 + 
+         posVC.z * vPlaneNormal4 + 
+         vOriginVC;
+}
+
+// convert vector position from vc to idx
+vec3 VCtoIS(vec3 posVC){
+  posVC = posVC - vOriginVC;
+  posVC = vec3(
+    dot(posVC, vPlaneNormal0),
+    dot(posVC, vPlaneNormal2),
+    dot(posVC, vPlaneNormal4));  
+  return posVC * vVCToIJK;
+}
+#endif
+
+//Rotate vector to view coordinate
+#if (vtkLightComplexity > 0) || (defined vtkGradientOpacityOn)
+void rotateToViewCoord(inout vec3 dirIS){
+  dirIS.xyz =
+    dirIS.x * vPlaneNormal0 +
+    dirIS.y * vPlaneNormal2 +
+    dirIS.z * vPlaneNormal4;
+}
+
+//Rotate vector to idx coordinate
+vec3 rotateToIDX(vec3 dirVC){
+  vec3 dirIS;
+  dirIS.xyz = vec3(
+    dot(dirVC, vPlaneNormal0),
+    dot(dirVC, vPlaneNormal2),
+    dot(dirVC, vPlaneNormal4));  
+  return dirIS;
+}
+#endif
+
+//=======================================================================
 // Given a normal compute the gradient opacity factors
 float computeGradientOpacityFactor(
   float normalMag, float goscale, float goshift, float gomin, float gomax)
@@ -304,16 +356,6 @@ float computeGradientOpacityFactor(
 #endif
 }
 
-//=======================================================================
-//Rotate gradients to view coordinate
-#if (vtkLightComplexity > 0) || (defined vtkGradientOpacityOn)
-void rotateToViewCoord(inout vec3 normalIDX){
-  normalIDX.xyz =
-  normalIDX.x * vPlaneNormal0 +
-  normalIDX.y * vPlaneNormal2 +
-  normalIDX.z * vPlaneNormal4;
-}
-#endif
 //=======================================================================
 // compute the normal and gradient magnitude for a position, uses forward difference
 #if (vtkLightComplexity > 0) || (defined vtkGradientOpacityOn)
@@ -533,16 +575,170 @@ mat4 computeMat4Normal(vec3 pos, vec4 tValue, vec3 tstep)
 }
 
 //=======================================================================
-// surface light contribution
+// global shadow - secondary ray
+#ifdef VolumeShadowOn
 
-#if vtkLightComplexity == 3
-// convert vector position from idx to vc
-vec3 IStoVC(vec3 posIS){
-  vec3 posVC = posIS / vVCToIJK;
-  return posVC.x * vPlaneNormal0 + posVC.y * vPlaneNormal2 + posVC.z * vPlaneNormal4 + vOriginVC;
+// henyey greenstein phase function
+float phase_function(float cos_angle)
+{
+  // divide by 2.0 instead of 4pi to increase intensity
+  return ((1.0-anisotropy2)/pow(1.0+anisotropy2-2.0*anisotropy*cos_angle, 1.5))/2.0;
+}
+
+float random()
+{ 
+  float rand = fract(sin(dot(gl_FragCoord.xy,vec2(12.9898,78.233)))*43758.5453123);
+  float jitter=texture2D(jtexture,gl_FragCoord.xy/32.).r;
+  uint pcg_state = floatBitsToUint(jitter);
+  uint state = pcg_state;
+  pcg_state = pcg_state * uint(747796405) + uint(2891336453);
+  uint word = ((state >> ((state >> uint(28)) + uint(4))) ^ state) * uint(277803737);
+  return (float((((word >> uint(22)) ^ word) >> 1 ))/float(2147483647) + rand)/2.0;
+}
+
+// Computes the intersection between a ray and a box
+struct Hit
+{
+  float tmin;
+  float tmax;
+};
+
+struct Ray
+{
+  vec3 origin;
+  vec3 dir;
+  vec3 invDir;
+};
+
+bool BBoxIntersect(vec3 boundMin, vec3 boundMax, const Ray r, out Hit hit)
+{
+  vec3 tbot = r.invDir * (boundMin - r.origin);
+  vec3 ttop = r.invDir * (boundMax - r.origin);
+  vec3 tmin = min(ttop, tbot);
+  vec3 tmax = max(ttop, tbot);
+  vec2 t = max(tmin.xx, tmin.yz);
+  float t0 = max(t.x, t.y);
+  t = min(tmax.xx, tmax.yz);
+  float t1 = min(t.x, t.y);
+  hit.tmin = t0;
+  hit.tmax = t1;
+  return t1 > max(t0,0.0);
+}
+
+// As BBoxIntersect requires the inverse of the ray coords,
+// this function is used to avoid numerical issues
+void safe_0_vector(inout Ray ray)
+{
+  if(abs(ray.dir.x) < EPSILON) ray.dir.x = sign(ray.dir.x) * EPSILON;
+  if(abs(ray.dir.y) < EPSILON) ray.dir.y = sign(ray.dir.y) * EPSILON;
+  if(abs(ray.dir.z) < EPSILON) ray.dir.z = sign(ray.dir.z) * EPSILON;
+}
+
+float volume_shadow(vec3 posIS, vec3 lightDirNormIS)
+{
+  float shadow = 1.0;
+  float opacity = 0.0;
+
+  // modify sample distance with a random number between 0.8 and 1.0
+  float sampleDistanceISVS_jitter = sampleDistanceISVS * mix(0.8, 1.0, random());
+  float opacityPrev = texture2D(otexture, vec2(getTextureValue(posIS).r * oscale0 + oshift0, 0.5)).r;
+  
+  // in case the first sample near surface has a very tiled light ray, we need to offset start position 
+  posIS += sampleDistanceISVS_jitter * lightDirNormIS;  
+
+  // compute the start and end points for the ray
+  Ray ray;
+  Hit hit;  
+  ray.origin = posIS;
+  ray.dir = lightDirNormIS;
+  safe_0_vector(ray);
+  ray.invDir = 1.0/ray.dir;
+  
+  if(!BBoxIntersect(vec3(0.0),vec3(1.0), ray, hit))
+  {
+    return 1.0;
+  }
+  vec4 scalar = vec4(0.0);
+  float maxdist = hit.tmax;
+  if(maxdist < EPSILON) {
+    return 1.0;
+  }
+
+  // interpolate shadow ray length between: 1 unit of sample distance in IS to SQRT3, based on globalIlluminationReach
+  float maxgi = mix(sampleDistanceISVS_jitter,SQRT3,giReach);
+  maxdist = min(maxdist,maxgi);
+
+  // support gradient opacity
+  #ifdef vtkGradientOpacityOn
+    vec4 normal;
+  #endif
+
+  vec3 current_step = sampleDistanceISVS_jitter * lightDirNormIS;
+  float maxSteps = ceil(maxdist/sampleDistanceISVS_jitter);
+  float opacityDelta = 0.0;
+
+  for (float i = 0.0; i < maxSteps; i++)
+  {
+    scalar = getTextureValue(posIS);
+    opacity = texture2D(otexture, vec2(scalar.r * oscale0 + oshift0, 0.5)).r;
+    #ifdef vtkGradientOpacityOn 
+      normal = computeNormal(posIS, scalar.a, vec3(1.0/vec3(volumeDimensions))); 
+      opacity *= computeGradientOpacityFactor(normal.w, goscale0, goshift0, gomin0, gomax0);
+    #endif    
+    shadow *= 1.0 - opacity;
+
+    // optimization: early termination
+    if (shadow < EPSILON){
+      return 0.0;
+    }
+
+    // optimization: increase/decrease sample distance based on changed in opacity value
+    opacityDelta = opacityPrev - opacity;
+    opacityPrev = opacity;
+    if (opacityDelta > 0.0){
+      current_step *= 0.9;
+    } else if (opacityDelta < 0.0){
+      current_step *= 1.1;
+    }
+    posIS += current_step;
+  }
+
+  return shadow;  
+}
+
+vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
+{
+  vec3 vertLight = vec3(0.0);
+  vec3 secondary_contrib = vec3(0.0);
+  // here we assume only positional light, no effect of cones
+  for (int i = 0; i < lightNum; i++)
+  {
+    #if(vtkLightComplexity==3)
+      if (lightPositional[i] == 1){
+        vertLight = lightPositionVC[i] - IStoVC(posIS);
+      }else{
+        vertLight = - lightDirectionVC[i];
+      }
+    #else
+      vertLight = - lightDirectionVC[i];
+    #endif
+    // here we assume achromatic light, only intensity
+    float dDotL = dot(viewDirectionVC, normalize(vertLight));
+    // isotropic scatter returns 0.5 instead of 1/4pi to increase intensity
+    float phase_attenuation = 0.5;
+    if (abs(anisotropy) > 0.01){
+      phase_attenuation = phase_function(dDotL);
+    }
+    float vol_shadow = volume_shadow(posIS, normalize(rotateToIDX(vertLight)));
+    secondary_contrib += tColor * vDiffuse * lightColor[i] * vol_shadow * phase_attenuation;     
+    secondary_contrib += tColor * vAmbient;
+  } 
+  return secondary_contrib;
 }
 #endif
 
+//=======================================================================
+// surface light contribution
 #if vtkLightComplexity > 0
   void applyLighting(inout vec3 tColor, vec4 normal)
   {
@@ -869,6 +1065,18 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
           #endif
         #endif
     #endif
+
+    #ifdef VolumeShadowOn
+      vec3 secondary_contrib = applyShadowRay(tColor.rgb, posIS, rayDirVC);
+      float vol_coef;
+      if (volumetricScatteringBlending == 1.0 || volumetricScatteringBlending == 0.0){
+        vol_coef = volumetricScatteringBlending;
+      } else {
+        vol_coef = 1.0 - (pow(volumetricScatteringBlending,0.3) - 1.0)*(pow(volumetricScatteringBlending,0.3) - 1.0);
+      }
+      tColor.rgb = (1.0 - vol_coef) * tColor.rgb + vol_coef * secondary_contrib;
+    #endif
+
   #if defined(vtkIndependentComponentsOn) && vtkNumComponents >= 2
     #if !defined(vtkComponent1Proportional)
       applyLighting(tColor1, normal1);
@@ -1242,6 +1450,9 @@ void computeIndexSpaceValues(out vec3 pos, out vec3 endPos, out float sampleDist
 
   float delta2 = length(endPos - pos);
   sampleDistanceIS = sampleDistance*delta2/delta;
+  #ifdef VolumeShadowOn
+    sampleDistanceISVS = sampleDistanceIS * volumeShadowSamplingDistFactor;
+  #endif
 }
 
 void main()

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -1190,9 +1190,7 @@ void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
       tValue = getTextureValue(posIS);
 
       // now map through opacity and color
-      if (texture2D(otexture, vec2(tValue.r * oscale0 + oshift0, 0.5)).r > EPSILON){
-        tColor = getColorForValue(tValue, posIS, tstep);
-      }
+      tColor = getColorForValue(tValue, posIS, tstep);
 
       float mix = (1.0 - color.a);
 

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -63,6 +63,7 @@ uniform float vSpecular;
 #endif
 
 //VTK::VolumeShadowOn
+//VTK::SurfaceShadowOn
 //VTK::VolumeShadow::Dec
 
 // define vtkComputeNormalFromOpacity
@@ -753,7 +754,7 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
     }
     tColor.rgb = tColor.rgb*(diffuse*vDiffuse + vAmbient) + specular*vSpecular;
   }
-  #if vtkLightComplexity < 3
+  #if vtkLightComplexity < 3 && defined(SurfaceShadowOn)
     void applyLightingDirectional(inout vec3 tColor, vec4 normal)
     {
       // everything in VC
@@ -1050,7 +1051,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
 
   // apply lighting if requested as appropriate
   #if vtkLightComplexity > 0
-    #if !defined(vtkComponent0Proportional)
+    #if !defined(vtkComponent0Proportional) && defined(SurfaceShadowOn)
         #if vtkLightComplexity < 3
           #ifdef vtkComputeNormalFromOpacity
             applyLightingDirectional(tColor.rgb, normalOpacity);

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -365,17 +365,17 @@ void rotateToViewCoord(inout vec3 normalIDX){
         }
         opacityInterp.x = texture2D(otexture, vec2(scalarInterp[0][0] * oscale0 + oshift0, 0.5)).r; 
         if (secondaryGradientMag.x >= 0.0){
-        // opacityInterp.x *= computeGradientOpacityFactor(secondaryGradientMag.x, goscale0, goshift0, gomin0, gomax0);
+          opacityInterp.x *= computeGradientOpacityFactor(secondaryGradientMag.x, goscale0, goshift0, gomin0, gomax0);
         }
     
         opacityInterp.y = texture2D(otexture, vec2(scalarInterp[0][1] * oscale0 + oshift0, 0.5)).r;
         if (secondaryGradientMag.y >= 0.0){
-        // opacityInterp.y *= computeGradientOpacityFactor(secondaryGradientMag.y, goscale0, goshift0, gomin0, gomax0);
+          opacityInterp.y *= computeGradientOpacityFactor(secondaryGradientMag.y, goscale0, goshift0, gomin0, gomax0);
         }
 
         opacityInterp.z = texture2D(otexture, vec2(scalarInterp[0][2] * oscale0 + oshift0, 0.5)).r;
         if (secondaryGradientMag.z >= 0.0){
-        // opacityInterp.z *= computeGradientOpacityFactor(secondaryGradientMag.z, goscale0, goshift0, gomin0, gomax0);
+          opacityInterp.z *= computeGradientOpacityFactor(secondaryGradientMag.z, goscale0, goshift0, gomin0, gomax0);
         }
 
         opacityG.xyz = opacityInterp - vec3(opacity,opacity,opacity);


### PR DESCRIPTION
### Context
Pull request for adding volume shadow support as part of realistic rendering module, also referred to as secondary shadow ray/secondary scatter. This pull request aligns with recent changes in VTK, but adds optimizations and two extra parameters to further  speed up rendering. Four parameters are included: 
 - `volumetricScatteringBlending`: 
     * range [0.0,1.0]
     * 0.0: surface shadow
     * 1.0: volume/global shadow
 - `globalIlluminationReach`: 
     * range [0.0,1.0]
     * 0.0: maximum volume shadow ray length is equal to 1 unit of sampling distance
     * 1.0: maximum volume shadow ray length is equal to the largest possible value of sqrt(3), i.e. no restriction on shadow ray
 - `volumeShadowSamplingDistFactor`: 
     * range [1.0, Infinity]
     * modifies sampling distance of shadow ray (`SamplingDistanceISVS`) based on sampling distance of primary ray casting (`SamplingDistanceIS`), primarily to increase speed
     * 1.0: `SamplingDistanceISVS` = 1.0 * `SamplingDistanceIS`
     * n: `SamplingDistanceISVS` = n * `SamplingDistanceIS`
 - `anisotropy`: 
     * range (-1.0,1.0)
     * -0.99: light scatters backward
     * 0.99: light scatters forward
     * 0.0: light scatter is isotropic (uniform in all direction)

### Results
**0: Overview**

![overview_go_compressed_cropped](https://user-images.githubusercontent.com/43657251/172893471-bc3e3f6a-ccf7-4d83-b70d-54a96d82619e.gif)
_Overview for volume with gradient opacity enabled - this gif is compressed with 2X speed and frame drop_

![overview_tf_cropped](https://user-images.githubusercontent.com/43657251/172895320-cfe9bcbf-2a4d-4e08-8b7b-babab4715a8b.gif)
_Overview for volume without gradient opacity - this gif has frame drop_

**1: volumetricScatteringBlending**

![blending](https://user-images.githubusercontent.com/43657251/172888893-0b502b0f-c87a-4854-a7d1-0d7a082e0297.gif)

Surface shadow seems to dominate the rendering result when it is on. So `volumetricScatteringBlending= 1.0` is drastically different from `volumetricScatteringBlending= 0.99`, but `volumetricScatteringBlending = 0.99` is pretty much similar to `volumetricScatteringBlending= 0.0`. I used a biased function so volume shadow is more prominent, though it didn't have a big effect. 

![image](https://user-images.githubusercontent.com/43657251/172887081-ac8e057e-f7e9-405f-a939-d4b2d03687a5.png)

**2: volumeShadowSamplingDistFactor**
Shadow ray sampling distance is either equal to or larger than primary ray sampling distance.

![samplingDist](https://user-images.githubusercontent.com/43657251/172887521-e3708cda-e134-4360-837e-f93e95ecc8f3.gif)

Besides the user-specified modification, `SamplingDistanceISVS` is also multiplied by a random number between 0.8 to 1.0 at each sample location. It slightly blurs the "layer effect" when `SamplingDistanceISVS` > `SamplingDistanceIS`. Additionally, it remove the "onion ring" that appears when `globalIlluminationReach = 0.0`. The onion ring appears because vtk.js uses jitter based on a white noise texture with size 32*32, and the same texture is repeated to cover the whole volume. The `random()` function introduced in this PR combine noise texture with another pseudorandom number generator to reduce unnatural artifacts.

![image](https://user-images.githubusercontent.com/43657251/172879822-6828d71b-3f36-4113-b5de-87b220502914.png)

**3: globalIlluminationReach**

![gir](https://user-images.githubusercontent.com/43657251/172890116-a84b6fa1-29c2-4e99-8e00-0def89b902c0.gif)

**4: anisotropy**

![ezgif com-gif-maker](https://user-images.githubusercontent.com/43657251/172909048-4b5e07fb-8c68-48e3-86b3-cf79f08c81e6.gif)

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes - pending
- vtkVolumeFS: add volume shadow support with performance optimization
- OpenGL/VolumeMapper: pass on uniforms to shader
- Core/VolumeMapper: add parameters and range check
- some code clean up

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Windows 10
  - **Browser**: Chrome 89.0.4389.128


<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
