### PR TITLE
feat(Rendering): add coordinate systems for props

### DIFF
--- a/Sources/Rendering/Core/Prop/Constants.js
+++ b/Sources/Rendering/Core/Prop/Constants.js
@@ -1,0 +1,8 @@
+export const CoordinateSystem = {
+  DISPLAY: 0,
+  WORLD: 1,
+};
+
+export default {
+  CoordinateSystem,
+};

--- a/Sources/Rendering/Core/Prop/index.d.ts
+++ b/Sources/Rendering/Core/Prop/index.d.ts
@@ -20,8 +20,8 @@ export interface IPropInitialValues {
 export interface vtkProp extends vtkObject {
 
     /**
-     * 
-     * @param estimatedRenderTime 
+     *
+     * @param estimatedRenderTime
      */
     addEstimatedRenderTime(estimatedRenderTime: number): void;
 
@@ -83,32 +83,32 @@ export interface vtkProp extends vtkObject {
     getNestedPickable(): boolean;
 
     /**
-     * Return the mtime of anything that would cause the rendered image to appear differently. 
-     * Usually this involves checking the mtime of the prop plus anything else it depends on such as properties, 
+     * Return the mtime of anything that would cause the rendered image to appear differently.
+     * Usually this involves checking the mtime of the prop plus anything else it depends on such as properties,
      * textures etc.
      */
     getRedrawMTime(): number
 
     /**
-     * 
+     *
      */
     getRendertimemultiplier(): number;
 
     /**
      * The value is returned in seconds. For simple geometry the accuracy may not be great
-     * due to buffering. For ray casting, which is already multi-resolution, 
-     * the current resolution of the image is factored into the time. We need the viewport 
+     * due to buffering. For ray casting, which is already multi-resolution,
+     * the current resolution of the image is factored into the time. We need the viewport
      * for viewing parameters that affect timing. The no-arguments version simply returns the value of the variable with no estimation.
      */
     getEstimatedRenderTime(): number;
 
     /**
-     * 
+     *
      */
     getAllocatedRenderTime(): number;
 
     /**
-     * 
+     *
      */
     getNestedProps(): any;
 
@@ -119,47 +119,47 @@ export interface vtkProp extends vtkObject {
     getParentProp(): vtkProp;
 
     /**
-     * 
+     *
      * Not implemented yet
      */
     getVolumes(): vtkVolume[];
 
     /**
-     * 
+     *
      */
     getUseBounds(): boolean;
 
     /**
-     * 
+     *
      */
     getSupportsSelection(): boolean;
 
     /**
-     * 
+     *
      */
     getTextures(): vtkTexture[];
 
     /**
-     * 
+     *
      * @param {vtkTexture} texture The vtkTexture instance.
      *
      */
     hasTexture(texture: vtkTexture): boolean;
 
     /**
-     * 
+     *
      * @param {vtkTexture} texture The vtkTexture instance.
      */
     addTexture(texture: vtkTexture): void;
 
     /**
-     * 
+     *
      * @param {vtkTexture} texture The vtkTexture instance.
      */
     removeTexture(texture: vtkTexture): void;
 
     /**
-     * 
+     *
      */
     removeAllTextures(): void;
 
@@ -169,15 +169,15 @@ export interface vtkProp extends vtkObject {
     restoreEstimatedRenderTime(): void;
 
     /**
-     * 
-     * @param allocatedRenderTime 
+     *
+     * @param allocatedRenderTime
      */
     setAllocatedRenderTime(allocatedRenderTime: number): void;
 
     /**
      * Set whether prop is dragable.
      * Even if true, prop may not be dragable if an ancestor prop is not dragable.
-     * @param dragable 
+     * @param dragable
      * @default true
      * @see getDragable
      * @see combineDragable
@@ -185,8 +185,8 @@ export interface vtkProp extends vtkObject {
     setDragable(dragable: boolean): boolean;
 
     /**
-     * 
-     * @param estimatedRenderTime 
+     *
+     * @param estimatedRenderTime
      */
     setEstimatedRenderTime(estimatedRenderTime: number): void;
 
@@ -221,7 +221,7 @@ export interface vtkProp extends vtkObject {
     setVisibility(visibility: boolean): boolean;
 
     /**
-     * In case the Visibility flag is true, tell if the bounds of this prop should be taken into 
+     * In case the Visibility flag is true, tell if the bounds of this prop should be taken into
      * account or ignored during the computation of other bounding boxes, like in vtkRenderer::ResetCamera().
      * @param useBounds
      * @default true
@@ -230,11 +230,25 @@ export interface vtkProp extends vtkObject {
 
     /**
      * This is used for culling and is a number between 0 and 1. It is used to create the allocated render time value.
-     * @param {Number} renderTimeMultiplier 
+     * @param {Number} renderTimeMultiplier
      */
     setRenderTimeMultiplier(renderTimeMultiplier: number): boolean;
 
     /**
+     * Indicate that this prop's data should be in world coordinates.
+     * Not all mappers support all coordinate systems.
+     */
+    setCoordinateSystemToWorld(): void;
+
+    /**
+     * Indicate that this prop's data should be in display coordinates.
+     * That is pixel coordinate with 0,0 in the lower left of the viewport
+     * and a z range of -1 at the near plane and 1 at the far.
+     * Not all mappers support all coordinate systems.
+     */
+     setCoordinateSystemToDisplay(): void;
+
+     /**
      * Not Implemented yet
      * Method fires PickEvent if the prop is picked.
      */
@@ -263,7 +277,7 @@ export function extend(publicAPI: object, model: object, initialValues?: IPropIn
 export function newInstance(initialValues?: IPropInitialValues): vtkProp;
 
 
-/** 
+/**
  * vtkProp is an abstract superclass for any objects that can exist in a
  * rendered scene (either 2D or 3D). Instances of vtkProp may respond to
  * various render methods (e.g., RenderOpaqueGeometry()). vtkProp also

--- a/Sources/Rendering/Core/Prop/index.js
+++ b/Sources/Rendering/Core/Prop/index.js
@@ -1,4 +1,7 @@
 import macro from 'vtk.js/Sources/macros';
+import Constants from 'vtk.js/Sources/Rendering/Core/Prop/Constants';
+
+const { CoordinateSystem } = Constants;
 
 function notImplemented(method) {
   return () => macro.vtkErrorMacro(`vtkProp::${method} - NOT IMPLEMENTED`);
@@ -87,6 +90,12 @@ function vtkProp(publicAPI, model) {
     model.textures = [];
     publicAPI.modified();
   };
+
+  // not all mappers support all coordinate systems
+  publicAPI.setCoordinateSystemToWorld = () =>
+    publicAPI.setCoordinateSystem(CoordinateSystem.WORLD);
+  publicAPI.setCoordinateSystemToDisplay = () =>
+    publicAPI.setCoordinateSystem(CoordinateSystem.DISPLAY);
 }
 
 // ----------------------------------------------------------------------------
@@ -95,16 +104,17 @@ function vtkProp(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   // _parentProp: null,
-  visibility: true,
-  pickable: true,
-  dragable: true,
-  useBounds: true,
   allocatedRenderTime: 10,
+  coordinateSystem: CoordinateSystem.WORLD,
+  dragable: true,
   estimatedRenderTime: 0,
-  savedEstimatedRenderTime: 0,
-  renderTimeMultiplier: 1,
   paths: null,
+  pickable: true,
+  renderTimeMultiplier: 1,
+  savedEstimatedRenderTime: 0,
   textures: [],
+  useBounds: true,
+  visibility: true,
 };
 
 // ----------------------------------------------------------------------------
@@ -116,12 +126,13 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.obj(publicAPI, model);
   macro.get(publicAPI, model, ['estimatedRenderTime', 'allocatedRenderTime']);
   macro.setGet(publicAPI, model, [
-    'visibility',
-    'pickable',
-    'dragable',
-    'useBounds',
-    'renderTimeMultiplier',
     '_parentProp',
+    'coordinateSystem',
+    'dragable',
+    'pickable',
+    'renderTimeMultiplier',
+    'useBounds',
+    'visibility',
   ]);
   macro.moveToProtected(publicAPI, model, ['parentProp']);
 
@@ -135,4 +146,4 @@ export const newInstance = macro.newInstance(extend, 'vtkProp');
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend };
+export default { newInstance, extend, ...Constants };

--- a/Sources/Rendering/Core/Property2D/index.js
+++ b/Sources/Rendering/Core/Property2D/index.js
@@ -66,4 +66,4 @@ export const newInstance = macro.newInstance(extend, 'vtkProperty2D');
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend };
+export default { newInstance, extend, ...Constants };

--- a/Sources/Rendering/WebGPU/BufferManager/index.js
+++ b/Sources/Rendering/WebGPU/BufferManager/index.js
@@ -198,7 +198,6 @@ function generateNormals(cellArray, pointArray) {
 // ----------------------------------------------------------------------------
 // vtkWebGPUBufferManager methods
 // ----------------------------------------------------------------------------
-
 function vtkWebGPUBufferManager(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkWebGPUBufferManager');

--- a/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
+++ b/Sources/Rendering/WebGPU/Glyph3DMapper/index.js
@@ -11,6 +11,15 @@ function vtkWebGPUGlyph3DCellArrayMapper(publicAPI, model) {
 
   const superClass = { ...publicAPI };
 
+  publicAPI.setGlyphInstances = (val) => {
+    model.glyphInstances = val;
+  };
+
+  publicAPI.updateBuffers = () => {
+    superClass.updateBuffers();
+    publicAPI.setNumberOfInstances(model.glyphInstances);
+  };
+
   publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
     const vDesc = pipeline.getShaderDescription('vertex');
     vDesc.addBuiltinInput('u32', '@builtin(instance_index) instanceIndex');
@@ -145,7 +154,7 @@ function vtkWebGPUGlyph3DMapper(publicAPI, model) {
 
       for (let i = 0; i < model.children.length; i++) {
         const cellMapper = model.children[i];
-        cellMapper.setNumberOfInstances(model.numInstances);
+        cellMapper.setGlyphInstances(model.numInstances);
       }
     }
   };

--- a/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
@@ -229,9 +229,7 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
       code = vtkWebGPUShaderCache.substitute(
         code,
         '//VTK::RenderEncoder::Impl',
-        [
-          'output.outColor = vec4<f32>(computedColor.rgb*computedColor.a, computedColor.a);',
-        ]
+        ['output.outColor = vec4<f32>(computedColor.rgb, computedColor.a);']
       ).result;
       fDesc.setCode(code);
     });

--- a/Sources/Rendering/WebGPU/PolyDataMapper2D/index.js
+++ b/Sources/Rendering/WebGPU/PolyDataMapper2D/index.js
@@ -1,0 +1,107 @@
+import * as macro from 'vtk.js/Sources/macros';
+import vtkWebGPUBufferManager from 'vtk.js/Sources/Rendering/WebGPU/BufferManager';
+import vtkWebGPUCellArrayMapper from 'vtk.js/Sources/Rendering/WebGPU/CellArrayMapper';
+import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
+
+import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
+
+const { PrimitiveTypes } = vtkWebGPUBufferManager;
+
+// ----------------------------------------------------------------------------
+// vtkWebGPUPolyDataMapper methods
+// ----------------------------------------------------------------------------
+
+function vtkWebGPUPolyDataMapper2D(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkWebGPUPolyDataMapper2D');
+
+  publicAPI.createCellArrayMapper = () =>
+    vtkWebGPUCellArrayMapper.newInstance();
+
+  publicAPI.buildPass = (prepass) => {
+    if (prepass) {
+      model.WebGPUActor = publicAPI.getFirstAncestorOfType('vtkWebGPUActor2D');
+      if (!model.renderable.getStatic()) {
+        model.renderable.update();
+      }
+
+      const poly = model.renderable.getInputData();
+
+      model.renderable.mapScalars(poly, 1.0);
+
+      publicAPI.updateCellArrayMappers(poly);
+    }
+  };
+
+  publicAPI.updateCellArrayMappers = (poly) => {
+    const prims = [
+      poly.getVerts(),
+      poly.getLines(),
+      poly.getPolys(),
+      poly.getStrips(),
+    ];
+
+    // we instantiate a cell array mapper for each cellArray that has cells
+    // and they handle the rendering of that cell array
+    const cellMappers = [];
+    let cellOffset = 0;
+    for (let i = PrimitiveTypes.Points; i <= PrimitiveTypes.Triangles; i++) {
+      if (prims[i].getNumberOfValues() > 0) {
+        if (!model.primitives[i]) {
+          model.primitives[i] = publicAPI.createCellArrayMapper();
+        }
+        const cellMapper = model.primitives[i];
+        cellMapper.setCellArray(prims[i]);
+        cellMapper.setCurrentInput(poly);
+        cellMapper.setCellOffset(cellOffset);
+        cellMapper.setPrimitiveType(i);
+        cellMapper.setRenderable(model.renderable);
+        cellMapper.setIs2D(true);
+        cellOffset += prims[i].getNumberOfCells();
+        cellMappers.push(cellMapper);
+      } else {
+        model.primitives[i] = null;
+      }
+    }
+
+    publicAPI.prepareNodes();
+    publicAPI.addMissingChildren(cellMappers);
+    publicAPI.removeUnusedNodes();
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  primitives: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkViewNode.extend(publicAPI, model, initialValues);
+
+  model.primitives = [];
+
+  // Object methods
+  vtkWebGPUPolyDataMapper2D(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(
+  extend,
+  'vtkWebGPUPolyDataMapper2D'
+);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };
+
+// Register ourself to WebGPU backend if imported
+registerOverride('vtkMapper2D', newInstance);

--- a/Sources/Rendering/WebGPU/Profiles/All.js
+++ b/Sources/Rendering/WebGPU/Profiles/All.js
@@ -4,8 +4,10 @@ import 'vtk.js/Sources/Rendering/WebGPU/Renderer';
 
 // Geometry
 import 'vtk.js/Sources/Rendering/WebGPU/Actor';
+import 'vtk.js/Sources/Rendering/WebGPU/Actor2D';
 import 'vtk.js/Sources/Rendering/WebGPU/CubeAxesActor';
 import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper';
+import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper2D';
 // import 'vtk.js/Sources/Rendering/WebGPU/Skybox';
 import 'vtk.js/Sources/Rendering/WebGPU/ScalarBarActor';
 import 'vtk.js/Sources/Rendering/WebGPU/Texture';

--- a/Sources/Rendering/WebGPU/Profiles/Geometry.js
+++ b/Sources/Rendering/WebGPU/Profiles/Geometry.js
@@ -4,8 +4,10 @@ import 'vtk.js/Sources/Rendering/WebGPU/Renderer';
 
 // Geometry
 import 'vtk.js/Sources/Rendering/WebGPU/Actor';
+import 'vtk.js/Sources/Rendering/WebGPU/Actor2D';
 import 'vtk.js/Sources/Rendering/WebGPU/CubeAxesActor';
 import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper';
+import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper2D';
 // import 'vtk.js/Sources/Rendering/WebGPU/Skybox';
 import 'vtk.js/Sources/Rendering/WebGPU/ScalarBarActor';
 import 'vtk.js/Sources/Rendering/WebGPU/Texture';

--- a/Sources/Rendering/WebGPU/index.js
+++ b/Sources/Rendering/WebGPU/index.js
@@ -1,5 +1,6 @@
 import vtkRenderWindow from './RenderWindow';
 import './Actor';
+import './Actor2D';
 import './Camera';
 import './CubeAxesActor';
 import './ForwardPass';
@@ -9,6 +10,7 @@ import './ImageMapper';
 import './ImageSlice';
 import './PixelSpaceCallbackMapper';
 import './PolyDataMapper';
+import './PolyDataMapper2D';
 import './Renderer';
 import './ScalarBarActor';
 import './SphereMapper';


### PR DESCRIPTION
This MR adds the noption of coordinate systems to vtkProp.
It currently adds WORLD as the default and DISPLAY as a
second option. DISPLAY coordinates are in pixels with 0,0 being
the lower left corner of the viewport and Z ranging from -1
near to 1 far. These coordinate systems are intended to be
implemented in the GPU.

This MR adds Actor2D and PolyDataMapper2D to WebGPU taking
advantage of the new coordinate systems.

This MR updates the ScalarBarActor to produce data in
DISPLAY coordinates. The old code used world coordinates
which meant that every time the camera changed the scalar
bar actor had to recompute it's data which is very expensive
resulting in hundreds of VBO's being created every second.
By using DISPLAY coordinate the data does not change with
camera changes, only with viewport changes or changes to
the source data/scalar bar actor itself which is far less
common.

With this MR the scalar bar actor functions on both WebGPU and
OpenGL and the Actor2D example works on both WebGPU and OpenGL.
