### PR TITLE
docs(EdgeLocator): fix parse and update types

### DIFF
--- a/Sources/Common/DataModel/EdgeLocator/index.d.ts
+++ b/Sources/Common/DataModel/EdgeLocator/index.d.ts
@@ -1,8 +1,16 @@
+import { Nullable } from "../../../types";
+
 /**
  *
  */
 export interface IEdgeLocatorInitialValues {
 	oriented?: boolean;
+}
+
+export interface IEdge<T = unknown> {
+	key: number;
+	edgeId: number;
+	value?: T;
 }
 
 export interface vtkEdgeLocator {
@@ -15,9 +23,9 @@ export interface vtkEdgeLocator {
 	 * Returns the inserted edge or null if no edge was inserted.
 	 * @param {Number} pointId0 Edge first point id
 	 * @param {Number} pointId1 Edge last point id
-	 * @return {key, edgeId, value} or null
+	 * @return {IEdge|null} an edge object ({ key, edgeId, value }) or null
 	 */
-	isInsertedEdge(pointId0: number, pointId1: number): { key: any; edgeId: number; value?: any } | null;
+	isInsertedEdge<T = unknown>(pointId0: number, pointId1: number): Nullable<IEdge<T>>;
 
 	/**
 	 * Insert edge if it does not already exist.
@@ -25,16 +33,12 @@ export interface vtkEdgeLocator {
 	 *
 	 * @param {Number} pointId0 Edge first point id
 	 * @param {Number} pointId1 Edge last point id
-	 * @param {any} value Optional value option
-	 * @return {key, edgeId, value}
+	 * @param {unknown} value Optional value option
+	 * @return {IEdge|null} an edge object ({ key, edgeId, value }) or null
 	 * @see insertEdge()
 	 * @see isInsertedEdge()
 	 */
-	insertUniqueEdge(
-		pointId0: number,
-		pointId1: number,
-		value?: any
-	): { key: any; edgeId: number; value?: any };
+	insertUniqueEdge<T>(pointId0: number, pointId1: number, value?: T): IEdge<T>;
 
 	/**
 	 * Insert edge. If the edge already exists, it is overwritten by this
@@ -43,15 +47,12 @@ export interface vtkEdgeLocator {
 	 * Returns the newly inserted edge.
 	 * @param {Number} pointId0 Edge first point id
 	 * @param {Number} pointId1 Edge last point id
-	 * @param {any} value Optional value option
-	 * @return {key, edgeId, value} or null
+	 * @param {unknown} value Optional value option
+	 * @return {Edge|null} an edge object ({ key, edgeId, value }) or null
 	 * @see isInsertedEdge
 	 * @see insertUniqueEdge
 	 */
-	insertEdge(pointId0: number,
-		pointId1: number,
-		value?: any
-	): { key: any; edgeId: number; value?: any };
+	insertEdge<T>(pointId0: number, pointId1: number, value?: T): IEdge<T>;
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/EdgeLocator/index.js
+++ b/Sources/Common/DataModel/EdgeLocator/index.js
@@ -30,7 +30,6 @@ class EdgeLocator {
   insertEdge(pointId0, pointId1, newEdgeValue) {
     // Generate a unique key
     const key = this.computeEdgeKey(pointId0, pointId1);
-    // Didn't find key, so add a new edge entry
     const node = { key, edgeId: this.edgeMap.size, value: newEdgeValue };
     this.edgeMap.set(key, node);
     return node;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The docs generation is failing due to an invalid jsdoctype entry in the EdgeLocator type definitions.

FYI @finetjul @daker  I've made some updates to the types to be more specific than just `any`.

### Results
The docs should generate cleanly.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Updated TypeScript definitions to be more specific than `any`.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
No tests are modified by this change.

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
