### PR TITLE
fix(WebGPU): fix extra rebuild on volume rendering

### DIFF
--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -147,7 +147,7 @@ function vtkWebGPUVolumePass(publicAPI, model) {
       ]);
     }
 
-    if (!model._volumeCopyQuadQuad) {
+    if (!model._volumeCopyQuad) {
       model._volumeCopyQuad = vtkWebGPUFullScreenQuad.newInstance();
       model._volumeCopyQuad.setPipelineHash('volpassfsq');
       model._volumeCopyQuad.setDevice(viewNode.getDevice());


### PR DESCRIPTION
Had a type that caused constant buffer reallocations
for volume rendering on WebGPU

