### PR TITLE
Fix clip closed surface

### DIFF
--- a/Sources/Common/DataModel/BoundingBox/index.js
+++ b/Sources/Common/DataModel/BoundingBox/index.js
@@ -45,14 +45,14 @@ export function reset(bounds) {
   return setBounds(bounds, INIT_BOUNDS);
 }
 
-export function addPoint(bounds, ...xyz) {
+export function addPoint(bounds, x, y, z) {
   const [xMin, xMax, yMin, yMax, zMin, zMax] = bounds;
-  bounds[0] = xMin < xyz[0] ? xMin : xyz[0];
-  bounds[1] = xMax > xyz[0] ? xMax : xyz[0];
-  bounds[2] = yMin < xyz[1] ? yMin : xyz[1];
-  bounds[3] = yMax > xyz[1] ? yMax : xyz[1];
-  bounds[4] = zMin < xyz[2] ? zMin : xyz[2];
-  bounds[5] = zMax > xyz[2] ? zMax : xyz[2];
+  bounds[0] = xMin < x ? xMin : x;
+  bounds[1] = xMax > x ? xMax : x;
+  bounds[2] = yMin < y ? yMin : y;
+  bounds[3] = yMax > y ? yMax : y;
+  bounds[4] = zMin < z ? zMin : z;
+  bounds[5] = zMax > z ? zMax : z;
   return bounds;
 }
 

--- a/Sources/Common/DataModel/IncrementalOctreeNode/index.d.ts
+++ b/Sources/Common/DataModel/IncrementalOctreeNode/index.d.ts
@@ -49,6 +49,21 @@ export interface vtkIncrementalOctreeNode extends vtkObject {
 	getBounds(bounds: Bounds): void;
 
 	/**
+	 * @param {Vector3} point
+	 */
+	getChildIndex(point: Vector3): number;
+	
+	/**
+	 * @param {Vector3} point
+	 */
+	containsPoint(point: Vector3): boolean;
+	
+	/**
+	 * @param {Vector3} point
+	 */
+	containsPointByData(point: Vector3): boolean;
+
+	/**
 	 * Given a point inserted to either this node (a leaf node) or a descendant
 	 * leaf (of this node --- when this node is a non-leaf node), update the
 	 * counter and the data bounding box for this node only. The data bounding box

--- a/Sources/Common/DataModel/Polygon/index.js
+++ b/Sources/Common/DataModel/Polygon/index.js
@@ -166,9 +166,9 @@ export function getBounds(poly, points, bounds) {
 
   for (let j = 1; j < n; j++) {
     points.getPoint(poly[j], p);
-    vtkBoundingBox.addPoint(bounds, p);
+    vtkBoundingBox.addPoint(bounds, ...p);
   }
-  const length = vtkBoundingBox.getLength(bounds);
+  const length = vtkBoundingBox.getLengths(bounds);
   return vtkMath.dot(length, length);
 }
 

--- a/Sources/Filters/General/ClipClosedSurface/index.js
+++ b/Sources/Filters/General/ClipClosedSurface/index.js
@@ -1080,9 +1080,9 @@ const DEFAULT_VALUES = {
   generateFaces: true,
   activePlaneId: -1,
 
-  baseColor: null,
-  clipColor: null,
-  activePlaneColor: null,
+  baseColor: [255 / 255, 99 / 255, 71 / 255], // Tomato
+  clipColor: [244 / 255, 164 / 255, 96 / 255], // Sandy brown
+  activePlaneColor: [227 / 255, 207 / 255, 87 / 255], // Banana
 
   triangulationErrorDisplay: false,
   // _idList: null,

--- a/Sources/Filters/General/ContourTriangulator/helper.js
+++ b/Sources/Filters/General/ContourTriangulator/helper.js
@@ -463,7 +463,7 @@ export function vtkCCSMakePolysFromLines(
           }
         }
 
-        if (!matches.length === 0) {
+        if (matches.length > 0) {
           // Multiple matches mean we need to decide which path to take
           if (matches.length > 1) {
             // Remove double-backs


### PR DESCRIPTION
Fix vtkClipClosedSurface filter.

### Context
The filter was taking a long time to compute.

### Results
This speeds-up the computation.

### Changes
This fix correctly merge polylines into a unique polygon but also compute polygon tolerance.

Closes #2570 

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
