### PR TITLE
feat: added nonlinear param to buildFunctionFromTable

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
@@ -1,3 +1,4 @@
+import vtkDataArray from '../../../Common/Core/DataArray';
 import { vtkObject } from '../../../interfaces';
 import { ColorSpace, Scale } from "./Constants";
 
@@ -200,6 +201,25 @@ export interface vtkColorTransferFunction extends vtkObject {
     size: number,
     withAlpha: boolean
   ): Float32Array;
+
+  /**
+   * Construct a color transfer function from a vtkDataArray.
+   * The order of values depends on the number of components
+   * of the array.
+   * 3 -> RGB
+   * 4 -> XRGB
+   * 5 -> RGBMS
+   * 6 -> XRGBMS
+   * 
+   * X represents the input value to a function
+   * RGB represents the red, green, and blue value output
+   * M represents the midpoint
+   * S represents sharpness
+   * @param {vtkDataArray} array
+   */
+   buildFunctionFromArray(
+    array: vtkDataArray,
+  ): void;
 
   /**
    * Construct a color transfer function from a table.

--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -871,6 +871,63 @@ function vtkColorTransferFunction(publicAPI, model) {
     return model.table;
   };
 
+  publicAPI.buildFunctionFromArray = (array) => {
+    publicAPI.removeAllPoints();
+    const numComponents = array.getNumberOfComponents();
+    for (let i = 0; i < array.getNumberOfTuples(); i++) {
+      switch (numComponents) {
+        case 3: {
+          model.nodes.push({
+            x: i,
+            r: array.getComponent(i, 0),
+            g: array.getComponent(i, 1),
+            b: array.getComponent(i, 2),
+            midpoint: 0.5,
+            sharpness: 0.0,
+          });
+          break;
+        }
+        case 4: {
+          model.nodes.push({
+            x: array.getComponent(i, 0),
+            r: array.getComponent(i, 1),
+            g: array.getComponent(i, 2),
+            b: array.getComponent(i, 3),
+            midpoint: 0.5,
+            sharpness: 0.0,
+          });
+          break;
+        }
+        case 5: {
+          model.nodes.push({
+            x: i,
+            r: array.getComponent(i, 0),
+            g: array.getComponent(i, 1),
+            b: array.getComponent(i, 2),
+            midpoint: array.getComponent(i, 4),
+            sharpness: array.getComponent(i, 5),
+          });
+          break;
+        }
+        case 6: {
+          model.nodes.push({
+            x: array.getComponent(i, 0),
+            r: array.getComponent(i, 1),
+            g: array.getComponent(i, 2),
+            b: array.getComponent(i, 3),
+            midpoint: array.getComponent(i, 4),
+            sharpness: array.getComponent(i, 5),
+          });
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    }
+    publicAPI.sortAndUpdateRange();
+  };
+
   //----------------------------------------------------------------------------
   publicAPI.buildFunctionFromTable = (xStart, xEnd, size, table) => {
     let inc = 0.0;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
In order to support sigmoid LUT based on dicom standard, non-linear LUT's need to be created on the fly any time a user changes the WW/WL. The current buildFunctionFromTable only support linearly spaced x input which is inefficient sampling for sigmoid functions. This change simply allows users to build functions from the long format as used in RGBLong.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
This change simply allows users to build functions from the long format as used in RGBLong.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
Because this is a surgical change, no new tests have been added.