### PR TITLE
fix(Shader): fix condition statement for gradient-based shadow

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -754,7 +754,8 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
     }
     tColor.rgb = tColor.rgb*(diffuse*vDiffuse + vAmbient) + specular*vSpecular;
   }
-  #if vtkLightComplexity < 3 && defined(SurfaceShadowOn)
+  #ifdef SurfaceShadowOn
+  #if vtkLightComplexity < 3
     vec3 applyLightingDirectional(inout vec3 tColor, vec4 normal)
     {
       // everything in VC
@@ -847,6 +848,7 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
       return tColor.rgb * (diffuse * vDiffuse + vAmbient) + specular*vSpecular;
     }
   #endif 
+  #endif
 #endif
 
 //=======================================================================


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Shader doesn't compile when `VolumetricScatteringBlending` is set to 1.0 due to an error in conditional statement. 

### Results
Fixed issue

### Changes
Changed #ifdef statement for gradient based lighting function declaration in vtkVolumeFS.glsl

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Windows 10
  - **Browser**: Chrome 89.0.4389.128

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
