### PR TITLE
fix(InteractorStyleTrackballCamera): null guard

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -277,6 +277,10 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //--------------------------------------------------------------------------
   publicAPI.handleMouseRotate = (renderer, position) => {
+    if (!model.previousPosition) {
+      return;
+    }
+
     const rwi = model._interactor;
 
     const dx = position.x - model.previousPosition.x;
@@ -312,6 +316,10 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //--------------------------------------------------------------------------
   publicAPI.handleMouseSpin = (renderer, position) => {
+    if (!model.previousPosition) {
+      return;
+    }
+
     const rwi = model._interactor;
     const camera = renderer.getActiveCamera();
     const center = rwi.getView().getViewportCenter(renderer);
@@ -335,6 +343,10 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //--------------------------------------------------------------------------
   publicAPI.handleMousePan = (renderer, position) => {
+    if (!model.previousPosition) {
+      return;
+    }
+
     const camera = renderer.getActiveCamera();
 
     // Calculate the focal depth since we'll be using it a lot
@@ -390,6 +402,10 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.handleMouseDolly = (renderer, position) => {
+    if (!model.previousPosition) {
+      return;
+    }
+
     const dy = position.y - model.previousPosition.y;
     const rwi = model._interactor;
     const center = rwi.getView().getViewportCenter(renderer);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
- Starting a dolly before mouse move or mouse press and then moving the mouse results in usage of `model.previousPosition` when it's not yet set.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- No more console errors for this corner case.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Guard against `model.previousPosition` being null/undefined.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
