### PR TITLE
fix(ColorTransferFunction): applyColorMap calls modified in more cases

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -1162,16 +1162,18 @@ function vtkColorTransferFunction(publicAPI, model) {
         model.colorSpace = ColorSpace.RGB;
       }
     }
+    let isModified = oldColorSpace !== JSON.stringify(model.colorSpace);
 
-    const oldNanColor = JSON.stringify(model.nanColor);
+    const oldNanColor = isModified || JSON.stringify(model.nanColor);
     if (colorMap.NanColor) {
       model.nanColor = [].concat(colorMap.NanColor);
       while (model.nanColor.length < 4) {
         model.nanColor.push(1.0);
       }
     }
+    isModified = isModified || oldNanColor !== JSON.stringify(model.nanColor);
 
-    const oldNodes = JSON.stringify(model.nodes);
+    const oldNodes = isModified || JSON.stringify(model.nodes);
     if (colorMap.RGBPoints) {
       const size = colorMap.RGBPoints.length;
       model.nodes = [];
@@ -1191,16 +1193,12 @@ function vtkColorTransferFunction(publicAPI, model) {
 
     const modifiedInvoked = publicAPI.sortAndUpdateRange();
 
-    if (!modifiedInvoked) {
-      const isModfied = [
-        [oldColorSpace, model.colorSpace],
-        [oldNanColor, model.nanColor],
-        [oldNodes, model.nodes],
-      ].some(([old, current]) => old !== JSON.stringify(current));
-      if (isModfied) publicAPI.modified();
-      return isModfied;
-    }
-    return modifiedInvoked;
+    const callModified =
+      !modifiedInvoked &&
+      (isModified || oldNodes !== JSON.stringify(model.nodes));
+    if (callModified) publicAPI.modified();
+
+    return modifiedInvoked || callModified;
   };
 }
 

--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -1152,6 +1152,7 @@ function vtkColorTransferFunction(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.applyColorMap = (colorMap) => {
+    const oldColorSpace = JSON.stringify(model.colorSpace);
     if (colorMap.ColorSpace) {
       model.colorSpace = ColorSpace[colorMap.ColorSpace.toUpperCase()];
       if (model.colorSpace === undefined) {
@@ -1161,12 +1162,16 @@ function vtkColorTransferFunction(publicAPI, model) {
         model.colorSpace = ColorSpace.RGB;
       }
     }
+
+    const oldNanColor = JSON.stringify(model.nanColor);
     if (colorMap.NanColor) {
       model.nanColor = [].concat(colorMap.NanColor);
       while (model.nanColor.length < 4) {
         model.nanColor.push(1.0);
       }
     }
+
+    const oldNodes = JSON.stringify(model.nodes);
     if (colorMap.RGBPoints) {
       const size = colorMap.RGBPoints.length;
       model.nodes = [];
@@ -1183,13 +1188,19 @@ function vtkColorTransferFunction(publicAPI, model) {
         });
       }
     }
-    // FIXME: not supported ?
-    // if (colorMap.IndexedColors) {
-    // }
-    // if (colorMap.Annotations) {
-    // }
 
-    publicAPI.sortAndUpdateRange();
+    const modifiedInvoked = publicAPI.sortAndUpdateRange();
+
+    if (!modifiedInvoked) {
+      const isModfied = [
+        [oldColorSpace, model.colorSpace],
+        [oldNanColor, model.nanColor],
+        [oldNodes, model.nodes],
+      ].some(([old, current]) => old !== JSON.stringify(current));
+      if (isModfied) publicAPI.modified();
+      return isModfied;
+    }
+    return modifiedInvoked;
   };
 }
 

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
@@ -9,14 +9,11 @@ import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
-import Constants from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/Constants';
 
 import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
 
 import baseline from './testColorTransferFunction.png';
 import baseline2 from './testColorTransferFunction2.png';
-
-const { ColorSpace } = Constants;
 
 test('Test Color Transfer Function', (t) => {
   const gc = testUtils.createGarbageCollector(t);
@@ -163,37 +160,59 @@ test('Test discretized color transfer function', (t) => {
   t.end();
 });
 
-test('Test applyColorMap calls modfied', (t) => {
+test('Test applyColorMap calls modified', (t) => {
   const ctf = vtkColorTransferFunction.newInstance();
 
   const colorMapA = {
-    ColorSpace: ColorSpace.RGB,
+    ColorSpace: 'RGB',
     RGBPoints: [0, 0, 0, 0, 1, 0, 0, 0],
   };
   const colorMapB = {
-    ColorSpace: ColorSpace.RGB,
+    ColorSpace: 'RGB',
     RGBPoints: [0, 0, 0, 0, 1, 1, 1, 1],
   };
 
   ctf.applyColorMap(colorMapA);
 
-  let isModfied = false;
+  let isModified = false;
   ctf.onModified(() => {
-    isModfied = true;
+    isModified = true;
   });
 
   ctf.applyColorMap(colorMapA);
-
   t.notOk(
-    isModfied,
+    isModified,
     `Expect applyColorMap does not call modified with same color map`
   );
 
   ctf.applyColorMap(colorMapB);
-
   t.ok(
-    isModfied,
+    isModified,
     `Expect applyColorMap calls modified with different color map`
+  );
+
+  colorMapB.ColorSpace = 'LAB';
+  isModified = false;
+  let modifiedReturn = ctf.applyColorMap(colorMapB);
+  t.ok(
+    isModified && modifiedReturn,
+    `Expect applyColorMap calls modified with different ColorSpace`
+  );
+
+  colorMapB.NanColor = [0, 0, 0, 1];
+  isModified = false;
+  modifiedReturn = ctf.applyColorMap(colorMapB);
+  t.ok(
+    isModified && modifiedReturn,
+    `Expect applyColorMap calls modified with different NanColor`
+  );
+
+  colorMapB.RGBPoints = [0, 0, 0, 0, 0.5, 1, 1, 1, 1, 1, 1, 1];
+  isModified = false;
+  modifiedReturn = ctf.applyColorMap(colorMapB);
+  t.ok(
+    isModified && modifiedReturn,
+    `Expect applyColorMap calls modified with different RGBPoints`
   );
 
   t.end();

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
@@ -9,11 +9,14 @@ import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+import Constants from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction/Constants';
 
 import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
 
 import baseline from './testColorTransferFunction.png';
 import baseline2 from './testColorTransferFunction2.png';
+
+const { ColorSpace } = Constants;
 
 test('Test Color Transfer Function', (t) => {
   const gc = testUtils.createGarbageCollector(t);
@@ -156,6 +159,42 @@ test('Test discretized color transfer function', (t) => {
       `Test discretized ctf value for ${value}, expect ${expectedRGB[idx]}`
     );
   });
+
+  t.end();
+});
+
+test('Test applyColorMap calls modfied', (t) => {
+  const ctf = vtkColorTransferFunction.newInstance();
+
+  const colorMapA = {
+    ColorSpace: ColorSpace.RGB,
+    RGBPoints: [0, 0, 0, 0, 1, 0, 0, 0],
+  };
+  const colorMapB = {
+    ColorSpace: ColorSpace.RGB,
+    RGBPoints: [0, 0, 0, 0, 1, 1, 1, 1],
+  };
+
+  ctf.applyColorMap(colorMapA);
+
+  let isModfied = false;
+  ctf.onModified(() => {
+    isModfied = true;
+  });
+
+  ctf.applyColorMap(colorMapA);
+
+  t.notOk(
+    isModfied,
+    `Expect applyColorMap does not call modified with same color map`
+  );
+
+  ctf.applyColorMap(colorMapB);
+
+  t.ok(
+    isModfied,
+    `Expect applyColorMap calls modified with different color map`
+  );
 
   t.end();
 });


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Similar shaped color maps passed to `ColorTransferFunction.applyColorMap()` did not always trigger publicAPI.modified()


### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
More exhaustive change checking in `applyColorMap`

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: 25.9.2
  - **OS**: LInux
  - **Browser**: Chrome 105

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
