### PR TITLE
Fix widgets with scaleInPixels by adding RenderWindowViewNode.getComputedDevicePixelRatio

### DIFF
--- a/Documentation/content/docs/concepts_widgets.md
+++ b/Documentation/content/docs/concepts_widgets.md
@@ -113,7 +113,7 @@ In order to scale a representation such that it retains the same size in
 display space, a widget representation should use the `scaleInPixels` property
 and the `getPixelWorldHeightAtCoord(coord)` method. When `scaleInPixels` is set
 to true, a widget representation should multiply whatever scaling they perform
-by the output of `getDisplayScaleAtCoord(coord)`.
+by the output of `getPixelWorldHeightAtCoord(coord)`.
 
 Look at the `SphereHandleRepresentation` as an example for how
 `getPixelWorldHeightAtCoord` is used.

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -327,7 +327,18 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	setViewStream(stream: vtkViewStream): boolean;
 
 	/**
-	 *
+	 * Sets the pixel width and height of the rendered image.  
+	 * 
+	 * WebGL and WebGPU render windows apply these values to 
+	 * the width and height attribute of the canvas element.
+	 * 
+	 * To match the device resolution in browser environments, 
+	 * multiply the container size by `window.devicePixelRatio`
+	 * `apiSpecificRenderWindow.setSize(Math.floor(containerWidth * devicePixelRatio), Math.floor(containerHeight * devicePixelRatio));
+	 * See the VTK.js FullscreenRenderWindow class for an example.
+	 * 
+	 * @see getComputedDevicePixelRatio()
+	 * 
 	 * @param {Vector2} size 
 	 */
 	setSize(size: Vector2): void;
@@ -363,14 +374,15 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	getVrResolution(): Vector2;
 
 	/**
-	 * Use to scale the size of a rendered canvas pixel to a browser CSS pixel.  
-	 * `const cssPixelWidth = renderedPixelWidth / apiRenderWindow.getComputedDevicePixelRatio()`
-	 * Rather than using window.devicePixelRatio directly, the device pixel ratio is inferred
-	 * from the container CSS pixel size and rendered image pixel size. The user can reduce the rendered size.
-	 * `apiSpecificRenderWindow.setSize(Math.floor(container.width * window.devicePixelRatio / 2), Math.floor(container.height * window.devicePixelRatio / 2))`
+	 * Scales the size of a browser CSS pixel to a rendered canvas pixel.  
+	 * `const renderedPixelWidth = cssPixelWidth * apiRenderWindow.getComputedDevicePixelRatio()`
+	 * Use to scale rendered objects to a consistent perceived size or DOM pixel position.
 	 * 
+	 * Rather than using window.devicePixelRatio directly, the device pixel ratio is inferred
+	 * from the container CSS pixel size and rendered image pixel size. The user directly sets the rendered pixel size.
+	 * 
+	 * @see setSize()
 	 * @see getContainerSize()
-	 * @see getSize()
 	 */
 	getComputedDevicePixelRatio(): number;
 }

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -361,6 +361,18 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 *
 	 */
 	getVrResolution(): Vector2;
+
+	/**
+	 * Use to scale the size of a rendered canvas pixel to a browser CSS pixel.  
+	 * `const cssPixelWidth = renderedPixelWidth / apiRenderWindow.getComputedDevicePixelRatio()`
+	 * Rather than using window.devicePixelRatio directly, the device pixel ratio is inferred
+	 * from the container CSS pixel size and rendered image pixel size. The user can reduce the rendered size.
+	 * `apiSpecificRenderWindow.setSize(Math.floor(container.width * window.devicePixelRatio / 2), Math.floor(container.height * window.devicePixelRatio / 2))`
+	 * 
+	 * @see getContainerSize()
+	 * @see getSize()
+	 */
+	getComputedDevicePixelRatio(): number;
 }
 
 /**

--- a/Sources/Rendering/SceneGraph/RenderWindowViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/RenderWindowViewNode/index.js
@@ -135,14 +135,19 @@ function vtkRenderWindowViewNode(publicAPI, model) {
     return publicAPI.displayToNormalizedDisplay(x2, y2, z);
   };
 
+  publicAPI.getComputedDevicePixelRatio = () =>
+    model.size[0] / publicAPI.getContainerSize()[0];
+
+  publicAPI.getContainerSize = () => {
+    macro.vtkErrorMacro('not implemented');
+  };
+
   publicAPI.getPixelData = (x1, y1, x2, y2) => {
     macro.vtkErrorMacro('not implemented');
-    return undefined;
   };
 
   publicAPI.createSelector = () => {
     macro.vtkErrorMacro('not implemented');
-    return undefined;
   };
 }
 

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -121,7 +121,7 @@ function vtkWidgetManager(publicAPI, model) {
     const [cwidth, cheight] = model._apiSpecificRenderWindow.getViewportSize(
       model._renderer
     );
-    const ratio = window.devicePixelRatio || 1;
+    const ratio = model._apiSpecificRenderWindow.getComputedDevicePixelRatio();
     const bwidth = String(cwidth / ratio);
     const bheight = String(cheight / ratio);
     const viewBox = `0 0 ${cwidth} ${cheight}`;
@@ -224,7 +224,11 @@ function vtkWidgetManager(publicAPI, model) {
     if (_renderer && _apiSpecificRenderWindow && _camera) {
       const [rwW, rwH] = _apiSpecificRenderWindow.getSize();
       const [vxmin, vymin, vxmax, vymax] = _renderer.getViewport();
-      const rendererPixelDims = [rwW * (vxmax - vxmin), rwH * (vymax - vymin)];
+      const pixelRatio = _apiSpecificRenderWindow.getComputedDevicePixelRatio();
+      const rendererPixelDims = [
+        (rwW * (vxmax - vxmin)) / pixelRatio,
+        (rwH * (vymax - vymin)) / pixelRatio,
+      ];
 
       const cameraPosition = _camera.getPosition();
       const cameraDir = _camera.getDirectionOfProjection();

--- a/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
+++ b/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
@@ -34,6 +34,10 @@ test.onlyIfWebGL('Test getPixelWorldHeightAtCoord', (t) => {
 
   const container = document.querySelector('body');
   const rwContainer = gc.registerDOMElement(document.createElement('div'));
+  // maintain consistent container size across browsers
+  rwContainer.style.width = '300px';
+  rwContainer.style.height = '300px';
+
   container.appendChild(rwContainer);
 
   const grw = vtkGenericRenderWindow.newInstance({ listenWindowResize: false });

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -48,8 +48,8 @@ const widget = vtkResliceCursorWidget.newInstance();
 const widgetState = widget.getWidgetState();
 widgetState.setKeepOrthogonality(true);
 widgetState.setOpacity(0.6);
-// Use devicePixelRatio in order to have the same display handle size on all devices
-widgetState.setSphereRadius(10 * window.devicePixelRatio);
+// Set size in CSS pixel space because scaleInPixels defaults to true
+widgetState.setSphereRadius(10);
 widgetState.setLineThickness(5);
 
 const showDebugActors = true;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Widget handles with `scaleInPixels` appear smaller when window.devicePixelRatio is more than 1.  Expected them to be the same CSS pixel size.

Smaller when screen "scale" setting is 200%:
![image](https://user-images.githubusercontent.com/16823231/195955796-c00eed6f-db91-49c6-96cd-a16684419e5f.png)


### Results
100% scale
![image](https://user-images.githubusercontent.com/16823231/195955993-0acf22cb-df47-4285-a816-3473ed7ef8be.png)

200% scale
![image](https://user-images.githubusercontent.com/16823231/195955906-09952795-906d-4b90-8fab-4e6701e67431.png)

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
Adds vtkRenderWindowViewNode.getComputedDevicePixelRatio using DOM container CSS pixel size and user set rendering pixel size.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
`npm run example -- ImageCroppingWidget` and change display settings or browser zoom.

- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: 25.9.1
  - **OS**: Linux
  - **Browser**: Chrome 105

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
