### PR TITLE
fix(MouseRangeManipulator): swap listener deletion

### DIFF
--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
@@ -142,18 +142,18 @@ function vtkMouseRangeManipulator(publicAPI, model) {
 
   //-------------------------------------------------------------------------
   publicAPI.removeHorizontalListener = () => {
-    if (model.verticalListener) {
-      incrementalDelta.delete(model.verticalListener);
-      delete model.verticalListener;
+    if (model.horizontalListener) {
+      incrementalDelta.delete(model.horizontalListener);
+      delete model.horizontalListener;
       publicAPI.modified();
     }
   };
 
   //-------------------------------------------------------------------------
   publicAPI.removeVerticalListener = () => {
-    if (model.horizontalListener) {
-      incrementalDelta.delete(model.horizontalListener);
-      delete model.horizontalListener;
+    if (model.verticalListener) {
+      incrementalDelta.delete(model.verticalListener);
+      delete model.verticalListener;
       publicAPI.modified();
     }
   };

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/test/testMouseRangeManipulator.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/test/testMouseRangeManipulator.js
@@ -1,0 +1,45 @@
+import test from 'tape-catch';
+
+import vtkMouseRangeManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseRangeManipulator';
+
+test('Test MouseRangeManipulator addition/removal', (t) => {
+  const manip = vtkMouseRangeManipulator.newInstance();
+
+  manip.setHorizontalListener(
+    0,
+    10,
+    1,
+    () => 5,
+    () => {}
+  );
+  t.ok(
+    manip.get('horizontalListener').horizontalListener,
+    'Has horizontal listener after setting'
+  );
+
+  manip.setVerticalListener(
+    0,
+    10,
+    1,
+    () => 5,
+    () => {}
+  );
+  t.ok(
+    manip.get('verticalListener').verticalListener,
+    'Has vertical listener after setting'
+  );
+
+  manip.removeHorizontalListener();
+  t.notOk(
+    manip.get('horizontalListener').horizontalListener,
+    'Horizontal listener removed'
+  );
+
+  manip.removeVerticalListener();
+  t.notOk(
+    manip.get('verticalListener').verticalListener,
+    'Vertical listener removed'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The MouseRangeManipulator incorrectly deletes the horiz listener when calling removeVerticalListener, and vice-versa.

### Results
Correct deletion of the appropriate listener.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
