### PR TITLE
feat(WebGPU): update to use half float buffers

### DIFF
--- a/Sources/Rendering/WebGPU/OpaquePass/index.js
+++ b/Sources/Rendering/WebGPU/OpaquePass/index.js
@@ -31,7 +31,7 @@ function vtkWebGPUOpaquePass(publicAPI, model) {
       model.colorTexture.create(device, {
         width: viewNode.getCanvas().width,
         height: viewNode.getCanvas().height,
-        format: 'bgra8unorm',
+        format: 'rgba16float',
         /* eslint-disable no-undef */
         /* eslint-disable no-bitwise */
         usage:

--- a/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
@@ -239,7 +239,7 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
       fragment: {
         targets: [
           {
-            format: 'bgra8unorm',
+            format: 'rgba16float',
             blend: {
               color: {
                 srcFactor: 'src-alpha',

--- a/Sources/Rendering/WebGPU/RenderEncoder/index.js
+++ b/Sources/Rendering/WebGPU/RenderEncoder/index.js
@@ -59,8 +59,8 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
       console.trace();
     } else {
       for (let i = 0; i < model.colorTextureViews.length; i++) {
-        const fmt = model.colorTextureViews[i].getTexture().getFormat();
-        if (fmt !== pd.fragment.targets[i].format) {
+        const fmt = model.colorTextureViews[i].getTexture()?.getFormat();
+        if (fmt && fmt !== pd.fragment.targets[i].format) {
           console.log(
             `mismatched attachments for attachment ${i} on pipeline ${pd.fragment.targets[i].format} while encoder has ${fmt}`
           );
@@ -74,8 +74,8 @@ function vtkWebGPURenderEncoder(publicAPI, model) {
       console.log('mismatched depth attachments');
       console.trace();
     } else if (model.depthTextureView) {
-      const dfmt = model.depthTextureView.getTexture().getFormat();
-      if (dfmt !== pd.depthStencil.format) {
+      const dfmt = model.depthTextureView.getTexture()?.getFormat();
+      if (dfmt && dfmt !== pd.depthStencil.format) {
         console.log(
           `mismatched depth attachments on pipeline ${pd.depthStencil.format} while encoder has ${dfmt}`
         );
@@ -211,7 +211,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     fragment: {
       targets: [
         {
-          format: 'bgra8unorm',
+          format: 'rgba16float',
           blend: {
             color: {
               srcFactor: 'src-alpha',

--- a/Sources/Rendering/WebGPU/TextureView/index.js
+++ b/Sources/Rendering/WebGPU/TextureView/index.js
@@ -26,6 +26,19 @@ function vtkWebGPUTextureView(publicAPI, model) {
     model.bindGroupLayoutEntry.texture.sampleType = tDetails.sampleType;
   };
 
+  publicAPI.createFromTextureHandle = (textureHandle, options) => {
+    model.texture = null;
+    model.options = options;
+    model.options.dimension = model.options.dimension || '2d';
+    model.options.label = model.label;
+    model.textureHandle = textureHandle;
+    model.handle = model.textureHandle.createView(model.options);
+    model.bindGroupLayoutEntry.texture.viewDimension = model.options.dimension;
+    const tDetails = vtkWebGPUTypes.getDetailsFromTextureFormat(options.format);
+    model.bindGroupLayoutEntry.texture.sampleType = tDetails.sampleType;
+    model.bindGroupTime.modified();
+  };
+
   publicAPI.getBindGroupEntry = () => {
     const foo = {
       resource: publicAPI.getHandle(),
@@ -57,7 +70,7 @@ function vtkWebGPUTextureView(publicAPI, model) {
 
   publicAPI.getBindGroupTime = () => {
     // check if the handle changed
-    if (model.texture.getHandle() !== model.textureHandle) {
+    if (model.texture && model.texture.getHandle() !== model.textureHandle) {
       model.textureHandle = model.texture.getHandle();
       model.handle = model.textureHandle.createView(model.options);
       model.bindGroupTime.modified();
@@ -67,7 +80,7 @@ function vtkWebGPUTextureView(publicAPI, model) {
 
   // if the texture has changed then get a new view
   publicAPI.getHandle = () => {
-    if (model.texture.getHandle() !== model.textureHandle) {
+    if (model.texture && model.texture.getHandle() !== model.textureHandle) {
       model.textureHandle = model.texture.getHandle();
       model.handle = model.textureHandle.createView(model.options);
       model.bindGroupTime.modified();

--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -629,7 +629,7 @@ function vtkWebGPUVolumePass(publicAPI, model) {
       fragment: {
         targets: [
           {
-            format: 'bgra8unorm',
+            format: 'rgba16float',
             blend: {
               color: {
                 srcFactor: 'one',


### PR DESCRIPTION
With this MR the WebGPU backend will use half float
buffers for the opaque pass, and blit that into the
target preferredFormat for the canvas.

