### PR TITLE
perf(WidgetManager): reduce capture/render calls

### DIFF
--- a/Sources/Widgets/Core/AbstractWidget/index.js
+++ b/Sources/Widgets/Core/AbstractWidget/index.js
@@ -112,7 +112,11 @@ export function extend(publicAPI, model, initialValues = {}) {
     'handleVisibility',
     '_widgetManager',
   ]);
-  macro.get(publicAPI, model, ['representations', 'widgetState']);
+  macro.get(publicAPI, model, [
+    'representations',
+    'widgetState',
+    'activeState',
+  ]);
   macro.moveToProtected(publicAPI, model, ['widgetManager']);
   macro.event(publicAPI, model, 'ActivateHandle');
 

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -299,9 +299,10 @@ function vtkWidgetManager(publicAPI, model) {
           w.deactivateAllHandles();
         }
       }
-      if (wantRender) {
-        model._interactor.render();
-      }
+    }
+
+    if (wantRender) {
+      model._interactor.render();
     }
   }
 

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -283,24 +283,27 @@ function vtkWidgetManager(publicAPI, model) {
     // Default cursor behavior
     model._apiSpecificRenderWindow.setCursor(widget ? 'pointer' : 'default');
 
+    let wantRender = false;
     if (model.widgetInFocus === widget && widget.hasFocus()) {
       activateHandle(widget);
-      // Ken FIXME
-      model._interactor.render();
-      model._interactor.render();
+      wantRender = true;
     } else {
       for (let i = 0; i < model.widgets.length; i++) {
         const w = model.widgets[i];
         if (w === widget && w.getNestedPickable()) {
           activateHandle(w);
           model.activeWidget = w;
+          wantRender = true;
         } else {
+          wantRender ||= !!w.get().activeState;
           w.deactivateAllHandles();
         }
       }
-      // Ken FIXME
-      model._interactor.render();
-      model._interactor.render();
+      if (wantRender) {
+        // Ken FIXME
+        model._interactor.render();
+        model._interactor.render();
+      }
     }
   }
 
@@ -524,17 +527,17 @@ function vtkWidgetManager(publicAPI, model) {
       // do we require a new capture?
       if (!model._capturedBuffers || model.captureOn === CaptureOn.MOUSE_MOVE) {
         await captureBuffers(x, y, x, y);
-      }
-
-      // or do we need a pixel that is outside the last capture?
-      const capturedRegion = model._capturedBuffers.area;
-      if (
-        x < capturedRegion[0] ||
-        x > capturedRegion[2] ||
-        y < capturedRegion[1] ||
-        y > capturedRegion[3]
-      ) {
-        await captureBuffers(x, y, x, y);
+      } else {
+        // or do we need a pixel that is outside the last capture?
+        const capturedRegion = model._capturedBuffers.area;
+        if (
+          x < capturedRegion[0] ||
+          x > capturedRegion[2] ||
+          y < capturedRegion[1] ||
+          y > capturedRegion[3]
+        ) {
+          await captureBuffers(x, y, x, y);
+        }
       }
 
       model.selections = model._capturedBuffers.generateSelection(x, y, x, y);

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -300,8 +300,6 @@ function vtkWidgetManager(publicAPI, model) {
         }
       }
       if (wantRender) {
-        // Ken FIXME
-        model._interactor.render();
         model._interactor.render();
       }
     }

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -295,7 +295,7 @@ function vtkWidgetManager(publicAPI, model) {
           model.activeWidget = w;
           wantRender = true;
         } else {
-          wantRender ||= !!w.get().activeState;
+          wantRender ||= !!w.getActiveState();
           w.deactivateAllHandles();
         }
       }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The WidgetManager triggers unnecessary renders which can be expensive while performing the picking operation.

### Results
- The WidgetManager triggers a render only when a widget selection changes.

### Changes
- [x] WidgetManager behavior changes to reduce renders.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Test widgets to verify nothing changes