### PR TITLE
fix(WebGPU): fix two issues in WebGPU

### DIFF
--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -158,6 +158,10 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       // tmpMat4 is now SC -> Index, save this as we need it later
       mat4.invert(tmp3Mat4, tmpMat4);
 
+      // need translation and scale
+      mat4.fromTranslation(tmp2Mat4, [0.5, 0.5, 0.5]);
+      mat4.multiply(tmpMat4, tmp2Mat4, tmpMat4);
+
       const dims = image.getDimensions();
       mat4.identity(tmp2Mat4);
       mat4.scale(tmp2Mat4, tmp2Mat4, [
@@ -198,15 +202,15 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       }
 
       ptsArray1[axis0] = nSlice;
-      ptsArray1[axis1] = ext[axis1 * 2];
-      ptsArray1[axis2] = ext[axis2 * 2];
+      ptsArray1[axis1] = ext[axis1 * 2] - 0.5;
+      ptsArray1[axis2] = ext[axis2 * 2] - 0.5;
       ptsArray1[3] = 1.0;
       vec4.transformMat4(ptsArray1, ptsArray1, tmp3Mat4);
       model.UBO.setArray('Origin', ptsArray1);
 
       ptsArray2[axis0] = nSlice;
-      ptsArray2[axis1] = ext[axis1 * 2 + 1];
-      ptsArray2[axis2] = ext[axis2 * 2];
+      ptsArray2[axis1] = ext[axis1 * 2 + 1] + 0.5;
+      ptsArray2[axis2] = ext[axis2 * 2] - 0.5;
       ptsArray2[3] = 1.0;
       vec4.transformMat4(ptsArray2, ptsArray2, tmp3Mat4);
       vec4.subtract(ptsArray2, ptsArray2, ptsArray1);
@@ -214,8 +218,8 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       model.UBO.setArray('Axis1', ptsArray2);
 
       ptsArray2[axis0] = nSlice;
-      ptsArray2[axis1] = ext[axis1 * 2];
-      ptsArray2[axis2] = ext[axis2 * 2 + 1];
+      ptsArray2[axis1] = ext[axis1 * 2] - 0.5;
+      ptsArray2[axis2] = ext[axis2 * 2 + 1] + 0.5;
       ptsArray2[3] = 1.0;
       vec4.transformMat4(ptsArray2, ptsArray2, tmp3Mat4);
       vec4.subtract(ptsArray2, ptsArray2, ptsArray1);
@@ -236,7 +240,7 @@ function vtkWebGPUImageMapper(publicAPI, model) {
 
         const target = iComps ? i : 0;
         const cfun = actor.getProperty().getRGBTransferFunction(target);
-        if (cfun && actor.getProperty().getUseLookupTableScalarRange()) {
+        if (cfun) {
           const cRange = cfun.getRange();
           cw = cRange[1] - cRange[0];
           cl = 0.5 * (cRange[1] + cRange[0]);

--- a/Sources/Rendering/WebGPU/Pipeline/index.js
+++ b/Sources/Rendering/WebGPU/Pipeline/index.js
@@ -79,17 +79,6 @@ function vtkWebGPUPipeline(publicAPI, model) {
   publicAPI.bindVertexInput = (renderEncoder, vInput) => {
     vInput.bindBuffers(renderEncoder);
   };
-
-  publicAPI.addDrawCallback = (cb) => {
-    model._drawCallbacks.push(cb);
-  };
-
-  // handle anything that needs to be done when drawing
-  publicAPI.draw = (encoder) => {
-    for (let cb = 0; cb < model._drawCallbacks.length; cb++) {
-      model._drawCallbacks[cb](encoder, publicAPI);
-    }
-  };
 }
 
 // ----------------------------------------------------------------------------
@@ -114,7 +103,6 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.layouts = [];
   model.shaderDescriptions = [];
-  model._drawCallbacks = [];
 
   macro.get(publicAPI, model, ['handle', 'pipelineDescription']);
   macro.setGet(publicAPI, model, [

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -83,7 +83,6 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
       }
     }
     model.boundPipeline = pl;
-    pl.draw(publicAPI);
   };
 
   publicAPI.replaceShaderCode = (pipeline) => {

--- a/Sources/Rendering/WebGPU/SimpleMapper/index.js
+++ b/Sources/Rendering/WebGPU/SimpleMapper/index.js
@@ -288,6 +288,10 @@ function vtkWebGPUSimpleMapper(publicAPI, model) {
     // bind the mapper bind group
     renderEncoder.activateBindGroup(model.bindGroup);
 
+    if (model.WebGPURenderer) {
+      model.WebGPURenderer.bindUBO(renderEncoder);
+    }
+
     // bind the vertex input
     pipeline.bindVertexInput(renderEncoder, model.vertexInput);
     const indexBuffer = model.vertexInput.getIndexBuffer();
@@ -337,7 +341,6 @@ function vtkWebGPUSimpleMapper(publicAPI, model) {
 
       if (model.WebGPURenderer) {
         model.pipeline.addBindGroupLayout(model.WebGPURenderer.getBindGroup());
-        model.pipeline.addDrawCallback(model.WebGPURenderer.bindUBO);
       }
 
       model.pipeline.addBindGroupLayout(model.bindGroup);


### PR DESCRIPTION
Fix an issue where the renderer UBO was being shared between
pipelines causing some multiviewport renderings to use an
incorrect UBO

Fix an issue in the ImageMapper where the world coordinates
and texture coordinates were not consistent with the new
definition of pixel ceneterd images.

Fix an issue where the range of a color transfer function
was being ignored in one place while used in building the table.

