### PR TITLE
fix(linewidget): moveHandle not visible and last point of polyline is ignored

### DIFF
--- a/Sources/Widgets/Representations/PolyLineRepresentation/index.js
+++ b/Sources/Widgets/Representations/PolyLineRepresentation/index.js
@@ -104,22 +104,7 @@ function vtkPolyLineRepresentation(publicAPI, model) {
         subStates.push(subState);
         return subStates;
       }, []);
-    let size = list.length;
-
-    // Do not render last point if not visible or too close from previous point.
-    if (size > 1) {
-      const lastState = list[list.length - 1];
-      const last = lastState.getOrigin();
-      const prevLast = list[list.length - 2].getOrigin();
-      let delta =
-        vtkMath.distance2BetweenPoints(last, prevLast) > model.threshold
-          ? 0
-          : 1;
-      if (!delta && lastState.isVisible && !lastState.isVisible()) {
-        delta++;
-      }
-      size -= delta;
-    }
+    const size = list.length;
 
     const points = allocateSize(size, model.closePolyLine && size > 2);
 

--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -176,6 +176,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
     model.widgetState.getMoveHandle().setVisible(false);
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -167,6 +167,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
     model.widgetState.getMoveHandle().setVisible(false);
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -278,6 +278,7 @@ export default function widgetBehavior(publicAPI, model) {
       ) {
         if (model.activeState.setOrigin) {
           model.activeState.setOrigin(worldCoords);
+          publicAPI.setMoveHandleVisibility(!publicAPI.isPlaced());
         } else {
           // Dragging line
           publicAPI

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -26,6 +26,23 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.getHandle = (handleIndex) =>
     model.widgetState[handleGetters[handleIndex]]();
 
+  /**
+   * Return the index in the of tbe handle in `representations` array,
+   * or -1 if the handle is not present in the widget state.
+   */
+  publicAPI.getHandleIndex = (handle) => {
+    switch (handle) {
+      case model.widgetState.getHandle1():
+        return 0;
+      case model.widgetState.getHandle2():
+        return 1;
+      case model.widgetState.getMoveHandle():
+        return 2;
+      default:
+        return -1;
+    }
+  };
+
   publicAPI.isPlaced = () =>
     getNumberOfPlacedHandles(model.widgetState) === MAX_POINTS;
 
@@ -159,12 +176,6 @@ export default function widgetBehavior(publicAPI, model) {
 
   // Handles visibility ---------------------------------------------------------
 
-  publicAPI.setMoveHandleVisibility = (visibility) => {
-    model.representations[2].setVisibilityFlagArray([visibility, visibility]);
-    model.widgetState.getMoveHandle().setVisible(visibility);
-    model.representations[2].updateActorVisibility();
-  };
-
   /**
    * Set actor visibility to true unless it is a NONE handle
    * and uses state visibility variable for the displayActor visibility to
@@ -212,7 +223,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
     if (handleIndex === 1) {
       publicAPI.placeText();
-      publicAPI.setMoveHandleVisibility(false);
+      publicAPI.loseFocus();
     }
   };
 
@@ -278,7 +289,9 @@ export default function widgetBehavior(publicAPI, model) {
       ) {
         if (model.activeState.setOrigin) {
           model.activeState.setOrigin(worldCoords);
-          publicAPI.setMoveHandleVisibility(!publicAPI.isPlaced());
+          publicAPI.updateHandleVisibility(
+            publicAPI.getHandleIndex(model.activeState)
+          );
         } else {
           // Dragging line
           publicAPI
@@ -356,7 +369,6 @@ export default function widgetBehavior(publicAPI, model) {
     if (!model.hasFocus && !publicAPI.isPlaced()) {
       model.activeState = model.widgetState.getMoveHandle();
       model.activeState.setShape(publicAPI.getHandle(0).getShape());
-      publicAPI.setMoveHandleVisibility(true);
       model.activeState.activate();
       model._interactor.requestAnimation(publicAPI);
       publicAPI.invokeStartInteractionEvent();
@@ -373,6 +385,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();

--- a/Sources/Widgets/Widgets3D/LineWidget/helpers.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/helpers.js
@@ -23,6 +23,10 @@ export function updateTextPosition(model) {
 }
 
 export function isHandlePlaced(handleIndex, widgetState) {
+  if (handleIndex === 2) {
+    return widgetState.getMoveHandle().getOrigin() != null;
+  }
+
   const handle1Origin = widgetState.getHandle1().getOrigin();
   if (handleIndex === 0) {
     return handle1Origin != null;

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -199,6 +199,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.deactivate();
     model.widgetState.getMoveHandle().deactivate();
     model.widgetState.getMoveHandle().setVisible(false);
+    model.widgetState.getMoveHandle().setOrigin(null);
     model.activeState = null;
     model.hasFocus = false;
     model._widgetManager.enablePicking();


### PR DESCRIPTION
Method `setMoveHandleVisibility` was called when the moveHandle origin was still `null`, causing it
to be filtered out (see ArrowHandleRepresentation:getRepresentationStates) and not rendered. 
Fix removing method `setMoveHandleVisibility` and using `updateHandleVisibility` to update moveHandle visibility.

---

When rendering a PolyLineRepresentation, the last point was ignored if not visible. On a LineWidget,
this was causing the line to disappear if the second point was hidden. 
Fix this by setting the origin of the moveHandle is set to null once the widget is placed.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

