### PR TITLE
perf: cache publicAPI.getHardwareMaximumLineWidth result

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -732,9 +732,18 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     });
   };
 
+  let hardwareMaximumLineWidth;
   publicAPI.getHardwareMaximumLineWidth = () => {
+    // We cache the result of this function because `getParameter` is slow
+    if (hardwareMaximumLineWidth != null) {
+      return hardwareMaximumLineWidth;
+    }
+
     const gl = publicAPI.get3DContext();
     const lineWidthRange = gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE);
+
+    hardwareMaximumLineWidth = lineWidthRange[1];
+
     return lineWidthRange[1];
   };
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Calling the webgl.getParameter is relatively slow, and if called many times can result in a bottleneck.

### Results
From my understanding the result of this call will not vary during a single session so it's safe to cache it.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
