### PR TITLE
fix(widgets): remove nullish coalescing operator

### DIFF
--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -42,7 +42,7 @@ export default function widgetBehavior(publicAPI, model) {
     picker.initializePickList();
     picker.setPickList(publicAPI.getNestedProps());
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       model.activeState === model.widgetState.getMoveHandle() &&
       model.widgetState.getHandleList().length < MAX_POINTS &&
@@ -76,7 +76,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleMouseMove = (callData) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       manipulator &&
       model.pickable &&

--- a/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/DistanceWidget/behavior.js
@@ -35,7 +35,7 @@ export default function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       model.activeState === model.widgetState.getMoveHandle() &&
       model.widgetState.getHandleList().length < MAX_POINTS &&
@@ -69,7 +69,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleMouseMove = (callData) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       manipulator &&
       model.pickable &&

--- a/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LabelWidget/behavior.js
@@ -49,7 +49,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
 
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       model.activeState === model.widgetState.getMoveHandle() &&
       manipulator
@@ -113,7 +113,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleMouseMove = (callData) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       manipulator &&
       model.pickable &&

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -57,7 +57,7 @@ export default function widgetBehavior(publicAPI, model) {
   function updateCursor(callData) {
     model._isDragging = true;
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     model.previousPosition = [
       ...manipulator.handleEvent(callData, model._apiSpecificRenderWindow),
     ];
@@ -264,7 +264,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleMouseMove = (callData) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       manipulator &&
       model.pickable &&

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -31,7 +31,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleEvent = (callData) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (manipulator && model.activeState && model.activeState.getActive()) {
       const normal = model._camera.getDirectionOfProjection();
       const up = model._camera.getViewUp();

--- a/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PolyLineWidget/behavior.js
@@ -21,7 +21,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   function updateMoveHandle(callData) {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (!manipulator) {
       return macro.VOID;
     }
@@ -86,7 +86,7 @@ export default function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       model.activeState === model.widgetState.getMoveHandle() &&
       manipulator

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -452,7 +452,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleMouseMove = (callData) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       !manipulator ||
       !model.activeState ||
@@ -511,7 +511,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleLeftButtonPress = (e) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       !model.activeState ||
       !model.activeState.getActive() ||

--- a/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SphereWidget/behavior.js
@@ -57,7 +57,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   function currentWorldCoords(e) {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     return manipulator.handleEvent(e, model._apiSpecificRenderWindow);
   }
 

--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -293,7 +293,7 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleMouseMove = (callData) => {
     const manipulator =
-      model.activeState?.getManipulator?.() ?? model.manipulator;
+      model.activeState?.getManipulator?.() || model.manipulator;
     if (
       !manipulator ||
       !model.activeState ||


### PR DESCRIPTION
Nullish coalescing operator (`??`) are a recent feature and are sometimes not recognized by old babel
versions. As a precaution, this commit removes these operators as they are not necessary and can be
easily replaced by logical OR (`||`).

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
