### PR TITLE
chore(export_scene_macro): fixes and improvements

### DIFF
--- a/Utilities/ParaView/export-scene-macro.py
+++ b/Utilities/ParaView/export-scene-macro.py
@@ -450,7 +450,7 @@ for rIdx in range(renderers.GetNumberOfItems()):
         dataArray = None
 
         if dsAttrs:
-            dataArray = dsAttrs.GetArray(colorArrayName)
+            dataArray = dsAttrs.GetAbstractArray(colorArrayName)
 
         if dataArray:
           # component = -1 => let specific instance get scalar from vector before mapping

--- a/Utilities/ParaView/export-scene-macro.py
+++ b/Utilities/ParaView/export-scene-macro.py
@@ -1,36 +1,41 @@
+import zipfile
+from urllib.parse import quote
+import hashlib
+import shutil
+import gzip
+import json
+import errno
+import time
+import os
+import sys
 
-### ----------------------------------------------------------------------- ###
-###                       Configure output location                         ###
-###
-### A top-level export directory will be created (if necessary) and used to
-### store all exported scenes.  Use the EXPORT_DIRECTORY pattern below to
-### customize where this directory should be.  Automatic replacement will
-### be done on the following variables if they appear in the pattern:
-###
-###   ${USER_HOME} : Will be replaced by the current user's home directory
-### ----------------------------------------------------------------------- ###
+from paraview.vtk import *
+from paraview import simple
+
+
+# ### ----------------------------------------------------------------------- ###
+# ###                       Configure output location                         ###
+# ###
+# A top-level export directory will be created (if necessary) and used to
+# store all exported scenes.  Use the EXPORT_DIRECTORY pattern below to
+# customize where this directory should be.  Automatic replacement will
+# be done on the following variables if they appear in the pattern:
+#
+# ${USER_HOME} : Will be replaced by the current user's home directory
+# ### ----------------------------------------------------------------------- ###
 
 EXPORT_DIRECTORY = '${USER_HOME}/vtkJsExport'
 FILENAME_EXTENSION = '.vtkjs'
 
-### ----------------------------------------------------------------------- ###
-###                   Convenience methods and definitions                   ###
-### ----------------------------------------------------------------------- ###
+# ### ----------------------------------------------------------------------- ###
+# ###                   Convenience methods and definitions                   ###
+# ### ----------------------------------------------------------------------- ###
 
-import sys, os, re, time, errno, json, math, gzip, shutil, argparse, hashlib
-
-from urllib.parse import quote
-import zipfile
-
-from paraview import simple
-from paraview.vtk import *
 
 try:
   from vtk.vtkFiltersGeometry import vtkCompositeDataGeometryFilter
-  from vtk.vtkCommonCore import vtkUnsignedCharArray
 except:
   from vtkFiltersGeometry import vtkCompositeDataGeometryFilter
-  from vtkCommonCore import vtkUnsignedCharArray
 
 USER_HOME = os.path.expanduser('~')
 ROOT_OUTPUT_DIRECTORY = EXPORT_DIRECTORY.replace('${USER_HOME}', USER_HOME)
@@ -56,6 +61,7 @@ writerMapping = {}
 
 # -----------------------------------------------------------------------------
 
+
 def getRangeInfo(array, component):
   r = array.GetRange(component)
   compRange = {}
@@ -63,6 +69,7 @@ def getRangeInfo(array, component):
   compRange['max'] = r[1]
   compRange['component'] = array.GetComponentName(component)
   return compRange
+
 
 # -----------------------------------------------------------------------------
 
@@ -73,9 +80,12 @@ def getRef(destDirectory, md5):
   ref['basepath'] = destDirectory
   return ref
 
+
 # -----------------------------------------------------------------------------
 
 objIds = []
+
+
 def getObjectId(obj):
   try:
     idx = objIds.index(obj)
@@ -87,9 +97,12 @@ def getObjectId(obj):
 
 # -----------------------------------------------------------------------------
 
-def dumpDataArray(datasetDir, dataDir, array, root = {}, compress = True):
+def dumpDataArray(datasetDir, dataDir, array, root=None, compress=True):
   if not array:
     return None
+
+  if root is None:
+    root = {}
 
   if array.GetDataType() == 12:
     # IdType need to be converted to Uint32
@@ -97,7 +110,8 @@ def dumpDataArray(datasetDir, dataDir, array, root = {}, compress = True):
     newArray = vtkTypeUInt32Array()
     newArray.SetNumberOfTuples(arraySize)
     for i in range(arraySize):
-      newArray.SetValue(i, -1 if array.GetValue(i) < 0 else array.GetValue(i))
+      newArray.SetValue(i, -1 if array.GetValue(i)
+                        < 0 else array.GetValue(i))
     pBuffer = memoryview(newArray)
   elif array.GetDataType() == 13:
     # vtkStringArray - write as utf-8 encoded string that contains a json array with the strings
@@ -114,8 +128,8 @@ def dumpDataArray(datasetDir, dataDir, array, root = {}, compress = True):
 
   if compress:
     with open(pPath, 'rb') as f_in, gzip.open(os.path.join(dataDir, pMd5 + '.gz'), 'wb') as f_out:
-        shutil.copyfileobj(f_in, f_out)
-        os.remove(pPath)
+      shutil.copyfileobj(f_in, f_out)
+      os.remove(pPath)
 
   root['ref'] = getRef(os.path.relpath(dataDir, datasetDir), pMd5)
   root['vtkClass'] = 'vtkDataArray'
@@ -135,9 +149,12 @@ def dumpDataArray(datasetDir, dataDir, array, root = {}, compress = True):
 
   return root
 
+
 # -----------------------------------------------------------------------------
 
-def dumpColorArray(datasetDir, dataDir, colorArrayInfo, root = {}, compress = True):
+def dumpColorArray(datasetDir, dataDir, colorArrayInfo, root=None, compress=True):
+  if root is None:
+    root = {}
 
   colorArray = colorArrayInfo['colorArray']
   location = colorArrayInfo['location']
@@ -146,63 +163,75 @@ def dumpColorArray(datasetDir, dataDir, colorArrayInfo, root = {}, compress = Tr
 
   if dumpedArray:
     root[location]['activeScalars'] = 0
-    root[location]['arrays'].append({ 'data': dumpedArray })
+    root[location]['arrays'].append({'data': dumpedArray})
 
   return root
 
+
 # -----------------------------------------------------------------------------
 
-def dumpTCoords(datasetDir, dataDir, dataset, root = {}, compress = True):
+def dumpTCoords(datasetDir, dataDir, dataset, root=None, compress=True):
+  if root is None:
+    root = {}
+
   tcoords = dataset.GetPointData().GetTCoords()
   if tcoords:
     dumpedArray = dumpDataArray(datasetDir, dataDir, tcoords, {}, compress)
     root['pointData']['activeTCoords'] = len(root['pointData']['arrays'])
-    root['pointData']['arrays'].append({ 'data': dumpedArray })
+    root['pointData']['arrays'].append({'data': dumpedArray})
+
 
 # -----------------------------------------------------------------------------
 
-def dumpNormals(datasetDir, dataDir, dataset, root = {}, compress = True):
+def dumpNormals(datasetDir, dataDir, dataset, root=None, compress=True):
+  if root is None:
+    root = {}
+
   normals = dataset.GetPointData().GetNormals()
   if normals:
     dumpedArray = dumpDataArray(datasetDir, dataDir, normals, {}, compress)
     root['pointData']['activeNormals'] = len(root['pointData']['arrays'])
-    root['pointData']['arrays'].append({ 'data': dumpedArray })
+    root['pointData']['arrays'].append({'data': dumpedArray})
+
 
 # -----------------------------------------------------------------------------
 
-def dumpAllArrays(datasetDir, dataDir, dataset, root = {}, compress = True):
+def dumpAllArrays(datasetDir, dataDir, dataset, root=None, compress=True):
+  if root is None:
+    root = {}
+
   root['pointData'] = {
-    'vtkClass': 'vtkDataSetAttributes',
-    "activeGlobalIds": -1,
-    "activeNormals": -1,
-    "activePedigreeIds": -1,
-    "activeScalars": -1,
-    "activeTCoords": -1,
-    "activeTensors": -1,
-    "activeVectors": -1,
-    "arrays": []
+      'vtkClass': 'vtkDataSetAttributes',
+      "activeGlobalIds": -1,
+      "activeNormals": -1,
+      "activePedigreeIds": -1,
+      "activeScalars": -1,
+      "activeTCoords": -1,
+      "activeTensors": -1,
+      "activeVectors": -1,
+      "arrays": []
   }
   root['cellData'] = {
-    'vtkClass': 'vtkDataSetAttributes',
-    "activeGlobalIds": -1,
-    "activeNormals": -1,
-    "activePedigreeIds": -1,
-    "activeScalars": -1,
-    "activeTCoords": -1,
-    "activeTensors": -1,
-    "activeVectors": -1,
-    "arrays": []
+      'vtkClass': 'vtkDataSetAttributes',
+      "activeGlobalIds": -1,
+      "activeNormals": -1,
+      "activePedigreeIds": -1,
+      "activeScalars": -1,
+      "activeTCoords": -1,
+      "activeTensors": -1,
+      "activeVectors": -1,
+      "arrays": []
   }
   root['fieldData'] = {
-    'vtkClass': 'vtkDataSetAttributes',
-    "activeGlobalIds": -1,
-    "activeNormals": -1,
-    "activePedigreeIds": -1,
-    "activeScalars": -1,
-    "activeTCoords": -1,
-    "activeTensors": -1,
-    "activeVectors": -1,
-    "arrays": []
+      'vtkClass': 'vtkDataSetAttributes',
+      "activeGlobalIds": -1,
+      "activeNormals": -1,
+      "activePedigreeIds": -1,
+      "activeScalars": -1,
+      "activeTCoords": -1,
+      "activeTensors": -1,
+      "activeVectors": -1,
+      "arrays": []
   }
 
   # Point data
@@ -211,9 +240,10 @@ def dumpAllArrays(datasetDir, dataDir, dataset, root = {}, compress = True):
   for i in range(pd_size):
     array = pd.GetAbstractArray(i)
     if array:
-      dumpedArray = dumpDataArray(datasetDir, dataDir, array, {}, compress)
+      dumpedArray = dumpDataArray(
+          datasetDir, dataDir, array, {}, compress)
       root['pointData']['activeScalars'] = 0
-      root['pointData']['arrays'].append({ 'data': dumpedArray })
+      root['pointData']['arrays'].append({'data': dumpedArray})
 
   # Cell data
   cd = dataset.GetCellData()
@@ -221,47 +251,57 @@ def dumpAllArrays(datasetDir, dataDir, dataset, root = {}, compress = True):
   for i in range(cd_size):
     array = cd.GetAbstractArray(i)
     if array:
-      dumpedArray = dumpDataArray(datasetDir, dataDir, array, {}, compress)
+      dumpedArray = dumpDataArray(
+          datasetDir, dataDir, array, {}, compress)
       root['cellData']['activeScalars'] = 0
-      root['cellData']['arrays'].append({ 'data': dumpedArray })
+      root['cellData']['arrays'].append({'data': dumpedArray})
 
   return root
 
+
 # -----------------------------------------------------------------------------
 
-def dumpPolyData(datasetDir, dataDir, dataset, colorArrayInfo, root = {}, compress = True):
+def dumpPolyData(datasetDir, dataDir, dataset, colorArrayInfo, root=None, compress=True):
+  if root is None:
+    root = {}
+
   root['vtkClass'] = 'vtkPolyData'
   container = root
 
   # Points
-  points = dumpDataArray(datasetDir, dataDir, dataset.GetPoints().GetData(), {}, compress)
+  points = dumpDataArray(datasetDir, dataDir,
+                         dataset.GetPoints().GetData(), {}, compress)
   points['vtkClass'] = 'vtkPoints'
   container['points'] = points
 
   # Cells
   _cells = container
 
-  ## Verts
+  # Verts
   if dataset.GetVerts() and dataset.GetVerts().GetData().GetNumberOfTuples() > 0:
-    _verts = dumpDataArray(datasetDir, dataDir, dataset.GetVerts().GetData(), {}, compress)
+    _verts = dumpDataArray(datasetDir, dataDir,
+                           dataset.GetVerts().GetData(), {}, compress)
     _cells['verts'] = _verts
     _cells['verts']['vtkClass'] = 'vtkCellArray'
 
-  ## Lines
+  # Lines
   if dataset.GetLines() and dataset.GetLines().GetData().GetNumberOfTuples() > 0:
-    _lines = dumpDataArray(datasetDir, dataDir, dataset.GetLines().GetData(), {}, compress)
+    _lines = dumpDataArray(datasetDir, dataDir,
+                           dataset.GetLines().GetData(), {}, compress)
     _cells['lines'] = _lines
     _cells['lines']['vtkClass'] = 'vtkCellArray'
 
-  ## Polys
+  # Polys
   if dataset.GetPolys() and dataset.GetPolys().GetData().GetNumberOfTuples() > 0:
-    _polys = dumpDataArray(datasetDir, dataDir, dataset.GetPolys().GetData(), {}, compress)
+    _polys = dumpDataArray(datasetDir, dataDir,
+                           dataset.GetPolys().GetData(), {}, compress)
     _cells['polys'] = _polys
     _cells['polys']['vtkClass'] = 'vtkCellArray'
 
-  ## Strips
+  # Strips
   if dataset.GetStrips() and dataset.GetStrips().GetData().GetNumberOfTuples() > 0:
-    _strips = dumpDataArray(datasetDir, dataDir, dataset.GetStrips().GetData(), {}, compress)
+    _strips = dumpDataArray(datasetDir, dataDir,
+                            dataset.GetStrips().GetData(), {}, compress)
     _cells['strips'] = _strips
     _cells['strips']['vtkClass'] = 'vtkCellArray'
 
@@ -269,17 +309,22 @@ def dumpPolyData(datasetDir, dataDir, dataset, colorArrayInfo, root = {}, compre
 
   dumpColorArray(datasetDir, dataDir, colorArrayInfo, container, compress)
 
-  ## PointData TCoords
+  # PointData TCoords
   dumpTCoords(datasetDir, dataDir, dataset, container, compress)
   # dumpNormals(datasetDir, dataDir, dataset, container, compress)
 
   return root
 
+
 # -----------------------------------------------------------------------------
 writerMapping['vtkPolyData'] = dumpPolyData
 # -----------------------------------------------------------------------------
 
-def dumpImageData(datasetDir, dataDir, dataset, colorArrayInfo, root = {}, compress = True):
+
+def dumpImageData(datasetDir, dataDir, dataset, colorArrayInfo, root=None, compress=True):
+  if root is None:
+    root = {}
+
   root['vtkClass'] = 'vtkImageData'
   container = root
 
@@ -291,11 +336,13 @@ def dumpImageData(datasetDir, dataDir, dataset, colorArrayInfo, root = {}, compr
 
   return root
 
+
 # -----------------------------------------------------------------------------
 writerMapping['vtkImageData'] = dumpImageData
 # -----------------------------------------------------------------------------
 
-def writeDataSet(filePath, dataset, outputDir, colorArrayInfo, newDSName = None, compress = True):
+
+def writeDataSet(filePath, dataset, outputDir, colorArrayInfo, newDSName=None, compress=True):
   fileName = quote(newDSName if newDSName else os.path.basename(filePath))
   datasetDir = os.path.join(outputDir, fileName)
   dataDir = os.path.join(datasetDir, 'data')
@@ -311,7 +358,7 @@ def writeDataSet(filePath, dataset, outputDir, colorArrayInfo, newDSName = None,
   if writer:
     writer(datasetDir, dataDir, dataset, colorArrayInfo, root, compress)
   else:
-    print (dataObject.GetClassName(), 'is not supported')
+    print(dataObject.GetClassName(), 'is not supported')
 
   with open(os.path.join(datasetDir, "index.json"), 'w') as f:
     f.write(json.dumps(root, indent=2))
@@ -319,6 +366,7 @@ def writeDataSet(filePath, dataset, outputDir, colorArrayInfo, newDSName = None,
   return datasetDir
 
 # -----------------------------------------------------------------------------
+
 
 def generateSceneName():
   srcs = simple.GetSources()
@@ -344,7 +392,9 @@ def generateSceneName():
 
 # -----------------------------------------------------------------------------
 
+
 componentIndex = 0
+
 
 def getComponentName(actor):
   global componentIndex
@@ -363,7 +413,8 @@ def getComponentName(actor):
       nameToUse = newName
     duplicates[nameToUse] = True
 
-    actorRep = simple.GetRepresentation(val).GetClientSideObject().GetActiveRepresentation().GetActor()
+    actorRep = simple.GetRepresentation(
+        val).GetClientSideObject().GetActiveRepresentation().GetActor()
     if actor == actorRep:
       return nameToUse
 
@@ -372,9 +423,9 @@ def getComponentName(actor):
   return nameToUse
 
 
-### ----------------------------------------------------------------------- ###
-###                          Main script contents                           ###
-### ----------------------------------------------------------------------- ###
+# ### ----------------------------------------------------------------------- ###
+# ###                          Main script contents                           ###
+# ### ----------------------------------------------------------------------- ###
 
 def mkdir_p(path):
   try:
@@ -384,6 +435,7 @@ def mkdir_p(path):
       pass
     else:
       raise
+
 
 # Generate timestamp and use it to make subdirectory within the top level output dir
 timeStamp = time.strftime("%a-%d-%b-%Y-%H-%M-%S")
@@ -411,7 +463,7 @@ for rIdx in range(renderers.GetNumberOfItems()):
 
     if hasattr(renProp, 'GetMapper'):
       mapper = renProp.GetMapper()
-      dataObject = mapper.GetInputDataObject(0, 0);
+      dataObject = mapper.GetInputDataObject(0, 0)
       dataset = None
 
       if dataObject.IsA('vtkCompositeDataSet'):
@@ -439,10 +491,12 @@ for rIdx in range(renderers.GetNumberOfItems()):
         arrayLocation = ''
 
         if scalarVisibility:
-          if scalarMode == 3 or scalarMode == 1: # VTK_SCALAR_MODE_USE_POINT_FIELD_DATA or VTK_SCALAR_MODE_USE_POINT_DATA
+          # VTK_SCALAR_MODE_USE_POINT_FIELD_DATA or VTK_SCALAR_MODE_USE_POINT_DATA
+          if scalarMode == 3 or scalarMode == 1:
             dsAttrs = dataset.GetPointData()
             arrayLocation = 'pointData'
-          elif scalarMode == 4 or scalarMode == 2: # VTK_SCALAR_MODE_USE_CELL_FIELD_DATA or VTK_SCALAR_MODE_USE_CELL_DATA
+          # VTK_SCALAR_MODE_USE_CELL_FIELD_DATA or VTK_SCALAR_MODE_USE_CELL_DATA
+          elif scalarMode == 4 or scalarMode == 2:
             dsAttrs = dataset.GetCellData()
             arrayLocation = 'cellData'
 
@@ -450,11 +504,12 @@ for rIdx in range(renderers.GetNumberOfItems()):
         dataArray = None
 
         if dsAttrs:
-            dataArray = dsAttrs.GetAbstractArray(colorArrayName)
+          dataArray = dsAttrs.GetAbstractArray(colorArrayName)
 
         if dataArray:
           # component = -1 => let specific instance get scalar from vector before mapping
-          colorArray = lookupTable.MapScalars(dataArray, colorMode, -1);
+          colorArray = lookupTable.MapScalars(
+              dataArray, colorMode, -1)
           colorArrayName = '__CustomRGBColorArray__'
           colorArray.SetName(colorArrayName)
           colorMode = 0
@@ -462,60 +517,71 @@ for rIdx in range(renderers.GetNumberOfItems()):
           colorArrayName = ''
 
         colorArrayInfo = {
-          'colorArray': colorArray,
-          'location': arrayLocation
+            'colorArray': colorArray,
+            'location': arrayLocation
         }
 
-        scDirs.append(writeDataSet('', dataset, outputDir, colorArrayInfo, newDSName=componentName, compress=doCompressArrays))
+        scDirs.append(writeDataSet('', dataset, outputDir, colorArrayInfo,
+                      newDSName=componentName, compress=doCompressArrays))
 
         # Handle texture if any
         textureName = None
         if renProp.GetTexture() and renProp.GetTexture().GetInput():
           textureData = renProp.GetTexture().GetInput()
-          textureName = 'texture_%d' % getObjectId(textureData);
+          textureName = 'texture_%d' % getObjectId(textureData)
           textureToSave[textureName] = textureData
 
-        representation = renProp.GetProperty().GetRepresentation() if hasattr(renProp, 'GetProperty') else 2
-        colorToUse = renProp.GetProperty().GetDiffuseColor() if hasattr(renProp, 'GetProperty') else [1, 1, 1]
+        representation = renProp.GetProperty().GetRepresentation(
+        ) if hasattr(renProp, 'GetProperty') else 2
+        colorToUse = renProp.GetProperty().GetDiffuseColor(
+        ) if hasattr(renProp, 'GetProperty') else [1, 1, 1]
         if representation == 1:
-            colorToUse = renProp.GetProperty().GetColor() if hasattr(renProp, 'GetProperty') else [1, 1, 1]
-        pointSize = renProp.GetProperty().GetPointSize() if hasattr(renProp, 'GetProperty') else 1.0
-        opacity = renProp.GetProperty().GetOpacity() if hasattr(renProp, 'GetProperty') else 1.0
-        edgeVisibility = renProp.GetProperty().GetEdgeVisibility() if hasattr(renProp, 'GetProperty') else false
+          colorToUse = renProp.GetProperty().GetColor() if hasattr(
+              renProp, 'GetProperty') else [1, 1, 1]
+        pointSize = renProp.GetProperty().GetPointSize(
+        ) if hasattr(renProp, 'GetProperty') else 1.0
+        opacity = renProp.GetProperty().GetOpacity() if hasattr(
+            renProp, 'GetProperty') else 1.0
+        edgeVisibility = renProp.GetProperty().GetEdgeVisibility(
+        ) if hasattr(renProp, 'GetProperty') else False
 
-        p3dPosition = renProp.GetPosition() if renProp.IsA('vtkProp3D') else [0, 0, 0]
-        p3dScale = renProp.GetScale() if renProp.IsA('vtkProp3D') else [1, 1, 1]
-        p3dOrigin = renProp.GetOrigin() if renProp.IsA('vtkProp3D') else [0, 0, 0]
-        p3dRotateWXYZ = renProp.GetOrientationWXYZ()  if renProp.IsA('vtkProp3D') else [0, 0, 0, 0]
+        p3dPosition = renProp.GetPosition() if renProp.IsA(
+            'vtkProp3D') else [0, 0, 0]
+        p3dScale = renProp.GetScale() if renProp.IsA(
+            'vtkProp3D') else [1, 1, 1]
+        p3dOrigin = renProp.GetOrigin() if renProp.IsA(
+            'vtkProp3D') else [0, 0, 0]
+        p3dRotateWXYZ = renProp.GetOrientationWXYZ(
+        ) if renProp.IsA('vtkProp3D') else [0, 0, 0, 0]
 
         sceneComponents.append({
-          "name": componentName,
-          "type": "httpDataSetReader",
-          "httpDataSetReader": {
-            "url": componentName
-          },
-          "actor": {
-            "origin": p3dOrigin,
-            "scale": p3dScale,
-            "position": p3dPosition,
-          },
-          "actorRotation": p3dRotateWXYZ,
-          "mapper": {
-            "colorByArrayName": colorArrayName,
-            "colorMode": colorMode,
-            "scalarMode": scalarMode
-          },
-          "property": {
-            "representation": representation,
-            "edgeVisibility": edgeVisibility,
-            "diffuseColor": colorToUse,
-            "pointSize": pointSize,
-            "opacity": opacity
-          },
-          "lookupTable": {
-            "tableRange": lookupTable.GetRange(),
-            "hueRange": lookupTable.GetHueRange() if hasattr(lookupTable, 'GetHueRange') else [0.5, 0]
-          }
+            "name": componentName,
+            "type": "httpDataSetReader",
+            "httpDataSetReader": {
+                "url": componentName
+            },
+            "actor": {
+                "origin": p3dOrigin,
+                "scale": p3dScale,
+                "position": p3dPosition,
+            },
+            "actorRotation": p3dRotateWXYZ,
+            "mapper": {
+                "colorByArrayName": colorArrayName,
+                "colorMode": colorMode,
+                "scalarMode": scalarMode
+            },
+            "property": {
+                "representation": representation,
+                "edgeVisibility": edgeVisibility,
+                "diffuseColor": colorToUse,
+                "pointSize": pointSize,
+                "opacity": opacity
+            },
+            "lookupTable": {
+                "tableRange": lookupTable.GetRange(),
+                "hueRange": lookupTable.GetHueRange() if hasattr(lookupTable, 'GetHueRange') else [0.5, 0]
+            }
         })
 
         if textureName:
@@ -523,21 +589,22 @@ for rIdx in range(renderers.GetNumberOfItems()):
 
 # Save texture data if any
 for key, val in textureToSave.items():
-  writeDataSet('', val, outputDir, None, newDSName=key, compress=doCompressArrays)
+  writeDataSet('', val, outputDir, None, newDSName=key,
+               compress=doCompressArrays)
 
 cameraClippingRange = activeView.GetActiveCamera().GetClippingRange()
 
 sceneDescription = {
-  "fetchGzip": doCompressArrays,
-  "background": activeView.Background.GetData(),
-  "camera": {
-    "focalPoint": activeView.CameraFocalPoint.GetData(),
-    "position": activeView.CameraPosition.GetData(),
-    "viewUp": activeView.CameraViewUp.GetData(),
-    "clippingRange": [ elt for elt in cameraClippingRange ]
-  },
-  "centerOfRotation": activeView.CenterOfRotation.GetData(),
-  "scene": sceneComponents
+    "fetchGzip": doCompressArrays,
+    "background": activeView.Background.GetData(),
+    "camera": {
+        "focalPoint": activeView.CameraFocalPoint.GetData(),
+        "position": activeView.CameraPosition.GetData(),
+        "viewUp": activeView.CameraViewUp.GetData(),
+        "clippingRange": [elt for elt in cameraClippingRange]
+    },
+    "centerOfRotation": activeView.CenterOfRotation.GetData(),
+    "scene": sceneComponents
 }
 
 indexFilePath = os.path.join(outputDir, 'index.json')
@@ -549,12 +616,13 @@ with open(indexFilePath, 'w') as outfile:
 # Now zip up the results and get rid of the temp directory
 
 sceneName = generateSceneName()
-sceneFileName = os.path.join(ROOT_OUTPUT_DIRECTORY, '%s%s' % (sceneName, FILENAME_EXTENSION))
+sceneFileName = os.path.join(
+    ROOT_OUTPUT_DIRECTORY, '%s%s' % (sceneName, FILENAME_EXTENSION))
 
 try:
   import zlib
   compression = zipfile.ZIP_DEFLATED
-except:
+except ImportError:
   compression = zipfile.ZIP_STORED
 
 zf = zipfile.ZipFile(sceneFileName, mode='w')
@@ -563,11 +631,12 @@ try:
   for dirName, subdirList, fileList in os.walk(outputDir):
     for fname in fileList:
       fullPath = os.path.join(dirName, fname)
-      relPath = '%s/%s' % (sceneName, os.path.relpath(fullPath, outputDir))
+      relPath = '%s/%s' % (sceneName,
+                           os.path.relpath(fullPath, outputDir))
       zf.write(fullPath, arcname=relPath, compress_type=compression)
 finally:
-    zf.close()
+  zf.close()
 
 shutil.rmtree(outputDir)
 
-print ('Finished exporting dataset to: ',sceneFileName)
+print('Finished exporting dataset to: ', sceneFileName)

--- a/Utilities/ParaView/export-scene-macro.py
+++ b/Utilities/ParaView/export-scene-macro.py
@@ -129,39 +129,6 @@ def dumpDataArray(datasetDir, dataDir, array, root = {}, compress = True):
 # -----------------------------------------------------------------------------
 
 def dumpColorArray(datasetDir, dataDir, colorArrayInfo, root = {}, compress = True):
-  root['pointData'] = {
-    'vtkClass': 'vtkDataSetAttributes',
-    "activeGlobalIds": -1,
-    "activeNormals": -1,
-    "activePedigreeIds": -1,
-    "activeScalars": -1,
-    "activeTCoords": -1,
-    "activeTensors": -1,
-    "activeVectors": -1,
-    "arrays": []
-  }
-  root['cellData'] = {
-    'vtkClass': 'vtkDataSetAttributes',
-    "activeGlobalIds": -1,
-    "activeNormals": -1,
-    "activePedigreeIds": -1,
-    "activeScalars": -1,
-    "activeTCoords": -1,
-    "activeTensors": -1,
-    "activeVectors": -1,
-    "arrays": []
-  }
-  root['fieldData'] = {
-    'vtkClass': 'vtkDataSetAttributes',
-    "activeGlobalIds": -1,
-    "activeNormals": -1,
-    "activePedigreeIds": -1,
-    "activeScalars": -1,
-    "activeTCoords": -1,
-    "activeTensors": -1,
-    "activeVectors": -1,
-    "arrays": []
-  }
 
   colorArray = colorArrayInfo['colorArray']
   location = colorArrayInfo['location']
@@ -288,6 +255,8 @@ def dumpPolyData(datasetDir, dataDir, dataset, colorArrayInfo, root = {}, compre
     _strips = dumpDataArray(datasetDir, dataDir, dataset.GetStrips().GetData(), {}, compress)
     _cells['strips'] = _strips
     _cells['strips']['vtkClass'] = 'vtkCellArray'
+
+  dumpAllArrays(datasetDir, dataDir, dataset, container, compress)
 
   dumpColorArray(datasetDir, dataDir, colorArrayInfo, container, compress)
 

--- a/Utilities/ParaView/export-scene-macro.py
+++ b/Utilities/ParaView/export-scene-macro.py
@@ -19,6 +19,7 @@ FILENAME_EXTENSION = '.vtkjs'
 
 import sys, os, re, time, errno, json, math, gzip, shutil, argparse, hashlib
 
+from urllib.parse import quote
 import zipfile
 
 from paraview import simple
@@ -295,7 +296,7 @@ writerMapping['vtkImageData'] = dumpImageData
 # -----------------------------------------------------------------------------
 
 def writeDataSet(filePath, dataset, outputDir, colorArrayInfo, newDSName = None, compress = True):
-  fileName = newDSName if newDSName else os.path.basename(filePath)
+  fileName = quote(newDSName if newDSName else os.path.basename(filePath))
   datasetDir = os.path.join(outputDir, fileName)
   dataDir = os.path.join(datasetDir, 'data')
 

--- a/Utilities/ParaView/export-scene-macro.py
+++ b/Utilities/ParaView/export-scene-macro.py
@@ -25,11 +25,11 @@ from paraview import simple
 from paraview.vtk import *
 
 try:
-  from vtk.vtkFiltersGeometryPython import vtkCompositeDataGeometryFilter
-  from vtk.vtkCommonCorePython import vtkUnsignedCharArray
+  from vtk.vtkFiltersGeometry import vtkCompositeDataGeometryFilter
+  from vtk.vtkCommonCore import vtkUnsignedCharArray
 except:
-  from vtkFiltersGeometryPython import vtkCompositeDataGeometryFilter
-  from vtkCommonCorePython import vtkUnsignedCharArray
+  from vtkFiltersGeometry import vtkCompositeDataGeometryFilter
+  from vtkCommonCore import vtkUnsignedCharArray
 
 USER_HOME = os.path.expanduser('~')
 ROOT_OUTPUT_DIRECTORY = EXPORT_DIRECTORY.replace('${USER_HOME}', USER_HOME)
@@ -96,9 +96,9 @@ def dumpDataArray(datasetDir, dataDir, array, root = {}, compress = True):
     newArray.SetNumberOfTuples(arraySize)
     for i in range(arraySize):
       newArray.SetValue(i, -1 if array.GetValue(i) < 0 else array.GetValue(i))
-    pBuffer = buffer(newArray)
+    pBuffer = memoryview(newArray)
   else:
-    pBuffer = buffer(array)
+    pBuffer = memoryview(array)
 
   pMd5 = hashlib.md5(pBuffer).hexdigest()
   pPath = os.path.join(dataDir, pMd5)
@@ -241,7 +241,7 @@ def dumpAllArrays(datasetDir, dataDir, dataset, root = {}, compress = True):
 
   # Cell data
   cd = dataset.GetCellData()
-  cd_size = pd.GetNumberOfArrays()
+  cd_size = cd.GetNumberOfArrays()
   for i in range(cd_size):
     array = cd.GetArray(i)
     if array:
@@ -430,6 +430,7 @@ for rIdx in range(renderers.GetNumberOfItems()):
     renProp = renProps.GetItemAsObject(rpIdx)
     if not renProp.GetVisibility():
       continue
+
     if hasattr(renProp, 'GetMapper'):
       mapper = renProp.GetMapper()
       dataObject = mapper.GetInputDataObject(0, 0);


### PR DESCRIPTION
### Context
Although ParaView supports exporting a scene to `*.vtkjs`, the `export_scene_macro` is still useful for rapid customization, prototyping, and educational purposes.

One of the examples is https://discourse.paraview.org/t/trouble-exporting-scene-to-vtkjs/9829/10, where the native export was incomplete, but fixing it in C++ was infeasible for me. This is why I looked at the macro, update
[SceneExplorer_node-18.x.html.zip](https://github.com/Kitware/vtk-js/files/9050061/SceneExplorer_node-18.x.html.zip)
d it to support Python 3, fixed some issues and added the features that were missing for my use case.
This PR also fixes https://github.com/Kitware/vtk-js/issues/2499 which I found while looking at the code.

### Results
* The macro runs again (didn't any more, tested in ParaView 5.10.1 on macOS)
* The macro does not only export arrays relevant for coloring but all existing arrays (and in contrast to the ParaView native export also `vtkStringArray`).

### Changes
The following changes have been made (see also git history):
* Fix errors (Python 3 compatibility, name of imported modules)
* Do not ignore vtkMultiBlockDataset when exporting
* Export all numeric arrays instead only the one needed for coloring the scene items
* Do not skip vtkStringArray when exporting to *.vtkjs
* Fixed export when names of scene items contain spaces or other special characters
* Support for coloring of scene items by non-numeric arrays (tested with string arrays)
* Python-style formatting

### Testing
- Run the macro from ParaView and inspect the produced `*.vtkjs` to see that all array data is now available.
- The exported scene can also be analyzed using a modified SceneExplorer, see attachment (from https://github.com/dasmy/SceneExplorer), where labels based on numeric and string-based arrays can be added to point data visualizations.
<img width="1578" alt="image" src="https://user-images.githubusercontent.com/5322274/177493462-3d623696-58c5-4310-9897-592523018f9c.png">

- Tested environment:
  - **vtk.js**: not relevant
  - **OS**: macOS
  - **Browser**: not relevant
  - **Paraview**: 5.10.1
