### PR TITLE
docs(scalarbaractor): add ScalarBarActor example

### DIFF
--- a/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
+++ b/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
@@ -1,0 +1,44 @@
+<table>
+  <tr>
+    <td>Min:</td>
+    <td>
+      <input type="number" id="min" value="0"></input>
+    </td>
+  </tr>
+  <tr>
+    <td>Max:</td>
+    <td>
+      <input type="number" id="max" value="0.25">
+    </td>
+  </tr>
+  <tr>
+    <td>Automated:</td>
+    <td>
+      <input type="checkbox" id="automated" checked>
+    </td>
+  </tr>
+  <tr>
+    <td>AxisLabel:</td>
+    <td>
+      <input type="string" id="axisLabel" value="Scalar Value">
+    </td>
+  </tr>
+  <tr>
+    <td>Draw Nan Annotation:</td>
+    <td>
+      <input type="checkbox" id="drawNanAnnotation" checked>
+    </td>
+  </tr>
+  <tr>
+    <td>Draw Below Swatch:</td>
+    <td>
+      <input type="checkbox" id="drawBelowRangeSwatch" checked>
+    </td>
+  </tr>
+  <tr>
+    <td>Draw Above Swatch:</td>
+    <td>
+      <input type="checkbox" id="drawAboveRangeSwatch" checked>
+    </td>
+  </tr>
+</table>

--- a/Sources/Rendering/Core/ScalarBarActor/example/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/example/index.js
@@ -1,0 +1,109 @@
+import 'vtk.js/Sources/favicon';
+import * as d3 from 'd3-scale';
+
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import 'vtk.js/Sources/Rendering/Profiles/Geometry';
+
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkScalarBarActor from 'vtk.js/Sources/Rendering/Core/ScalarBarActor';
+import controlPanel from './controlPanel.html';
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance();
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+fullScreenRenderer.addController(controlPanel);
+
+// ----------------------------------------------------------------------------
+// Add a cube source
+// ----------------------------------------------------------------------------
+const cone = vtkConeSource.newInstance();
+const mapper = vtkMapper.newInstance();
+mapper.setInputData(cone.getOutputData());
+const actor = vtkActor.newInstance();
+actor.setMapper(mapper);
+actor.getProperty().setColor(0.0, 0.0, 1.0);
+actor.getProperty().setOpacity(0.5);
+
+renderer.addActor(actor);
+renderer.resetCamera();
+renderWindow.render();
+
+const scalarBarActor = vtkScalarBarActor.newInstance();
+renderer.addActor(scalarBarActor);
+const lut = mapper.getLookupTable();
+scalarBarActor.setScalarsToColors(lut);
+
+// Change the number of ticks (TODO: add numberOfTicks to ScalarBarActor)
+function generateTicks(numberOfTicks) {
+  return (helper) => {
+    const lastTickBounds = helper.getLastTickBounds();
+    // compute tick marks for axes
+    const scale = d3
+      .scaleLinear()
+      .domain([0.0, 1.0])
+      .range([lastTickBounds[0], lastTickBounds[1]]);
+    const samples = scale.ticks(numberOfTicks);
+    const ticks = samples.map((tick) => scale(tick));
+    const format = scale.tickFormat(
+      ticks[0],
+      ticks[ticks.length - 1],
+      numberOfTicks
+    );
+    const tickStrings = ticks
+      .map(format)
+      .map((tick) => Number(parseFloat(tick).toPrecision(12)).toPrecision()); // d3 sometimes adds unwanted whitespace
+    helper.setTicks(ticks);
+    helper.setTickStrings(tickStrings);
+  };
+}
+scalarBarActor.setGenerateTicks(generateTicks(10));
+
+const minInput = document.querySelector('#min');
+const onMinChanged = () => {
+  lut.setRange(parseFloat(minInput.value), lut.getRange()[1]);
+  renderWindow.render();
+};
+minInput.addEventListener('input', onMinChanged);
+onMinChanged();
+
+const maxInput = document.querySelector('#max');
+const onMaxChanged = () => {
+  lut.setRange(lut.getRange()[0], parseFloat(maxInput.value));
+  renderWindow.render();
+};
+maxInput.addEventListener('input', onMaxChanged);
+onMaxChanged();
+
+document.querySelector('#automated').addEventListener('change', (event) => {
+  scalarBarActor.setAutomated(event.target.checked);
+  renderWindow.render();
+});
+document.querySelector('#axisLabel').addEventListener('change', (event) => {
+  scalarBarActor.setAxisLabel(event.target.value);
+  renderWindow.render();
+});
+document
+  .querySelector('#drawNanAnnotation')
+  .addEventListener('change', (event) => {
+    scalarBarActor.setDrawNanAnnotation(event.target.checked);
+    renderWindow.render();
+  });
+document
+  .querySelector('#drawBelowRangeSwatch')
+  .addEventListener('change', (event) => {
+    scalarBarActor.setDrawBelowRangeSwatch(event.target.checked);
+    renderWindow.render();
+  });
+document
+  .querySelector('#drawAboveRangeSwatch')
+  .addEventListener('change', (event) => {
+    scalarBarActor.setDrawAboveRangeSwatch(event.target.checked);
+    renderWindow.render();
+  });


### PR DESCRIPTION
### Context
I needed to debug vtkScalarBarActor hence I wanted a convenient way to play with it.

### Results
I added an example to ply with vtkScalarBarActor.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
