### PR TITLE
perf(OpenGLRenderWindow): caching proxy gl context

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/ContextProxy.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/ContextProxy.js
@@ -1,0 +1,61 @@
+export function createContextProxyHandler() {
+  const cache = new Map();
+
+  const getParameterHandler = {
+    apply(target, gl, args) {
+      if (cache.has(args[0])) {
+        return cache.get(args[0]);
+      }
+      return target.apply(gl, args);
+    },
+  };
+
+  // only supports single-value setters
+  function cachedSetterHandler(key) {
+    return {
+      apply(target, gl, args) {
+        cache.set(key, args[0]);
+        return target.apply(gl, args);
+      },
+    };
+  }
+
+  // When a property is accessed on the webgl context proxy,
+  // it's accessed is intercepted. If the property name matches
+  // any of the keys of `propHandlers`, then that handler is called
+  // with the following arguments: (gl, prop, receiver, propValue)
+  // - gl (WebGL2RenderingContext): the underlying webgl context
+  // - propName (string): the property name
+  // - receiver (Proxy): the webgl context proxy
+  // - propValue (unknown): the value of `gl[propName]`
+
+  const propHandlers = Object.create(null);
+
+  // Sets getParameter(property) as a cached getter proxy.
+  // propValue.bind(gl) is to avoid Illegal Invocation errors.
+  propHandlers.getParameter = (gl, prop, receiver, propValue) =>
+    new Proxy(propValue.bind(gl), getParameterHandler);
+
+  // Sets depthMask(flag) as a cached setter proxy.
+  propHandlers.depthMask = (gl, prop, receiver, propValue) =>
+    new Proxy(propValue.bind(gl), cachedSetterHandler(gl.DEPTH_WRITEMASK));
+
+  return {
+    get(gl, prop, receiver) {
+      let value = Reflect.get(gl, prop, receiver);
+      if (value instanceof Function) {
+        // prevents Illegal Invocation errors
+        value = value.bind(gl);
+      }
+
+      const propHandler = propHandlers[prop];
+      if (propHandler) {
+        return propHandler(gl, prop, receiver, value);
+      }
+
+      return value;
+    },
+  };
+}
+
+export default { createContextProxyHandler };

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -8,6 +8,7 @@ import vtkOpenGLTextureUnitManager from 'vtk.js/Sources/Rendering/OpenGL/Texture
 import vtkOpenGLViewNodeFactory from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
 import vtkRenderPass from 'vtk.js/Sources/Rendering/SceneGraph/RenderPass';
 import vtkRenderWindowViewNode from 'vtk.js/Sources/Rendering/SceneGraph/RenderWindowViewNode';
+import { createContextProxyHandler } from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow/ContextProxy';
 
 const { vtkDebugMacro, vtkErrorMacro } = macro;
 
@@ -89,6 +90,8 @@ export function popMonitorGLContextCount(cb) {
 function vtkOpenGLRenderWindow(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkOpenGLRenderWindow');
+
+  const cachingContextHandler = createContextProxyHandler();
 
   publicAPI.getViewNodeFactory = () => model.myFactory;
 
@@ -284,7 +287,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
         model.canvas.getContext('experimental-webgl', options);
     }
 
-    return result;
+    return new Proxy(result, cachingContextHandler);
   };
 
   // Request an XR session on the user device with WebXR,


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
This is the continuation of #2484, since I could not push to @FezVrasta's branch.

We use ES6 proxies to cache calls to getParameter and depthMask.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- improved performance on repeated calls to getParameter, which go through the cache rather than the webgl context.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Implemented a Proxy around the webgl context.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
