### PR TITLE
perf: attach webglcontextlost/webglcontextrestored only once

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -92,6 +92,26 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.getViewNodeFactory = () => model.myFactory;
 
+  // prevent default context lost handler
+  model.canvas.addEventListener(
+    'webglcontextlost',
+    (event) => {
+      event.preventDefault();
+    },
+    false
+  );
+
+  model.canvas.addEventListener(
+    'webglcontextrestored',
+    publicAPI.restoreContext,
+    false
+  );
+
+  // Cache the value here as calling it on each frame is expensive
+  const isImmersiveVrSupported =
+    navigator.xr !== undefined &&
+    navigator.xr.isSessionSupported('immersive-vr');
+
   // Auto update style
   const previousSize = [0, 0];
   function updateWindow() {
@@ -244,10 +264,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     let result = null;
 
     // Do we have webxr support
-    if (
-      navigator.xr !== undefined &&
-      navigator.xr.isSessionSupported('immersive-vr')
-    ) {
+    if (isImmersiveVrSupported) {
       publicAPI.invokeHaveVRDisplay();
     }
 
@@ -266,21 +283,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
         model.canvas.getContext('webgl', options) ||
         model.canvas.getContext('experimental-webgl', options);
     }
-
-    // prevent default context lost handler
-    model.canvas.addEventListener(
-      'webglcontextlost',
-      (event) => {
-        event.preventDefault();
-      },
-      false
-    );
-
-    model.canvas.addEventListener(
-      'webglcontextrestored',
-      publicAPI.restoreContext,
-      false
-    );
 
     return result;
   };


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context

Attaching event listeners anytime `get3dcontext` is called is very expensive and slows everything down.

![image](https://user-images.githubusercontent.com/5382443/173409600-64f1902d-66a6-46f0-a3ee-0b253ccc72ce.png)


### Results

get3dcontext will be almost free with this change.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

### Funding
This contribution is funded by [Sirona Medical](https://sironamedical.com).


