### PR TITLE
fix(shapewidget): fix subtraction in compute text position

### DIFF
--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -333,7 +333,8 @@ export default function widgetBehavior(publicAPI, model) {
         );
       const displayPlaneNormal = vtkMath.subtract(
         displayPlaneNormalPoint,
-        displayPlaneOrigin
+        displayPlaneOrigin,
+        []
       );
 
       // Project view plane into bounding box


### PR DESCRIPTION
Subtract needed a third parameter as output (even though it also returns the result) and not putting it was throwing an error. I added a third vector 

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code