### PR TITLE
docs(scalarbaractor): support negative numbers

### DIFF
--- a/Sources/Rendering/Core/ScalarBarActor/example/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/example/index.js
@@ -1,5 +1,6 @@
 import 'vtk.js/Sources/favicon';
 import * as d3 from 'd3-scale';
+import { formatDefaultLocale } from 'd3-format';
 
 // Load the rendering pieces we want to use (for both WebGL and WebGPU)
 import 'vtk.js/Sources/Rendering/Profiles/Geometry';
@@ -51,6 +52,8 @@ function generateTicks(numberOfTicks) {
       .range([lastTickBounds[0], lastTickBounds[1]]);
     const samples = scale.ticks(numberOfTicks);
     const ticks = samples.map((tick) => scale(tick));
+    // Replace minus "\u2212" with hyphen-minus "\u002D" so that parseFloat() works
+    formatDefaultLocale({ minus: '\u002D' });
     const format = scale.tickFormat(
       ticks[0],
       ticks[ticks.length - 1],


### PR DESCRIPTION

### Context
Scalarbar actor ticks for negative values were displayed as NaN.
d3 uses minus character instead of hyphen-minus. This is why parseFloat failed to convert the string to a number.

### Results
Negative values are now correctly displayed.

### Changes
Replace minus char with hyphen-minus char.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
