### PR TITLE
Implement vtkQuad

### DIFF
--- a/Sources/Common/DataModel/Quad/Constants.js
+++ b/Sources/Common/DataModel/Quad/Constants.js
@@ -1,0 +1,8 @@
+export const QuadWithLineIntersectionState = {
+  NO_INTERSECTION: 0,
+  YES_INTERSECTION: 1,
+};
+
+export default {
+  QuadWithLineIntersectionState,
+};

--- a/Sources/Common/DataModel/Quad/index.d.ts
+++ b/Sources/Common/DataModel/Quad/index.d.ts
@@ -1,0 +1,91 @@
+import { Vector3, Vector4 } from '../../../types';
+import vtkCell, { ICellInitialValues } from '../Cell';
+import { IIntersectWithLine } from '../Triangle';
+
+export interface IQuadInitialValues extends ICellInitialValues {}
+
+export interface vtkQuad extends vtkCell {
+  getCellType(): number;
+  /**
+   * Get the topological dimensional of the cell (0, 1, 2 or 3).
+   */
+  getCellDimension(): number;
+  getNumberOfEdges(): number;
+  getNumberOfFaces(): number;
+
+  /**
+   * Compute the intersection point of the intersection between quad and
+   * line defined by p1 and p2. tol Tolerance use for the position evaluation
+   * x is the point which intersect triangle (computed in function) pcoords
+   * parametric coordinates (computed in function) A javascript object is
+   * returned :
+   *
+   * ```js
+   * {
+   *    evaluation: define if the triangle has been intersected or not
+   *    subId: always set to 0
+   *    t: parametric coordinate along the line.
+   *    betweenPoints: Define if the intersection is between input points
+   * }
+   * ```
+   *
+   * @param {Vector3} p1 The first point coordinate.
+   * @param {Vector3} p2 The second point coordinate.
+   * @param {Number} tol The tolerance to use.
+   * @param {Vector3} x The point which intersect triangle.
+   * @param {Vector3} pcoords The parametric coordinates.
+   */
+  intersectWithLine(
+    p1: Vector3,
+    p2: Vector3,
+    tol: number,
+    x: Vector3,
+    pcoords: Vector3
+  ): IIntersectWithLine;
+
+  /**
+   * Determine global coordinate (x]) from subId and parametric coordinates.
+   * @param {Vector3} pcoords The parametric coordinates.
+   * @param {Vector3} x The x point coordinate.
+   * @param {Number[]} weights The number of weights.
+   */
+  evaluateLocation(pcoords: Vector3, x: Vector3, weights: number[]): void;
+
+  /*
+   *  Compute iso-parametric interpolation functions
+   * @param {Vector3} pcoords The parametric coordinates.
+   * @param {Vector4} sf out weights.
+   */
+  interpolationFunctions(pcoords: Vector3, sf: Vector4);
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkQuad characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {IQuadInitialValues} [initialValues] (default: {})
+ */
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: IQuadInitialValues
+): void;
+
+/**
+ * Method used to create a new instance of vtkQuad.
+ * @param {IQuadInitialValues} [initialValues] for pre-setting some of its content
+ */
+export function newInstance(initialValues?: IQuadInitialValues): vtkQuad;
+
+/**
+ * vtkQuad is a cell which represents a quadrilateral. It may contain static
+ * methods to make some computations directly link to quads.
+ *
+ * @see vtkCell
+ */
+export declare const vtkQuad: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+};
+export default vtkQuad;

--- a/Sources/Common/DataModel/Quad/index.js
+++ b/Sources/Common/DataModel/Quad/index.js
@@ -1,0 +1,260 @@
+import macro from 'vtk.js/Sources/macros';
+import vtkCell from 'vtk.js/Sources/Common/DataModel/Cell';
+import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import { CellType } from 'vtk.js/Sources/Common/DataModel/CellTypes/Constants';
+import vtkTriangle from 'vtk.js/Sources/Common/DataModel/Triangle';
+import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
+
+function intersectionStruct() {
+  return {
+    intersected: false,
+    subId: -1,
+    x: [0.0, 0.0, 0.0],
+    pCoords: [0.0, 0.0, 0.0],
+    t: -1,
+  };
+}
+
+function vtkQuad(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkQuad');
+
+  publicAPI.getCellDimension = () => 2;
+  publicAPI.getCellType = () => CellType.VTK_QUAD;
+  publicAPI.getNumberOfEdges = () => 4;
+  publicAPI.getNumberOfFaces = () => 0;
+
+  publicAPI.intersectWithLine = (p1, p2, tol, x, pcoords) => {
+    let outObj = {
+      subId: 0,
+      t: Number.MAX_VALUE,
+      intersect: 0,
+      betweenPoints: false,
+    };
+    let diagonalCase;
+    const point0 = model.points.getPoint(0, []);
+    const point1 = model.points.getPoint(1, []);
+    const point2 = model.points.getPoint(2, []);
+    const point3 = model.points.getPoint(3, []);
+    const d1 = vtkMath.distance2BetweenPoints(point0, point2);
+    const d2 = vtkMath.distance2BetweenPoints(point1, point3);
+
+    /* Figure out how to uniquely tessellate the quad. Watch out for
+     * equivalent triangulations (i.e., the triangulation is equivalent
+     * no matter where the diagonal). In this case use the point ids as
+     * a tie breaker to ensure unique triangulation across the quad.
+     */
+
+    // rare case; discriminate based on point id
+    if (d1 === d2) {
+      // find the maximum id
+      let id;
+      let maxId = 0;
+      let maxIdx = 0;
+      for (let i = 0; i < 4; i++) {
+        id = model.pointsIds[i];
+        if (id > maxId) {
+          maxId = id;
+          maxIdx = i;
+        }
+      }
+      if (maxIdx === 0 || maxIdx === 2) {
+        diagonalCase = 0;
+      } else {
+        diagonalCase = 1;
+      }
+    } else if (d1 < d2) {
+      diagonalCase = 0;
+    } else {
+      diagonalCase = 1;
+    }
+    let points = null;
+    if (!model.triangle) {
+      model.triangle = vtkTriangle.newInstance();
+      points = vtkPoints.newInstance();
+      points.setNumberOfPoints(3);
+      model.triangle.initialize(points);
+    } else {
+      points = model.triangle.getPoints();
+    }
+
+    let firstIntersect;
+    const firstIntersectTmpObj = intersectionStruct();
+
+    let secondIntersect;
+    const secondIntersectTmpObj = intersectionStruct();
+
+    let useFirstIntersection;
+    let useSecondIntersection;
+
+    switch (diagonalCase) {
+      case 0:
+        points.setPoint(0, ...point0);
+        points.setPoint(1, ...point1);
+        points.setPoint(2, ...point2);
+        firstIntersect = model.triangle.intersectWithLine(
+          p1,
+          p2,
+          tol,
+          firstIntersectTmpObj.x,
+          firstIntersectTmpObj.pCoords
+        );
+
+        points.setPoint(0, ...point2);
+        points.setPoint(1, ...point3);
+        points.setPoint(2, ...point0);
+        secondIntersect = model.triangle.intersectWithLine(
+          p1,
+          p2,
+          tol,
+          secondIntersectTmpObj.x,
+          secondIntersectTmpObj.pCoords
+        );
+
+        useFirstIntersection =
+          firstIntersect.intersect && secondIntersect.intersect
+            ? firstIntersect.t <= secondIntersect.t
+            : firstIntersect.intersect;
+
+        useSecondIntersection =
+          firstIntersect.intersect && secondIntersect.intersect
+            ? secondIntersect.t < firstIntersect.t
+            : secondIntersect.intersect;
+
+        if (useFirstIntersection) {
+          outObj = firstIntersect;
+
+          x[0] = firstIntersectTmpObj.x[0];
+          x[1] = firstIntersectTmpObj.x[1];
+          x[2] = firstIntersectTmpObj.x[2];
+
+          pcoords[0] =
+            firstIntersectTmpObj.pCoords[0] + firstIntersectTmpObj.pCoords[1];
+          pcoords[1] = firstIntersectTmpObj.pCoords[1];
+          pcoords[2] = firstIntersectTmpObj.pCoords[2];
+        } else if (useSecondIntersection) {
+          outObj = secondIntersect;
+          x[0] = secondIntersectTmpObj.x[0];
+          x[1] = secondIntersectTmpObj.x[1];
+          x[2] = secondIntersectTmpObj.x[2];
+
+          pcoords[0] =
+            1.0 -
+            (secondIntersectTmpObj.pCoords[0] +
+              secondIntersectTmpObj.pCoords[1]);
+          pcoords[1] = 1 - secondIntersectTmpObj.pCoords[1];
+          pcoords[2] = secondIntersectTmpObj.pCoords[2];
+        }
+
+        break;
+      case 1:
+        points.setPoint(0, ...point0);
+        points.setPoint(1, ...point1);
+        points.setPoint(2, ...point3);
+        firstIntersect = model.triangle.intersectWithLine(
+          p1,
+          p2,
+          tol,
+          firstIntersectTmpObj.x,
+          firstIntersectTmpObj.pCoords
+        );
+
+        points.setPoint(0, ...point2);
+        points.setPoint(1, ...point3);
+        points.setPoint(2, ...point1);
+        secondIntersect = model.triangle.intersectWithLine(
+          p1,
+          p2,
+          tol,
+          secondIntersectTmpObj.x,
+          secondIntersectTmpObj.pCoords
+        );
+
+        useFirstIntersection =
+          firstIntersect.intersect && secondIntersect.intersect
+            ? firstIntersect.t <= secondIntersect.t
+            : firstIntersect.intersect;
+
+        useSecondIntersection =
+          firstIntersect.intersect && secondIntersect.intersect
+            ? secondIntersect.t < firstIntersect.t
+            : secondIntersect.intersect;
+
+        if (useFirstIntersection) {
+          outObj = firstIntersect;
+          x[0] = firstIntersectTmpObj.x[0];
+          x[1] = firstIntersectTmpObj.x[1];
+          x[2] = firstIntersectTmpObj.x[2];
+
+          pcoords[0] = firstIntersectTmpObj.pCoords[0];
+          pcoords[1] = firstIntersectTmpObj.pCoords[1];
+          pcoords[2] = firstIntersectTmpObj.pCoords[2];
+        } else if (useSecondIntersection) {
+          outObj = secondIntersect;
+
+          x[0] = secondIntersectTmpObj.x[0];
+          x[1] = secondIntersectTmpObj.x[1];
+          x[2] = secondIntersectTmpObj.x[2];
+          pcoords[0] = 1 - secondIntersectTmpObj.pCoords[0];
+          pcoords[1] = 1 - secondIntersectTmpObj.pCoords[1];
+          pcoords[2] = secondIntersectTmpObj.pCoords[2];
+        }
+        break;
+      default:
+        break;
+    }
+    return outObj;
+  };
+
+  publicAPI.interpolationFunctions = (pcoords, weights) => {
+    const rm = 1 - pcoords[0];
+    const sm = 1 - pcoords[1];
+
+    weights[0] = rm * sm;
+    weights[1] = pcoords[0] * sm;
+    weights[2] = pcoords[0] * pcoords[1];
+    weights[3] = rm * pcoords[1];
+  };
+
+  publicAPI.evaluateLocation = (pcoords, x, weights) => {
+    const point = [];
+
+    // Calculate the weights
+    publicAPI.interpolationFunctions(pcoords, weights);
+
+    x[0] = 0.0;
+    x[1] = 0.0;
+    x[2] = 0.0;
+
+    for (let i = 0; i < 4; i++) {
+      model.points.getPoint(i, point);
+      for (let j = 0; j < 3; j++) {
+        x[j] += point[j] * weights[i];
+      }
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  vtkCell.extend(publicAPI, model, initialValues);
+
+  vtkQuad(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkQuad');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Common/DataModel/Quad/test/testQuad.js
+++ b/Sources/Common/DataModel/Quad/test/testQuad.js
@@ -1,0 +1,85 @@
+import test from 'tape-catch';
+import vtkQuad from 'vtk.js/Sources/Common/DataModel/Quad';
+import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
+import { QuadWithLineIntersectionState } from 'vtk.js/Sources/Common/DataModel/Quad/Constants';
+
+test('Test vtkQuad instance', (t) => {
+  t.ok(vtkQuad, 'Make sure the class definition exists');
+  const instance = vtkQuad.newInstance();
+  t.ok(instance);
+  t.end();
+});
+
+test('Test vtkQuad intersectWithLine flat', (t) => {
+  const points = vtkPoints.newInstance();
+  points.setNumberOfPoints(4);
+  points.setData(Float32Array.from([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]));
+  // Add points
+  const quad = vtkQuad.newInstance();
+  quad.initialize(points);
+
+  // No intersection
+  let p1 = [0, 2, 0];
+  let p2 = [0, 2, 1];
+  const tol = 0.01;
+  const x = [];
+  const pcoords = [];
+  let intersection;
+  intersection = quad.intersectWithLine(p1, p2, tol, x, pcoords);
+  t.equal(
+    intersection.intersect,
+    QuadWithLineIntersectionState.NO_INTERSECTION
+  );
+
+  // Intersect on v1
+  p1 = [0, 0, 0];
+  p2 = [0, 0, 1];
+  intersection = quad.intersectWithLine(p1, p2, tol, x, pcoords);
+  t.equal(
+    intersection.intersect,
+    QuadWithLineIntersectionState.YES_INTERSECTION
+  );
+  t.equal(intersection.t, 0);
+  t.deepEqual(x, p1);
+  t.deepEqual(pcoords, [0, 0, 0]);
+
+  // Intersect on v3
+  p1 = [1, 1, 1];
+  p2 = [1, 1, 0];
+  intersection = quad.intersectWithLine(p1, p2, tol, x, pcoords);
+  t.equal(
+    intersection.intersect,
+    QuadWithLineIntersectionState.YES_INTERSECTION
+  );
+  t.equal(intersection.t, 1);
+  t.deepEqual(x, p2);
+  t.deepEqual(pcoords, [1, 1, 0]);
+
+  // No intersection if finite line
+  p1 = [-2, 0, 0];
+  p2 = [-1, 0, 0];
+  intersection = quad.intersectWithLine(p1, p2, tol, x, pcoords);
+  t.equal(
+    intersection.intersect,
+    QuadWithLineIntersectionState.NO_INTERSECTION
+  );
+
+  // Parallel to v2,v3
+  p1 = [2, 0, 0];
+  p2 = [2, 1, 0];
+  intersection = quad.intersectWithLine(p1, p2, tol, x, pcoords);
+  t.equal(
+    intersection.intersect,
+    QuadWithLineIntersectionState.NO_INTERSECTION
+  );
+
+  // Line coplanar to quad
+  p1 = [0.5, -1, 0];
+  p2 = [0.5, 1, 0];
+  intersection = quad.intersectWithLine(p1, p2, tol, x, pcoords);
+  t.equal(
+    intersection.intersect,
+    QuadWithLineIntersectionState.NO_INTERSECTION
+  );
+  t.end();
+});

--- a/Sources/Common/DataModel/Triangle/index.d.ts
+++ b/Sources/Common/DataModel/Triangle/index.d.ts
@@ -3,84 +3,94 @@ import vtkCell, { ICellInitialValues } from '../Cell';
 
 export interface ITriangleInitialValues extends ICellInitialValues {}
 
-interface IIntersectWithLine {
-	intersect: number;
-	t: number;
-	subId: number;
-	evaluation?: number;
-	betweenPoints?: boolean;
+export interface IIntersectWithLine {
+  intersect: number;
+  t: number;
+  subId: number;
+  evaluation?: number;
+  betweenPoints?: boolean;
 }
 
 export interface vtkTriangle extends vtkCell {
+  /**
+   * Get the topological dimensional of the cell (0, 1, 2 or 3).
+   */
+  getCellDimension(): number;
 
-	/**
-	 * Get the topological dimensional of the cell (0, 1, 2 or 3).
-	 */
-	getCellDimension(): number;
+  /**
+   * Compute the intersection point of the intersection between triangle and
+   * line defined by p1 and p2. tol Tolerance use for the position evaluation
+   * x is the point which intersect triangle (computed in function) pcoords
+   * parametric coordinates (computed in function) A javascript object is
+   * returned :
+   *
+   * ```js
+   * {
+   *    evaluation: define if the triangle has been intersected or not
+   *    subId: always set to 0
+   *    t: parametric coordinate along the line.
+   *    betweenPoints: Define if the intersection is between input points
+   * }
+   * ```
+   *
+   * @param {Vector3} p1 The first point coordinate.
+   * @param {Vector3} p2 The second point coordinate.
+   * @param {Number} tol The tolerance to use.
+   * @param {Vector3} x The point which intersect triangle.
+   * @param {Vector3} pcoords The parametric coordinates.
+   */
+  intersectWithLine(
+    p1: Vector3,
+    p2: Vector3,
+    tol: number,
+    x: Vector3,
+    pcoords: Vector3
+  ): IIntersectWithLine;
 
-	/**
-	 * Compute the intersection point of the intersection between triangle and
-	 * line defined by p1 and p2. tol Tolerance use for the position evaluation
-	 * x is the point which intersect triangle (computed in function) pcoords
-	 * parametric coordinates (computed in function) A javascript object is
-	 * returned :
-	 *
-	 * ```js
-	 * {
-	 *    evaluation: define if the triangle has been intersected or not
-	 *    subId: always set to 0
-	 *    t: parametric coordinate along the line.
-	 *    betweenPoints: Define if the intersection is between input points
-	 * }
-	 * ```
-	 * 
-	 * @param {Vector3} p1 The first point coordinate.
-	 * @param {Vector3} p2 The second point coordinate.
-	 * @param {Number} tol The tolerance to use.
-	 * @param {Vector3} x The point which intersect triangle.
-	 * @param {Vector3} pcoords The parametric coordinates.
-	 */
-	intersectWithLine(p1: Vector3, p2: Vector3, tol: number, x: Vector3, pcoords: Vector3): IIntersectWithLine;
+  /**
+   * Evaluate the position of x in relation with triangle.
+   *
+   * Compute the closest point in the cell.
+   * - pccords parametric coordinate (computed in function)
+   * - weights Interpolation weights in cell.
+   * - the number of weights is equal to the number of points defining the
+   *   cell (computed in function).
+   *
+   * A javascript object is returned :
+   *
+   * ```js
+   * {
+   *   evaluation: 1 = inside 0 = outside -1 = problem during execution
+   *   subId: always set to 0
+   *   dist2: squared distance from x to cell
+   * }
+   * ```
+   *
+   * @param {Vector3} x The x point coordinate.
+   * @param {Vector3} closestPoint The closest point coordinate.
+   * @param {Vector3} pcoords The parametric coordinates.
+   * @param {Number[]} weights The number of weights.
+   */
+  evaluatePosition(
+    x: Vector3,
+    closestPoint: Vector3,
+    pcoords: Vector3,
+    weights: number[]
+  ): IIntersectWithLine;
 
-	/**
-	 * Evaluate the position of x in relation with triangle. 
-	 * 
-	 * Compute the closest point in the cell. 
-	 * - pccords parametric coordinate (computed in function)
-	 * - weights Interpolation weights in cell. 
-	 * - the number of weights is equal to the number of points defining the
-	 *   cell (computed in function). 
-	 * 
-	 * A javascript object is returned :
-	 * 
-	 * ```js
-	 * {
-	 *   evaluation: 1 = inside 0 = outside -1 = problem during execution
-	 *   subId: always set to 0
-	 *   dist2: squared distance from x to cell
-	 * }
-	 * ```
-	 * 
-	 * @param {Vector3} x The x point coordinate.
-	 * @param {Vector3} closestPoint The closest point coordinate.
-	 * @param {Vector3} pcoords The parametric coordinates.
-	 * @param {Number[]} weights The number of weights.
-	 */
-	evaluatePosition(x: Vector3, closestPoint: Vector3, pcoords: Vector3, weights: number[]): IIntersectWithLine
+  /**
+   * Determine global coordinate (x]) from subId and parametric coordinates.
+   * @param {Vector3} pcoords The parametric coordinates.
+   * @param {Vector3} x The x point coordinate.
+   * @param {Number[]} weights The number of weights.
+   */
+  evaluateLocation(pcoords: Vector3, x: Vector3, weights: number[]): void;
 
-	/**
-	 * Determine global coordinate (x]) from subId and parametric coordinates.
-	 * @param {Vector3} pcoords The parametric coordinates.
-	 * @param {Vector3} x The x point coordinate.
-	 * @param {Number[]} weights The number of weights.
-	 */
-	evaluateLocation(pcoords: Vector3, x: Vector3, weights: number[]): void;
-
-	/**
-	 * Get the distance of the parametric coordinate provided to the cell.
-	 * @param {Vector3} pcoords The parametric coordinates.
-	 */
-	getParametricDistance(pcoords: Vector3): number;
+  /**
+   * Get the distance of the parametric coordinate provided to the cell.
+   * @param {Vector3} pcoords The parametric coordinates.
+   */
+  getParametricDistance(pcoords: Vector3): number;
 }
 
 /**
@@ -90,14 +100,19 @@ export interface vtkTriangle extends vtkCell {
  * @param model object on which data structure will be bounds (protected)
  * @param {ITriangleInitialValues} [initialValues] (default: {})
  */
-export function extend(publicAPI: object, model: object, initialValues?: ITriangleInitialValues): void;
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: ITriangleInitialValues
+): void;
 
 /**
  * Method used to create a new instance of vtkTriangle.
  * @param {ITriangleInitialValues} [initialValues] for pre-setting some of its content
  */
-export function newInstance(initialValues?: ITriangleInitialValues): vtkTriangle;
-
+export function newInstance(
+  initialValues?: ITriangleInitialValues
+): vtkTriangle;
 
 /**
  * Compute the normal direction according to the three vertex which composed a
@@ -107,7 +122,12 @@ export function newInstance(initialValues?: ITriangleInitialValues): vtkTriangle
  * @param {Vector3} v3 The third point coordinate.
  * @param {Vector3} n The normal coordinate.
  */
-export function computeNormalDirection(v1: Vector3, v2: Vector3, v3: Vector3, n: Vector3): void;
+export function computeNormalDirection(
+  v1: Vector3,
+  v2: Vector3,
+  v3: Vector3,
+  n: Vector3
+): void;
 
 /**
  * Compute the normalized normal of a triangle composed of three points. The
@@ -117,18 +137,23 @@ export function computeNormalDirection(v1: Vector3, v2: Vector3, v3: Vector3, n:
  * @param {Vector3} v3 The third point coordinate.
  * @param {Vector3} n The normal coordinate.
  */
-export function computeNormal(v1: Vector3, v2: Vector3, v3: Vector3, n: Vector3): void;
+export function computeNormal(
+  v1: Vector3,
+  v2: Vector3,
+  v3: Vector3,
+  n: Vector3
+): void;
 
 /**
  * vtkTriangle is a cell which representant a triangle. It contains static
  * method to make some computations directly link to triangle.
- * 
+ *
  * @see vtkCell
  */
 export declare const vtkTriangle: {
-	newInstance: typeof newInstance,
-	extend: typeof extend;
-	computeNormalDirection: typeof computeNormalDirection;
-	computeNormal: typeof computeNormal;
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+  computeNormalDirection: typeof computeNormalDirection;
+  computeNormal: typeof computeNormal;
 };
 export default vtkTriangle;

--- a/Sources/Rendering/Core/CellPicker/index.js
+++ b/Sources/Rendering/Core/CellPicker/index.js
@@ -4,6 +4,7 @@ import vtkLine from 'vtk.js/Sources/Common/DataModel/Line';
 import vtkPicker from 'vtk.js/Sources/Rendering/Core/Picker';
 import vtkPolyLine from 'vtk.js/Sources/Common/DataModel/PolyLine';
 import vtkTriangle from 'vtk.js/Sources/Common/DataModel/Triangle';
+import vtkQuad from 'vtk.js/Sources/Common/DataModel/Quad';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import { CellType } from 'vtk.js/Sources/Common/DataModel/CellTypes/Constants';
 import { vec3 } from 'gl-matrix';
@@ -17,6 +18,7 @@ function createCellMap() {
     [CellType.VTK_LINE]: vtkLine.newInstance(),
     [CellType.VTK_POLY_LINE]: vtkPolyLine.newInstance(),
     [CellType.VTK_TRIANGLE]: vtkTriangle.newInstance(),
+    [CellType.VTK_QUAD]: vtkQuad.newInstance(),
   };
 }
 
@@ -239,7 +241,6 @@ function vtkCellPicker(publicAPI, model) {
         mat[6] * model.pickNormal[1] +
         mat[10] * model.pickNormal[2];
     }
-
     return tMin;
   };
 

--- a/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
+++ b/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
@@ -6,8 +6,11 @@ import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
 import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
 import vtkCellPicker from 'vtk.js/Sources/Rendering/Core/CellPicker';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
 
 const { SlicingMode } = vtkImageMapper;
@@ -84,4 +87,123 @@ test('Test vtkCellPicker instance', (t) => {
   const instance = vtkCellPicker.newInstance();
   t.ok(instance);
   t.end();
+});
+
+test('Test vtkCellPicker on triangles', (t) => {
+  // Create some control UI
+  const gc = testUtils.createGarbageCollector(t);
+  const container = document.querySelector('body');
+  const renderWindowContainer = gc.registerDOMElement(
+    document.createElement('div')
+  );
+  container.appendChild(renderWindowContainer);
+
+  // Setup window
+  const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+  const renderer = gc.registerResource(vtkRenderer.newInstance());
+  renderWindow.addRenderer(renderer);
+
+  // Create what we will view
+  const points = Float32Array.from([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]);
+  const polys = new Float32Array([3, 0, 1, 2, 3, 0, 2, 3]);
+  const polyData = vtkPolyData.newInstance();
+  polyData.getPoints().setData(points);
+  polyData.getPolys().setData(polys);
+
+  const mapper = vtkMapper.newInstance();
+  mapper.setInputData(polyData);
+  const actor = vtkActor.newInstance();
+  actor.setMapper(mapper);
+
+  renderer.addActor(actor);
+
+  // now create something to view it, in this case webgl
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
+  glwindow.setContainer(renderWindowContainer);
+  renderWindow.addView(glwindow);
+  glwindow.setSize(400, 400);
+
+  renderer.resetCamera();
+  renderWindow.render();
+
+  // Test picker
+  const picker = vtkCellPicker.newInstance();
+
+  const p = [125, 200, 0];
+  picker.pick(p, renderer);
+
+  const actors = picker.getActors();
+
+  t.equal(actors.length, 1);
+  t.equal(actors[0], actor);
+
+  const positions = picker.getPickedPositions();
+  t.equal(positions.length, 1);
+  const xyz = positions[0];
+  const expectedPosition = [0.22548094716167097, 0.5, 0];
+  t.assert(
+    areEquals(xyz, expectedPosition),
+    'Float-compare picked position to expected.'
+  );
+
+  gc.releaseResources();
+});
+
+test('Test vtkCellPicker on quads', (t) => {
+  // Create some control UI
+  const gc = testUtils.createGarbageCollector(t);
+  const container = document.querySelector('body');
+  const renderWindowContainer = gc.registerDOMElement(
+    document.createElement('div')
+  );
+  container.appendChild(renderWindowContainer);
+
+  // Setup window
+  const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+  const renderer = gc.registerResource(vtkRenderer.newInstance());
+  renderWindow.addRenderer(renderer);
+
+  // Create what we will view
+  const points = Float32Array.from([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]);
+  const polys = new Float32Array([4, 0, 1, 2, 3]);
+  const polyData = vtkPolyData.newInstance();
+  polyData.getPoints().setData(points);
+  polyData.getPolys().setData(polys);
+
+  const mapper = vtkMapper.newInstance();
+  mapper.setInputData(polyData);
+  const actor = vtkActor.newInstance();
+  actor.setMapper(mapper);
+
+  renderer.addActor(actor);
+
+  // now create something to view it, in this case webgl
+  const glwindow = gc.registerResource(renderWindow.newAPISpecificView());
+  glwindow.setContainer(renderWindowContainer);
+  renderWindow.addView(glwindow);
+  glwindow.setSize(400, 400);
+
+  renderer.resetCamera();
+  renderWindow.render();
+
+  // Test picker
+  const picker = vtkCellPicker.newInstance();
+
+  const p = [125, 200, 0];
+  picker.pick(p, renderer);
+  const actors = picker.getActors();
+
+  t.equal(actors.length, 1);
+  t.equal(actors[0], actor);
+
+  const positions = picker.getPickedPositions();
+  t.equal(positions.length, 1);
+  const xyz = positions[0];
+  const expectedPosition = [0.22548094716167097, 0.5, 0];
+  t.assert(
+    areEquals(xyz, expectedPosition),
+    'Float-compare picked position to expected.'
+  );
+
+  gc.releaseResources();
 });


### PR DESCRIPTION
### Context
This MR aims to implement the vtkQuad class as suggested by @finetjul in #2508 

### Changes
Created vtkQuad class. Type script updated but unsure on how to change documentation?
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
Added unit tests but two are failing for the pcoords, I have copied the behaviour in the cxx library but the tests are from the vtkTriangle vtk.js class so they may be incorrect, I am not familiar enough with how these are calculated as to whether they are correct. Maybe @finetjul you could take a look?
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: latest
  - **OS**: Mac OS 12.4
  - **Browser**:  Chrome (through karma)