### PR TITLE
fix: vtkScalarsToColors.getRange() should ignore min max values

### DIFF
--- a/Sources/Common/Core/ScalarsToColors/index.d.ts
+++ b/Sources/Common/Core/ScalarsToColors/index.d.ts
@@ -105,10 +105,8 @@ export interface vtkScalarsToColors extends vtkObject {
 
 	/**
 	 * 
-	 * @param {Number} min 
-	 * @param {Number} max 
 	 */
-	getRange(min: number, max: number): Range;
+	getRange(): Range;
 
 	/**
 	 * Get which component of a vector to map to colors.

--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -510,7 +510,7 @@ function vtkScalarsToColors(publicAPI, model) {
   publicAPI.getNumberOfAvailableColors = () => 256 * 256 * 256;
 
   publicAPI.setRange = (min, max) => publicAPI.setMappingRange(min, max);
-  publicAPI.getRange = (min, max) => publicAPI.getMappingRange();
+  publicAPI.getRange = () => publicAPI.getMappingRange();
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
vtkScalarsToColors.getRange() should ignore min max values
#2603 related

<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
