### PR TITLE
fix(Shader): normalize scalar gradient range

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -1065,7 +1065,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
     #ifdef VolumeShadowOn
       vec3 tColorVS = applyShadowRay(tColor.rgb, posIS, rayDirVC);
       #ifdef SurfaceShadowOn
-        float vol_coef = volumetricScatteringBlending * (1.0 - tColor.a * exp(normalLight.w));
+        float vol_coef = volumetricScatteringBlending * (1.0 - tColor.a / 2.0) * (1.0 - atan(normalLight.w) * INV4PI);
         tColor.rgb = (1.0-vol_coef) * tColorS + vol_coef * tColorVS;
       #else
         tColor.rgb = tColorVS;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Normalize `vol_coef` calculation when scalar gradient magnitude is greater than 1. Previously assumed that scalar gradient magnitude is always in range [0,1], which is not the case, leading to color brightness to increase exponentially with gradient magnitude.

### Results
Fixed abnormal color range, volume blending transition is smooth regardless of gradient magnitude range.

### Changes
Replace `exp()` with `atan()`, which normalizes gradient magnitude from [0, infinity) to [0,1]

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Windows 10
  - **Browser**: Chrome 89.0.4389.128


<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
