### PR TITLE
refactor(vtkreslicecursorwidget): simplify vtkImageReslice resliceAxe…

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -15,7 +15,7 @@ import {
 } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
-import { vec4, mat4 } from 'gl-matrix';
+import { mat4 } from 'gl-matrix';
 import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 
 const VTK_INT_MAX = 2147483647;
@@ -430,10 +430,13 @@ function vtkResliceCursorWidget(publicAPI, model) {
 
     const newResliceAxes = mat4.identity(new Float64Array(16));
 
+    const planeOrigin = planeSource.getOrigin();
+
     for (let i = 0; i < 3; i++) {
-      newResliceAxes[4 * i + 0] = planeAxis1[i];
-      newResliceAxes[4 * i + 1] = planeAxis2[i];
-      newResliceAxes[4 * i + 2] = normal[i];
+      newResliceAxes[i] = planeAxis1[i];
+      newResliceAxes[4 + i] = planeAxis2[i];
+      newResliceAxes[8 + i] = normal[i];
+      newResliceAxes[12 + i] = planeOrigin[i];
     }
 
     const spacingX =
@@ -445,18 +448,6 @@ function vtkResliceCursorWidget(publicAPI, model) {
       Math.abs(planeAxis2[0] * spacing[0]) +
       Math.abs(planeAxis2[1] * spacing[1]) +
       Math.abs(planeAxis2[2] * spacing[2]);
-
-    const planeOrigin = [...planeSource.getOrigin(), 1.0];
-    const originXYZW = [];
-    const newOriginXYZW = [];
-
-    vec4.transformMat4(originXYZW, planeOrigin, newResliceAxes);
-    mat4.transpose(newResliceAxes, newResliceAxes);
-    vec4.transformMat4(newOriginXYZW, originXYZW, newResliceAxes);
-
-    newResliceAxes[4 * 3 + 0] = newOriginXYZW[0];
-    newResliceAxes[4 * 3 + 1] = newOriginXYZW[1];
-    newResliceAxes[4 * 3 + 2] = newOriginXYZW[2];
 
     // Compute a new set of resliced extents
     let extentX = 0;


### PR DESCRIPTION
…s matrix configuration

For an orthonormal matrix, the transpose is mathematically identical to the inverse.

### Context
See
https://discourse.vtk.org/t/need-help-to-understand-how-to-set-resliceaxes-for-imagereslice/9697/4
https://gitlab.kitware.com/vtk/vtk/-/blob/master/Interaction/Widgets/vtkResliceCursorRepresentation.cxx#L534

### Results
The code related to configuring vtkImageReslice is simplified and faster.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome

