### PR TITLE
chore(vtkFieldData): update types

### DIFF
--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
@@ -1,12 +1,12 @@
 import { vtkObject } from "../../../interfaces" ;
 import { Nullable } from "../../../types";
-import vtkDataArray from "../../Core/DataArray";
+import type vtkDataArray from "../../Core/DataArray";
 
 /**
  * 
  */
 export interface IFieldDataInitialValues {
-	arrays?: Array<any>;
+	arrays?: vtkDataArray[];
 	copyFieldFlags?: Array<any>;
 	doCopyAllOn?: boolean;
 	doCopyAllOff?: boolean;
@@ -16,7 +16,7 @@ export interface IFieldDataInitialValues {
  * 
  */
 interface IArrayWithIndex {
-	array: any,
+	array: vtkDataArray,
 	index: number;
 }
 
@@ -75,13 +75,13 @@ export interface vtkFieldData extends vtkObject {
 	/**
 	 * Get all arrays.
 	 */
-	getArrays(): any;
+	getArrays(): vtkDataArray[];
 
 	/**
 	 * 
-	 * @param {any} arraySpec 
+	 * @param {number | string} arraySpec index or name of the array
 	 */
-	getArray(arraySpec: any): void;
+	getArray(arraySpec: number | string): Nullable<vtkDataArray>;
 
 	/**
 	 * Get an array by its name.
@@ -99,7 +99,7 @@ export interface vtkFieldData extends vtkObject {
 	 * Get an array by its index.
 	 * @param {Number} idx The index of the array.
 	 */
-	getArrayByIndex(idx: number): Nullable<any>;
+	getArrayByIndex(idx: number): Nullable<vtkDataArray>;
 
 	/**
 	 * Return true if there exists an array with the given arraName. False otherwise.


### PR DESCRIPTION
### Context
updated types for vtkFielddata see #2567 

### Results
- typescript for field data is more expressive

### Changes
 updated `vtkFieldData.arrays` to be of type `vtkDataArray` instead of `any` I believe this is the only type the arrays should be

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Mac OSX 12.5