### PR TITLE
Clean reslice cursor widget

### DIFF
--- a/Examples/Geometry/DepthTest/index.js
+++ b/Examples/Geometry/DepthTest/index.js
@@ -289,9 +289,9 @@ resetCameraPosition();
 // Use OpenGL as the backend to view the all this
 // ----------------------------------------------------------------------------
 
-const openglRenderWindow = vtkOpenGLRenderWindow.newInstance();
-renderWindow.addView(openglRenderWindow);
-openglRenderWindow.setContainer(container);
+const openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
+renderWindow.addView(openGLRenderWindow);
+openGLRenderWindow.setContainer(container);
 
 const textCanvas = document.createElement('canvas');
 textCanvas.classList.add(style.container, 'textCanvas');
@@ -304,7 +304,7 @@ textCtx = textCanvas.getContext('2d');
 // ----------------------------------------------------------------------------
 
 const interactor = vtkRenderWindowInteractor.newInstance();
-interactor.setView(openglRenderWindow);
+interactor.setView(openGLRenderWindow);
 interactor.initialize();
 interactor.bindEvents(container);
 
@@ -315,7 +315,7 @@ function resize() {
   const dims = container.getBoundingClientRect();
   windowWidth = Math.floor(dims.width);
   windowHeight = Math.floor(dims.height);
-  openglRenderWindow.setSize(windowWidth, windowHeight);
+  openGLRenderWindow.setSize(windowWidth, windowHeight);
   textCanvas.setAttribute('width', windowWidth);
   textCanvas.setAttribute('height', windowHeight);
   if (debugHandler) {

--- a/Examples/Geometry/SimpleCone/index.js
+++ b/Examples/Geometry/SimpleCone/index.js
@@ -43,8 +43,8 @@ renderer.resetCamera();
 // Use OpenGL as the backend to view the all this
 // ----------------------------------------------------------------------------
 
-const openglRenderWindow = vtkOpenGLRenderWindow.newInstance();
-renderWindow.addView(openglRenderWindow);
+const openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
+renderWindow.addView(openGLRenderWindow);
 
 // ----------------------------------------------------------------------------
 // Create a div section to put this into
@@ -52,21 +52,21 @@ renderWindow.addView(openglRenderWindow);
 
 const container = document.createElement('div');
 document.querySelector('body').appendChild(container);
-openglRenderWindow.setContainer(container);
+openGLRenderWindow.setContainer(container);
 
 // ----------------------------------------------------------------------------
 // Capture size of the container and set it to the renderWindow
 // ----------------------------------------------------------------------------
 
 const { width, height } = container.getBoundingClientRect();
-openglRenderWindow.setSize(width, height);
+openGLRenderWindow.setSize(width, height);
 
 // ----------------------------------------------------------------------------
 // Setup an interactor to handle mouse events
 // ----------------------------------------------------------------------------
 
 const interactor = vtkRenderWindowInteractor.newInstance();
-interactor.setView(openglRenderWindow);
+interactor.setView(openGLRenderWindow);
 interactor.initialize();
 interactor.bindEvents(container);
 

--- a/Examples/Geometry/SpheresAndLabels/index.js
+++ b/Examples/Geometry/SpheresAndLabels/index.js
@@ -68,8 +68,8 @@ renderer.resetCamera();
 // Use OpenGL as the backend to view the all this
 // ----------------------------------------------------------------------------
 
-const openglRenderWindow = vtkOpenGLRenderWindow.newInstance();
-renderWindow.addView(openglRenderWindow);
+const openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
+renderWindow.addView(openGLRenderWindow);
 
 // ----------------------------------------------------------------------------
 // Create a div section to put this into
@@ -78,7 +78,7 @@ renderWindow.addView(openglRenderWindow);
 const container = document.createElement('div');
 container.classList.add(style.container);
 document.querySelector('body').appendChild(container);
-openglRenderWindow.setContainer(container);
+openGLRenderWindow.setContainer(container);
 
 const textCanvas = document.createElement('canvas');
 textCanvas.classList.add(style.container, 'textCanvas');
@@ -91,7 +91,7 @@ textCtx = textCanvas.getContext('2d');
 // ----------------------------------------------------------------------------
 
 const interactor = vtkRenderWindowInteractor.newInstance();
-interactor.setView(openglRenderWindow);
+interactor.setView(openGLRenderWindow);
 interactor.initialize();
 interactor.bindEvents(container);
 
@@ -100,7 +100,7 @@ interactor.setInteractorStyle(vtkInteractorStyleTrackballCamera.newInstance());
 // Handle window resize
 function resize() {
   dims = container.getBoundingClientRect();
-  openglRenderWindow.setSize(dims.width, dims.height);
+  openGLRenderWindow.setSize(dims.width, dims.height);
   textCanvas.setAttribute('width', dims.width);
   textCanvas.setAttribute('height', dims.height);
   renderWindow.render();

--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -37,11 +37,11 @@ function vtkViewProxy(publicAPI, model) {
   model.renderer = vtkRenderer.newInstance({ background: [0, 0, 0] });
   model.renderWindow.addRenderer(model.renderer);
 
-  model.openglRenderWindow = model.renderWindow.newAPISpecificView();
-  model.renderWindow.addView(model.openglRenderWindow);
+  model._openGLRenderWindow = model.renderWindow.newAPISpecificView();
+  model.renderWindow.addView(model._openGLRenderWindow);
 
   model.interactor = vtkRenderWindowInteractor.newInstance();
-  model.interactor.setView(model.openglRenderWindow);
+  model.interactor.setView(model._openGLRenderWindow);
 
   model.interactorStyle3D = vtkInteractorStyleManipulator.newInstance();
   model.interactorStyle2D = vtkInteractorStyleManipulator.newInstance();
@@ -171,14 +171,14 @@ function vtkViewProxy(publicAPI, model) {
     if (model.container) {
       model.orientationWidget.setEnabled(false);
       model.interactor.unbindEvents(model.container);
-      model.openglRenderWindow.setContainer(null);
+      model._openGLRenderWindow.setContainer(null);
       model.cornerAnnotation.setContainer(null);
     }
 
     model.container = container;
 
     if (container) {
-      model.openglRenderWindow.setContainer(container);
+      model._openGLRenderWindow.setContainer(container);
       model.cornerAnnotation.setContainer(container);
       model.interactor.initialize();
       model.interactor.bindEvents(container);
@@ -197,7 +197,7 @@ function vtkViewProxy(publicAPI, model) {
       const devicePixelRatio = window.devicePixelRatio || 1;
       const width = Math.max(10, Math.floor(devicePixelRatio * dims.width));
       const height = Math.max(10, Math.floor(devicePixelRatio * dims.height));
-      model.openglRenderWindow.setSize(width, height);
+      model._openGLRenderWindow.setSize(width, height);
       publicAPI.invokeResize({ width, height });
       publicAPI.renderLater();
     }
@@ -593,7 +593,7 @@ function vtkViewProxy(publicAPI, model) {
     // in reverse order
     model.interactor.delete();
     model.renderer.delete();
-    model.openglRenderWindow.delete();
+    model._openGLRenderWindow.delete();
     model.renderWindow.delete();
   }, publicAPI.delete);
 
@@ -637,7 +637,7 @@ function extend(publicAPI, model, initialValues = {}) {
     'interactor',
     'interactorStyle2D',
     'interactorStyle3D',
-    'openglRenderWindow', // todo breaking? convert to apiSpecificWindow
+    '_openGLRenderWindow', // todo breaking? convert to apiSpecificWindow
     'orientationAxesType',
     'presetToOrientationAxes',
     'renderer',
@@ -645,6 +645,7 @@ function extend(publicAPI, model, initialValues = {}) {
     'representations',
     'useParallelRendering',
   ]);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
   macro.event(publicAPI, model, 'Resize');
 
   // Object specific methods

--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -63,17 +63,17 @@ function vtkRenderWindow(publicAPI, model) {
       return;
     }
     view.setRenderable(publicAPI);
-    model.views.push(view);
+    model._views.push(view);
     publicAPI.modified();
   };
 
   // Remove renderer
   publicAPI.removeView = (view) => {
-    model.views = model.views.filter((r) => r !== view);
+    model._views = model._views.filter((r) => r !== view);
     publicAPI.modified();
   };
 
-  publicAPI.hasView = (view) => model.views.indexOf(view) !== -1;
+  publicAPI.hasView = (view) => model._views.indexOf(view) !== -1;
 
   // handle any pre render initializations
   publicAPI.preRender = () => {
@@ -90,7 +90,7 @@ function vtkRenderWindow(publicAPI, model) {
     if (model.interactor) {
       model.interactor.render();
     } else {
-      model.views.forEach((view) => view.traverseAllPasses());
+      model._views.forEach((view) => view.traverseAllPasses());
     }
   };
 
@@ -125,7 +125,7 @@ function vtkRenderWindow(publicAPI, model) {
 
   publicAPI.captureImages = (format = 'image/png', opts = {}) => {
     macro.setImmediate(publicAPI.render);
-    return model.views
+    return model._views
       .map((view) =>
         view.captureNextImage ? view.captureNextImage(format, opts) : undefined
       )
@@ -157,11 +157,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, [
     'interactor',
     'numberOfLayers',
-    'views',
+    '_views',
     'defaultViewAPI',
   ]);
   macro.get(publicAPI, model, ['neverRendered']);
   macro.getArray(publicAPI, model, ['renderers']);
+  macro.moveToProtected(publicAPI, model, ['views']);
   macro.event(publicAPI, model, 'completion');
 
   // Object methods

--- a/Sources/Rendering/Misc/CanvasView/index.js
+++ b/Sources/Rendering/Misc/CanvasView/index.js
@@ -13,7 +13,7 @@ function vtkCanvasView(publicAPI, model) {
   // Auto update style
   function updateWindow() {
     // Canvas size
-    if (model.renderable) {
+    if (model._renderable) {
       model.canvas.setAttribute('width', model.size[0]);
       model.canvas.setAttribute('height', model.size[1]);
     }
@@ -122,8 +122,8 @@ function vtkCanvasView(publicAPI, model) {
   // --------------------------------------------------------------------------
   // Make us look like a View (i.e.: vtkOpenGLRenderWindow)
   // --------------------------------------------------------------------------
-  model.renderable = publicAPI;
-  model.renderers = [publicAPI];
+  model._renderable = publicAPI;
+  model._renderers = [publicAPI];
   publicAPI.traverseAllPasses = () => {};
   publicAPI.isInViewport = () => true;
   publicAPI.getInteractive = () => true;
@@ -164,7 +164,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.obj(publicAPI, model, initialValues);
 
   // Build VTK API
-  macro.get(publicAPI, model, ['useBackgroundImage', 'renderable']);
+  macro.get(publicAPI, model, ['useBackgroundImage', '_renderable']);
 
   macro.setGet(publicAPI, model, [
     'canvas',
@@ -174,7 +174,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
 
   macro.setGetArray(publicAPI, model, ['size'], 2);
-  macro.getArray(publicAPI, model, ['renderers']);
+  macro.getArray(publicAPI, model, ['_renderers']);
+  macro.moveToProtected(publicAPI, model, ['renderable', 'renderers']);
 
   // Object methods
   vtkCanvasView(publicAPI, model);

--- a/Sources/Rendering/Misc/GenericRenderWindow/index.js
+++ b/Sources/Rendering/Misc/GenericRenderWindow/index.js
@@ -23,15 +23,15 @@ function vtkGenericRenderWindow(publicAPI, model) {
   model.renderWindow.addRenderer(model.renderer);
 
   // OpenGLRenderWindow
-  model.openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
-  model.renderWindow.addView(model.openGLRenderWindow);
+  model._openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
+  model.renderWindow.addView(model._openGLRenderWindow);
 
   // Interactor
   model.interactor = vtkRenderWindowInteractor.newInstance();
   model.interactor.setInteractorStyle(
     vtkInteractorStyleTrackballCamera.newInstance()
   );
-  model.interactor.setView(model.openGLRenderWindow);
+  model.interactor.setView(model._openGLRenderWindow);
   model.interactor.initialize();
 
   // Expose background
@@ -45,7 +45,7 @@ function vtkGenericRenderWindow(publicAPI, model) {
     if (model.container) {
       const dims = model.container.getBoundingClientRect();
       const devicePixelRatio = window.devicePixelRatio || 1;
-      model.openGLRenderWindow.setSize(
+      model._openGLRenderWindow.setSize(
         Math.floor(dims.width * devicePixelRatio),
         Math.floor(dims.height * devicePixelRatio)
       );
@@ -62,7 +62,7 @@ function vtkGenericRenderWindow(publicAPI, model) {
 
     // Switch container
     model.container = el;
-    model.openGLRenderWindow.setContainer(model.container);
+    model._openGLRenderWindow.setContainer(model.container);
 
     // Bind to new container
     if (model.container) {
@@ -73,7 +73,7 @@ function vtkGenericRenderWindow(publicAPI, model) {
   // Properly release GL context
   publicAPI.delete = macro.chain(
     publicAPI.setContainer,
-    model.openGLRenderWindow.delete,
+    model._openGLRenderWindow.delete,
     publicAPI.delete
   );
 
@@ -104,10 +104,11 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.get(publicAPI, model, [
     'renderWindow',
     'renderer',
-    'openGLRenderWindow',
+    '_openGLRenderWindow',
     'interactor',
     'container',
   ]);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
   macro.event(publicAPI, model, 'resize');
 
   // Object specific methods

--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -19,7 +19,7 @@ function vtkOpenGLActor(publicAPI, model) {
       model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
@@ -48,7 +48,7 @@ function vtkOpenGLActor(publicAPI, model) {
     if (
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;
@@ -66,7 +66,7 @@ function vtkOpenGLActor(publicAPI, model) {
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
       !model.renderable.getIsOpaque() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;
@@ -85,7 +85,7 @@ function vtkOpenGLActor(publicAPI, model) {
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
       model.renderable.getIsOpaque() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;

--- a/Sources/Rendering/OpenGL/Actor2D/index.js
+++ b/Sources/Rendering/OpenGL/Actor2D/index.js
@@ -20,7 +20,7 @@ function vtkOpenGLActor2D(publicAPI, model) {
       model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
@@ -61,7 +61,7 @@ function vtkOpenGLActor2D(publicAPI, model) {
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
       !model.renderable.getIsOpaque() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;
@@ -80,7 +80,7 @@ function vtkOpenGLActor2D(publicAPI, model) {
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
       model.renderable.getIsOpaque() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;
@@ -97,7 +97,7 @@ function vtkOpenGLActor2D(publicAPI, model) {
       !model.oglmapper ||
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable)
     ) {
       return;

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -15,9 +15,9 @@ function vtkOpenGLCamera(publicAPI, model) {
 
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
       model.context = model._openGLRenderWindow.getContext();
     }
   };
@@ -25,7 +25,7 @@ function vtkOpenGLCamera(publicAPI, model) {
   // Renders myself
   publicAPI.opaquePass = (prepass) => {
     if (prepass) {
-      const tsize = model.openGLRenderer.getTiledSizeAndOrigin();
+      const tsize = model._openGLRenderer.getTiledSizeAndOrigin();
       model.context.viewport(
         tsize.lowerLeftU,
         tsize.lowerLeftV,
@@ -62,7 +62,7 @@ function vtkOpenGLCamera(publicAPI, model) {
       );
       mat4.transpose(model.keyMatrices.wcvc, model.keyMatrices.wcvc);
 
-      const aspectRatio = model.openGLRenderer.getAspectRatio();
+      const aspectRatio = model._openGLRenderer.getAspectRatio();
 
       mat4.copy(
         model.keyMatrices.vcpc,

--- a/Sources/Rendering/OpenGL/CubeAxesActor/index.js
+++ b/Sources/Rendering/OpenGL/CubeAxesActor/index.js
@@ -14,9 +14,9 @@ function vtkOpenGLCubeAxesActor(publicAPI, model) {
   // Builds myself.
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model.openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
 
       if (!model.CubeAxesActorHelper.getRenderable()) {
         model.CubeAxesActorHelper.setRenderable(model.renderable);
@@ -31,15 +31,15 @@ function vtkOpenGLCubeAxesActor(publicAPI, model) {
 
   publicAPI.opaquePass = (prepass, renderPass) => {
     if (prepass) {
-      const camera = model.openGLRenderer
-        ? model.openGLRenderer.getRenderable().getActiveCamera()
+      const camera = model._openGLRenderer
+        ? model._openGLRenderer.getRenderable().getActiveCamera()
         : null;
-      const tsize = model.openGLRenderer.getTiledSizeAndOrigin();
+      const tsize = model._openGLRenderer.getTiledSizeAndOrigin();
 
       model.CubeAxesActorHelper.updateAPISpecificData(
         [tsize.usize, tsize.vsize],
         camera,
-        model.openGLRenderWindow.getRenderable()
+        model._openGLRenderWindow.getRenderable()
       );
     }
   };

--- a/Sources/Rendering/OpenGL/ForwardPass/index.js
+++ b/Sources/Rendering/OpenGL/ForwardPass/index.js
@@ -19,7 +19,7 @@ function vtkForwardPass(publicAPI, model) {
     }
 
     // we just render our delegates in order
-    model.currentParent = parent;
+    model._currentParent = parent;
 
     // build
     publicAPI.setCurrentOperation('buildPass');

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -443,9 +443,9 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
     const numPts = garray.length / 16;
 
     let compositePass = false;
-    if (model.openGLRenderer.getSelector()) {
+    if (model._openGLRenderer.getSelector()) {
       if (
-        model.openGLRenderer.getSelector().getCurrentPass() ===
+        model._openGLRenderer.getSelector().getCurrentPass() ===
         PassTypes.COMPOSITE_INDEX_PASS
       ) {
         compositePass = true;
@@ -485,7 +485,7 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
           // draw the array multiple times with different cam matrix
           for (let p = 0; p < numPts; ++p) {
             if (compositePass) {
-              model.openGLRenderer.getSelector().renderCompositeIndex(p);
+              model._openGLRenderer.getSelector().renderCompositeIndex(p);
             }
             publicAPI.updateGlyphShaderParameters(
               normalMatrixUsed,
@@ -495,7 +495,7 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
               garray,
               narray,
               p,
-              compositePass ? model.openGLRenderer.getSelector() : null
+              compositePass ? model._openGLRenderer.getSelector() : null
             );
             gl.drawArrays(mode, 0, cabo.getElementCount());
           }

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -52,16 +52,16 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model.openGLImageSlice = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLImageSlice'
       );
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
       model.context = model._openGLRenderWindow.getContext();
       model.tris.setOpenGLRenderWindow(model._openGLRenderWindow);
       model.openGLTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
       model.colorTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
       model.pwfTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
-      const ren = model.openGLRenderer.getRenderable();
-      model.openGLCamera = model.openGLRenderer.getViewNodeFor(
+      const ren = model._openGLRenderer.getRenderable();
+      model.openGLCamera = model._openGLRenderer.getViewNodeFor(
         ren.getActiveCamera()
       );
       // is slice set by the camera
@@ -103,7 +103,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
   // Renders myself
   publicAPI.render = () => {
     const actor = model.openGLImageSlice.getRenderable();
-    const ren = model.openGLRenderer.getRenderable();
+    const ren = model._openGLRenderer.getRenderable();
     publicAPI.renderPiece(ren, actor);
   };
 

--- a/Sources/Rendering/OpenGL/ImageSlice/index.js
+++ b/Sources/Rendering/OpenGL/ImageSlice/index.js
@@ -25,7 +25,7 @@ function vtkOpenGLImageSlice(publicAPI, model) {
       model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
@@ -44,7 +44,7 @@ function vtkOpenGLImageSlice(publicAPI, model) {
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
       !model.renderable.getIsOpaque() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;
@@ -63,7 +63,7 @@ function vtkOpenGLImageSlice(publicAPI, model) {
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
       model.renderable.getIsOpaque() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;

--- a/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
+++ b/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
@@ -15,14 +15,14 @@ function vtkOpenGLPixelSpaceCallbackMapper(publicAPI, model) {
   model.classHierarchy.push('vtkOpenGLPixelSpaceCallbackMapper');
 
   publicAPI.opaquePass = (prepass, renderPass) => {
-    model.openGLRenderer =
+    model._openGLRenderer =
       publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-    model._openGLRenderWindow = model.openGLRenderer.getParent();
-    const aspectRatio = model.openGLRenderer.getAspectRatio();
-    const camera = model.openGLRenderer
-      ? model.openGLRenderer.getRenderable().getActiveCamera()
+    model._openGLRenderWindow = model._openGLRenderer.getParent();
+    const aspectRatio = model._openGLRenderer.getAspectRatio();
+    const camera = model._openGLRenderer
+      ? model._openGLRenderer.getRenderable().getActiveCamera()
       : null;
-    const tsize = model.openGLRenderer.getTiledSizeAndOrigin();
+    const tsize = model._openGLRenderer.getTiledSizeAndOrigin();
     let texels = null;
 
     if (model.renderable.getUseZValues()) {

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -53,11 +53,11 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     if (prepass) {
       model.currentRenderPass = null;
       model.openGLActor = publicAPI.getFirstAncestorOfType('vtkOpenGLActor');
-      model.openGLRenderer =
+      model._openGLRenderer =
         model.openGLActor.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model.openGLRenderer.getParent();
-      model.openGLCamera = model.openGLRenderer.getViewNodeFor(
-        model.openGLRenderer.getRenderable().getActiveCamera()
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model.openGLCamera = model._openGLRenderer.getViewNodeFor(
+        model._openGLRenderer.getRenderable().getActiveCamera()
       );
     }
   };
@@ -94,7 +94,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       }
     }
     const actor = model.openGLActor.getRenderable();
-    const ren = model.openGLRenderer.getRenderable();
+    const ren = model._openGLRenderer.getRenderable();
     publicAPI.renderPiece(ren, actor);
   };
 
@@ -958,7 +958,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
 
     // hardware picking always offset due to saved zbuffer
     // This gets you above the saved surface depth buffer.
-    const selector = model.openGLRenderer.getSelector();
+    const selector = model._openGLRenderer.getSelector();
     if (
       selector &&
       selector.getFieldAssociation() ===
@@ -977,7 +977,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       '//VTK::Picking::Dec',
     ]).result;
 
-    if (!model.openGLRenderer.getSelector()) {
+    if (!model._openGLRenderer.getSelector()) {
       return;
     }
     if (
@@ -1390,10 +1390,10 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     cellBO.setMapperShaderParameters(
       ren,
       actor,
-      model.openGLRenderer.getTiledSizeAndOrigin()
+      model._openGLRenderer.getTiledSizeAndOrigin()
     );
 
-    const selector = model.openGLRenderer.getSelector();
+    const selector = model._openGLRenderer.getSelector();
     cellBO
       .getProgram()
       .setUniform3fArray(
@@ -1544,7 +1544,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       : model.openGLActor.getKeyMatrices();
 
     if (actor.getCoordinateSystem() === CoordinateSystem.DISPLAY) {
-      const size = model.openGLRenderer.getTiledSizeAndOrigin();
+      const size = model._openGLRenderer.getTiledSizeAndOrigin();
       mat4.identity(model.tmpMat4);
       model.tmpMat4[0] = 2.0 / size.usize;
       model.tmpMat4[12] = -1.0;
@@ -1671,7 +1671,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
   };
 
   publicAPI.updateMaximumPointCellIds = (ren, actor) => {
-    const selector = model.openGLRenderer.getSelector();
+    const selector = model._openGLRenderer.getSelector();
     if (!selector) {
       return;
     }
@@ -1696,16 +1696,16 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     model.primitiveIDOffset = 0;
     model.vertexIDOffset = 0;
 
-    const picking = getPickState(model.openGLRenderer);
+    const picking = getPickState(model._openGLRenderer);
     if (model.lastSelectionState !== picking) {
       model.selectionStateChanged.modified();
       model.lastSelectionState = picking;
     }
 
-    if (model.openGLRenderer.getSelector()) {
+    if (model._openGLRenderer.getSelector()) {
       switch (picking) {
         default:
-          model.openGLRenderer.getSelector().renderProp(actor);
+          model._openGLRenderer.getSelector().renderProp(actor);
       }
     }
 
@@ -1729,7 +1729,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       actor.getProperty().getEdgeVisibility() &&
       representation === Representation.SURFACE;
 
-    const selector = model.openGLRenderer.getSelector();
+    const selector = model._openGLRenderer.getSelector();
     // If we are picking points, we need to tell it to the helper
     const pointPicking =
       selector &&

--- a/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
@@ -35,11 +35,11 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
     if (prepass) {
       model.openGLActor2D =
         publicAPI.getFirstAncestorOfType('vtkOpenGLActor2D');
-      model.openGLRenderer =
+      model._openGLRenderer =
         model.openGLActor2D.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model.openGLRenderer.getParent();
-      model.openGLCamera = model.openGLRenderer.getViewNodeFor(
-        model.openGLRenderer.getRenderable().getActiveCamera()
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model.openGLCamera = model._openGLRenderer.getViewNodeFor(
+        model._openGLRenderer.getRenderable().getActiveCamera()
       );
     }
   };
@@ -90,7 +90,7 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
       }
     }
     const actor = model.openGLActor2D.getRenderable();
-    const ren = model.openGLRenderer.getRenderable();
+    const ren = model._openGLRenderer.getRenderable();
     publicAPI.renderPiece(ren, actor);
   };
 
@@ -122,10 +122,10 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
   publicAPI.renderPieceStart = (ren, actor) => {
     model.primitiveIDOffset = 0;
 
-    if (model.openGLRenderer.getSelector()) {
-      switch (model.openGLRenderer.getSelector().getCurrentPass()) {
+    if (model._openGLRenderer.getSelector()) {
+      switch (model._openGLRenderer.getSelector().getCurrentPass()) {
         default:
-          model.openGLRenderer.getSelector().renderProp(actor);
+          model._openGLRenderer.getSelector().renderProp(actor);
       }
     }
     // make sure the BOs are up to date
@@ -600,10 +600,10 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
       cellBO.setMapperShaderParameters(
         ren,
         actor,
-        model.openGLRenderer.getTiledSizeAndOrigin()
+        model._openGLRenderer.getTiledSizeAndOrigin()
       );
 
-      const selector = model.openGLRenderer.getSelector();
+      const selector = model._openGLRenderer.getSelector();
       cellBO
         .getProgram()
         .setUniform3fArray(
@@ -675,7 +675,7 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
     size[0] = round((size[0] * (visVP[2] - visVP[0])) / (vport[2] - vport[0]));
     size[1] = round((size[1] * (visVP[3] - visVP[1])) / (vport[3] - vport[1]));
 
-    const winSize = model.openGLRenderer.getParent().getSize();
+    const winSize = model._openGLRenderer.getParent().getSize();
 
     const xoff = round(actorPos[0] - (visVP[0] - vport[0]) * winSize[0]);
     const yoff = round(actorPos[1] - (visVP[1] - vport[1]) * winSize[1]);

--- a/Sources/Rendering/OpenGL/ScalarBarActor/index.js
+++ b/Sources/Rendering/OpenGL/ScalarBarActor/index.js
@@ -14,9 +14,9 @@ function vtkOpenGLScalarBarActor(publicAPI, model) {
   // Builds myself.
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
 
       if (!model.scalarBarActorHelper.getRenderable()) {
         model.scalarBarActorHelper.setRenderable(model.renderable);
@@ -31,10 +31,10 @@ function vtkOpenGLScalarBarActor(publicAPI, model) {
 
   publicAPI.opaquePass = (prepass, renderPass) => {
     if (prepass) {
-      const camera = model.openGLRenderer
-        ? model.openGLRenderer.getRenderable().getActiveCamera()
+      const camera = model._openGLRenderer
+        ? model._openGLRenderer.getRenderable().getActiveCamera()
         : null;
-      const tsize = model.openGLRenderer.getTiledSizeAndOrigin();
+      const tsize = model._openGLRenderer.getTiledSizeAndOrigin();
 
       model.scalarBarActorHelper.updateAPISpecificData(
         [tsize.usize, tsize.vsize],

--- a/Sources/Rendering/OpenGL/Skybox/index.js
+++ b/Sources/Rendering/OpenGL/Skybox/index.js
@@ -23,14 +23,14 @@ function vtkOpenGLSkybox(publicAPI, model) {
   // Builds myself.
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
       model.context = model._openGLRenderWindow.getContext();
       model.tris.setOpenGLRenderWindow(model._openGLRenderWindow);
       model.openGLTexture.setOpenGLRenderWindow(model._openGLRenderWindow);
-      const ren = model.openGLRenderer.getRenderable();
-      model.openGLCamera = model.openGLRenderer.getViewNodeFor(
+      const ren = model._openGLRenderer.getRenderable();
+      model.openGLCamera = model._openGLRenderer.getViewNodeFor(
         ren.getActiveCamera()
       );
     }
@@ -46,7 +46,7 @@ function vtkOpenGLSkybox(publicAPI, model) {
   };
 
   publicAPI.opaquePass = (prepass, renderPass) => {
-    if (prepass && !model.openGLRenderer.getSelector()) {
+    if (prepass && !model._openGLRenderer.getSelector()) {
       publicAPI.updateBufferObjects();
 
       model.context.depthMask(true);
@@ -60,7 +60,7 @@ function vtkOpenGLSkybox(publicAPI, model) {
       const texUnit = model.openGLTexture.getTextureUnit();
       model.tris.getProgram().setUniformi('sbtexture', texUnit);
 
-      const ren = model.openGLRenderer.getRenderable();
+      const ren = model._openGLRenderer.getRenderable();
 
       const keyMats = model.openGLCamera.getKeyMatrices(ren);
       const imat = new Float64Array(16);

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -23,10 +23,10 @@ function vtkOpenGLTexture(publicAPI, model) {
     if (renWin) {
       model._openGLRenderWindow = renWin;
     } else {
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       // sync renderable properties
-      model._openGLRenderWindow = model.openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getParent();
     }
     model.context = model._openGLRenderWindow.getContext();
     if (model.renderable.getInterpolate()) {
@@ -1464,7 +1464,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  _openGLRenderWindow: null,
+  // _openGLRenderWindow: null,
   context: null,
   handle: 0,
   sendParametersTime: null,
@@ -1525,6 +1525,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'handle',
     'target',
   ]);
+  macro.moveToProtected(publicAPI, model, ['openGLRenderWindow']);
 
   // Object methods
   vtkOpenGLTexture(publicAPI, model);

--- a/Sources/Rendering/OpenGL/Volume/index.js
+++ b/Sources/Rendering/OpenGL/Volume/index.js
@@ -22,7 +22,7 @@ function vtkOpenGLVolume(publicAPI, model) {
       model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       model.context = model._openGLRenderWindow.getContext();
       publicAPI.prepareNodes();
@@ -44,7 +44,7 @@ function vtkOpenGLVolume(publicAPI, model) {
     if (
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
-      (model.openGLRenderer.getSelector() &&
+      (model._openGLRenderer.getSelector() &&
         !model.renderable.getNestedPickable())
     ) {
       return;

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -82,10 +82,10 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
       model.openGLVolume = publicAPI.getFirstAncestorOfType('vtkOpenGLVolume');
       const actor = model.openGLVolume.getRenderable();
-      model.openGLRenderer =
+      model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      const ren = model.openGLRenderer.getRenderable();
-      model.openGLCamera = model.openGLRenderer.getViewNodeFor(
+      const ren = model._openGLRenderer.getRenderable();
+      model.openGLCamera = model._openGLRenderer.getViewNodeFor(
         ren.getActiveCamera()
       );
       publicAPI.renderPiece(ren, actor);
@@ -1087,14 +1087,14 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       return [model._smallViewportWidth, model._smallViewportHeight];
     }
 
-    const { usize, vsize } = model.openGLRenderer.getTiledSizeAndOrigin();
+    const { usize, vsize } = model._openGLRenderer.getTiledSizeAndOrigin();
 
     return [usize, vsize];
   };
 
   publicAPI.getRenderTargetOffset = () => {
     const { lowerLeftU, lowerLeftV } =
-      model.openGLRenderer.getTiledSizeAndOrigin();
+      model._openGLRenderer.getTiledSizeAndOrigin();
 
     return [lowerLeftU, lowerLeftV];
   };

--- a/Sources/Rendering/SceneGraph/RenderPass/index.js
+++ b/Sources/Rendering/SceneGraph/RenderPass/index.js
@@ -27,7 +27,7 @@ function vtkRenderPass(publicAPI, model) {
     }
 
     // we just render our delegates in order
-    model.currentParent = parent;
+    model._currentParent = parent;
 
     model.preDelegateOperations.forEach((val) => {
       publicAPI.setCurrentOperation(val);
@@ -65,10 +65,11 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.get(publicAPI, model, ['currentOperation']);
   macro.setGet(publicAPI, model, [
     'delegates',
-    'currentParent',
+    '_currentParent',
     'preDelegateOperations',
     'postDelegateOperations',
   ]);
+  macro.moveToProtected(publicAPI, model, ['currentParent']);
 
   // Object methods
   vtkRenderPass(publicAPI, model);

--- a/Sources/Rendering/WebGPU/ForwardPass/index.js
+++ b/Sources/Rendering/WebGPU/ForwardPass/index.js
@@ -48,7 +48,7 @@ function vtkForwardPass(publicAPI, model) {
     }
 
     // we just render our delegates in order
-    model.currentParent = parent;
+    model._currentParent = parent;
 
     // build
     publicAPI.setCurrentOperation('buildPass');

--- a/Sources/Rendering/WebGPU/HardwareSelectionPass/index.js
+++ b/Sources/Rendering/WebGPU/HardwareSelectionPass/index.js
@@ -19,7 +19,7 @@ function vtkWebGPUHardwareSelectionPass(publicAPI, model) {
       return;
     }
 
-    model.currentParent = null;
+    model._currentParent = null;
 
     // build
     publicAPI.setCurrentOperation('buildPass');

--- a/Sources/Rendering/WebGPU/HardwareSelector/index.js
+++ b/Sources/Rendering/WebGPU/HardwareSelector/index.js
@@ -271,23 +271,23 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
   // based on the passed in size etc but it gets messy so for now we always
   // render the full size window and copy it to the buffers.
   publicAPI.getSourceDataAsync = async (renderer) => {
-    if (!renderer || !model.WebGPURenderWindow) {
+    if (!renderer || !model._WebGPURenderWindow) {
       vtkErrorMacro('Renderer and view must be set before calling Select.');
       return false;
     }
 
     // todo revisit making selection part of core
     // then we can do this in core
-    model.WebGPURenderWindow.getRenderable().preRender();
+    model._WebGPURenderWindow.getRenderable().preRender();
 
-    if (!model.WebGPURenderWindow.getInitialized()) {
-      model.WebGPURenderWindow.initialize();
+    if (!model._WebGPURenderWindow.getInitialized()) {
+      model._WebGPURenderWindow.initialize();
       await new Promise((resolve) => {
-        model.WebGPURenderWindow.onInitialized(resolve);
+        model._WebGPURenderWindow.onInitialized(resolve);
       });
     }
 
-    const webGPURenderer = model.WebGPURenderWindow.getViewNodeFor(renderer);
+    const webGPURenderer = model._WebGPURenderWindow.getViewNodeFor(renderer);
 
     if (!webGPURenderer) {
       return false;
@@ -298,12 +298,12 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
     const originalSuppress = webGPURenderer.getSuppressClear();
     webGPURenderer.setSuppressClear(true);
 
-    model._selectionPass.traverse(model.WebGPURenderWindow, webGPURenderer);
+    model._selectionPass.traverse(model._WebGPURenderWindow, webGPURenderer);
 
     // restore original background
     webGPURenderer.setSuppressClear(originalSuppress);
 
-    const device = model.WebGPURenderWindow.getDevice();
+    const device = model._WebGPURenderWindow.getDevice();
     const texture = model._selectionPass.getColorTexture();
     const depthTexture = model._selectionPass.getDepthTexture();
 
@@ -317,7 +317,7 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
       fieldAssociation: model.fieldAssociation,
       renderer,
       webGPURenderer,
-      webGPURenderWindow: model.WebGPURenderWindow,
+      webGPURenderWindow: model._WebGPURenderWindow,
       width: texture.getWidth(),
       height: texture.getHeight(),
     };
@@ -339,7 +339,7 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
     /* eslint-enable no-bitwise */
     /* eslint-enable no-undef */
 
-    const cmdEnc = model.WebGPURenderWindow.getCommandEncoder();
+    const cmdEnc = model._WebGPURenderWindow.getCommandEncoder();
     cmdEnc.copyTextureToBuffer(
       {
         texture: texture.getHandle(),
@@ -418,7 +418,7 @@ function vtkWebGPUHardwareSelector(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  WebGPURenderWindow: null,
+  // WebGPURenderWindow: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -431,7 +431,8 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model._selectionPass = vtkWebGPUHardwareSelectionPass.newInstance();
 
-  macro.setGet(publicAPI, model, ['WebGPURenderWindow']);
+  macro.setGet(publicAPI, model, ['_WebGPURenderWindow']);
+  macro.moveToProtected(publicAPI, model, ['WebGPURenderWindow']);
 
   // Object methods
   vtkWebGPUHardwareSelector(publicAPI, model);

--- a/Sources/Rendering/WebGPU/OpaquePass/index.js
+++ b/Sources/Rendering/WebGPU/OpaquePass/index.js
@@ -19,7 +19,7 @@ function vtkWebGPUOpaquePass(publicAPI, model) {
     }
 
     // we just render our delegates in order
-    model.currentParent = viewNode;
+    model._currentParent = viewNode;
 
     const device = viewNode.getDevice();
 

--- a/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/WebGPU/OrderIndependentTranslucentPass/index.js
@@ -50,7 +50,7 @@ function vtkWebGPUOrderIndependentTranslucentPass(publicAPI, model) {
     }
 
     // we just render our delegates in order
-    model.currentParent = viewNode;
+    model._currentParent = viewNode;
 
     const device = viewNode.getDevice();
 

--- a/Sources/Rendering/WebGPU/VolumePass/index.js
+++ b/Sources/Rendering/WebGPU/VolumePass/index.js
@@ -167,7 +167,7 @@ function vtkWebGPUVolumePass(publicAPI, model) {
     }
 
     // we just render our delegates in order
-    model.currentParent = viewNode;
+    model._currentParent = viewNode;
 
     // create stuff we need
     publicAPI.initialize(viewNode);

--- a/Sources/Testing/setupTestEnv.js
+++ b/Sources/Testing/setupTestEnv.js
@@ -47,6 +47,10 @@ function BufferedObjectPipe() {
     scheduleFlush();
   };
 
+  /**
+   * Called when karma is loaded in browser.
+   * @param {*} reader
+   */
   const setReader = (r) => {
     reader = r;
   };

--- a/Sources/Testing/testSerialization.js
+++ b/Sources/Testing/testSerialization.js
@@ -8,6 +8,14 @@ import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';
 import vtkScalarsToColors from 'vtk.js/Sources/Common/Core/ScalarsToColors';
 
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+import Common from 'vtk.js/Sources/Common';
+import Filters from 'vtk.js/Sources/Filters';
+import Imaging from 'vtk.js/Sources/Imaging';
+import Interaction from 'vtk.js/Sources/Interaction';
+import IO from 'vtk.js/Sources/IO';
+import Rendering from 'vtk.js/Sources/Rendering';
+import VTKProxy from 'vtk.js/Sources/Proxy';
+import Widgets from 'vtk.js/Sources/Widgets';
 
 const { vtkDebugMacro } = macro;
 
@@ -116,4 +124,59 @@ classToTest.forEach((testName) => {
     t.equal(JSON.stringify(instance), 'null');
     t.end();
   });
+});
+
+function findVTKObjects(objects) {
+  return Object.entries(objects).reduce((res, [className, object]) => {
+    if (typeof object !== 'object' || object == null) {
+      return res;
+    }
+    if (object.newInstance) {
+      res[className] = object;
+      return res;
+    }
+
+    return Object.assign(res, findVTKObjects(object));
+  }, {});
+}
+
+// If this test is hanging, it is due to a problem in `getState()`.
+test(`Test serialization of`, (t) => {
+  const VTK = {
+    Common,
+    Filters,
+    Imaging,
+    Interaction,
+    IO,
+    Rendering,
+    VTKProxy,
+    Widgets,
+  };
+  // List of classes that can't be instantiated with default arguments.
+  const classesToIgnore = [
+    'vtkDataArray',
+    'vtkStringArray',
+    'vtkVariantArray',
+    'vtkITKImageReader',
+    'vtkITKPolyDataReader',
+    'vtkFullScreenRenderWindow',
+    'vtkAbstractWidget',
+  ];
+  const onlyClasses = [];
+  const allObjects = findVTKObjects(VTK);
+
+  Object.entries(allObjects).forEach(([className, factory]) => {
+    if (
+      !classesToIgnore.includes(className) &&
+      (onlyClasses.length === 0 || onlyClasses.includes(className))
+    ) {
+      t.comment(`${className}.newInstance()`);
+      const instance = factory.newInstance();
+      // If an error occurs here, you may have a cyclical dependency in the JSON
+      // returned by getState(). This is typically fixed by making some model
+      // variables protected (prefixed with _).
+      JSON.stringify(instance);
+    }
+  });
+  t.end();
 });

--- a/Sources/Widgets/Representations/CircleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/CircleContextRepresentation/index.js
@@ -1,13 +1,7 @@
 import macro from 'vtk.js/Sources/macros';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkCircleSource from 'vtk.js/Sources/Filters/Sources/CircleSource';
-import vtkContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ContextRepresentation';
-import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
-import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
-import vtkWidgetRepresentation from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
-
-import { ScalarMode } from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
-import { vec3, mat3 } from 'gl-matrix';
+import vtkGlyphRepresentation from 'vtk.js/Sources/Widgets/Representations/GlyphRepresentation';
+import { Behavior } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation/Constants';
 
 // ----------------------------------------------------------------------------
 // vtkCircleContextRepresentation methods
@@ -18,167 +12,74 @@ function vtkCircleContextRepresentation(publicAPI, model) {
   model.classHierarchy.push('vtkCircleContextRepresentation');
 
   // --------------------------------------------------------------------------
-  // Internal polydata dataset
-  // --------------------------------------------------------------------------
-
-  // --------------------------------------------------------------------------
   // Generic rendering pipeline
   // --------------------------------------------------------------------------
 
-  model.pipelines = {
-    circle: {
-      source: publicAPI,
-      glyph: vtkCircleSource.newInstance({
-        resolution: model.glyphResolution,
-        radius: 1,
-        lines: model.drawBorder,
-        face: model.drawFace,
-      }),
-      mapper: vtkGlyph3DMapper.newInstance({
-        orientationArray: 'direction',
-        scaleArray: 'scale',
-        scaleMode: vtkGlyph3DMapper.ScaleModes.SCALE_BY_COMPONENTS,
-        colorByArrayName: 'color',
-        scalarMode: ScalarMode.USE_POINT_FIELD_DATA,
-      }),
-      actor: vtkActor.newInstance({ pickable: false, _parentProp: publicAPI }),
-    },
-  };
-
-  model.pipelines.circle.actor.getProperty().setOpacity(0.2);
-  model.pipelines.circle.mapper.setOrientationModeToMatrix();
-  model.pipelines.circle.mapper.setResolveCoincidentTopology(true);
-  model.pipelines.circle.mapper.setResolveCoincidentTopologyPolygonOffsetParameters(
+  model._pipeline.actor.getProperty().setOpacity(0.2);
+  model._pipeline.mapper.setResolveCoincidentTopology(true);
+  model._pipeline.mapper.setResolveCoincidentTopologyPolygonOffsetParameters(
     -1,
     -1
   );
-
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.circle);
-
-  publicAPI.addActor(model.pipelines.circle.actor);
-
-  model.transform = vtkMatrixBuilder.buildFromDegree();
 
   // --------------------------------------------------------------------------
 
   publicAPI.setGlyphResolution = macro.chain(
     publicAPI.setGlyphResolution,
-    (r) => model.pipelines.circle.glyph.setResolution(r)
+    model._pipeline.glyph.setResolution
   );
 
   // --------------------------------------------------------------------------
 
-  publicAPI.setDrawBorder = (draw) => {
-    model.pipelines.circle.glyph.setLines(draw);
-  };
+  publicAPI.setDrawBorder = macro.chain(publicAPI.setDrawBorder, (draw) =>
+    model._pipeline.glyph.setLines(draw)
+  );
 
   // --------------------------------------------------------------------------
 
-  publicAPI.setDrawFace = (draw) => {
-    model.pipelines.circle.glyph.setFace(draw);
-  };
+  publicAPI.setDrawFace = macro.chain(publicAPI.setDrawFace, (draw) =>
+    model._pipeline.glyph.setFace(draw)
+  );
 
   // --------------------------------------------------------------------------
 
   publicAPI.setOpacity = (opacity) => {
-    model.pipelines.circle.actor.getProperty().setOpacity(opacity);
+    model._pipeline.actor.getProperty().setOpacity(opacity);
   };
-
-  const superGetRepresentationStates = publicAPI.getRepresentationStates;
-  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
-    superGetRepresentationStates(input).filter(
-      (state) => state.getOrigin?.() && state.isVisible?.()
-    );
-  // --------------------------------------------------------------------------
-
-  publicAPI.requestData = (inData, outData) => {
-    const list = publicAPI.getRepresentationStates(inData[0]);
-    const totalCount = list.length;
-
-    const points = publicAPI
-      .allocateArray('points', 'Float32Array', 3, totalCount)
-      .getData();
-    const color = publicAPI
-      .allocateArray('color', ...publicAPI.computeColorType(list), totalCount)
-      .getData();
-    const scale = publicAPI
-      .allocateArray('scale', 'Float32Array', 3, totalCount)
-      .getData();
-    const direction = publicAPI
-      .allocateArray('direction', 'Float32Array', 9, totalCount)
-      .getData();
-
-    for (let i = 0; i < totalCount; i++) {
-      const state = list[i];
-      const isActive = state.getActive();
-      const scaleFactor = isActive ? model.activeScaleFactor : 1;
-
-      const coord = state.getOrigin();
-      points[i * 3 + 0] = coord[0];
-      points[i * 3 + 1] = coord[1];
-      points[i * 3 + 2] = coord[2];
-
-      const right = state.getRight ? state.getRight() : [1, 0, 0];
-      const up = state.getUp ? state.getUp() : [0, 1, 0];
-      const dir = state.getDirection ? state.getDirection() : [0, 0, 1];
-      const rotation = [...right, ...up, ...dir];
-
-      let scale3 = state.getScale3 ? state.getScale3() : [1, 1, 1];
-      scale3 = scale3.map((x) => (x === 0 ? 2 * model.defaultScale : 2 * x));
-
-      // Reorient rotation and scale3 since the circle source faces X instead of Z
-      const reorientCircleSource4 = vtkMatrixBuilder
-        .buildFromDegree()
-        .rotateFromDirections([1, 0, 0], [0, 0, 1]) // from X to Z
-        .getMatrix();
-      const reorientCircleSource3 = [];
-      mat3.fromMat4(reorientCircleSource3, reorientCircleSource4);
-      vec3.transformMat4(scale3, scale3, reorientCircleSource4);
-      mat3.multiply(rotation, rotation, reorientCircleSource3);
-
-      for (let j = 0; j < 9; j += 1) {
-        direction[i * 9 + j] = rotation[j];
-      }
-
-      const scale1 =
-        (state.getScale1 ? state.getScale1() : model.defaultScale) / 2;
-
-      scale[i * 3 + 0] = scale1 * scaleFactor * scale3[0];
-      scale[i * 3 + 1] = scale1 * scaleFactor * scale3[1];
-      scale[i * 3 + 2] = scale1 * scaleFactor * scale3[2];
-
-      typedArray.color[i] =
-        model.useActiveColor && isActive ? model.activeColor : state.getColor();
-    }
-
-    model.internalPolyData.modified();
-    outData[0] = model.internalPolyData;
-  };
-
-  // --------------------------------------------------------------------------
-  // Initialization
-  // --------------------------------------------------------------------------
 }
 
 // ----------------------------------------------------------------------------
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
-  glyphResolution: 32,
-  defaultScale: 1,
-  drawBorder: false,
-  drawFace: true,
-};
+function defaultValues(initialValues) {
+  return {
+    behavior: Behavior.CONTEXT,
+    glyphResolution: 32,
+    drawBorder: false,
+    drawFace: true,
+    ...initialValues,
+    _pipeline: {
+      glyph:
+        initialValues?.pipeline?.glyph ??
+        vtkCircleSource.newInstance({
+          resolution: initialValues.glyphResolution ?? 32,
+          radius: 1,
+          lines: initialValues.drawBorder ?? false,
+          face: initialValues.drawFace ?? true,
+          direction: [0, 0, 1],
+        }),
+      ...initialValues?.pipeline,
+    },
+  };
+}
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
-
-  vtkContextRepresentation.extend(publicAPI, model, initialValues);
-  macro.setGet(publicAPI, model, ['glyphResolution', 'defaultScale']);
-  macro.get(publicAPI, model, ['glyph', 'mapper', 'actor']);
+  vtkGlyphRepresentation.extend(publicAPI, model, defaultValues(initialValues));
+  macro.setGet(publicAPI, model, ['glyphResolution', 'drawFace', 'drawBorder']);
+  macro.get(publicAPI, model._pipeline, ['glyph', 'mapper', 'actor']);
 
   // Object specific methods
   vtkCircleContextRepresentation(publicAPI, model);

--- a/Sources/Widgets/Representations/CircleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/CircleContextRepresentation/index.js
@@ -17,7 +17,7 @@ function vtkCircleContextRepresentation(publicAPI, model) {
 
   model._pipeline.actor.getProperty().setOpacity(0.2);
   model._pipeline.mapper.setResolveCoincidentTopology(true);
-  model._pipeline.mapper.setResolveCoincidentTopologyPolygonOffsetParameters(
+  model._pipeline.mapper.setRelativeCoincidentTopologyPolygonOffsetParameters(
     -1,
     -1
   );

--- a/Sources/Widgets/Representations/ConvexFaceContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/ConvexFaceContextRepresentation/index.js
@@ -3,6 +3,7 @@ import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ContextRepresentation';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+import { allocateArray } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 
 import { Behavior } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation/Constants';
 import { RenderingTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
@@ -25,14 +26,10 @@ function vtkConvexFaceContextRepresentation(publicAPI, model) {
   model.internalPolyData.getPoints().setData(model.points, 3);
   model.internalPolyData.getPolys().setData(model.cells);
 
-  function allocateSize(size) {
-    const points = publicAPI
-      .allocateArray('points', 'Float32Array', 3, size)
-      .getData();
-    const oldCellsSize = model.internalPolyData.getPolys().getNumberOfValues();
-    const cells = publicAPI
-      .allocateArray('polys', 'Uint8Array', 1, size + 1)
-      .getData();
+  function allocateSize(polyData, size) {
+    const points = allocateArray(polyData, 'points', size).getData();
+    const oldCellsSize = polyData.getPolys().getNumberOfValues();
+    const cells = allocateArray(polyData, 'polys', size + 1).getData();
     if (oldCellsSize !== cells.length) {
       cells[0] = size;
       for (let i = 0; i < size; i++) {
@@ -63,7 +60,7 @@ function vtkConvexFaceContextRepresentation(publicAPI, model) {
     const list = publicAPI.getRepresentationStates(inData[0]);
     const validState = list.filter((state) => state.getOrigin());
 
-    const points = allocateSize(validState.length);
+    const points = allocateSize(allocateSize, validState.length);
 
     for (let i = 0; i < validState.length; i++) {
       const coords = validState[i].getOrigin();

--- a/Sources/Widgets/Representations/CubeHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/CubeHandleRepresentation/index.js
@@ -1,13 +1,6 @@
 import macro from 'vtk.js/Sources/macros';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
-import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
-import vtkHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/HandleRepresentation';
-
-import { ScalarMode } from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
-import vtkWidgetRepresentation, {
-  getPixelWorldHeightAtCoord,
-} from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
+import vtkGlyphRepresentation from 'vtk.js/Sources/Widgets/Representations/GlyphRepresentation';
 
 // ----------------------------------------------------------------------------
 // vtkCubeHandleRepresentation methods
@@ -16,98 +9,24 @@ import vtkWidgetRepresentation, {
 function vtkCubeHandleRepresentation(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkCubeHandleRepresentation');
-
-  // --------------------------------------------------------------------------
-  // Internal polydata dataset
-  // --------------------------------------------------------------------------
-
-  // --------------------------------------------------------------------------
-  // Generic rendering pipeline
-  // --------------------------------------------------------------------------
-
-  model.pipelines = {
-    cubes: {
-      source: publicAPI,
-      glyph: vtkCubeSource.newInstance(),
-      mapper: vtkGlyph3DMapper.newInstance({
-        scaleArray: 'scale',
-        colorByArrayName: 'color',
-        scalarMode: ScalarMode.USE_POINT_FIELD_DATA,
-      }),
-      actor: vtkActor.newInstance({ parentProp: publicAPI }),
-    },
-  };
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.cubes);
-  publicAPI.addActor(model.pipelines.cubes.actor);
-
-  const superGetRepresentationStates = publicAPI.getRepresentationStates;
-  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
-    superGetRepresentationStates(input).filter(
-      (state) => state.getOrigin?.() && state.isVisible?.()
-    );
-  // --------------------------------------------------------------------------
-
-  publicAPI.requestData = (inData, outData) => {
-    const list = publicAPI.getRepresentationStates(inData[0]);
-    const totalCount = list.length;
-
-    const points = publicAPI
-      .allocateArray('points', 'Float32Array', 3, totalCount)
-      .getData();
-    const color = publicAPI
-      .allocateArray('color', ...publicAPI.computeColorType(list), totalCount)
-      .getData();
-    const scale = publicAPI
-      .allocateArray('scale', 'Float32Array', 1, totalCount)
-      .getData();
-
-    for (let i = 0; i < totalCount; i++) {
-      const state = list[i];
-      const isActive = state.getActive();
-      const scaleFactor = isActive ? model.activeScaleFactor : 1;
-
-      const coord = state.getOrigin();
-      if (coord) {
-        points[i * 3 + 0] = coord[0];
-        points[i * 3 + 1] = coord[1];
-        points[i * 3 + 2] = coord[2];
-
-        scale[i] =
-          scaleFactor *
-          (state.getScale1 ? state.getScale1() : model.defaultScale);
-
-        if (publicAPI.getScaleInPixels()) {
-          scale[i] *= getPixelWorldHeightAtCoord(
-            coord,
-            model.displayScaleParams
-          );
-        }
-
-        typedArray.color[i] =
-          model.useActiveColor && isActive
-            ? model.activeColor
-            : state.getColor();
-      }
-    }
-
-    model.internalPolyData.modified();
-    outData[0] = model.internalPolyData;
-  };
 }
 
 // ----------------------------------------------------------------------------
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = { defaultScale: 1 };
-
 // ----------------------------------------------------------------------------
+function defaultValues(initialValues) {
+  return {
+    _pipeline: {
+      glyph: vtkCubeSource.newInstance(),
+    },
+    ...initialValues,
+  };
+}
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
-
-  vtkHandleRepresentation.extend(publicAPI, model, initialValues);
-  macro.get(publicAPI, model, ['defaultScale']);
+  vtkGlyphRepresentation.extend(publicAPI, model, defaultValues(initialValues));
 
   // Object specific methods
   vtkCubeHandleRepresentation(publicAPI, model);

--- a/Sources/Widgets/Representations/GlyphRepresentation/index.js
+++ b/Sources/Widgets/Representations/GlyphRepresentation/index.js
@@ -1,0 +1,316 @@
+import macro from 'vtk.js/Sources/macros';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
+import vtkHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/HandleRepresentation';
+import vtkContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ContextRepresentation';
+import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+
+import { ScalarMode } from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
+import vtkWidgetRepresentation, {
+  getPixelWorldHeightAtCoord,
+  allocateArray,
+} from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
+import { Behavior } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation/Constants';
+import { OrientationModes } from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper/Constants';
+
+// ----------------------------------------------------------------------------
+// vtkGlyphRepresentation methods
+// ----------------------------------------------------------------------------
+export function origin(publicAPI, model) {
+  return (polyData, states) => {
+    const points = allocateArray(polyData, 'points', states.length).getData();
+    let j = 0;
+    for (let i = 0; i < states.length; ++i) {
+      const coord = states[i].getOrigin();
+      points[j++] = coord[0];
+      points[j++] = coord[1];
+      points[j++] = coord[2];
+    }
+  };
+}
+export function noPosition(publicAPI, model) {
+  return (polyData, states) => {
+    allocateArray(polyData, 'points', 0);
+  };
+}
+export function color3(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setColorByArrayName('color');
+    const colors = allocateArray(
+      polyData,
+      'color',
+      states.length,
+      'Uint8Array', // RGB
+      3
+    ).getData();
+    let j = 0;
+    for (let i = 0; i < states.length; ++i) {
+      let c3 = states[i].getColor3();
+      if (states[i].getActive() && model.useActiveColor) {
+        c3 = model.activeColor;
+      }
+      colors[j++] = c3[0];
+      colors[j++] = c3[1];
+      colors[j++] = c3[2];
+    }
+  };
+}
+export function color(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setColorByArrayName('color');
+    const colors = allocateArray(polyData, 'color', states.length).getData();
+    for (let i = 0; i < states.length; ++i) {
+      let c = states[i].getColor();
+      if (states[i].getActive() && model.useActiveColor) {
+        c = model.activeColor;
+      }
+      colors[i] = c;
+    }
+  };
+}
+export function noColor(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setColorByArrayName(null);
+  };
+}
+export function scale3(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setScaleArray('scale');
+    model._pipeline.mapper.setScaleFactor(1);
+    model._pipeline.mapper.setScaling(true);
+    model._pipeline.mapper.setScaleMode(
+      vtkGlyph3DMapper.ScaleModes.SCALE_BY_COMPONENTS
+    );
+    const scales = allocateArray(
+      polyData,
+      'scale',
+      states.length,
+      'Float32Array',
+      3
+    ).getData();
+    let j = 0;
+    for (let i = 0; i < states.length; ++i) {
+      const state = states[i];
+      let scaleFactor = state.getActive() ? model.activeScaleFactor : 1;
+      if (publicAPI.getScaleInPixels()) {
+        scaleFactor *= getPixelWorldHeightAtCoord(
+          state.getOrigin(),
+          model.displayScaleParams
+        );
+      }
+      const scale = state.getScale3?.() ?? model.defaultScale;
+      scales[j++] = scaleFactor * scale[0];
+      scales[j++] = scaleFactor * scale[1];
+      scales[j++] = scaleFactor * scale[2];
+    }
+  };
+}
+export function scale1(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setScaleArray('scale');
+    model._pipeline.mapper.setScaleFactor(1);
+    model._pipeline.mapper.setScaling(true);
+    const scales = allocateArray(polyData, 'scale', states.length).getData();
+    for (let i = 0; i < states.length; ++i) {
+      const state = states[i];
+      let scaleFactor = state.getActive() ? model.activeScaleFactor : 1;
+      if (publicAPI.getScaleInPixels()) {
+        scaleFactor *= getPixelWorldHeightAtCoord(
+          state.getOrigin(),
+          model.displayScaleParams
+        );
+      }
+      const scale = state.getScale1?.() ?? model.defaultScale;
+      scales[i] = scaleFactor * scale;
+    }
+  };
+}
+export function noScale(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setScaleArray(null);
+    model._pipeline.mapper.setScaleFactor(model.defaultScale);
+    model._pipeline.mapper.setScaling(model.defaultScale !== 1);
+  };
+}
+export function direction(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setOrientationArray('orientation');
+    model._pipeline.mapper.setOrientationMode(OrientationModes.MATRIX);
+    const orientation = allocateArray(
+      polyData,
+      'orientation',
+      states.length,
+      'Float32Array',
+      9
+    ).getData();
+    for (let i = 0; i < states.length; ++i) {
+      const state = states[i];
+      const right = state.getRight ? state.getRight() : [1, 0, 0];
+      const up = state.getUp ? state.getUp() : [0, 1, 0];
+      const dir = state.getDirection ? state.getDirection() : [0, 0, 1];
+      orientation.set(right, 9 * i);
+      orientation.set(up, 9 * i + 3);
+      orientation.set(dir, 9 * i + 6);
+    }
+  };
+}
+export function noOrientation(publicAPI, model) {
+  return (polyData, states) => {
+    model._pipeline.mapper.setOrientationArray(null);
+  };
+}
+
+function vtkGlyphRepresentation(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkGlyphRepresentation');
+  const superClass = { ...publicAPI };
+  const internalPolyData = vtkPolyData.newInstance({ mtime: 0 });
+
+  function hasMixin(states, ...requiredMixins) {
+    return requiredMixins.every(
+      (requiredMixin) =>
+        states[0]?.[`get${macro.capitalize(requiredMixin)}`]?.() != null
+    );
+  }
+  // --------------------------------------------------------------------------
+  // Generic rendering pipeline
+  // --------------------------------------------------------------------------
+
+  // --------------------------------------------------------------------------
+
+  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
+    superClass
+      .getRepresentationStates(input)
+      .filter((state) => state.getOrigin?.() && state.isVisible?.());
+
+  // --------------------------------------------------------------------------
+  publicAPI.getMixins = (states) => {
+    const glyphProperties = {};
+    if (hasMixin(states, 'origin')) {
+      glyphProperties.position = model.applyMixin.origin;
+    } else {
+      glyphProperties.position = model.applyMixin.noPosition;
+    }
+
+    if (hasMixin(states, 'color3')) {
+      glyphProperties.color = model.applyMixin.color3;
+    } else if (hasMixin(states, 'color')) {
+      glyphProperties.color = model.applyMixin.color;
+    } else {
+      glyphProperties.color = model.applyMixin.noColor;
+    }
+
+    if (hasMixin(states, 'scale3')) {
+      glyphProperties.scale = model.applyMixin.scale3;
+    } else if (hasMixin(states, 'scale1')) {
+      glyphProperties.scale = model.applyMixin.scale1;
+    } else {
+      glyphProperties.scale = model.applyMixin.noScale;
+    }
+
+    if (hasMixin(states, 'direction')) {
+      glyphProperties.orientation = model.applyMixin.direction;
+    } else {
+      glyphProperties.orientation = model.applyMixin.noOrientation;
+    }
+    return glyphProperties;
+  };
+
+  publicAPI.requestData = (inData, outData) => {
+    const states = publicAPI.getRepresentationStates(inData[0]);
+    outData[0] = internalPolyData;
+
+    const glyphProperties = publicAPI.getMixins(states);
+
+    Object.values(glyphProperties).forEach((property) =>
+      property(internalPolyData, states)
+    );
+
+    internalPolyData.getPoints().modified();
+    internalPolyData.modified();
+  };
+
+  vtkWidgetRepresentation.connectPipeline(model._pipeline);
+  publicAPI.addActor(model._pipeline.actor);
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+function defaultValues(publicAPI, model, initialValues) {
+  return {
+    defaultScale: 1,
+    ...initialValues,
+    _pipeline: {
+      source: initialValues.pipeline?.source ?? publicAPI,
+      glyph:
+        initialValues.pipeline?.glyph ?? // in case glyph was provided
+        vtkSphereSource.newInstance({
+          phiResolution: 8,
+          thetaResolution: 8,
+        }),
+      mapper:
+        initialValues.pipeline?.mapper ?? // in case mapper was provided
+        vtkGlyph3DMapper.newInstance({
+          scalarMode: ScalarMode.USE_POINT_FIELD_DATA,
+        }),
+      actor:
+        initialValues.pipeline?.actor ?? // in case actor was provided
+        vtkActor.newInstance({ parentProp: publicAPI }),
+      ...initialValues.pipeline, // in case there is something else to add to pipeline
+    },
+    applyMixin: {
+      origin: initialValues.applyMixin?.origin ?? origin(publicAPI, model),
+      noPosition:
+        initialValues.applyMixin?.noPosition ?? noPosition(publicAPI, model),
+      color3: initialValues.applyMixin?.color3 ?? color3(publicAPI, model),
+      color: initialValues.applyMixin?.color ?? color(publicAPI, model),
+      noColor: initialValues.applyMixin?.noColor ?? noColor(publicAPI, model),
+      scale3: initialValues.applyMixin?.scale3 ?? scale3(publicAPI, model),
+      scale1: initialValues.applyMixin?.scale1 ?? scale1(publicAPI, model),
+      noScale: initialValues.applyMixin?.noScale ?? noScale(publicAPI, model),
+      direction:
+        initialValues.applyMixin?.direction ?? direction(publicAPI, model),
+      noOrientation:
+        initialValues.applyMixin?.noOrientation ??
+        noOrientation(publicAPI, model),
+      ...initialValues.applyMixin,
+    },
+  };
+}
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  if (initialValues.behavior === Behavior.CONTEXT) {
+    vtkContextRepresentation.extend(
+      publicAPI,
+      model,
+      defaultValues(publicAPI, model, initialValues)
+    );
+  } else {
+    vtkHandleRepresentation.extend(
+      publicAPI,
+      model,
+      defaultValues(publicAPI, model, initialValues)
+    );
+  }
+
+  macro.setGet(publicAPI, model._pipeline, ['defaultScale']);
+  macro.get(publicAPI, model._pipeline, ['glyph', 'mapper', 'actor']);
+  // Expose the mixin functions to allow overwriting
+  macro.setGet(publicAPI, model.applyMixin, Object.keys(model.applyMixin));
+
+  // Object specific methods
+  vtkGlyphRepresentation(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkGlyphRepresentation');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
+++ b/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
@@ -105,54 +105,54 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
   model.plane = vtkPlane.newInstance();
   model.matrix = vtkMatrixBuilder.buildFromDegree();
 
-  model.pipelines = {};
-  model.pipelines.outline = {
+  model._pipelines = {};
+  model._pipelines.outline = {
     source: vtkCubeSource.newInstance(),
     mapper: vtkMapper.newInstance(),
     actor: vtkActor.newInstance({ pickable: false, _parentProp: publicAPI }),
   };
 
-  model.pipelines.plane = {
+  model._pipelines.plane = {
     source: vtkCutter.newInstance({ cutFunction: model.plane }),
     filter: vtkClosedPolyLineToSurfaceFilter.newInstance(),
     mapper: vtkMapper.newInstance(),
     actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
 
-  model.pipelines.origin = {
+  model._pipelines.origin = {
     source: vtkSphereSource.newInstance(),
     mapper: vtkMapper.newInstance(),
     actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
 
-  model.pipelines.normal = {
+  model._pipelines.normal = {
     source: vtkCylinderSource.newInstance(),
     mapper: vtkMapper.newInstance(),
     actor: vtkActor.newInstance({ pickable: true, _parentProp: publicAPI }),
   };
 
-  model.pipelines.display2D = {
+  model._pipelines.display2D = {
     source: publicAPI,
     mapper: vtkPixelSpaceCallbackMapper.newInstance(),
     actor: vtkActor.newInstance({ pickable: false, _parentProp: publicAPI }),
   };
 
   // Plane generation pipeline
-  model.pipelines.plane.source.setInputConnection(
-    model.pipelines.outline.source.getOutputPort()
+  model._pipelines.plane.source.setInputConnection(
+    model._pipelines.outline.source.getOutputPort()
   );
 
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.outline);
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.plane);
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.origin);
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.normal);
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.display2D);
+  vtkWidgetRepresentation.connectPipeline(model._pipelines.outline);
+  vtkWidgetRepresentation.connectPipeline(model._pipelines.plane);
+  vtkWidgetRepresentation.connectPipeline(model._pipelines.origin);
+  vtkWidgetRepresentation.connectPipeline(model._pipelines.normal);
+  vtkWidgetRepresentation.connectPipeline(model._pipelines.display2D);
 
-  publicAPI.addActor(model.pipelines.outline.actor);
-  publicAPI.addActor(model.pipelines.plane.actor);
-  publicAPI.addActor(model.pipelines.origin.actor);
-  publicAPI.addActor(model.pipelines.normal.actor);
-  publicAPI.addActor(model.pipelines.display2D.actor);
+  publicAPI.addActor(model._pipelines.outline.actor);
+  publicAPI.addActor(model._pipelines.plane.actor);
+  publicAPI.addActor(model._pipelines.origin.actor);
+  publicAPI.addActor(model._pipelines.normal.actor);
+  publicAPI.addActor(model._pipelines.display2D.actor);
 
   // --------------------------------------------------------------------------
 
@@ -171,7 +171,7 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
     // Update cube parameters
     // --------------------------------
 
-    model.pipelines.outline.source.setCenter(
+    model._pipelines.outline.source.setCenter(
       (bounds[0] + bounds[1]) * 0.5,
       (bounds[2] + bounds[3]) * 0.5,
       (bounds[4] + bounds[5]) * 0.5
@@ -179,9 +179,9 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
     const xRange = bounds[1] - bounds[0];
     const yRange = bounds[3] - bounds[2];
     const zRange = bounds[5] - bounds[4];
-    model.pipelines.outline.source.setXLength(xRange);
-    model.pipelines.outline.source.setYLength(yRange);
-    model.pipelines.outline.source.setZLength(zRange);
+    model._pipelines.outline.source.setXLength(xRange);
+    model._pipelines.outline.source.setYLength(yRange);
+    model._pipelines.outline.source.setZLength(zRange);
 
     // --------------------------------
     // Update normal parameters
@@ -192,7 +192,7 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
       pixelScale = getPixelWorldHeightAtCoord(origin, model.displayScaleParams);
     }
 
-    model.pipelines.normal.source.set({
+    model._pipelines.normal.source.set({
       height: Math.max(xRange, yRange, zRange),
       radius:
         model.handleSizeRatio *
@@ -201,7 +201,7 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
         pixelScale,
       resolution: model.sphereResolution,
     });
-    const yAxis = model.pipelines.normal.source.getOutputData();
+    const yAxis = model._pipelines.normal.source.getOutputData();
     const newAxis = vtkPolyData.newInstance();
     newAxis.shallowCopy(yAxis);
     newAxis
@@ -213,16 +213,16 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
       .translate(origin[0], origin[1], origin[2])
       .rotateFromDirections([0, 1, 0], normal)
       .apply(newAxis.getPoints().getData());
-    model.pipelines.normal.mapper.setInputData(newAxis);
+    model._pipelines.normal.mapper.setInputData(newAxis);
 
     // --------------------------------
     // Update origin parameters
     // --------------------------------
 
-    model.pipelines.origin.actor.setPosition(origin);
+    model._pipelines.origin.actor.setPosition(origin);
     const handleScale =
       model.handleSizeRatio * Math.min(xRange, yRange, zRange) * pixelScale;
-    model.pipelines.origin.actor.setScale(
+    model._pipelines.origin.actor.setScale(
       handleScale,
       handleScale,
       handleScale
@@ -233,13 +233,13 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
     // --------------------------------
 
     vtkWidgetRepresentation.applyStyles(
-      model.pipelines,
+      model._pipelines,
       model.representationStyle,
       state.getActive() && state.getActiveHandle()
     );
 
     const output = vtkPolyData.newInstance();
-    output.shallowCopy(model.pipelines.plane.filter.getOutputData());
+    output.shallowCopy(model._pipelines.plane.filter.getOutputData());
     outData[0] = output;
   };
 
@@ -250,8 +250,8 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
   publicAPI.setSphereResolution = (res) => {
     model.sphereResolution = res;
     return (
-      model.pipelines.origin.source.setPhiResolution(res) &&
-      model.pipelines.origin.source.setThetaResolution(res)
+      model._pipelines.origin.source.setPhiResolution(res) &&
+      model._pipelines.origin.source.setThetaResolution(res)
     );
   };
 
@@ -264,7 +264,7 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
 
     // Apply static and inactive
     vtkWidgetRepresentation.applyStyles(
-      model.pipelines,
+      model._pipelines,
       model.representationStyle
     );
 
@@ -280,21 +280,23 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
     const { planeVisible, originVisible, normalVisible, outlineVisible } =
       model;
     if (renderingType === RenderingTypes.PICKING_BUFFER) {
-      model.pipelines.plane.actor.setVisibility(planeVisible);
-      model.pipelines.origin.actor.setVisibility(originVisible);
-      model.pipelines.normal.actor.setVisibility(normalVisible);
+      model._pipelines.plane.actor.setVisibility(planeVisible);
+      model._pipelines.origin.actor.setVisibility(originVisible);
+      model._pipelines.normal.actor.setVisibility(normalVisible);
       //
-      model.pipelines.plane.actor.getProperty().setOpacity(1);
+      model._pipelines.plane.actor.getProperty().setOpacity(1);
     } else {
-      model.pipelines.outline.actor.setVisibility(outlineVisible && ctxVisible);
-      model.pipelines.plane.actor.setVisibility(planeVisible && hVisible);
-      model.pipelines.origin.actor.setVisibility(originVisible && hVisible);
-      model.pipelines.normal.actor.setVisibility(normalVisible && hVisible);
+      model._pipelines.outline.actor.setVisibility(
+        outlineVisible && ctxVisible
+      );
+      model._pipelines.plane.actor.setVisibility(planeVisible && hVisible);
+      model._pipelines.origin.actor.setVisibility(originVisible && hVisible);
+      model._pipelines.normal.actor.setVisibility(normalVisible && hVisible);
       //
       const state = model.inputData[0];
       if (state) {
         vtkWidgetRepresentation.applyStyles(
-          model.pipelines,
+          model._pipelines,
           model.representationStyle,
           state.getActive() && state.getActiveHandle()
         );
@@ -312,13 +314,13 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
     state.setActiveHandle(prop);
 
     switch (prop) {
-      case model.pipelines.plane.actor:
+      case model._pipelines.plane.actor:
         state.setUpdateMethodName('updateFromPlane');
         break;
-      case model.pipelines.origin.actor:
+      case model._pipelines.origin.actor:
         state.setUpdateMethodName('updateFromOrigin');
         break;
-      case model.pipelines.normal.actor:
+      case model._pipelines.normal.actor:
         state.setUpdateMethodName('updateFromNormal');
         break;
       default:

--- a/Sources/Widgets/Representations/SphereContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/SphereContextRepresentation/index.js
@@ -1,104 +1,51 @@
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
-import { ScalarMode } from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
-import vtkContextRepresentation from 'vtk.js/Sources/Widgets/Representations/ContextRepresentation';
-import vtkWidgetRepresentation from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 import macro from 'vtk.js/Sources/macros';
+import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import vtkGlyphRepresentation from 'vtk.js/Sources/Widgets/Representations/GlyphRepresentation';
+import { Behavior } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation/Constants';
 
 function vtkSphereContextRepresentation(publicAPI, model) {
   model.classHierarchy.push('vtkSphereContextRepresentation');
 
-  model.pipelines = {
-    circle: {
-      source: publicAPI,
-      glyph: vtkSphereSource.newInstance({
-        phiResolution: model.glyphResolution,
-        thetaResolution: model.glyphResolution,
-      }),
-      mapper: vtkGlyph3DMapper.newInstance({
-        scaleArray: 'scale',
-        scaleMode: vtkGlyph3DMapper.ScaleModes.SCALE_BY_MAGNITUDE,
-        colorByArrayName: 'color',
-        scalarMode: ScalarMode.USE_POINT_FIELD_DATA,
-      }),
-      actor: vtkActor.newInstance({ pickable: false, parentProp: publicAPI }),
-    },
-  };
-
-  model.pipelines.circle.actor.getProperty().setOpacity(0.2);
-
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.circle);
-  publicAPI.addActor(model.pipelines.circle.actor);
-
   publicAPI.setGlyphResolution = macro.chain(
     publicAPI.setGlyphResolution,
-    (r) => model.pipelines.circle.glyph.setResolution(r)
+    model._pipeline.glyph.setThetaResolution,
+    model._pipeline.glyph.setPhiResolution
   );
+
   publicAPI.setDrawBorder = (draw) => {
-    model.pipelines.circle.glyph.setLines(draw);
+    model._pipeline.glyph.setLines(draw);
   };
   publicAPI.setDrawFace = (draw) => {
-    model.pipelines.circle.glyph.setFace(draw);
+    model._pipeline.glyph.setFace(draw);
   };
   publicAPI.setOpacity = (opacity) => {
-    model.pipelines.circle.actor.getProperty().setOpacity(opacity);
+    model._pipeline.actor.getProperty().setOpacity(opacity);
   };
-  const superGetRepresentationStates = publicAPI.getRepresentationStates;
-  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
-    superGetRepresentationStates(input).filter(
-      (state) => state.getOrigin?.() && state.isVisible?.()
-    );
-  publicAPI.requestData = (inData, outData) => {
-    const list = publicAPI.getRepresentationStates(inData[0]);
-    const totalCount = list.length;
 
-    const points = publicAPI
-      .allocateArray('points', 'Float32Array', 3, totalCount)
-      .getData();
-    const color = publicAPI
-      .allocateArray('color', ...publicAPI.computeColorType(list), totalCount)
-      .getData();
-    const scale = publicAPI
-      .allocateArray('scale', 'Float32Array', 1, totalCount)
-      .getData();
-
-    for (let i = 0; i < totalCount; i += 1) {
-      const state = list[i];
-      const isActive = state.getActive();
-      const scaleFactor = isActive ? model.activeScaleFactor : 1;
-
-      const coord = state.getOrigin();
-      points[i * 3 + 0] = coord[0];
-      points[i * 3 + 1] = coord[1];
-      points[i * 3 + 2] = coord[2];
-
-      scale[i] =
-        scaleFactor *
-        (state.getScale1 ? state.getScale1() : model.defaultScale);
-
-      typedArray.color[i] =
-        model.useActiveColor && isActive ? model.activeColor : state.getColor();
-    }
-
-    model.internalPolyData.modified();
-    outData[0] = model.internalPolyData;
-  };
+  model._pipeline.actor.getProperty().setOpacity(0.2);
 }
 
-const DEFAULT_VALUES = {
-  glyphResolution: 32,
-  defaultScale: 1,
-  drawBorder: false,
-  drawFace: true,
-};
+function defaultValues(initialValues) {
+  return {
+    glyphResolution: 32,
+    drawBorder: false,
+    drawFace: true,
+    behavior: Behavior.CONTEXT,
+    _pipeline: {
+      glyph: vtkSphereSource.newInstance({
+        phiResolution: initialValues.glyphResolution ?? 32,
+        thetaResolution: initialValues.glyphResolution ?? 32,
+      }),
+    },
+    ...initialValues,
+  };
+}
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
-  vtkContextRepresentation.extend(publicAPI, model, initialValues);
-  macro.setGet(publicAPI, model, ['glyphResolution', 'defaultScale']);
+  vtkGlyphRepresentation.extend(publicAPI, model, defaultValues(initialValues));
+  macro.setGet(publicAPI, model, ['glyphResolution']);
 
   vtkSphereContextRepresentation(publicAPI, model);
 }

--- a/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/SphereHandleRepresentation/index.js
@@ -1,14 +1,7 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
-import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
-import vtkHandleRepresentation from 'vtk.js/Sources/Widgets/Representations/HandleRepresentation';
+import vtkGlyphRepresentation from 'vtk.js/Sources/Widgets/Representations/GlyphRepresentation';
 import vtkPixelSpaceCallbackMapper from 'vtk.js/Sources/Rendering/Core/PixelSpaceCallbackMapper';
-import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
-
-import { ScalarMode } from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
-import vtkWidgetRepresentation, {
-  getPixelWorldHeightAtCoord,
-} from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 
 // ----------------------------------------------------------------------------
 // vtkSphereHandleRepresentation methods
@@ -17,10 +10,6 @@ import vtkWidgetRepresentation, {
 function vtkSphereHandleRepresentation(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkSphereHandleRepresentation');
-
-  // --------------------------------------------------------------------------
-  // Internal polydata dataset
-  // --------------------------------------------------------------------------
 
   // --------------------------------------------------------------------------
   // Generic rendering pipeline
@@ -39,16 +28,12 @@ function vtkSphereHandleRepresentation(publicAPI, model) {
   publicAPI.addActor(model.displayActor);
   model.alwaysVisibleActors = [model.displayActor];
 
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.sphere);
-  publicAPI.addActor(model.pipelines.sphere.actor);
-
   // --------------------------------------------------------------------------
 
-  publicAPI.getGlyphResolution = () =>
-    model.pipelines.sphere.glyph.getPhiResolution();
+  publicAPI.getGlyphResolution = () => model._pipeline.glyph.getPhiResolution();
   publicAPI.setGlyphResolution = (resolution) =>
-    model.pipelines.sphere.glyph.setPhiResolution(resolution) ||
-    model.pipelines.sphere.glyph.setThetaResolution(resolution);
+    model._pipeline.glyph.setPhiResolution(resolution) ||
+    model._pipeline.glyph.setThetaResolution(resolution);
 
   // --------------------------------------------------------------------------
 
@@ -73,91 +58,16 @@ function vtkSphereHandleRepresentation(publicAPI, model) {
     model.displayCallback = callback;
     model.displayMapper.setCallback(callback ? callbackProxy : null);
   };
-
-  const superGetRepresentationStates = publicAPI.getRepresentationStates;
-  publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
-    superGetRepresentationStates(input).filter(
-      (state) => state.getOrigin?.() && state.isVisible?.()
-    );
-
-  // --------------------------------------------------------------------------
-
-  publicAPI.requestData = (inData, outData) => {
-    const list = publicAPI.getRepresentationStates(inData[0]);
-    const totalCount = list.length;
-
-    const points = publicAPI
-      .allocateArray('points', 'Float32Array', 3, totalCount)
-      .getData();
-
-    const color = publicAPI
-      .allocateArray('color', ...publicAPI.computeColorType(list), totalCount)
-      .getData();
-    const scale = publicAPI
-      .allocateArray('scale', 'Float32Array', 1, totalCount)
-      .getData();
-
-    for (let i = 0; i < totalCount; i++) {
-      const state = list[i];
-      const isActive = state.getActive();
-      const scaleFactor = isActive ? model.activeScaleFactor : 1;
-
-      const coord = state.getOrigin();
-      points[i * 3 + 0] = coord[0];
-      points[i * 3 + 1] = coord[1];
-      points[i * 3 + 2] = coord[2];
-
-      scale[i] =
-        scaleFactor *
-        (state.getScale1 ? state.getScale1() : model.defaultScale);
-
-      if (publicAPI.getScaleInPixels()) {
-        scale[i] *= getPixelWorldHeightAtCoord(coord, model.displayScaleParams);
-      }
-
-      publicAPI.colorize(color, i, state);
-    }
-
-    model.internalPolyData.modified();
-    outData[0] = model.internalPolyData;
-  };
 }
 
 // ----------------------------------------------------------------------------
 // Object factory
 // ----------------------------------------------------------------------------
 
-function defaultValues(publicAPI, initialValues) {
-  return {
-    defaultScale: 1,
-    pipelines: {
-      sphere: {
-        source: publicAPI,
-        glyph: vtkSphereSource.newInstance({
-          phiResolution: 8,
-          thetaResolution: 8,
-        }),
-        mapper: vtkGlyph3DMapper.newInstance({
-          scaleArray: 'scale',
-          colorByArrayName: 'color',
-          scalarMode: ScalarMode.USE_POINT_FIELD_DATA,
-        }),
-        actor: vtkActor.newInstance({ parentProp: publicAPI }),
-      },
-    },
-    ...initialValues,
-  };
-}
-
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  vtkHandleRepresentation.extend(
-    publicAPI,
-    model,
-    defaultValues(publicAPI, initialValues)
-  );
-  macro.get(publicAPI, model.pipelines.sphere, ['glyph', 'mapper', 'actor']);
+  vtkGlyphRepresentation.extend(publicAPI, model, initialValues);
 
   // Object specific methods
   vtkSphereHandleRepresentation(publicAPI, model);

--- a/Sources/Widgets/Representations/SplineContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/SplineContextRepresentation/index.js
@@ -6,7 +6,9 @@ import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkSpline3D from 'vtk.js/Sources/Common/DataModel/Spline3D';
 import vtkTriangleFilter from 'vtk.js/Sources/Filters/General/TriangleFilter';
 import vtkLineFilter from 'vtk.js/Sources/Filters/General/LineFilter';
-import vtkWidgetRepresentation from '../WidgetRepresentation';
+import vtkWidgetRepresentation, {
+  allocateArray,
+} from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 
 // ----------------------------------------------------------------------------
 // vtkSplineContextRepresentation methods
@@ -22,7 +24,7 @@ function vtkSplineContextRepresentation(publicAPI, model) {
 
   model.internalPolyData = vtkPolyData.newInstance({ mtime: 0 });
 
-  model.pipelines = {
+  model._pipelines = {
     area: {
       source: publicAPI,
       filter: vtkTriangleFilter.newInstance(),
@@ -37,16 +39,16 @@ function vtkSplineContextRepresentation(publicAPI, model) {
     },
   };
 
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.area);
-  model.pipelines.area.actor.getProperty().setOpacity(0.2);
-  model.pipelines.area.actor.getProperty().setColor(0, 1, 0);
-  publicAPI.addActor(model.pipelines.area.actor);
+  vtkWidgetRepresentation.connectPipeline(model._pipelines.area);
+  model._pipelines.area.actor.getProperty().setOpacity(0.2);
+  model._pipelines.area.actor.getProperty().setColor(0, 1, 0);
+  publicAPI.addActor(model._pipelines.area.actor);
 
-  vtkWidgetRepresentation.connectPipeline(model.pipelines.border);
-  model.pipelines.border.actor.getProperty().setOpacity(1);
-  model.pipelines.border.actor.getProperty().setColor(0.1, 1, 0.1);
-  model.pipelines.border.actor.setVisibility(model.outputBorder);
-  publicAPI.addActor(model.pipelines.border.actor);
+  vtkWidgetRepresentation.connectPipeline(model._pipelines.border);
+  model._pipelines.border.actor.getProperty().setOpacity(1);
+  model._pipelines.border.actor.getProperty().setColor(0.1, 1, 0.1);
+  model._pipelines.border.actor.setVisibility(model.outputBorder);
+  publicAPI.addActor(model._pipelines.border.actor);
 
   // --------------------------------------------------------------------------
   const superGetRepresentationStates = publicAPI.getRepresentationStates;
@@ -89,14 +91,11 @@ function vtkSplineContextRepresentation(publicAPI, model) {
     });
     spline.computeCoefficients(inPoints);
 
-    const outPoints = publicAPI
-      .allocateArray(
-        'points',
-        'Float32Array',
-        3,
-        (numVertices + !closed) * model.resolution
-      )
-      .getData();
+    const outPoints = allocateArray(
+      model.internalPolyData,
+      'points',
+      (numVertices + !closed) * model.resolution
+    ).getData();
     const outCells = new Uint32Array(numVertices * model.resolution + 2);
     outCells[0] = numVertices * model.resolution + 1;
     outCells[numVertices * model.resolution + 1] = 0;
@@ -132,14 +131,15 @@ function vtkSplineContextRepresentation(publicAPI, model) {
       .getLines()
       .setData(model.outputBorder ? outCells : []);
 
+    model.internalPolyData.modified();
     outData[0] = model.internalPolyData;
 
-    model.pipelines.area.filter.update();
-    model.pipelines.border.actor
+    model._pipelines.area.filter.update();
+    model._pipelines.border.actor
       .getProperty()
       .setColor(
         ...(inPoints.length <= 3 ||
-        model.pipelines.area.filter.getErrorCount() === 0
+        model._pipelines.area.filter.getErrorCount() === 0
           ? model.borderColor
           : model.errorBorderColor)
       );
@@ -148,13 +148,13 @@ function vtkSplineContextRepresentation(publicAPI, model) {
   publicAPI.getSelectedState = (prop, compositeID) => model.state;
 
   function updateAreaVisibility() {
-    model.pipelines.area.actor.setVisibility(model.fill);
+    model._pipelines.area.actor.setVisibility(model.fill);
   }
 
   publicAPI.setFill = macro.chain(publicAPI.setFill, updateAreaVisibility);
 
   publicAPI.setOutputBorder = macro.chain(publicAPI.setOutputBorder, (v) =>
-    model.pipelines.border.actor.setVisibility(v)
+    model._pipelines.border.actor.setVisibility(v)
   );
 }
 

--- a/Sources/Widgets/Representations/WidgetRepresentation/index.d.ts
+++ b/Sources/Widgets/Representations/WidgetRepresentation/index.d.ts
@@ -1,3 +1,5 @@
+import vtkDataArray from "../../../Common/Core/DataArray";
+import vtkPolyData from "../../../Common/DataModel/PolyData";
 import { vtkObject } from "../../../interfaces";
 import vtkProp from "../../../Rendering/Core/Prop";
 export interface IDisplayScaleParams {
@@ -70,7 +72,7 @@ export function newInstance(initialValues?: IWidgetRepresentationInitialValues):
  */
 export function getPixelWorldHeightAtCoord(worldCoord: number[], displayScaleParams: IDisplayScaleParams): number[];
 
-export interface IPipeline {
+export interface IWidgetPipeline {
 	source?: object,
 	filter?: object,
 	glyph?: object,
@@ -82,9 +84,27 @@ export interface IPipeline {
  * If provided, connects `filter` (otherwise `source`) to mapper
  * If provided, connects glyph as 2nd input to mapper. This is typically for the glyph mapper.
  * Connects mapper to actor.
- * @param {IPipeline} pipeline of source, filter, mapper and actor to connect
+ * @param {IWidgetPipeline} pipeline of source, filter, mapper and actor to connect
  */
-export function connectPipeline(pipeline: IPipeline) {}
+export function connectPipeline(pipeline: IWidgetPipeline): void;
+
+/**
+ * Allocate or resize a vtkPoint(name='point'), vtkCellArray (name=
+ * 'line'|'poly') or vtkDataArray (name=any) and add it to the vtkPolyData.
+ * If allocated, the array is automatically added to the polydata
+ * Connects mapper to actor.
+ * @param {vtkPolyData} polyData The polydata to add array to
+ * @param {string} name The name of the array to add (special handling for
+ * 'point', 'line, 'poly')
+ * @param {Number} numberOfTuples The number of tuples to (re)allocate.
+ * @param {String} dataType The typed array type name.
+ * @param {Number} numberOfComponents The number of components of the array.
+ */
+ export function allocateArray(polyData: vtkPolyData,
+    name: string,
+    numberOfTuples: number,
+    dataType?: string,
+    numberOfComponents?: number): vtkDataArray|null;
 
 export declare const vtkWidgetRepresentation: {
 	newInstance: typeof newInstance;

--- a/Sources/Widgets/Representations/index.js
+++ b/Sources/Widgets/Representations/index.js
@@ -2,12 +2,14 @@ import vtkCircleContextRepresentation from './CircleContextRepresentation';
 import vtkContextRepresentation from './ContextRepresentation';
 import vtkConvexFaceContextRepresentation from './ConvexFaceContextRepresentation';
 import vtkCubeHandleRepresentation from './CubeHandleRepresentation';
+import vtkGlyphRepresentation from './GlyphRepresentation';
 import vtkHandleRepresentation from './HandleRepresentation';
 import vtkImplicitPlaneRepresentation from './ImplicitPlaneRepresentation';
 import vtkLineHandleRepresentation from './LineHandleRepresentation';
 import vtkOutlineContextRepresentation from './OutlineContextRepresentation';
 import vtkPolyLineRepresentation from './PolyLineRepresentation';
 import vtkSphereHandleRepresentation from './SphereHandleRepresentation';
+import vtkSplineContextRepresentation from './SplineContextRepresentation';
 import vtkWidgetRepresentation from './WidgetRepresentation';
 
 export default {
@@ -15,11 +17,13 @@ export default {
   vtkContextRepresentation,
   vtkConvexFaceContextRepresentation,
   vtkCubeHandleRepresentation,
+  vtkGlyphRepresentation,
   vtkHandleRepresentation,
   vtkImplicitPlaneRepresentation,
   vtkLineHandleRepresentation,
   vtkOutlineContextRepresentation,
   vtkPolyLineRepresentation,
   vtkSphereHandleRepresentation,
+  vtkSplineContextRepresentation,
   vtkWidgetRepresentation,
 };

--- a/Sources/Widgets/Widgets3D/AngleWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/example/index.js
@@ -22,12 +22,12 @@ const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
 });
 const renderer = fullScreenRenderer.getRenderer();
 
-const cone = vtkCubeSource.newInstance();
+const cube = vtkCubeSource.newInstance();
 const mapper = vtkMapper.newInstance();
 const actor = vtkActor.newInstance();
 
 actor.setMapper(mapper);
-mapper.setInputConnection(cone.getOutputPort());
+mapper.setInputConnection(cube.getOutputPort());
 actor.getProperty().setOpacity(0.5);
 
 renderer.addActor(actor);
@@ -40,12 +40,13 @@ const widgetManager = vtkWidgetManager.newInstance();
 widgetManager.setRenderer(renderer);
 
 const widget = vtkAngleWidget.newInstance();
-widget.placeWidget(cone.getOutputData().getBounds());
+// widget.placeWidget(cube.getOutputData().getBounds());
 
 widgetManager.addWidget(widget);
 
 renderer.resetCamera();
 widgetManager.enablePicking();
+fullScreenRenderer.getInteractor().render();
 
 // -----------------------------------------------------------
 // UI control handling

--- a/Sources/Widgets/Widgets3D/AngleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/index.js
@@ -38,8 +38,10 @@ function vtkAngleWidget(publicAPI, model) {
       case ViewTypes.VOLUME:
       default:
         return [
-          { builder: vtkSphereHandleRepresentation, labels: ['handles'] },
-          { builder: vtkSphereHandleRepresentation, labels: ['moveHandle'] },
+          {
+            builder: vtkSphereHandleRepresentation,
+            labels: ['handles', 'moveHandle'],
+          },
           {
             builder: vtkPolyLineRepresentation,
             labels: ['handles', 'moveHandle'],

--- a/Sources/Widgets/Widgets3D/EllipseWidget/state.js
+++ b/Sources/Widgets/Widgets3D/EllipseWidget/state.js
@@ -28,7 +28,7 @@ export default function generateState() {
         mixins: ['origin', 'color', 'scale3', 'visible', 'orientation'],
         name: 'ellipseHandle',
         initialValues: {
-          visible: false,
+          // visible: false,
           scale3: [1, 1, 1],
         },
       })

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -394,7 +394,6 @@ export default function widgetBehavior(publicAPI, model) {
       planeNormal
     );
 
-    console.log('Rotate', publicAPI.getActiveLineName());
     publicAPI.rotateLineInView(publicAPI.getActiveLineName(), radianAngle);
   };
 

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testMultipleRotationPlanes.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testMultipleRotationPlanes.js
@@ -61,7 +61,9 @@ function createView(gc, viewType, widget) {
   obj.interactor.setInteractorStyle(
     gc.registerResource(vtkInteractorStyleImage.newInstance())
   );
-  obj.widgetInstance = obj.widgetManager.addWidget(widget, viewType);
+  obj.widgetInstance = gc.registerResource(
+    obj.widgetManager.addWidget(widget, viewType)
+  );
   obj.widgetManager.enablePicking();
   // Use to update all renderers buffer when actors are moved
   obj.widgetManager.setCaptureOn(CaptureOn.MOUSE_MOVE);

--- a/Sources/Widgets/Widgets3D/SplineWidget/test/testSplineWidget.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/test/testSplineWidget.js
@@ -125,9 +125,12 @@ test.onlyIfWebGL('Test vtkSplineWidget rendering and picking', (t) => {
 
     return sel.selectAsync(renderer, 200, 200, 210, 210).then((res) => {
       t.equal(res.length, 1);
-      t.equal(
-        res[0].getProperties().prop.getParentProp(),
-        widgets[0].getRepresentations()[1]
+      t.ok(
+        // do not use equal to avoid serializing representation
+        Object.is(
+          res[0].getProperties().prop.getParentProp(),
+          widgets[0].getRepresentations()[1]
+        )
       );
     });
   }

--- a/Utilities/config/rules-tests.js
+++ b/Utilities/config/rules-tests.js
@@ -17,6 +17,34 @@ module.exports = [
     ],
   },
   {
+    test: /\.css$/,
+    exclude: /\.module\.css$/,
+    use: [
+      { loader: 'style-loader' },
+      { loader: 'css-loader' },
+      { loader: 'postcss-loader' },
+    ],
+  },
+  {
+    test: /\.module\.css$/,
+    use: [
+      { loader: 'style-loader' },
+      {
+        loader: 'css-loader',
+        options: {
+          modules: {
+            localIdentName: '[name]-[local]_[sha512:hash:base64:5]',
+          },
+        },
+      },
+      { loader: 'postcss-loader' },
+    ],
+  },
+  {
+    test: /\.svg$/,
+    type: 'asset/source',
+  },
+  {
     test: /\.js$/,
     use: [
       { loader: 'babel-loader' },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -91,7 +91,7 @@ module.exports = function init(config) {
       },
     },
     // browserNoActivityTimeout: 600000,
-    browserDisconnectTimeout: 10000,
+    browserDisconnectTimeout: 100000,
     browserDisconnectTolerance: 3,
 
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "release:create-packages": "node ./Utilities/ci/build-npm-package.js",
     "test": "karma start ./karma.conf.js",
     "test:headless": "karma start ./karma.conf.js --browsers ChromeHeadlessNoSandbox --single-run",
-    "test:debug": "karma start ./karma.conf.js --no-single-run",
+    "test:debug": "karma start ./karma.conf.js --log-level debug --no-single-run",
     "test:firefox": "karma start ./karma.conf.js --browsers Firefox",
     "test:webgpu": "cross-env WEBGPU=1 NO_WEBGL=1 karma start ./karma.conf.js --browsers ChromeWebGPU --no-single-run",
     "test:firefox-debug": "karma start ./karma.conf.js --browsers Firefox --no-single-run",


### PR DESCRIPTION
### Context
The goal is to simplify the customization of the Reslice Cursor widget.

### Results
The Reslice Cursor widget is now using low-level widget representations that can be easily customized.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
