### PR TITLE
fix(ResliceCursorWidget): Use correct moving factor

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -88,10 +88,7 @@ export default function widgetBehavior(publicAPI, model) {
     if (isScrolling) {
       if (model.previousPosition.y !== callData.position.y) {
         const step = model.previousPosition.y - callData.position.y;
-        publicAPI.translateCenterOnCurrentDirection(
-          step,
-          callData.pokedRenderer
-        );
+        publicAPI.translateCenterOnPlaneDirection(step);
         model.previousPosition = callData.position;
 
         publicAPI.invokeInternalInteractionEvent();
@@ -134,7 +131,7 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleMouseWheel = (calldata) => {
     const step = calldata.spinY;
     isScrolling = true;
-    publicAPI.translateCenterOnCurrentDirection(step, calldata.pokedRenderer);
+    publicAPI.translateCenterOnPlaneDirection(step);
 
     publicAPI.invokeInternalInteractionEvent();
     isScrolling = false;
@@ -202,15 +199,8 @@ export default function widgetBehavior(publicAPI, model) {
     });
   };
 
-  publicAPI.translateCenterOnCurrentDirection = (nbSteps, renderer) => {
-    const dirProj = renderer
-      .getRenderWindow()
-      .getRenderers()[0]
-      .getActiveCamera()
-      .getDirectionOfProjection();
-
-    // Direction of the projection is the inverse of what we want
-    const direction = vtkMath.multiplyScalar(dirProj, -1);
+  publicAPI.translateCenterOnPlaneDirection = (nbSteps) => {
+    const dirProj = model.widgetState.getPlanes()[model.viewType].normal;
 
     const oldCenter = model.widgetState.getCenter();
     const image = model.widgetState.getImage();
@@ -220,13 +210,14 @@ export default function widgetBehavior(publicAPI, model) {
     // https://math.stackexchange.com/questions/71423/what-is-the-term-for-the-projection-of-a-vector-onto-the-unit-cube
     const absDirProj = dirProj.map((value) => Math.abs(value));
     const index = absDirProj.indexOf(Math.max(...absDirProj));
-    const movingFactor = nbSteps * (imageSpacing[index] / dirProj[index]);
+    const movingFactor =
+      (nbSteps * imageSpacing[index]) / Math.abs(dirProj[index]);
 
     // Define the potentially new center
     let newCenter = [
-      oldCenter[0] + movingFactor * direction[0],
-      oldCenter[1] + movingFactor * direction[1],
-      oldCenter[2] + movingFactor * direction[2],
+      oldCenter[0] + movingFactor * dirProj[0],
+      oldCenter[1] + movingFactor * dirProj[1],
+      oldCenter[2] + movingFactor * dirProj[2],
     ];
     newCenter = publicAPI.getBoundedCenter(newCenter);
 


### PR DESCRIPTION
### Changes
When computing the new center of the reslice cursor widget during mouse wheel, we previously applied twice the sign of the dirproj. Now it's applied only once.

@finetjul 