### PR TITLE
fix(renderwindowinteractor): resolve WebXR AR touch event error on Android

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -552,6 +552,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
           model.lastGamepadValues[gp.index] = {
             left: { buttons: {} },
             right: { buttons: {} },
+            none: { buttons: {} },
           };
         }
         for (let b = 0; b < gp.buttons.length; ++b) {
@@ -762,7 +763,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       if (pointers.length === 0) {
         const callData = {
           ...getModifierKeysFor(EMPTY_MOUSE_EVENT),
-          position: pointers[0].position,
+          position: getScreenEventPositionFor(event),
           deviceType: getDeviceTypeFor(event),
         };
         publicAPI.leftButtonReleaseEvent(callData);


### PR DESCRIPTION
Short-term fix for issue where touching the screen on an Android device
during an AR session would crash the scene as a result of bad touch
event handling and XR Gamepad API polling. New behavior is no crash.
Future commit should add ability to parse data from event for interactivity.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Supports recent WebXR developments on mobile, including feedback from [WebXR examples](https://kitware.github.io/vtk-js/docs/develop_webxr.html).

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

AR scene no longer crashes on touch on Android device in local testing.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->

- Fixes issue with bad access on touch-end event
- Fixes issue with unexpected handedness parameter for WebXR Gamepad data

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) --> `master`
  - **OS**: <!-- ex: Windows 10, iOS 13.6 --> Windows 10, Android 11
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 --> Chrome 103.0.5060.114

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
