### PR TITLE
fix(ViewNode): delete scene graph nodes

### DIFF
--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -162,6 +162,7 @@ function vtkViewNode(publicAPI, model) {
           deleted = [];
         }
         deleted.push(child);
+        child.delete();
       } else {
         child.setVisited(false);
       }
@@ -183,6 +184,14 @@ function vtkViewNode(publicAPI, model) {
       ret.setRenderable(dataObj);
     }
     return ret;
+  };
+
+  const parentDelete = publicAPI.delete;
+  publicAPI.delete = () => {
+    for (let i = 0; i < model.children.length; i++) {
+      model.children[i].delete();
+    }
+    parentDelete();
   };
 }
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Scene graph node destructors are not invoked when pruned. As a result, certain references may be retained (e.g. in [vtkOpenGLVolumeMapper](https://github.com/Kitware/vtk-js/blob/master/Sources/Rendering/OpenGL/VolumeMapper/index.js#L1115)), resulting in a memory leak.

### Results
- Scene graph nodes have their `.delete()` method called appropriately.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] vtkViewNode overrides `delete()` to call delete on children

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- No tests are changed. Test results are checked by CI.
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
