### PR TITLE
fix(polylinerepresentation): do not ignore last hidden point

### DIFF
--- a/Sources/Widgets/Representations/PolyLineRepresentation/index.js
+++ b/Sources/Widgets/Representations/PolyLineRepresentation/index.js
@@ -104,22 +104,7 @@ function vtkPolyLineRepresentation(publicAPI, model) {
         subStates.push(subState);
         return subStates;
       }, []);
-    let size = list.length;
-
-    // Do not render last point if not visible or too close from previous point.
-    if (size > 1) {
-      const lastState = list[list.length - 1];
-      const last = lastState.getOrigin();
-      const prevLast = list[list.length - 2].getOrigin();
-      let delta =
-        vtkMath.distance2BetweenPoints(last, prevLast) > model.threshold
-          ? 0
-          : 1;
-      if (!delta && lastState.isVisible && !lastState.isVisible()) {
-        delta++;
-      }
-      size -= delta;
-    }
+    const size = list.length;
 
     const points = allocateSize(size, model.closePolyLine && size > 2);
 

--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -164,6 +164,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
     model.widgetState.getMoveHandle().setVisible(false);
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -157,6 +157,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
     model.widgetState.getMoveHandle().setVisible(false);
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -211,7 +211,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
     if (handleIndex === 1) {
       publicAPI.placeText();
-      publicAPI.setMoveHandleVisibility(false);
+      publicAPI.loseFocus();
     }
   };
 
@@ -367,6 +367,8 @@ export default function widgetBehavior(publicAPI, model) {
     }
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
+    publicAPI.setMoveHandleVisibility(false);
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -189,6 +189,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
     model.widgetState.getMoveHandle().setVisible(false);
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();


### PR DESCRIPTION
When rendering a PolyLineRepresentation, the last point was ignored if not visible. On a LineWidget,
this was causing the line to disappear if the second point was hidden. Fix this by adding a
`ignoreLastHiddenPoint` property, which can be set to false (default) to suppress this behavior.
Also, the origin of the moveHandle is set to null once the widget is placed.

![Screenshot from 2022-06-14 10-18-14](https://user-images.githubusercontent.com/88332582/173529164-4fb0dbf6-eca6-473c-bc6e-765aef8de148.png)
![Screenshot from 2022-06-14 10-18-22](https://user-images.githubusercontent.com/88332582/173529186-5acdf58b-6457-4e96-bc91-6813154f5fba.png)

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
