### PR TITLE
fix(cellarraybufferobject.js): fix selectionsMaps cells array creation

### DIFF
--- a/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
+++ b/Sources/Rendering/OpenGL/CellArrayBufferObject/index.js
@@ -297,9 +297,7 @@ function vtkOpenGLCellArrayBufferObject(publicAPI, model) {
         );
         newPoints.set(selectionMaps.points);
         selectionMaps.points = newPoints;
-        const newCells = new Int32Array(
-          caboCount + selectionMaps.points.length
-        );
+        const newCells = new Int32Array(caboCount + selectionMaps.cells.length);
         newCells.set(selectionMaps.cells);
         selectionMaps.cells = newCells;
       }


### PR DESCRIPTION
New cells array was created using points length and would overflow in some cases. Fixed to use cells length.


### Context
Using vtk.js version 25.8.3. We have functionality where surfaces of a visualization can be hidden. A few surfaces before everything is hidden the OpenGL selectionsMap cell&point counts change so that there are more cells than points.

The cells array length is initiated with length from points, thus causing Int32Array overflow.

```
CellArrayBufferObject.js:280 Uncaught RangeError: offset is out of bounds
    at Int32Array.set (<anonymous>)
    at publicAPI.createVBO (CellArrayBufferObject.js:280:18)
    at publicAPI.buildBufferObjects (PolyDataMapper.js:1274:63)
    at publicAPI.updateBufferObjects (PolyDataMapper.js:1144:17)
    at publicAPI.renderPieceStart (PolyDataMapper.js:1041:15)
    at publicAPI.renderPiece (PolyDataMapper.js:1127:15)
    at publicAPI.render (PolyDataMapper.js:99:15)
    at publicAPI.opaquePass (PolyDataMapper.js:82:17)
    at publicAPI.apply (ViewNode.js:42:7)
    at publicAPI.traverse (ViewNode.js:29:15)
```

### Results

With this fix the issue is no more. All surfaces can be hidden and then brought back to visible.

### Changes

Fixed the probable copy-paste error.

