### PR TITLE
Local ambient occlusion

### DIFF
--- a/Sources/Rendering/Core/VolumeMapper/index.d.ts
+++ b/Sources/Rendering/Core/VolumeMapper/index.d.ts
@@ -95,6 +95,24 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	getAnisotropy(): number;
 
 	/**
+	 * Get local ambient occlusion flag
+	 * @default false
+	 */
+	getLocalAmbientOcclusion(): boolean;
+
+	/**
+	 * Get kernel size for local ambient occlusion
+	 * @default 15
+	 */
+	getKernelSize(): number;
+
+	/**
+	 * Get kernel radius for local ambient occlusion
+	 * @default 7
+	 */
+	getKernelRadius(): number;
+
+	/**
 	 * 
 	 * @param x 
 	 * @param y 
@@ -186,7 +204,28 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	 * Value of -1.0 means light scatters backward, value of 1.0 means light scatters forward.
 	 * @param anisotropy
 	 */
-	setAnisotropy(anisotropy: number): number;
+	setAnisotropy(anisotropy: number): void;
+
+	/**
+	 * Set whether to turn on local ambient occlusion (LAO). LAO is only effective if shading is on and volumeScatterBlendCoef is set to 0.
+	 * LAO effect is added to ambient lighting, so the ambient component of the actor needs to be great than 0.
+	 * @param localAmbientOcclusion
+	 */
+	setLocalAmbientOcclusion(localAmbientOcclusion: boolean): void;
+
+	/**
+	 * Set kernel size for local ambient occlusion. It specifies the number of rays that are randomly sampled in the hemisphere.
+	 * Value is clipped between 1 and 32.
+	 * @param kernelSize
+	 */
+	setKernelSize(kernelSize: number): void;
+
+	/**
+	 * Set kernel radius for local ambient occlusion. It specifies the number of samples that are considered on each random ray.
+	 * Value must be greater than or equal to 1.
+	 * @param kernelRadius
+	 */
+	setKernelRadius(kernelRadius: number): void;
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/VolumeMapper/index.d.ts
+++ b/Sources/Rendering/Core/VolumeMapper/index.d.ts
@@ -104,13 +104,13 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	 * Get kernel size for local ambient occlusion
 	 * @default 15
 	 */
-	getKernelSize(): number;
+	getLaoKernelSize(): number;
 
 	/**
 	 * Get kernel radius for local ambient occlusion
 	 * @default 7
 	 */
-	getKernelRadius(): number;
+	getLaoKernelRadius(): number;
 
 	/**
 	 * 
@@ -218,14 +218,14 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	 * Value is clipped between 1 and 32.
 	 * @param kernelSize
 	 */
-	setKernelSize(kernelSize: number): void;
+	setLaoKernelSize(laoKernelSize: number): void;
 
 	/**
 	 * Set kernel radius for local ambient occlusion. It specifies the number of samples that are considered on each random ray.
 	 * Value must be greater than or equal to 1.
 	 * @param kernelRadius
 	 */
-	setKernelRadius(kernelRadius: number): void;
+	setLaoKernelRadius(laoKernelRadius: number): void;
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/VolumeMapper/index.d.ts
+++ b/Sources/Rendering/Core/VolumeMapper/index.d.ts
@@ -104,13 +104,13 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	 * Get kernel size for local ambient occlusion
 	 * @default 15
 	 */
-	getLaoKernelSize(): number;
+	getLAOKernelSize(): number;
 
 	/**
 	 * Get kernel radius for local ambient occlusion
 	 * @default 7
 	 */
-	getLaoKernelRadius(): number;
+	getLAOKernelRadius(): number;
 
 	/**
 	 * 
@@ -216,16 +216,16 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	/**
 	 * Set kernel size for local ambient occlusion. It specifies the number of rays that are randomly sampled in the hemisphere.
 	 * Value is clipped between 1 and 32.
-	 * @param kernelSize
+	 * @param LAOKernelSize
 	 */
-	setLaoKernelSize(laoKernelSize: number): void;
+	setLAOKernelSize(LAOKernelSize: number): void;
 
 	/**
 	 * Set kernel radius for local ambient occlusion. It specifies the number of samples that are considered on each random ray.
 	 * Value must be greater than or equal to 1.
-	 * @param kernelRadius
+	 * @param LAOKernelRadius
 	 */
-	setLaoKernelRadius(laoKernelRadius: number): void;
+	setLAOKernelRadius(LAOKernelRadius: number): void;
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -93,6 +93,16 @@ function vtkVolumeMapper(publicAPI, model) {
     model.anisotropy = vtkMath.clampValue(at, -0.99, 0.99);
     publicAPI.modified();
   };
+
+  publicAPI.setKernelSize = (ks) => {
+    model.kernelSize = vtkMath.floor(vtkMath.clampValue(ks, 1, 32));
+    publicAPI.modified();
+  };
+
+  publicAPI.setKernelRadius = (kr) => {
+    model.kernelRadius = kr >= 1 ? kr : 1;
+    publicAPI.modified();
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -116,6 +126,10 @@ const DEFAULT_VALUES = {
   globalIlluminationReach: 0.0,
   volumeShadowSamplingDistFactor: 5.0,
   anisotropy: 0.0,
+  // local ambient occlusion
+  localAmbientOcclusion: false,
+  kernelSize: 15,
+  kernelRadius: 7,
 };
 
 // ----------------------------------------------------------------------------
@@ -138,6 +152,9 @@ export function extend(publicAPI, model, initialValues = {}) {
     'globalIlluminationReach',
     'volumeShadowSamplingDistFactor',
     'anisotropy',
+    'localAmbientOcclusion',
+    'kernelSize',
+    'kernelRadius',
   ]);
 
   macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -75,31 +75,25 @@ function vtkVolumeMapper(publicAPI, model) {
     publicAPI.setFilterMode(FilterMode.RAW);
   };
 
-  publicAPI.setGlobalIlluminationReach = (gl) => {
+  publicAPI.setGlobalIlluminationReach = (gl) =>
     superClass.setGlobalIlluminationReach(vtkMath.clampValue(gl, 0.0, 1.0));
-  };
 
-  publicAPI.setVolumetricScatteringBlending = (vsb) => {
+  publicAPI.setVolumetricScatteringBlending = (vsb) =>
     superClass.setVolumetricScatteringBlending(
       vtkMath.clampValue(vsb, 0.0, 1.0)
     );
-  };
 
-  publicAPI.setVolumeShadowSamplingDistFactor = (vsdf) => {
+  publicAPI.setVolumeShadowSamplingDistFactor = (vsdf) =>
     superClass.setVolumeShadowSamplingDistFactor(vsdf >= 1.0 ? vsdf : 1.0);
-  };
 
-  publicAPI.setAnisotropy = (at) => {
+  publicAPI.setAnisotropy = (at) =>
     superClass.setAnisotropy(vtkMath.clampValue(at, -0.99, 0.99));
-  };
 
-  publicAPI.setLaoKernelSize = (ks) => {
-    superClass.setLaoKernelSize(vtkMath.floor(vtkMath.clampValue(ks, 1, 32)));
-  };
+  publicAPI.setLAOKernelSize = (ks) =>
+    superClass.setLAOKernelSize(vtkMath.floor(vtkMath.clampValue(ks, 1, 32)));
 
-  publicAPI.setLaoKernelRadius = (kr) => {
-    superClass.setLaoKernelRadius(kr >= 1 ? kr : 1);
-  };
+  publicAPI.setLAOKernelRadius = (kr) =>
+    superClass.setLAOKernelRadius(kr >= 1 ? kr : 1);
 }
 
 // ----------------------------------------------------------------------------
@@ -125,8 +119,8 @@ const DEFAULT_VALUES = {
   anisotropy: 0.0,
   // local ambient occlusion
   localAmbientOcclusion: false,
-  laoKernelSize: 15,
-  laoKernelRadius: 7,
+  LAOKernelSize: 15,
+  LAOKernelRadius: 7,
 };
 
 // ----------------------------------------------------------------------------
@@ -150,8 +144,8 @@ export function extend(publicAPI, model, initialValues = {}) {
     'volumeShadowSamplingDistFactor',
     'anisotropy',
     'localAmbientOcclusion',
-    'laoKernelSize',
-    'laoKernelRadius',
+    'LAOKernelSize',
+    'LAOKernelRadius',
   ]);
 
   macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);

--- a/Sources/Rendering/Core/VolumeMapper/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/index.js
@@ -13,6 +13,8 @@ function vtkVolumeMapper(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkVolumeMapper');
 
+  const superClass = { ...publicAPI };
+
   publicAPI.getBounds = () => {
     const input = publicAPI.getInputData();
     if (!input) {
@@ -74,34 +76,29 @@ function vtkVolumeMapper(publicAPI, model) {
   };
 
   publicAPI.setGlobalIlluminationReach = (gl) => {
-    model.globalIlluminationReach = vtkMath.clampValue(gl, 0.0, 1.0);
-    publicAPI.modified();
+    superClass.setGlobalIlluminationReach(vtkMath.clampValue(gl, 0.0, 1.0));
   };
 
   publicAPI.setVolumetricScatteringBlending = (vsb) => {
-    model.volumetricScatteringBlending = vtkMath.clampValue(vsb, 0.0, 1.0);
-
-    publicAPI.modified();
+    superClass.setVolumetricScatteringBlending(
+      vtkMath.clampValue(vsb, 0.0, 1.0)
+    );
   };
 
   publicAPI.setVolumeShadowSamplingDistFactor = (vsdf) => {
-    model.volumeShadowSamplingDistFactor = vsdf >= 1.0 ? vsdf : 1.0;
-    publicAPI.modified();
+    superClass.setVolumeShadowSamplingDistFactor(vsdf >= 1.0 ? vsdf : 1.0);
   };
 
   publicAPI.setAnisotropy = (at) => {
-    model.anisotropy = vtkMath.clampValue(at, -0.99, 0.99);
-    publicAPI.modified();
+    superClass.setAnisotropy(vtkMath.clampValue(at, -0.99, 0.99));
   };
 
-  publicAPI.setKernelSize = (ks) => {
-    model.kernelSize = vtkMath.floor(vtkMath.clampValue(ks, 1, 32));
-    publicAPI.modified();
+  publicAPI.setLaoKernelSize = (ks) => {
+    superClass.setLaoKernelSize(vtkMath.floor(vtkMath.clampValue(ks, 1, 32)));
   };
 
-  publicAPI.setKernelRadius = (kr) => {
-    model.kernelRadius = kr >= 1 ? kr : 1;
-    publicAPI.modified();
+  publicAPI.setLaoKernelRadius = (kr) => {
+    superClass.setLaoKernelRadius(kr >= 1 ? kr : 1);
   };
 }
 
@@ -128,8 +125,8 @@ const DEFAULT_VALUES = {
   anisotropy: 0.0,
   // local ambient occlusion
   localAmbientOcclusion: false,
-  kernelSize: 15,
-  kernelRadius: 7,
+  laoKernelSize: 15,
+  laoKernelRadius: 7,
 };
 
 // ----------------------------------------------------------------------------
@@ -153,8 +150,8 @@ export function extend(publicAPI, model, initialValues = {}) {
     'volumeShadowSamplingDistFactor',
     'anisotropy',
     'localAmbientOcclusion',
-    'kernelSize',
-    'kernelRadius',
+    'laoKernelSize',
+    'laoKernelRadius',
   ]);
 
   macro.setGetArray(publicAPI, model, ['ipScalarRange'], 2);

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -208,7 +208,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         ).result;
       }
       if (
-        model.renderable.getVolumetricScatteringBlending() == 0.0 &&
+        model.renderable.getVolumetricScatteringBlending() === 0.0 &&
         model.renderable.getLocalAmbientOcclusion() &&
         actor.getProperty().getAmbient() > 0.0
       ) {
@@ -335,7 +335,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       ).result;
     }
     if (
-      model.renderable.getVolumetricScatteringBlending() == 0.0 &&
+      model.renderable.getVolumetricScatteringBlending() === 0.0 &&
       model.renderable.getLocalAmbientOcclusion() &&
       actor.getProperty().getAmbient() > 0.0
     ) {
@@ -910,7 +910,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       );
     }
     if (
-      model.renderable.getVolumetricScatteringBlending() == 0.0 &&
+      model.renderable.getVolumetricScatteringBlending() === 0.0 &&
       model.renderable.getLocalAmbientOcclusion() &&
       actor.getProperty().getAmbient() > 0.0
     ) {

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -344,7 +344,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         '//VTK::LAO::Dec',
         [
           `uniform int kernelRadius;`,
-          `uniform vec2 kernelSample[${model.renderable.getLaoKernelRadius()}];`,
+          `uniform vec2 kernelSample[${model.renderable.getLAOKernelRadius()}];`,
           `uniform int kernelSize;`,
         ],
         false
@@ -914,7 +914,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       model.renderable.getLocalAmbientOcclusion() &&
       actor.getProperty().getAmbient() > 0.0
     ) {
-      const ks = model.renderable.getLaoKernelSize();
+      const ks = model.renderable.getLAOKernelSize();
       program.setUniformi('kernelSize', ks);
       const kernelSample = [];
       for (let i = 0; i < ks; i++) {
@@ -924,7 +924,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       program.setUniform2fv('kernelSample', kernelSample);
       program.setUniformi(
         'kernelRadius',
-        model.renderable.getLaoKernelRadius()
+        model.renderable.getLAOKernelRadius()
       );
     }
   };

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -344,7 +344,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         '//VTK::LAO::Dec',
         [
           `uniform int kernelRadius;`,
-          `uniform vec2 kernelSample[${model.renderable.getKernelRadius()}];`,
+          `uniform vec2 kernelSample[${model.renderable.getLaoKernelRadius()}];`,
           `uniform int kernelSize;`,
         ],
         false
@@ -914,7 +914,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       model.renderable.getLocalAmbientOcclusion() &&
       actor.getProperty().getAmbient() > 0.0
     ) {
-      const ks = model.renderable.getKernelSize();
+      const ks = model.renderable.getLaoKernelSize();
       program.setUniformi('kernelSize', ks);
       const kernelSample = [];
       for (let i = 0; i < ks; i++) {
@@ -922,7 +922,10 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         kernelSample[i * 2 + 1] = Math.random() * 0.5;
       }
       program.setUniform2fv('kernelSample', kernelSample);
-      program.setUniformi('kernelRadius', model.renderable.getKernelRadius());
+      program.setUniformi(
+        'kernelRadius',
+        model.renderable.getLaoKernelRadius()
+      );
     }
   };
 

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -64,6 +64,8 @@ uniform float vSpecular;
 
 //VTK::VolumeShadowOn
 //VTK::SurfaceShadowOn
+//VTK::localAmbientOcclusionOn
+//VTK::LAO::Dec
 //VTK::VolumeShadow::Dec
 
 // define vtkComputeNormalFromOpacity
@@ -201,10 +203,13 @@ uniform vec4 ipScalarRangeMax;
 // global and custom variables (a temporary section before photorealistics rendering module is complete)
 vec3 rayDirVC;
 float sampleDistanceISVS;
+float sampleDistanceIS;
 
 #define SQRT3    1.7321
 #define INV4PI   0.0796
 #define EPSILON  0.001
+#define PI       3.1415
+#define PI2      9.8696
 
 //=======================================================================
 // Webgl2 specific version of functions
@@ -484,10 +489,14 @@ float computeGradientOpacityFactor(
     result.z = getTextureValue(pos + vec3(0.0, 0.0, tstep.z)).a - scalar;  
     // divide by spacing  
     result.xyz /= vSpacing;  
-    result.w = length(result.xyz);  
-    // rotate to View Coords  
-    rotateToViewCoord(result.xyz);
-    return vec4(normalize(result.xyz),result.w);  
+    result.w = length(result.xyz);
+    if (result.w > 0.0){
+      // rotate to View Coords  
+      rotateToViewCoord(result.xyz);
+      return vec4(normalize(result.xyz),result.w);  
+    } else {
+      return vec4(0.0);
+    }
   }  
 #endif
 
@@ -577,15 +586,7 @@ mat4 computeMat4Normal(vec3 pos, vec4 tValue, vec3 tstep)
 
 //=======================================================================
 // global shadow - secondary ray
-#ifdef VolumeShadowOn
-
-// henyey greenstein phase function
-float phase_function(float cos_angle)
-{
-  // divide by 2.0 instead of 4pi to increase intensity
-  return ((1.0-anisotropy2)/pow(1.0+anisotropy2-2.0*anisotropy*cos_angle, 1.5))/2.0;
-}
-
+#if defined(VolumeShadowOn) || defined(localAmbientOcclusionOn)
 float random()
 { 
   float rand = fract(sin(dot(gl_FragCoord.xy,vec2(12.9898,78.233)))*43758.5453123);
@@ -595,6 +596,15 @@ float random()
   pcg_state = pcg_state * uint(747796405) + uint(2891336453);
   uint word = ((state >> ((state >> uint(28)) + uint(4))) ^ state) * uint(277803737);
   return (float((((word >> uint(22)) ^ word) >> 1 ))/float(2147483647) + rand)/2.0;
+}
+#endif
+
+#ifdef VolumeShadowOn
+// henyey greenstein phase function
+float phase_function(float cos_angle)
+{
+  // divide by 2.0 instead of 4pi to increase intensity
+  return ((1.0-anisotropy2)/pow(1.0+anisotropy2-2.0*anisotropy*cos_angle, 1.5))/2.0;
 }
 
 // Computes the intersection between a ray and a box
@@ -739,6 +749,67 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
 #endif
 
 //=======================================================================
+// local ambient occlusion
+#ifdef localAmbientOcclusionOn
+vec3 sample_direction_uniform(int i)
+{
+  float rand = random() * 0.5;
+  float theta = PI2 * (kernelSample[i][0] + rand);
+  float phi = acos(2.0 * (kernelSample[i][1] + rand) -1.0) / 2.5;
+  return normalize(vec3(cos(theta)*sin(phi), sin(theta)*sin(phi), cos(phi)));
+}
+
+// return a matrix that transform startDir into z axis; startDir should be normalized
+mat3 zBaseRotationalMatrix(vec3 startDir){
+  vec3 axis = cross(startDir, vec3(0.0,0.0,1.0));
+  float cosA = startDir.z;
+  float k = 1.0 / (1.0 + cosA);
+  mat3 matrix = mat3((axis.x * axis.x * k) + cosA, (axis.y * axis.x * k) - axis.z, (axis.z * axis.x * k) + axis.y,
+              (axis.x * axis.y * k) + axis.z, (axis.y * axis.y * k) + cosA, (axis.z * axis.y * k) - axis.x,
+              (axis.x * axis.z * k) - axis.y, (axis.y * axis.z * k) + axis.x, (axis.z * axis.z * k) + cosA);
+  return matrix;
+}
+
+float computeLAO(vec3 posIS, float opacity, vec3 lightDir, vec4 normal){
+  // apply LAO only at selected locations, otherwise return full brightness
+  if (normal.w > 0.0 && opacity > 0.05){
+    float total_transmittance = 0.0;
+    mat3 inverseRotateBasis = inverse(zBaseRotationalMatrix(normalize(-normal.xyz)));
+    vec3 currPos, randomDirStep;
+    float weight, transmittance, sampled_transmittance;
+    for (int i = 0; i < kernelSize; i++)
+    {
+      randomDirStep = inverseRotateBasis * sample_direction_uniform(i) * sampleDistanceIS;
+      weight = 1.0 - dot(normalize(lightDir), normalize(randomDirStep));
+      currPos = posIS;
+      transmittance = 1.0;
+      for (int j = 0; j < kernelRadius ; j++){
+        currPos += randomDirStep;
+        // check if it's at clipping plane, if so return full brightness
+        if (all(greaterThan(currPos, vec3(EPSILON))) && all(lessThan(currPos,vec3(1.0-EPSILON)))){
+          sampled_transmittance = 1.0 - texture2D(otexture, vec2(getTextureValue(currPos).r * oscale0 + oshift0, 0.5)).r;
+          transmittance *= sampled_transmittance;
+        }
+        else{
+          break;
+        }
+      }
+      total_transmittance += transmittance / float(kernelRadius) * weight;
+
+      // early termination if fully translucent
+      if (total_transmittance > 1.0 - EPSILON){
+        return 1.0;
+      }
+    }
+    // average transmittance and reduce variance
+    return clamp(total_transmittance / float(kernelSize), 0.3, 1.0); 
+  } else {
+    return 1.0;
+  }
+}
+#endif
+
+//=======================================================================
 // surface light contribution
 #if vtkLightComplexity > 0
   void applyLighting(inout vec3 tColor, vec4 normal)
@@ -756,11 +827,14 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
   }
   #ifdef SurfaceShadowOn
   #if vtkLightComplexity < 3
-    vec3 applyLightingDirectional(inout vec3 tColor, vec4 normal)
+    vec3 applyLightingDirectional(vec3 posIS, vec4 tColor, vec4 normal)
     {
       // everything in VC
       vec3 diffuse = vec3(0.0);
       vec3 specular = vec3(0.0);
+      #ifdef localAmbientOcclusionOn
+        vec3 ambient = vec3(0.0);
+      #endif        
       vec3 vertLightDirection;
       for (int i = 0; i < lightNum; i++){
         float ndotL,vdotR;
@@ -780,15 +854,25 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
             specular += pow(vdotR, vSpecularPower) * lightColor[i];
           }
         }
+        #ifdef localAmbientOcclusionOn
+            ambient += computeLAO(posIS, tColor.a, vertLightDirection, normal);
+        #endif
       }  
-      return tColor.rgb*(diffuse*vDiffuse + vAmbient) + specular*vSpecular;
+      #ifdef localAmbientOcclusionOn
+        return tColor.rgb * (diffuse * vDiffuse + vAmbient * ambient) + specular*vSpecular;
+      #else 
+        return tColor.rgb * (diffuse * vDiffuse + vAmbient) + specular*vSpecular;
+      #endif    
     }
   #else
-    vec3 applyLightingPositional(inout vec3 tColor, vec4 normal, vec3 posVC)
+    vec3 applyLightingPositional(vec3 posIS, vec4 tColor, vec4 normal, vec3 posVC)
     {
       // everything in VC
       vec3 diffuse = vec3(0.0);
       vec3 specular = vec3(0.0);
+      #ifdef localAmbientOcclusionOn
+        vec3 ambient = vec3(0.0);
+      #endif      
       vec3 vertLightDirection;
       for (int i = 0; i < lightNum; i++){
         float distance,attenuation,ndotL,vdotR;
@@ -826,6 +910,9 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
               specular += pow(vdotR, vSpecularPower) * attenuation * lightColor[i];
             }
           }
+          #ifdef localAmbientOcclusionOn
+            ambient += computeLAO(posIS, tColor.a, vertLightDirection, normal);
+          #endif          
         } else {
           vertLightDirection = lightDirectionVC[i];
           ndotL = dot(normal.xyz, vertLightDirection);
@@ -843,9 +930,16 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
               specular += pow(vdotR, vSpecularPower) * lightColor[i];
             }
           }
+          #ifdef localAmbientOcclusionOn
+            ambient += computeLAO(posIS, tColor.a, vertLightDirection, normal);
+          #endif          
         }
       }
-      return tColor.rgb * (diffuse * vDiffuse + vAmbient) + specular*vSpecular;
+      #ifdef localAmbientOcclusionOn
+        return tColor.rgb * (diffuse * vDiffuse + vAmbient * ambient) + specular*vSpecular;
+      #else 
+        return tColor.rgb * (diffuse * vDiffuse + vAmbient) + specular*vSpecular;
+      #endif
     }
   #endif 
   #endif
@@ -1148,7 +1242,7 @@ bool valueWithinScalarRange(vec4 val, vec4 min, vec4 max) {
 //=======================================================================
 // Apply the specified blend mode operation along the ray's path.
 //
-void applyBlend(vec3 posIS, vec3 endIS, float sampleDistanceIS, vec3 tdims)
+void applyBlend(vec3 posIS, vec3 endIS, vec3 tdims)
 {
   vec3 tstep = 1.0/tdims;
 
@@ -1432,7 +1526,7 @@ vec2 computeRayDistances(vec3 rayDir, vec3 tdims)
 // Compute the index space starting position (pos) and end
 // position
 //
-void computeIndexSpaceValues(out vec3 pos, out vec3 endPos, out float sampleDistanceIS, vec3 rayDir, vec2 dists)
+void computeIndexSpaceValues(out vec3 pos, out vec3 endPos, vec3 rayDir, vec2 dists)
 {
   // compute starting and ending values in volume space
   pos = vertexVCVSOutput + dists.x*rayDir;
@@ -1489,9 +1583,8 @@ void main()
   // IS = Index Space
   vec3 posIS;
   vec3 endIS;
-  float sampleDistanceIS;
-  computeIndexSpaceValues(posIS, endIS, sampleDistanceIS, rayDirVC, rayStartEndDistancesVC);
+  computeIndexSpaceValues(posIS, endIS, rayDirVC, rayStartEndDistancesVC);
 
   // Perform the blending operation along the ray
-  applyBlend(posIS, endIS, sampleDistanceIS, tdims);
+  applyBlend(posIS, endIS, tdims);
 }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Add local ambient occlusion feature as part of the cinematic rendering module. Volumetric shading often return sharp shadows that completely occlude parts of the volume. LAO renders soft shadow and provides an alternative to work around the issue.

### Results
Images taken with different kernel size and kernel radius, only ambient lighting is on:

![Screenshot 2022-07-19 152114](https://user-images.githubusercontent.com/43657251/179836457-c2162205-edcb-4dc2-8e3c-b911d936ea09.png)

Two other interactive samples are available:
[Ultrasound data](https://kitwaremedical.github.io/vtk.js-render-tests/LAODemoFetus.html)
[Head CT](https://kitwaremedical.github.io/vtk.js-render-tests/LAODemoHead.html)

Random directions are sampled by combining `Math.random()` function and shader's jitter texture. Final light translucency is thresholded to be greater than 0.3 to reduce variance. To speed up rendering, full brightness is returned at sample positions with `gradient magnitude = 0` or `opacity < 0.05`, hence fog-like tissue can be seen in above image. Fully brightness is also returned at clipping plane (not shown in image). 

Speckle is still visible at some parameter settings, which can be improved by increasing the diffuse factor.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [X] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Windows 10
  - **Browser**: Chrome 89.0.4389.128


<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
