### PR TITLE
fix(mapper): modify mapper when clearing clipping planes

### DIFF
--- a/Sources/Rendering/Core/AbstractMapper/index.d.ts
+++ b/Sources/Rendering/Core/AbstractMapper/index.d.ts
@@ -35,13 +35,15 @@ export interface vtkAbstractMapper extends vtkAbstractMapperBase {
 
 	/**
 	 * Remove all clipping planes.
+	 * @return true if there were planes, false otherwise.
 	 */
-	removeAllClippingPlanes(): void;
+	removeAllClippingPlanes(): boolean;
 
-	/**
-	 * Remove clipping plane.
-	 * @param {vtkPlane} plane
-	 */
+	 /**
+	  * Remove clipping plane.
+	  * @param {vtkPlane} plane
+	  * @return true if plane existed and therefore is removed, false otherwise.
+	  */
 	removeClippingPlane(plane: vtkPlane): boolean;
 
 	/**

--- a/Sources/Rendering/Core/AbstractMapper/index.js
+++ b/Sources/Rendering/Core/AbstractMapper/index.js
@@ -25,7 +25,12 @@ function vtkAbstractMapper(publicAPI, model) {
   publicAPI.getNumberOfClippingPlanes = () => model.clippingPlanes.length;
 
   publicAPI.removeAllClippingPlanes = () => {
+    if (model.clippingPlanes.length === 0) {
+      return false;
+    }
     model.clippingPlanes.length = 0;
+    publicAPI.modified();
+    return true;
   };
 
   publicAPI.removeClippingPlane = (clippingPlane) => {


### PR DESCRIPTION
Removing a clipping plane was modifying the mapper, while removing them all wasn't.

### Context
See #1287 

### Results
Mapper is modified when removing all clipping planes

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
