### PR TITLE
fix(dragging): uniformize dragging behavior between widgets

### DIFF
--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -5,7 +5,7 @@ const MAX_POINTS = 3;
 
 export default function widgetBehavior(publicAPI, model) {
   model.classHierarchy.push('vtkAngleWidgetProp');
-  let isDragging = null;
+  model._isDragging = false;
 
   const picker = vtkPointPicker.newInstance();
   picker.setPickFromList(1);
@@ -60,8 +60,8 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
       newHandle.setManipulator(manipulator);
-    } else {
-      isDragging = true;
+    } else if (model.dragable) {
+      model._isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
     }
@@ -92,7 +92,9 @@ export default function widgetBehavior(publicAPI, model) {
 
       if (
         worldCoords.length &&
-        (model.activeState === model.widgetState.getMoveHandle() || isDragging)
+        (model.activeState === model.widgetState.getMoveHandle() ||
+          model._isDragging) &&
+        model.activeState.setOrigin // e.g. the line is pickable but not draggable
       ) {
         model.activeState.setOrigin(worldCoords);
         publicAPI.invokeInteractionEvent();
@@ -110,11 +112,26 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleLeftButtonRelease = () => {
-    if (isDragging && model.pickable) {
+    if (
+      !model.activeState ||
+      !model.activeState.getActive() ||
+      !model.pickable
+    ) {
+      return macro.VOID;
+    }
+    if (
+      model.hasFocus &&
+      model.widgetState.getHandleList().length === MAX_POINTS
+    ) {
+      publicAPI.loseFocus();
+      return macro.VOID;
+    }
+
+    if (model._isDragging) {
       model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);
-      publicAPI.invokeEndInteractionEvent();
+      model._isDragging = false;
     } else if (model.activeState !== model.widgetState.getMoveHandle()) {
       model.widgetState.deactivate();
     }
@@ -123,17 +140,12 @@ export default function widgetBehavior(publicAPI, model) {
       (model.hasFocus && !model.activeState) ||
       (model.activeState && !model.activeState.getActive())
     ) {
-      publicAPI.invokeEndInteractionEvent();
       model._widgetManager.enablePicking();
       model._interactor.render();
     }
 
-    // Don't make any more points
-    if (model.widgetState.getHandleList().length === MAX_POINTS) {
-      publicAPI.loseFocus();
-    }
-
-    isDragging = false;
+    publicAPI.invokeEndInteractionEvent();
+    return macro.EVENT_ABORT;
   };
 
   // --------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -4,7 +4,7 @@ const MAX_POINTS = 2;
 
 export default function widgetBehavior(publicAPI, model) {
   model.classHierarchy.push('vtkDistanceWidgetProp');
-  let isDragging = null;
+  model._isDragging = false;
 
   // --------------------------------------------------------------------------
   // Display 2D
@@ -53,8 +53,8 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
       newHandle.setManipulator(manipulator);
-    } else {
-      isDragging = true;
+    } else if (model.dragable) {
+      model._isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
     }
@@ -68,13 +68,6 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleMouseMove = (callData) => {
-    if (
-      model.hasFocus &&
-      model.widgetState.getHandleList().length === MAX_POINTS
-    ) {
-      publicAPI.loseFocus();
-      return macro.VOID;
-    }
     const manipulator =
       model.activeState?.getManipulator?.() ?? model.manipulator;
     if (
@@ -92,7 +85,9 @@ export default function widgetBehavior(publicAPI, model) {
 
       if (
         worldCoords.length &&
-        (model.activeState === model.widgetState.getMoveHandle() || isDragging)
+        (model.activeState === model.widgetState.getMoveHandle() ||
+          model._isDragging) &&
+        model.activeState.setOrigin // e.g. the line is pickable but not draggable
       ) {
         model.activeState.setOrigin(worldCoords);
         publicAPI.invokeInteractionEvent();
@@ -108,11 +103,26 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleLeftButtonRelease = () => {
-    if (isDragging && model.pickable) {
+    if (
+      !model.activeState ||
+      !model.activeState.getActive() ||
+      !model.pickable
+    ) {
+      return macro.VOID;
+    }
+    if (
+      model.hasFocus &&
+      model.widgetState.getHandleList().length === MAX_POINTS
+    ) {
+      publicAPI.loseFocus();
+      return macro.VOID;
+    }
+
+    if (model._isDragging) {
       model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);
-      publicAPI.invokeEndInteractionEvent();
+      model._isDragging = false;
     } else if (model.activeState !== model.widgetState.getMoveHandle()) {
       model.widgetState.deactivate();
     }
@@ -121,12 +131,12 @@ export default function widgetBehavior(publicAPI, model) {
       (model.hasFocus && !model.activeState) ||
       (model.activeState && !model.activeState.getActive())
     ) {
-      publicAPI.invokeEndInteractionEvent();
       model._widgetManager.enablePicking();
       model._interactor.render();
     }
 
-    isDragging = false;
+    publicAPI.invokeEndInteractionEvent();
+    return macro.EVENT_ABORT;
   };
 
   // --------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/LineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/index.js
@@ -194,7 +194,6 @@ function vtkLineWidget(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   // manipulator: null,
-  isDragging: false,
 };
 
 // ----------------------------------------------------------------------------
@@ -203,7 +202,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
-  macro.setGet(publicAPI, model, ['manipulator', 'isDragging']);
+  macro.setGet(publicAPI, model, ['manipulator']);
 
   vtkLineWidget(publicAPI, model);
 }

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -2,7 +2,7 @@ import macro from 'vtk.js/Sources/macros';
 
 export default function widgetBehavior(publicAPI, model) {
   model.classHierarchy.push('vtkPolyLineWidgetProp');
-  let isDragging = null;
+  model._isDragging = false;
 
   // --------------------------------------------------------------------------
   // Display 2D
@@ -33,7 +33,9 @@ export default function widgetBehavior(publicAPI, model) {
 
     if (
       worldCoords.length &&
-      (model.activeState === model.widgetState.getMoveHandle() || isDragging)
+      (model.activeState === model.widgetState.getMoveHandle() ||
+        model._isDragging) &&
+      model.activeState.setOrigin // e.g. the line is pickable but not draggable
     ) {
       model.activeState.setOrigin(worldCoords);
       publicAPI.invokeInteractionEvent();
@@ -96,8 +98,8 @@ export default function widgetBehavior(publicAPI, model) {
       newHandle.setColor(moveHandle.getColor());
       newHandle.setScale1(moveHandle.getScale1());
       newHandle.setManipulator(manipulator);
-    } else {
-      isDragging = true;
+    } else if (model.dragable) {
+      model._isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
     }
@@ -133,11 +135,19 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleLeftButtonRelease = () => {
-    if (isDragging && model.pickable) {
+    if (
+      !model.activeState ||
+      !model.activeState.getActive() ||
+      !model.pickable
+    ) {
+      return macro.VOID;
+    }
+
+    if (model._isDragging) {
       model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);
-      publicAPI.invokeEndInteractionEvent();
+      model._isDragging = false;
     } else if (model.activeState !== model.widgetState.getMoveHandle()) {
       model.widgetState.deactivate();
     }
@@ -146,12 +156,12 @@ export default function widgetBehavior(publicAPI, model) {
       (model.hasFocus && !model.activeState) ||
       (model.activeState && !model.activeState.getActive())
     ) {
-      publicAPI.invokeEndInteractionEvent();
       model._widgetManager.enablePicking();
       model._interactor.render();
     }
 
-    isDragging = false;
+    publicAPI.invokeEndInteractionEvent();
+    return macro.EVENT_ABORT;
   };
 
   // --------------------------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -17,7 +17,7 @@ import {
 } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants';
 
 export default function widgetBehavior(publicAPI, model) {
-  let isDragging = null;
+  model._isDragging = false;
   let isScrolling = false;
 
   // Reset "updateMethodName" attribute when no actors are selected
@@ -62,7 +62,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonPress = (callData) => {
     if (model.activeState && model.activeState.getActive()) {
-      isDragging = true;
+      model._isDragging = true;
       const viewType = model.widgetState.getActiveViewType();
       const currentPlaneNormal = model.widgetState.getPlanes()[viewType].normal;
       model.planeManipulator.setWidgetOrigin(model.widgetState.getCenter());
@@ -82,7 +82,7 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.handleMouseMove = (callData) => {
-    if (isDragging && model.pickable && model.dragable) {
+    if (model._isDragging) {
       return publicAPI.handleEvent(callData);
     }
     if (isScrolling) {
@@ -101,10 +101,10 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.handleLeftButtonRelease = () => {
-    if (isDragging || isScrolling) {
+    if (model._isDragging || isScrolling) {
       publicAPI.endScrolling();
     }
-    isDragging = false;
+    model._isDragging = false;
     model.widgetState.deactivate();
   };
 

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -18,6 +18,7 @@ const EPSILON = 1e-6;
 
 export default function widgetBehavior(publicAPI, model) {
   model.classHierarchy.push('vtkShapeWidgetProp');
+  model._isDragging = false;
 
   model.keysDown = {};
 
@@ -489,7 +490,7 @@ export default function widgetBehavior(publicAPI, model) {
         publicAPI.updateShapeBounds();
         publicAPI.invokeInteractionEvent();
       }
-    } else if (model.isDragging) {
+    } else if (model._isDragging) {
       if (model.activeState === model.point1Handle) {
         model.point1Handle.setOrigin(worldCoords);
         model.point1 = worldCoords;
@@ -501,7 +502,7 @@ export default function widgetBehavior(publicAPI, model) {
       publicAPI.invokeInteractionEvent();
     }
 
-    return model.hasFocus || model.isDragging ? macro.EVENT_ABORT : macro.VOID;
+    return model.hasFocus || model._isDragging ? macro.EVENT_ABORT : macro.VOID;
   };
 
   // --------------------------------------------------------------------------
@@ -548,17 +549,16 @@ export default function widgetBehavior(publicAPI, model) {
     if (
       model.point1 &&
       (model.activeState === model.point1Handle ||
-        model.activeState === model.point2Handle)
+        model.activeState === model.point2Handle) &&
+      model.dragable
     ) {
-      model.isDragging = true;
+      model._isDragging = true;
       model._apiSpecificRenderWindow.setCursor('grabbing');
       model._interactor.requestAnimation(publicAPI);
-      publicAPI.invokeStartInteractionEvent();
-
-      return macro.EVENT_ABORT;
     }
 
-    return macro.VOID;
+    publicAPI.invokeStartInteractionEvent();
+    return macro.EVENT_ABORT;
   };
 
   // --------------------------------------------------------------------------
@@ -566,8 +566,8 @@ export default function widgetBehavior(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.handleLeftButtonRelease = (e) => {
-    if (model.isDragging) {
-      model.isDragging = false;
+    if (model._isDragging) {
+      model._isDragging = false;
       model._apiSpecificRenderWindow.setCursor('pointer');
       model.widgetState.deactivate();
       model._interactor.cancelAnimation(publicAPI);

--- a/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
@@ -9,7 +9,7 @@ export default function widgetBehavior(publicAPI, model) {
   const shapeHandle = state.getSphereHandle();
 
   // Set while moving the center or border handle.
-  model.isDragging = false;
+  model._isDragging = false;
   // The last world coordinate of the mouse cursor during dragging.
   model.previousPosition = null;
 
@@ -102,7 +102,7 @@ export default function widgetBehavior(publicAPI, model) {
       }
       updateSphere();
     }
-    model.isDragging = true;
+    model._isDragging = true;
     model._apiSpecificRenderWindow.setCursor('grabbing');
     model.previousPosition = [...currentWorldCoords(e)];
     publicAPI.invokeStartInteractionEvent();
@@ -110,7 +110,7 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.handleLeftButtonRelease = (e) => {
-    if (!model.isDragging) {
+    if (!model._isDragging) {
       model.activeState = null;
       return macro.VOID;
     }
@@ -118,7 +118,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.previousPosition = null;
       model._widgetManager.enablePicking();
       model._apiSpecificRenderWindow.setCursor('pointer');
-      model.isDragging = false;
+      model._isDragging = false;
       model.activeState = null;
       state.deactivate();
     }
@@ -127,7 +127,7 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.handleMouseMove = (e) => {
-    if (!model.isDragging) {
+    if (!model._isDragging) {
       model.activeState = null;
       return macro.VOID;
     }
@@ -165,13 +165,13 @@ export default function widgetBehavior(publicAPI, model) {
     borderHandle.setVisible(false);
     centerHandle.setOrigin(null);
     borderHandle.setOrigin(null);
-    model.isDragging = true;
+    model._isDragging = true;
     model.activeState = moveHandle;
     model._interactor.render();
   };
 
   publicAPI.loseFocus = () => {
-    model.isDragging = false;
+    model._isDragging = false;
     model.activeState = null;
   };
 }


### PR DESCRIPTION
Uniformize dragging behavior to make it similar between all widgets: 
- always add the protected variable `_isDragging` in the model (if the widget can be dragged)
- do not change cursor & do not request animation if `model.dragable` is false
- refactor `handleLeftButtonRelease()` method to always return a value (`macro.VOID` or `macro.EVENT_ABORT`), and to correctly call `invokeEndInteractionEvent()`
- fix some cursors inconsistencies 

Also fixes a small bug in Angle/Distance/PolyLineWidget where we were calling `setOrigin` on a
PolyLineRepresentation.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
