### PR TITLE
fix(vtkremoteview): added type for disconnectImageStream in vtkRemote…

### DIFF
--- a/Sources/Rendering/Misc/RemoteView/index.d.ts
+++ b/Sources/Rendering/Misc/RemoteView/index.d.ts
@@ -1,5 +1,6 @@
 import { vtkObject } from '../../../interfaces';
 import vtkCanvasView from '../CanvasView';
+import vtkImageStream from '../../../IO/Core/ImageStream';
 import vtkViewStream from '../../../IO/Core/ImageStream/ViewStream';
 
 interface IRemoteViewInitialValues {
@@ -188,13 +189,18 @@ export function newInstance(
   initialValues?: IRemoteViewInitialValues
 ): vtkRemoteView;
 
-export function connectImageStream(session: any): any;
+export function connectImageStream(session: any): void;
+
+export function disconnectImageStream(): void;
+
 /**
  * vtkRemoteView provides a way to create a remote view.
  */
 export declare const vtkRemoteView: {
   newInstance: typeof newInstance;
   extend: typeof extend;
+  SHARED_IMAGE_STREAM: vtkImageStream;
   connectImageStream: typeof connectImageStream;
+  disconnectImageStream: typeof disconnectImageStream;
 };
 export default vtkRemoteView;


### PR DESCRIPTION
…View

fix #2562

# Changes 

Added types for disconnectImageStream, SHARED_IMAGE_STREAM in vtkRemoteView.

Referred to these files for copying the types

https://github.com/Kitware/vtk-js/blob/dc94f8e2204adf2ff4a8fc84bace16c942e8cc7c/Sources/IO/Core/ImageStream/index.d.ts#L13-L21

https://github.com/Kitware/vtk-js/blob/dc94f8e2204adf2ff4a8fc84bace16c942e8cc7c/Sources/IO/Core/ImageStream/index.d.ts#L38

https://github.com/Kitware/vtk-js/blob/dc94f8e2204adf2ff4a8fc84bace16c942e8cc7c/Sources/Rendering/Misc/RemoteView/index.js#L7-L9

