### PR TITLE
fix(WidgetManager): handle touch support

### DIFF
--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -29,16 +29,10 @@ function convert(xx, yy, pb, area) {
     return 0;
   }
   const offset = (yy * (area[2] - area[0] + 1) + xx) * 4;
-  const rgb = [];
-  rgb[0] = pb[offset];
-  rgb[1] = pb[offset + 1];
-  rgb[2] = pb[offset + 2];
-  let val = rgb[2];
-  val *= 256;
-  val += rgb[1];
-  val *= 256;
-  val += rgb[0];
-  return val;
+  const r = pb[offset];
+  const g = pb[offset + 1];
+  const b = pb[offset + 2];
+  return (b * 256 + g) * 256 + r;
 }
 
 function getID(low24, high8) {


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
- Touch widget support is broken. Related: https://discourse.vtk.org/t/reslicecursorwidget-does-not-operate-the-cross-selector-normally-on-the-mobile-touch-screen/8743/8
- Multiple widget managers cause freezes. Related: #2435, #2438

FYI @finetjul. I'm still investigating, but here is something that might work.

### Results
- touch should work on widgets
- multiple widget managers should not freeze

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested widgets:
  - polyline widget with an orientation marker widget

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
