### PR TITLE
fix(AbstractWidgetFactory): avoid race condition

### DIFF
--- a/Sources/Widgets/Core/AbstractWidgetFactory/index.js
+++ b/Sources/Widgets/Core/AbstractWidgetFactory/index.js
@@ -179,19 +179,17 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
   let unsubscribe = NoOp;
   publicAPI.delete = macro.chain(publicAPI.delete, () => unsubscribe());
 
-  // Defer after object instantiation so model.widgetState actually exist
-  setTimeout(() => {
-    if (model.widgetState) {
-      unsubscribe = model.widgetState.onModified(() =>
-        publicAPI.invokeWidgetChange(model.widgetState)
-      ).unsubscribe;
-    }
-  }, 0);
+  if (model.widgetState) {
+    unsubscribe = model.widgetState.onModified(() =>
+      publicAPI.invokeWidgetChange(model.widgetState)
+    ).unsubscribe;
+  }
 }
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, initialValues);
   macro.obj(publicAPI, model);
   macro.get(publicAPI, model, ['widgetState']);
   macro.event(publicAPI, model, 'WidgetChange');

--- a/Sources/Widgets/Widgets3D/AngleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/index.js
@@ -29,8 +29,6 @@ function vtkAngleWidget(publicAPI, model) {
     'defaultScale',
     'scaleInPixels',
   ];
-  model.behavior = widgetBehavior;
-  model.widgetState = stateGenerator();
 
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
@@ -102,14 +100,17 @@ function vtkAngleWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues) => ({
   // manipulator: null,
-};
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['manipulator']);

--- a/Sources/Widgets/Widgets3D/DistanceWidget/index.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/index.js
@@ -29,8 +29,6 @@ function vtkDistanceWidget(publicAPI, model) {
     'defaultScale',
     'scaleInPixels',
   ];
-  model.behavior = widgetBehavior;
-  model.widgetState = stateGenerator();
 
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
@@ -95,14 +93,17 @@ function vtkDistanceWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues) => ({
   // manipulator: null,
-};
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['manipulator']);

--- a/Sources/Widgets/Widgets3D/EllipseWidget/index.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/index.js
@@ -35,7 +35,6 @@ function vtkEllipseWidget(publicAPI, model) {
     'opacity',
   ];
 
-  model.behavior = widgetBehavior;
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
       case ViewTypes.DEFAULT:
@@ -67,7 +66,6 @@ function vtkEllipseWidget(publicAPI, model) {
   // initialization
   // --------------------------------------------------------------------------
 
-  model.widgetState = stateGenerator();
   publicAPI.setManipulator(
     model.manipulator ||
       vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
@@ -78,6 +76,8 @@ function vtkEllipseWidget(publicAPI, model) {
 
 function defaultValues(initialValues) {
   return {
+    behavior: widgetBehavior,
+    widgetState: stateGenerator(),
     modifierBehavior: {
       None: {
         [BehaviorCategory.PLACEMENT]:

--- a/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImageCroppingWidget/index.js
@@ -101,8 +101,6 @@ function vtkImageCroppingWidget(publicAPI, model) {
 
   // --- Widget Requirement ---------------------------------------------------
 
-  model.behavior = behavior;
-  model.widgetState = state();
   model.methodsToLink = ['scaleInPixels'];
 
   // Given a view type (geometry, slice, volume), return a description
@@ -168,16 +166,19 @@ function vtkImageCroppingWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues) => ({
   // cornerManipulator: null,
   // edgeManipulator: null,
-  // faceManipulator: null
-};
+  // faceManipulator: null,
+  behavior,
+  widgetState: state(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, [

--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
@@ -155,10 +155,6 @@ function vtkImplicitPlaneWidget(publicAPI, model) {
 
   // --- Widget Requirement ---------------------------------------------------
 
-  model.widgetState = vtkImplicitPlaneRepresentation.generateState();
-
-  model.behavior = widgetBehavior;
-
   model.methodsToLink = [
     'representationStyle',
     'sphereResolution',
@@ -184,12 +180,16 @@ function vtkImplicitPlaneWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {};
+const defaultValues = (initialValues) => ({
+  behavior: widgetBehavior,
+  widgetState: vtkImplicitPlaneRepresentation.generateState(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
 

--- a/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/index.js
+++ b/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/index.js
@@ -28,8 +28,6 @@ function vtkInteractiveOrientationWidget(publicAPI, model) {
     'glyphResolution',
     'defaultScale',
   ];
-  model.behavior = widgetBehavior;
-  model.widgetState = generateState();
 
   publicAPI.setBounds = (bounds) => {
     const handles = model.widgetState.getStatesWithLabel('handles');
@@ -129,12 +127,16 @@ function vtkInteractiveOrientationWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {};
+const defaultValues = (initialValues) => ({
+  behavior: widgetBehavior,
+  widgetState: generateState(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
 

--- a/Sources/Widgets/Widgets3D/LabelWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LabelWidget/index.js
@@ -28,9 +28,6 @@ function vtkLabelWidget(publicAPI, model) {
     'scaleInPixels',
   ];
 
-  model.behavior = widgetBehavior;
-  model.widgetState = stateGenerator();
-
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
       case ViewTypes.DEFAULT:
@@ -86,6 +83,8 @@ function vtkLabelWidget(publicAPI, model) {
 
 function defaultValues(initialValues) {
   return {
+    behavior: widgetBehavior,
+    widgetState: stateGenerator(),
     ...initialValues,
   };
 }

--- a/Sources/Widgets/Widgets3D/LineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/index.js
@@ -22,9 +22,6 @@ function vtkLineWidget(publicAPI, model) {
 
   const superClass = { ...publicAPI };
 
-  model.widgetState = stateGenerator();
-  model.behavior = widgetBehavior;
-
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
@@ -188,14 +185,17 @@ function vtkLineWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues) => ({
   // manipulator: null,
-};
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['manipulator']);

--- a/Sources/Widgets/Widgets3D/PaintWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/index.js
@@ -19,8 +19,6 @@ function vtkPaintWidget(publicAPI, model) {
   const superClass = { ...publicAPI };
 
   // --- Widget Requirement ---------------------------------------------------
-  model.behavior = widgetBehavior;
-  model.widgetState = stateGenerator(model.radius);
 
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
@@ -67,17 +65,20 @@ function vtkPaintWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues) => ({
   // manipulator: null,
   radius: 1,
   painting: false,
   color: [1],
-};
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(initialValues?.radius ?? 1),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
 

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/index.js
@@ -31,8 +31,6 @@ function vtkPolyLineWidget(publicAPI, model) {
     'useActiveColor',
     'scaleInPixels',
   ];
-  model.behavior = widgetBehavior;
-  model.widgetState = stateGenerator();
 
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
@@ -102,14 +100,17 @@ function vtkPolyLineWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
-  // manipulator: null,
-};
+const defaultValues = (initialValues) => ({
+  manipulator: null,
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['manipulator']);

--- a/Sources/Widgets/Widgets3D/RectangleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/RectangleWidget/index.js
@@ -33,7 +33,6 @@ function vtkRectangleWidget(publicAPI, model) {
 
   // --- Widget Requirement ---------------------------------------------------
 
-  model.behavior = widgetBehavior;
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
       case ViewTypes.DEFAULT:
@@ -65,7 +64,6 @@ function vtkRectangleWidget(publicAPI, model) {
   // initialization
   // --------------------------------------------------------------------------
 
-  model.widgetState = stateGenerator();
   model.manipulator = vtkPlanePointManipulator.newInstance({
     useCameraNormal: true,
   });
@@ -75,6 +73,8 @@ function vtkRectangleWidget(publicAPI, model) {
 
 function defaultValues(initialValues) {
   return {
+    behavior: widgetBehavior,
+    widgetState: stateGenerator(),
     modifierBehavior: {
       None: {
         [BehaviorCategory.PLACEMENT]:

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -248,9 +248,6 @@ function vtkResliceCursorWidget(publicAPI, model) {
   // initialization
   // --------------------------------------------------------------------------
 
-  model.behavior = widgetBehavior;
-  model.widgetState = stateGenerator();
-
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
       case ViewTypes.XY_PLANE:
@@ -591,12 +588,16 @@ function vtkResliceCursorWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {};
+const defaultValues = (initialValues) => ({
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
 

--- a/Sources/Widgets/Widgets3D/SphereWidget/index.js
+++ b/Sources/Widgets/Widgets3D/SphereWidget/index.js
@@ -13,7 +13,6 @@ function vtkSphereWidget(publicAPI, model) {
 
   const superClass = { ...publicAPI };
 
-  model.behavior = widgetBehavior;
   model.methodsToLink = ['scaleInPixels'];
 
   publicAPI.getRepresentationsForViewType = (viewType) => [
@@ -54,15 +53,20 @@ function vtkSphereWidget(publicAPI, model) {
   // initialization
   // --------------------------------------------------------------------------
 
-  model.widgetState = stateGenerator();
   publicAPI.setManipulator(
     model.manipulator ||
       vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
   );
 }
 
+const defaultValues = (initialValues) => ({
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(),
+  ...initialValues,
+});
+
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, {}, initialValues);
+  Object.assign(model, defaultValues(initialValues));
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['manipulator', 'widgetState']);
   vtkSphereWidget(publicAPI, model);

--- a/Sources/Widgets/Widgets3D/SplineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/index.js
@@ -29,8 +29,6 @@ function vtkSplineWidget(publicAPI, model) {
     'errorBorderColor',
     'scaleInPixels',
   ];
-  model.behavior = widgetBehavior;
-  model.widgetState = stateGenerator();
 
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
@@ -75,7 +73,7 @@ function vtkSplineWidget(publicAPI, model) {
 
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues) => ({
   // manipulator: null,
   freehandMinDistance: 0.1,
   allowFreehand: true,
@@ -83,12 +81,15 @@ const DEFAULT_VALUES = {
   defaultCursor: 'pointer',
   handleSizeInPixels: 10, // propagates to SplineContextRepresentation
   resetAfterPointPlacement: false,
-};
+  behavior: widgetBehavior,
+  widgetState: stateGenerator(),
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, [


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
The setTimeout can cause a race condition, where a widget can be
instantiated and subsequently deleted, causing an error.

This changes the way widgets are to be written. Rather than assigning
behavior and widgetState members directly, we pass them into the
vtkAbstractWidgetFactory constructor.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- Removes a race condition in vtkAbstractWidgetFactory

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] Tested existing widgets to ensure functionality is not broken
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
