### PR TITLE
fix(volume-shader): disable cinematic rendering if 2+ components

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -914,6 +914,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
       mat4 normalMat = computeMat4Normal(posIS, tValue, tstep);
       #if !defined(vtkComponent0Proportional)
         vec4 normal0 = normalMat[0];
+        vec4 normalLight = computeNormal(posIS, tValue.a, tstep); // for case: vtkLightComplexity > 0 && defined(vtkIndependentComponentsOn) && (vtkNumComponents > 1) && !defined(vtkComponent0Proportional)
       #endif
       #if !defined(vtkComponent1Proportional)
         vec4 normal1 = normalMat[1];

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -914,7 +914,6 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
       mat4 normalMat = computeMat4Normal(posIS, tValue, tstep);
       #if !defined(vtkComponent0Proportional)
         vec4 normal0 = normalMat[0];
-        vec4 normalLight = computeNormal(posIS, tValue.a, tstep); // for case: vtkLightComplexity > 0 && defined(vtkIndependentComponentsOn) && (vtkNumComponents > 1) && !defined(vtkComponent0Proportional)
       #endif
       #if !defined(vtkComponent1Proportional)
         vec4 normal1 = normalMat[1];
@@ -1057,41 +1056,49 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
 
   // apply lighting if requested as appropriate
   #if vtkLightComplexity > 0
-    #if !defined(vtkComponent0Proportional) && defined(SurfaceShadowOn)
-        #if vtkLightComplexity < 3
-            vec3 tColorS = applyLightingDirectional(tColor.rgb, normalLight);
-        #else
-            vec3 tColorS = applyLightingPositional(tColor.rgb, normalLight, IStoVC(posIS));
+    #if !defined(vtkComponent0Proportional) 
+      #if vtkNumComponents == 1
+    
+        #ifdef SurfaceShadowOn
+            #if vtkLightComplexity < 3
+                vec3 tColorS = applyLightingDirectional(tColor.rgb, normalLight);
+            #else
+                vec3 tColorS = applyLightingPositional(tColor.rgb, normalLight, IStoVC(posIS));
+            #endif
         #endif
-    #endif
 
-    #ifdef VolumeShadowOn
-      vec3 tColorVS = applyShadowRay(tColor.rgb, posIS, rayDirVC);
-      #ifdef SurfaceShadowOn
-        float vol_coef = volumetricScatteringBlending * (1.0 - tColor.a / 2.0) * (1.0 - atan(normalLight.w) * INV4PI);
-        tColor.rgb = (1.0-vol_coef) * tColorS + vol_coef * tColorVS;
+        #ifdef VolumeShadowOn
+          vec3 tColorVS = applyShadowRay(tColor.rgb, posIS, rayDirVC);
+          #ifdef SurfaceShadowOn
+            float vol_coef = volumetricScatteringBlending * (1.0 - tColor.a / 2.0) * (1.0 - atan(normalLight.w) * INV4PI);
+            tColor.rgb = (1.0-vol_coef) * tColorS + vol_coef * tColorVS;
+          #else
+            tColor.rgb = tColorVS;
+          #endif
+        #else
+            tColor.rgb = tColorS;
+        #endif
+        
       #else
-        tColor.rgb = tColorVS;
+        applyLighting(tColor.rgb, normal0);
       #endif
-    #else
-        tColor.rgb = tColorS;
     #endif
 
-  #if defined(vtkIndependentComponentsOn) && vtkNumComponents >= 2
-    #if !defined(vtkComponent1Proportional)
-      applyLighting(tColor1, normal1);
+    #if defined(vtkIndependentComponentsOn) && vtkNumComponents >= 2
+      #if !defined(vtkComponent1Proportional)
+        applyLighting(tColor1, normal1);
+      #endif
+    #if vtkNumComponents >= 3
+      #if !defined(vtkComponent2Proportional)
+        applyLighting(tColor2, normal2);
+      #endif
+    #if vtkNumComponents >= 4
+      #if !defined(vtkComponent3Proportional)
+        applyLighting(tColor3, normal3);
+      #endif
     #endif
-  #if vtkNumComponents >= 3
-    #if !defined(vtkComponent2Proportional)
-      applyLighting(tColor2, normal2);
     #endif
-  #if vtkNumComponents >= 4
-    #if !defined(vtkComponent3Proportional)
-      applyLighting(tColor3, normal3);
     #endif
-  #endif
-  #endif
-  #endif
   #endif
 
 // perform final independent blend as needed


### PR DESCRIPTION
### Context
fix #2520 

### Results
No shader compile errors.

### Changes
Fallback to classic lighting when 2+ components

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
`npm run example TestVolumeTypes` and add components.
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: master
  - **OS**: Ubuntu 22.04
  - **Browser**: Chrome 103

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
