### PR TITLE
fix(WebGPU): fix a number of test failures

### DIFF
--- a/Sources/Rendering/WebGPU/Actor2D/index.js
+++ b/Sources/Rendering/WebGPU/Actor2D/index.js
@@ -127,6 +127,8 @@ function vtkWebGPUActor2D(publicAPI, model) {
           -center[1],
           -center[2],
         ]);
+      } else {
+        mat4.copy(model.keyMatrices.bcsc, model.keyMatrices.bcwc);
       }
       model.keyMatricesTime.modified();
     }

--- a/Sources/Rendering/WebGPU/BufferManager/index.js
+++ b/Sources/Rendering/WebGPU/BufferManager/index.js
@@ -53,7 +53,7 @@ function _getFormatForDataArray(dataArray) {
       break;
     case 3:
       // only 32bit types support x3
-      if (!format.contains('32')) {
+      if (!format.includes('32')) {
         vtkErrorMacro(`unsupported x3 type for ${format}`);
       }
       format += 'x3';

--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -211,6 +211,8 @@ function vtkWebGPUTexture(publicAPI, model) {
     return tDetails.numComponents;
   };
 
+  publicAPI.getDimensions = () => (model.depth > 1 ? 3 : 2);
+
   publicAPI.resizeToMatch = (tex) => {
     if (
       tex.getWidth() !== model.width ||

--- a/Sources/Rendering/WebGPU/Types/index.js
+++ b/Sources/Rendering/WebGPU/Types/index.js
@@ -330,7 +330,7 @@ function getByteStrideFromBufferFormat(format) {
   // options are x2, x3, x4 or nothing
   let numComp = 1;
   if (format[format.length - 2] === 'x') {
-    numComp = format[format.length - 1];
+    numComp = Number(format[format.length - 1]);
   }
 
   const sizeStart = numComp === 1 ? format.length - 1 : format.length - 3;
@@ -353,7 +353,7 @@ function getNumberOfComponentsFromBufferFormat(format) {
   // options are x2, x3, x4 or nothing
   let numComp = 1;
   if (format[format.length - 2] === 'x') {
-    numComp = format[format.length - 1];
+    numComp = Number(format[format.length - 1]);
   }
   return numComp;
 }
@@ -419,7 +419,7 @@ function getByteStrideFromShaderFormat(format) {
   let numComp = 1;
 
   if (format.substring(0, 3) === 'vec') {
-    numComp = format[3];
+    numComp = Number(format[3]);
   } else if (format.substring(0, 3) === 'mat') {
     numComp = format[3] * format[5];
   }


### PR DESCRIPTION
Since WebGPU tests were last run a number of issues crept in
some due to WebGPU changes some due to changes in classes
outside of WebGPU.

- fix a bad use of string.contains which should have
  been string.includes

- fix a case where cell normals and point normals
  were using the shader program, shared pipeline hash

- better support for 3d texture coordinates

- fix a case where Actor2D could use an undefined matrix

There are still some new failures due to the Hardware selector
test being modified to test features that were only implemented
on the WebGL side plus failures that were present from before.

