### PR TITLE
docs(ts): fix TypedArray definition

### DIFF
--- a/Sources/Common/Core/CellArray/index.d.ts
+++ b/Sources/Common/Core/CellArray/index.d.ts
@@ -25,9 +25,9 @@ export interface vtkCellArray extends vtkDataArray {
 
 	/**
 	 * Set the data of this array.
-	 * @param {TypedArray} typedArray The Array value.
+	 * @param {Number[]|TypedArray} typedArray The Array value.
 	 */
-	setData(typedArray: TypedArray): void;
+	setData(typedArray: number[]|TypedArray): void;
 
 	/**
 	 * Returns the point indices at the given location as a subarray.

--- a/Sources/Common/Core/DataArray/index.d.ts
+++ b/Sources/Common/Core/DataArray/index.d.ts
@@ -1,5 +1,5 @@
 import { vtkObject, vtkRange } from "../../../interfaces";
-import { float, int, Nullable, TypedArray } from "../../../types";
+import { float, int, Nullable, Range, TypedArray } from "../../../types";
 
 
 /**
@@ -30,7 +30,7 @@ export interface IDataArrayInitialValues {
 	empty?: boolean;
 	name?: string;
 	numberOfComponents?: number;
-	rangeTuple?: [number, number];
+	rangeTuple?: Range;
 	size?: number;
 	values?: Array<number>|TypedArray;
 }
@@ -60,21 +60,21 @@ export interface vtkDataArray extends vtkObject {
 	/**
 	 *
 	 */
-	getData(): TypedArray;
+	getData(): number[]|TypedArray;
 
 	/**
 	 * Get the range of the given component.
 	 *
 	 * @param {Number} componentIndex (default: -1)
 	 */
-	getRange(componentIndex?: number): [number, number];
+	getRange(componentIndex?: number): Range;
 
 	/**
 	 *
 	 * @param {vtkRange} rangeValue
 	 * @param {Number} componentIndex
 	 */
-	setRange(rangeValue: vtkRange, componentIndex: number): [number, number];
+	setRange(rangeValue: vtkRange, componentIndex: number): Range;
 
 	/**
 	 * Set the given tuple at the given index.
@@ -223,10 +223,10 @@ export interface vtkDataArray extends vtkObject {
 	 * If this dataArray's numberOfComponents doesn't divide the given array's
 	 * length, this dataArray's numberOfComponents is set to 1.
 	 *
-	 * @param {TypedArray} typedArray
-	 * @param {Number} [numberOfComponents]
+	 * @param {Number[]|TypedArray} typedArray The Array value.
+	 * @param {Number} [numberOfComponents] 
 	 */
-	setData(typedArray: TypedArray, numberOfComponents?: number): void;
+	setData(typedArray: number[]|TypedArray, numberOfComponents?: number): void;
 
 	/**
 	 * Get the state of this array.

--- a/Sources/Common/Core/MatrixBuilder/index.d.ts
+++ b/Sources/Common/Core/MatrixBuilder/index.d.ts
@@ -78,11 +78,11 @@ declare interface Transform {
 	 * iterations (sets of 3) to loop through. Assumes the `typedArray` is an
 	 * array of multiples of 3, unless specifically handling with offset and
 	 * iterations. Returns the instance for chaining.
-	 * @param {TypedArray} typedArray 
+	 * @param {Number[]|TypedArray} typedArray The Array value.
 	 * @param {Number} [offset] 
 	 * @param {Number} [nbIterations] 
 	 */
-	apply(typedArray: TypedArray, offset?: number, nbIterations?: number): Transform
+	apply(typedArray: number[]|TypedArray, offset?: number, nbIterations?: number): Transform
 
 	/**
 	 * Returns the internal `mat4` matrix.

--- a/Sources/types.d.ts
+++ b/Sources/types.d.ts
@@ -22,7 +22,6 @@ declare type double = number;
 declare type int = number;
 
 declare type TypedArray =
-  | number[]
   | Uint32Array
   | Uint16Array
   | Uint8Array


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Type `TypedArray` shouldn't include `number[]`

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
