### PR TITLE
Image reslice oriented image support

### DIFF
--- a/Sources/Common/Core/Math/Constants.js
+++ b/Sources/Common/Core/Math/Constants.js
@@ -1,0 +1,12 @@
+export const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+export const IDENTITY_3X3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+export const EPSILON = 1e-6;
+export const VTK_SMALL_NUMBER = 1.0e-12;
+
+export default {
+  IDENTITY,
+  IDENTITY_3X3,
+  EPSILON,
+  VTK_SMALL_NUMBER,
+};

--- a/Sources/Common/Core/Math/index.d.ts
+++ b/Sources/Common/Core/Math/index.d.ts
@@ -490,10 +490,39 @@ export function transpose3x3(in_3x3: Matrix3x3, outT_3x3: Matrix3x3): void;
 export function invert3x3(in_3x3: Matrix3x3, outI_3x3: Matrix3x3): void;
 
 /**
+ * Set mat to the identity matrix.
+ * @param {Number} n The size of the matrix.
+ * @param {Number[]} mat The output matrix.
+ * @see isIdentity()
+ * @see identity3x3()
+ */
+export function identity(n: number, mat: number[]): void;
+
+/**
  * Set mat_3x3 to the identity matrix.
  * @param {Matrix3x3} mat_3x3 The input 3x3 matrix.
+ * @see isIdentity3x3()
+ * @see identity()
  */
 export function identity3x3(mat_3x3: Matrix3x3): void;
+
+/**
+ * Returns true if provided matrix is the identity matrix.
+ * @param {Number[]} mat The 3x3 matrix to check
+ * @param {Number} [eps] The tolerance value.
+ * @see isIdentity()
+ * @see identity()
+ */
+export function isIdentity(mat: Matrix3x3, eps?: number): boolean;
+
+/**
+ * Returns true if provided 3x3 matrix is the identity matrix.
+ * @param {Matrix3x3} mat The 3x3 matrix to check
+ * @param {Number} [eps] The tolerance value.
+ * @see isIdentity()
+ * @see identity3x3()
+ */
+export function isIdentity3x3(mat: Matrix3x3, eps?: number): boolean;
 
 /**
  * Calculate the determinant of a 3x3 matrix.
@@ -606,13 +635,14 @@ export function solveLinearSystem(A: Matrix, x: number[], size: number): number;
 
 /**
  *
- * @param {Matrix} A 
- * @param {Matrix} AI 
- * @param {Number} [size] 
+ * @param {Matrix} A The input matrix. It is modified during the inversion.
+ * @param {Matrix} AI The output inverse matrix. Can be the same as input matrix.
+ * @param {Number} [size] The square size of the matrix to invert : 4 for a 4x4
  * @param {Number[]} [index] 
  * @param {Number[]} [column] 
+ * @return AI on success, null otherwise
  */
-export function invertMatrix(A: Matrix, AI: Matrix, size?: number, index?: number[], column?: number[]): number;
+export function invertMatrix(A: Matrix, AI: Matrix, size?: number, index?: number[], column?: number[]): Matrix|null;
 
 /**
  *

--- a/Sources/Common/Core/MatrixBuilder/index.d.ts
+++ b/Sources/Common/Core/MatrixBuilder/index.d.ts
@@ -1,4 +1,4 @@
-import { mat4 } from 'gl-matrix';
+import { mat3, mat4 } from 'gl-matrix';
 import { TypedArray, Vector3 } from '../../../types';
 
 declare interface Transform {
@@ -67,9 +67,20 @@ declare interface Transform {
 	multiply(mat4x4: mat4): Transform
 
 	/**
+	 * Multiply the current matrix with the provided 3x3 matrix.
+	 * @param {mat3} mat3x3 column-first matrix
+	 */
+	 multiply3x3(mat3x3: mat3): Transform
+	
+	/**
 	 * Resets the MatrixBuilder to the Identity matrix.
-	 */	
+	 */
 	identity(): Transform
+
+	/**
+	 * Inverts the MatrixBuilder matrix.
+	 */
+	invert(): Transform
 
 	/**
 	 * Multiplies the array by the MatrixBuilder's internal matrix, in sets of

--- a/Sources/Common/Core/MatrixBuilder/index.js
+++ b/Sources/Common/Core/MatrixBuilder/index.js
@@ -2,10 +2,9 @@ import { vec3, mat4, glMatrix } from 'gl-matrix';
 
 // eslint-disable-next-line import/no-cycle
 import { areMatricesEqual } from 'vtk.js/Sources/Common/Core/Math';
+import { IDENTITY } from 'vtk.js/Sources/Common/Core/Math/Constants';
 
 const NoOp = (v) => v;
-
-const IDENTITY = mat4.identity(new Float64Array(16));
 
 const EPSILON = 1e-6;
 
@@ -81,6 +80,33 @@ class Transform {
 
   multiply(mat4x4) {
     mat4.multiply(this.matrix, this.matrix, mat4x4);
+    return this;
+  }
+
+  multiply3x3(mat3x3) {
+    mat4.multiply(this.matrix, this.matrix, [
+      mat3x3[0],
+      mat3x3[1],
+      mat3x3[2],
+      0,
+      mat3x3[3],
+      mat3x3[4],
+      mat3x3[5],
+      0,
+      mat3x3[6],
+      mat3x3[7],
+      mat3x3[8],
+      0,
+      0,
+      0,
+      0,
+      1,
+    ]);
+    return this;
+  }
+
+  invert() {
+    mat4.invert(this.matrix, this.matrix);
     return this;
   }
 

--- a/Sources/Common/DataModel/ImageData/index.js
+++ b/Sources/Common/DataModel/ImageData/index.js
@@ -232,52 +232,6 @@ function vtkImageData(publicAPI, model) {
     mat4.invert(model.worldToIndex, model.indexToWorld);
   };
 
-  //
-  // The direction matrix is a 3x3 basis for the I, J, K axes
-  // of the image. The rows of the matrix correspond to the
-  // axes directions in world coordinates. Direction must
-  // form an orthonormal basis, results are undefined if
-  // it is not.
-  //
-  publicAPI.setDirection = (...args) => {
-    if (model.deleted) {
-      vtkErrorMacro('instance deleted - cannot call any method');
-      return false;
-    }
-
-    let array = args;
-    // allow an array passed as a single arg.
-    if (
-      array.length === 1 &&
-      (Array.isArray(array[0]) ||
-        array[0].constructor === Float32Array ||
-        array[0].constructor === Float64Array)
-    ) {
-      array = array[0];
-    }
-
-    if (array.length !== 9) {
-      throw new RangeError('Invalid number of values for array setter');
-    }
-    let changeDetected = false;
-    model.direction.forEach((item, index) => {
-      if (item !== array[index]) {
-        if (changeDetected) {
-          return;
-        }
-        changeDetected = true;
-      }
-    });
-
-    if (changeDetected) {
-      for (let i = 0; i < 9; ++i) {
-        model.direction[i] = array[i];
-      }
-      publicAPI.modified();
-    }
-    return true;
-  };
-
   publicAPI.indexToWorld = (ain, aout = []) => {
     vec3.transformMat4(aout, ain, model.indexToWorld);
     return aout;
@@ -512,8 +466,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.worldToIndex = new Float64Array(16);
 
   // Set/Get methods
-  macro.get(publicAPI, model, ['direction', 'indexToWorld', 'worldToIndex']);
+  macro.get(publicAPI, model, ['indexToWorld', 'worldToIndex']);
   macro.setGetArray(publicAPI, model, ['origin', 'spacing'], 3);
+  macro.setGetArray(publicAPI, model, ['direction'], 9);
   macro.getArray(publicAPI, model, ['extent'], 6);
 
   // Object specific methods

--- a/Sources/Common/Transform/Transform/index.js
+++ b/Sources/Common/Transform/Transform/index.js
@@ -1,0 +1,56 @@
+import { vec3 } from 'gl-matrix';
+import macro from 'vtk.js/Sources/macros';
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import { IDENTITY } from 'vtk.js/Sources/Common/Core/Math/Constants';
+
+// ----------------------------------------------------------------------------
+// vtkTransform methods
+// ----------------------------------------------------------------------------
+// eslint-disable-next-line import/no-mutable-exports
+let newInstance;
+
+function vtkTransform(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push(
+    'vtkAbstractTransform',
+    'vtkHomogeneousTransform',
+    'vtkTransform'
+  );
+
+  publicAPI.transformPoint = (point, out) => {
+    vec3.transformMat4(out, point, model.matrix);
+    return out;
+  };
+
+  publicAPI.getInverse = () =>
+    newInstance({
+      matrix: vtkMath.invertMatrix(Array.from(model.matrix), [], 4),
+    });
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  matrix: [...IDENTITY],
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+  macro.obj(publicAPI, model);
+
+  macro.setGetArray(publicAPI, model, ['matrix'], 16);
+
+  vtkTransform(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+newInstance = macro.newInstance(extend, 'vtkTransform');
+export { newInstance };
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Common/Transform/index.js
+++ b/Sources/Common/Transform/index.js
@@ -1,5 +1,7 @@
 import vtkLandmarkTransform from './LandmarkTransform';
+import vtkTransform from './Transform';
 
 export default {
   vtkLandmarkTransform,
+  vtkTransform,
 };

--- a/Sources/Imaging/Core/ImageReslice/test/testImageReslice.py
+++ b/Sources/Imaging/Core/ImageReslice/test/testImageReslice.py
@@ -1,0 +1,75 @@
+import vtk;
+dims = [10, 10, 10];
+s = 0.1;
+imageData = vtk.vtkImageData()
+imageData.SetDimensions(dims[0], dims[1], dims[2]);
+imageData.SetSpacing(s, s, s);
+imageData.AllocateScalars(vtk.VTK_UNSIGNED_CHAR, 1);
+for z in range(dims[2]):
+    for y in range(dims[1]):
+        for x in range(dims[0]):
+            imageData.SetScalarComponentFromDouble(x, y, z, 0, 256 * ((z * dims[0] * dims[1] + y * dims[0] + x) % (dims[0] * dims[1])) / (dims[0] * dims[1]));
+
+axes = vtk.vtkTransform();
+# axes.RotateZ(45);
+reslice = vtk.vtkImageReslice();
+reslice.SetOutputDimensionality(2);
+reslice.SetInputData(imageData);
+reslice.SetResliceAxes(axes.GetMatrix());
+reslice.SetInterpolationModeToNearestNeighbor();
+reslice.BorderOn();
+reslice.SetOutputScalarType(vtk.VTK_UNSIGNED_SHORT);
+reslice.SetScalarScale(65535 / 255);
+reslice.SetAutoCropOutput(1);
+# reslice.SetOutputOrigin(dims[0] * s/2, dims[1] * s/2, dims[2] *s/2);
+
+mapper = vtk.vtkImageSliceMapper();
+# mapper.SetInputData(imageData);
+mapper.SetInputConnection(reslice.GetOutputPort());
+actor = vtk.vtkImageActor();
+actor.SetMapper(mapper);
+actor.GetProperty().SetInterpolationTypeToNearest();
+
+
+ip = actor.GetProperty();
+ip.SetColorLevel(65535/2);
+ip.SetColorWindow(65535);
+
+renderer = vtk.vtkRenderer();
+renderer.AddActor(actor);
+renderer.SetBackground(0.32, 0.34, 0.43);
+
+vm = vtk.vtkSmartVolumeMapper();
+vm.SetBlendModeToComposite();
+vm.SetInputData(imageData);
+#vm.SetInputConnection(reslice.GetOutputPort());
+
+volumeProperty = vtk.vtkVolumeProperty();
+volumeProperty.ShadeOff();
+
+compositeOpacity = vtk.vtkPiecewiseFunction();
+compositeOpacity.AddPoint(255.0,0.0);
+compositeOpacity.AddPoint(255.0,1.0);
+volumeProperty.SetScalarOpacity(compositeOpacity);
+
+color = vtk.vtkColorTransferFunction();
+color.AddRGBPoint(0.0,  0.0,0.0,0.0);
+color.AddRGBPoint(255.0,1.0,1.0,1.0);
+volumeProperty.SetColor(color);
+
+volume = vtk.vtkVolume();
+volume.SetMapper(vm);
+volume.SetProperty(volumeProperty);
+actor.SetUserTransform(axes);
+
+# volume.SetUserTransform(axes);
+# renderer.AddViewProp(volume);
+
+renderWindow = vtk.vtkRenderWindow();
+renderWindow.SetSize(400,400);
+renderWindow.AddRenderer(renderer);
+
+renderWindowInteractor = vtk.vtkRenderWindowInteractor();
+renderWindowInteractor.SetRenderWindow(renderWindow);
+renderWindowInteractor.Initialize();
+renderWindowInteractor.Start();

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -728,7 +728,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     mat3.multiply(
       model.idxNormalMatrix,
       model.idxNormalMatrix,
-      model.currentInput.getDirection()
+      model.currentInput.getDirectionByReference()
     );
 
     const maxSamples =

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testLabelmapOutlineManyRenderer.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testLabelmapOutlineManyRenderer.js
@@ -74,10 +74,10 @@ function createLabelPipeline(backgroundImageData, gc) {
   );
   labelMapData.getPointData().setScalars(dataArray);
 
-  labelMapData.setDimensions(...backgroundImageData.getDimensions());
-  labelMapData.setSpacing(...backgroundImageData.getSpacing());
-  labelMapData.setOrigin(...backgroundImageData.getOrigin());
-  labelMapData.setDirection(...backgroundImageData.getDirection());
+  labelMapData.setDimensions(backgroundImageData.getDimensionsByReference());
+  labelMapData.setSpacing(backgroundImageData.getSpacingByReference());
+  labelMapData.setOrigin(backgroundImageData.getOriginByReference());
+  labelMapData.setDirection(backgroundImageData.getDirectionByReference());
 
   labelMapData.computeTransforms();
 

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -576,7 +576,7 @@ export function setGet(publicAPI, model, fieldNames) {
 export function getArray(publicAPI, model, fieldNames) {
   fieldNames.forEach((field) => {
     publicAPI[`get${_capitalize(field)}`] = () =>
-      model[field] ? [].concat(model[field]) : model[field];
+      model[field] ? Array.from(model[field]) : model[field];
     publicAPI[`get${_capitalize(field)}ByReference`] = () => model[field];
   });
 }
@@ -632,9 +632,10 @@ export function setArray(
           }
         }
         changeDetected =
-          model[field] == null ||
-          model[field].some((item, index) => item !== array[index]) ||
-          model[field].length !== array.length;
+          model[field] == null || model[field].length !== array.length;
+        for (let i = 0; !changeDetected && i < array.length; ++i) {
+          changeDetected = model[field][i] !== array[i];
+        }
         if (changeDetected && needCopy) {
           array = Array.from(array);
         }

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "doc:publish": "kw-doc -c ./Documentation/config.js -mp",
     "doc:generate-api": "node ./Documentation/generate-api-docs.js",
     "example": "node ./Utilities/ExampleRunner/example-runner-cli.js -c ./Documentation/config.js",
+    "example:webgpu": "cross-env WEBGPU=1 NO_WEBGL=1 node ./Utilities/ExampleRunner/example-runner-cli.js -c ./Documentation/config.js",
     "dev:esm": "npm run build:esm -- -w",
     "dev:umd": "webpack --watch --config webpack.dev.js --progress",
     "build": "npm run build:release",


### PR DESCRIPTION

### Context
DICOM files may produce oriented image data (vtkImageData.getDirection() returns a non identity 3x3 matrix). 
Oriented images are currently not supported in vtkImageReslice.

### Results
This PR adds support of oriented image data in vtkImageReslice.
It is therefore available in the ResliceCursor widget.
vtkImageReslice.resliceTransform is also supported for homogeneous transforms.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
