### PR TITLE
feat(OpenGLRendering): Add radon blending mode

### DIFF
--- a/Examples/Volume/VolumeMapperBlendModes/controller.html
+++ b/Examples/Volume/VolumeMapperBlendModes/controller.html
@@ -8,15 +8,40 @@
         <option value="2">Minimum Intensity</option>
         <option value="3">Average Intensity</option>
         <option value="4">Additive Intensity</option>
+        <option value="5">Radon transform</option>
       </select>
     </td>
   </tr>
+
   <tr class="ipScalar" style="display:none;">
     <td>IP Scalar Min</td>
     <td><input class="scalarMin" type="range" min="0" max="1" value="0" step="0.01"></td>
   </tr>
+
   <tr class="ipScalar" style="display:none;">
     <td><p>IP Scalar Max</p></td>
     <td><input class="scalarMax" type="range" min="0" max="1" value="1" step="0.01"></td>
+  </tr>
+
+  <tr class="radonScalar"  style="display:none;">
+    <td>First hounsfield:</td>
+    <td><input class="minHounsfield" type="range" min="-1024" max="3071" step="5"></td>
+    <td><label id="minHounsfieldLabel"></label></td>
+    <td>Absorption:</td>
+    <td><input class="minAbsorption" type="range" min="0" max="0.1" step="0.001"></td>
+    <td><label id="minAbsorptionLabel"></label></td>
+  </tr>
+  <tr class="radonScalar"  style="display:none;">
+    <td>Max hounsfield:</td>
+    <td><input class="maxHounsfield" type="range" min="-1024" max="3071" step="5"></td>
+    <td><label id="maxHounsfieldLabel"></label></td>
+    <td>Absorption:</td>
+    <td><input class="maxAbsorption" type="range" min="0" max="0.1" step="0.001"></td>
+    <td><label id="maxAbsorptionLabel"></label></td>
+  </tr>
+  <tr>
+    <td>Sample distance:</td>
+    <td><input class="sampleDistance" type="range" min="0.1" max="2.5" step="0.1"></td>
+    <td><label id="sampleDistanceLabel"></label></td>
   </tr>
 </table>

--- a/Examples/Volume/VolumeMapperBlendModes/index.js
+++ b/Examples/Volume/VolumeMapperBlendModes/index.js
@@ -31,33 +31,55 @@ fullScreenRenderer.addController(controlPanel);
 // ----------------------------------------------------------------------------
 // Example code
 // ----------------------------------------------------------------------------
-// Server is not sending the .gz and with the compress header
-// Need to fetch the true file name and uncompress it locally
-// ----------------------------------------------------------------------------
-
+const minHounsfieldLabel = document.querySelector('#minHounsfieldLabel');
+const maxHounsfieldLabel = document.querySelector('#maxHounsfieldLabel');
+const maxAbsorptionLabel = document.querySelector('#maxAbsorptionLabel');
+const minAbsorptionLabel = document.querySelector('#minAbsorptionLabel');
+const sampleDistanceLabel = document.querySelector('#sampleDistanceLabel');
 const reader = vtkHttpDataSetReader.newInstance({ fetchGzip: true });
+const initialSampleDistance = 1.3;
 
 const actor = vtkVolume.newInstance();
 const mapper = vtkVolumeMapper.newInstance();
-mapper.setSampleDistance(1.3);
+mapper.setSampleDistance(initialSampleDistance);
 mapper.setPreferSizeOverAccuracy(true);
 actor.setMapper(mapper);
 
-// create color and opacity transfer functions
-const ofun = vtkPiecewiseFunction.newInstance();
-ofun.addPoint(-3024, 0.1);
-ofun.addPoint(-637.62, 0.1);
-ofun.addPoint(700, 0.5);
-ofun.addPoint(3071, 0.9);
+const radonParameters = {
+  minHounsfield: 1000, // water HU for headsq (normally 0)
+  minAbsorption: 0.01,
+  maxHounsfield: 2500, // bone HU for headsq
+  maxAbsorption: 0.03,
+};
+let sampleDistance = initialSampleDistance;
+sampleDistanceLabel.innerHTML = sampleDistance.toFixed(1);
 
-const ctfun = vtkColorTransferFunction.newInstance();
-ctfun.addRGBPoint(-3024, 0, 0, 0);
-ctfun.addRGBPoint(-637.62, 0, 0, 0);
-ctfun.addRGBPoint(700, 1, 1, 1);
-ctfun.addRGBPoint(3071, 1, 1, 1);
+function updatePiecewiseFunction() {
+  minHounsfieldLabel.innerHTML = radonParameters.minHounsfield.toFixed(0);
+  minAbsorptionLabel.innerHTML = radonParameters.minAbsorption.toFixed(3);
+  maxHounsfieldLabel.innerHTML = radonParameters.maxHounsfield.toFixed(0);
+  maxAbsorptionLabel.innerHTML = radonParameters.maxAbsorption.toFixed(3);
 
-actor.getProperty().setRGBTransferFunction(0, ctfun);
-actor.getProperty().setScalarOpacity(0, ofun);
+  const currentBlendMode = mapper.getBlendMode();
+  let opacityFunction;
+
+  if (currentBlendMode === 5) {
+    opacityFunction = vtkVolumeMapper.createRadonTransferFunction(
+      radonParameters.minHounsfield,
+      radonParameters.minAbsorption,
+      radonParameters.maxHounsfield,
+      radonParameters.maxAbsorption
+    );
+  } else {
+    opacityFunction = vtkPiecewiseFunction.newInstance();
+    opacityFunction.addPoint(-3024, 0.1);
+    opacityFunction.addPoint(-637.62, 0.1);
+    opacityFunction.addPoint(700, 0.5);
+    opacityFunction.addPoint(3071, 0.9);
+  }
+  actor.getProperty().setScalarOpacity(0, opacityFunction);
+}
+
 actor.getProperty().setScalarOpacityUnitDistance(0, 3.0);
 actor.getProperty().setInterpolationTypeToLinear();
 actor.getProperty().setShade(true);
@@ -68,38 +90,87 @@ actor.getProperty().setSpecularPower(10.0);
 
 mapper.setInputConnection(reader.getOutputPort());
 
-function updateBlendMode(event) {
-  const blendMode = parseInt(event.target.value, 10);
-  const ipScalarEls = document.querySelectorAll('.ipScalar');
+function updateMin(event) {
+  radonParameters.minHounsfield = event.target.valueAsNumber;
+  updatePiecewiseFunction();
+  renderWindow.render();
+}
 
-  mapper.setBlendMode(blendMode);
-  mapper.setIpScalarRange(0.0, 1.0);
+function updateMax(event) {
+  radonParameters.maxHounsfield = event.target.valueAsNumber;
+  updatePiecewiseFunction();
+  renderWindow.render();
+}
 
-  // if average or additive blend mode
-  if (blendMode === 3 || blendMode === 4) {
-    // Show scalar ui
-    for (let i = 0; i < ipScalarEls.length; i += 1) {
-      const el = ipScalarEls[i];
-      el.style.display = 'table-row';
-    }
-  } else {
-    // Hide scalar ui
-    for (let i = 0; i < ipScalarEls.length; i += 1) {
-      const el = ipScalarEls[i];
-      el.style.display = 'none';
-    }
-  }
+function updateScalarValue(event) {
+  radonParameters.maxAbsorption = event.target.valueAsNumber;
+  updatePiecewiseFunction();
+  renderWindow.render();
+}
 
+function updateScalarValue2(event) {
+  radonParameters.minAbsorption = event.target.valueAsNumber;
+  updatePiecewiseFunction();
+  renderWindow.render();
+}
+
+function updateSampleDistance(event) {
+  sampleDistance = event.target.valueAsNumber;
+  sampleDistanceLabel.innerHTML = sampleDistance.toFixed(3);
+  mapper.setSampleDistance(sampleDistance);
   renderWindow.render();
 }
 
 function updateScalarMin(event) {
-  mapper.setIpScalarRange(event.target.value, mapper.getIpScalarRange()[1]);
+  mapper.setIpScalarRange(
+    event.target.valueAsNumber,
+    mapper.getIpScalarRange()[1]
+  );
   renderWindow.render();
 }
 
 function updateScalarMax(event) {
-  mapper.setIpScalarRange(mapper.getIpScalarRange()[0], event.target.value);
+  mapper.setIpScalarRange(
+    mapper.getIpScalarRange()[0],
+    event.target.valueAsNumber
+  );
+  renderWindow.render();
+}
+
+function updateBlendMode(event) {
+  const currentBlendMode = parseInt(event.target.value, 10);
+  const ipScalarEls = document.querySelectorAll('.ipScalar');
+  const radonScalars = document.querySelectorAll('.radonScalar');
+
+  mapper.setBlendMode(currentBlendMode);
+  mapper.setIpScalarRange(0.0, 1.0);
+
+  // if average or additive blend mode
+  for (let i = 0; i < ipScalarEls.length; i += 1) {
+    const el = ipScalarEls[i];
+    el.style.display =
+      currentBlendMode === 3 || currentBlendMode === 4 ? 'table-row' : 'none';
+  }
+
+  // Radon
+  for (let i = 0; i < radonScalars.length; i += 1) {
+    const el = radonScalars[i];
+    el.style.display = currentBlendMode === 5 ? 'table-row' : 'none';
+  }
+
+  const colorTransferFunction = vtkColorTransferFunction.newInstance();
+  if (currentBlendMode === 5) {
+    colorTransferFunction.addRGBPoint(0, 0, 0, 0);
+    colorTransferFunction.addRGBPoint(1, 1, 1, 1);
+  } else {
+    colorTransferFunction.addRGBPoint(-3024, 0, 0, 0);
+    colorTransferFunction.addRGBPoint(-637.62, 0, 0, 0);
+    colorTransferFunction.addRGBPoint(700, 1, 1, 1);
+    colorTransferFunction.addRGBPoint(3071, 1, 1, 1);
+  }
+  actor.getProperty().setRGBTransferFunction(0, colorTransferFunction);
+  updatePiecewiseFunction();
+
   renderWindow.render();
 }
 
@@ -110,14 +181,37 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`).then(() => {
     interactor.setDesiredUpdateRate(15.0);
     renderer.resetCamera();
     renderer.getActiveCamera().elevation(-70);
-    renderWindow.render();
+    updatePiecewiseFunction();
 
     const el = document.querySelector('.blendMode');
     el.addEventListener('change', updateBlendMode);
+
     const scalarMinEl = document.querySelector('.scalarMin');
     scalarMinEl.addEventListener('input', updateScalarMin);
     const scalarMaxEl = document.querySelector('.scalarMax');
     scalarMaxEl.addEventListener('input', updateScalarMax);
+
+    const minInput = document.querySelector('.minHounsfield');
+    minInput.addEventListener('input', updateMin);
+    const maxInput = document.querySelector('.maxHounsfield');
+    maxInput.addEventListener('input', updateMax);
+    const maxAbsorptionInput = document.querySelector('.maxAbsorption');
+    maxAbsorptionInput.addEventListener('input', updateScalarValue);
+    const minAbsorptionInput = document.querySelector('.minAbsorption');
+    minAbsorptionInput.addEventListener('input', updateScalarValue2);
+    const unitV = document.querySelector('.sampleDistance');
+    unitV.addEventListener('input', updateSampleDistance);
+
+    minInput.value = radonParameters.minHounsfield;
+    maxInput.value = radonParameters.maxHounsfield;
+    maxAbsorptionInput.value = radonParameters.maxAbsorption;
+    minAbsorptionInput.value = radonParameters.minAbsorption;
+    unitV.value = sampleDistance;
+
+    el.value = 5;
+    const evt = document.createEvent('HTMLEvents');
+    evt.initEvent('change', false, true);
+    el.dispatchEvent(evt);
   });
 });
 
@@ -129,6 +223,5 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`).then(() => {
 global.source = reader;
 global.mapper = mapper;
 global.actor = actor;
-global.ofun = ofun;
 global.renderer = renderer;
 global.renderWindow = renderWindow;

--- a/Sources/Rendering/Core/VolumeMapper/Constants.d.ts
+++ b/Sources/Rendering/Core/VolumeMapper/Constants.d.ts
@@ -4,8 +4,9 @@ export declare enum BlendMode {
 	MINIMUM_INTENSITY_BLEND = 2,
 	AVERAGE_INTENSITY_BLEND = 3,
 	ADDITIVE_INTENSITY_BLEND = 4,
+	RADON_TRANSFORM_BLEND = 5,
 }
-	
+
 export declare enum FilterMode {
 	OFF = 0,
 	NORMALIZED = 1,

--- a/Sources/Rendering/Core/VolumeMapper/Constants.js
+++ b/Sources/Rendering/Core/VolumeMapper/Constants.js
@@ -4,6 +4,7 @@ export const BlendMode = {
   MINIMUM_INTENSITY_BLEND: 2,
   AVERAGE_INTENSITY_BLEND: 3,
   ADDITIVE_INTENSITY_BLEND: 4,
+  RADON_TRANSFORM_BLEND: 5,
 };
 
 export const FilterMode = {

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -2,8 +2,44 @@ import macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import Constants from 'vtk.js/Sources/Rendering/Core/VolumeMapper/Constants';
 import vtkAbstractMapper from 'vtk.js/Sources/Rendering/Core/AbstractMapper';
+import vtkPiecewiseFunction from 'vtk.js/Sources/Common/DataModel/PiecewiseFunction';
 
 const { BlendMode, FilterMode } = Constants;
+
+function createRadonTransferFunction(
+  firstAbsorbentMaterialHounsfieldValue,
+  firstAbsorbentMaterialAbsorption,
+  maxAbsorbentMaterialHounsfieldValue,
+  maxAbsorbentMaterialAbsorption,
+  outputTransferFunction
+) {
+  let ofun = null;
+  if (outputTransferFunction) {
+    ofun = outputTransferFunction;
+    ofun.removeAllPoints();
+  } else {
+    ofun = vtkPiecewiseFunction.newInstance();
+  }
+  ofun.addPointLong(-1024, 0, 1, 1); // air (i.e. material with no absorption)
+  ofun.addPoint(
+    firstAbsorbentMaterialHounsfieldValue,
+    firstAbsorbentMaterialAbsorption
+  );
+  ofun.addPoint(
+    maxAbsorbentMaterialHounsfieldValue,
+    maxAbsorbentMaterialAbsorption
+  );
+
+  return ofun;
+}
+
+// ----------------------------------------------------------------------------
+// Static API
+// ----------------------------------------------------------------------------
+
+export const STATIC = {
+  createRadonTransferFunction,
+};
 
 // ----------------------------------------------------------------------------
 // vtkVolumeMapper methods
@@ -50,6 +86,10 @@ function vtkVolumeMapper(publicAPI, model) {
 
   publicAPI.setBlendModeToAdditiveIntensity = () => {
     publicAPI.setBlendMode(BlendMode.ADDITIVE_INTENSITY_BLEND);
+  };
+
+  publicAPI.setBlendModeToRadonTransform = () => {
+    publicAPI.setBlendMode(BlendMode.RADON_TRANSFORM_BLEND);
   };
 
   publicAPI.getBlendModeAsString = () =>
@@ -162,4 +202,4 @@ export const newInstance = macro.newInstance(extend, 'vtkVolumeMapper');
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend };
+export default { newInstance, extend, ...STATIC };

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -1435,6 +1435,38 @@ void applyBlend(vec3 posIS, vec3 endIS, vec3 tdims)
 
     gl_FragData[0] = getColorForValue(sum, posIS, tstep);
   #endif
+  #if vtkBlendMode == 5 // RADON
+    float normalizedRayIntensity = 1.0;
+
+    // handle very thin volumes
+    if (raySteps <= 1.0)
+    {
+      tValue = getTextureValue(posIS);
+      normalizedRayIntensity = normalizedRayIntensity - sampleDistance*texture2D(otexture, vec2(tValue.r * oscale0 + oshift0, 0.5)).r;
+      gl_FragData[0] = texture2D(ctexture, vec2(normalizedRayIntensity * cscale0 + cshift0, 0.5));
+      return;
+    }
+
+    posIS += (jitter*stepIS);
+
+    for (int i = 0; i < //VTK::MaximumSamplesValue ; ++i)
+    {
+      if (stepsTraveled + 1.0 >= raySteps) { break; }
+
+      // compute the scalar value
+      tValue = getTextureValue(posIS);
+
+      // Convert scalar value to normalizedRayIntensity coefficient and accumulate normalizedRayIntensity
+      normalizedRayIntensity = normalizedRayIntensity - sampleDistance*texture2D(otexture, vec2(tValue.r * oscale0 + oshift0, 0.5)).r;
+
+      posIS += stepIS;
+      stepsTraveled++;
+    }
+
+    // map normalizedRayIntensity to color
+    gl_FragData[0] = texture2D(ctexture, vec2(normalizedRayIntensity * cscale0 + cshift0, 0.5));
+
+  #endif
 }
 
 //=======================================================================


### PR DESCRIPTION
### Context
Add the possibility to use the radon transform in blending mode.

### Results
![image](https://user-images.githubusercontent.com/11785751/179485516-5bd1f95d-9196-4b03-bd52-1e1cedd5c492.png)

### Changes
Updated vtkVolumeFS glsl file to introduce radon transform.

### PR and Code Checklist
- [x] Clean example code to fit with previous example and adapt values to the loaded volume

### Testing
You can see the changes by running the VolumeMapperBlendModes example.


@finetjul @martinken 
The first needed code review is for the glsl file. I'll update the example code later.