### PR TITLE
perf(OpenGLTexture): conditional getExtension call

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -644,10 +644,14 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     // if the opengl data type is half float
     // then the data array must be u16
-    const halfFloatExt = model.context.getExtension('OES_texture_half_float');
-    const halfFloat = model._openGLRenderWindow.getWebgl2()
-      ? model.openGLDataType === model.context.HALF_FLOAT
-      : halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
+    let halfFloat = false;
+    if (model._openGLRenderWindow.getWebgl2()) {
+      halfFloat = model.openGLDataType === model.context.HALF_FLOAT;
+    } else {
+      const halfFloatExt = model.context.getExtension('OES_texture_half_float');
+      halfFloat =
+        halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
+    }
 
     if (halfFloat) {
       for (let idx = 0; idx < data.length; idx++) {
@@ -1103,10 +1107,14 @@ function vtkOpenGLTexture(publicAPI, model) {
     const useHalfFloatType = true;
     publicAPI.getOpenGLDataType(dataType, useHalfFloatType);
 
-    const halfFloatExt = model.context.getExtension('OES_texture_half_float');
-    const useHalfFloat = model._openGLRenderWindow.getWebgl2()
-      ? model.openGLDataType === model.context.HALF_FLOAT
-      : halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
+    let useHalfFloat = false;
+    if (model._openGLRenderWindow.getWebgl2()) {
+      useHalfFloat = model.openGLDataType === model.context.HALF_FLOAT;
+    } else {
+      const halfFloatExt = model.context.getExtension('OES_texture_half_float');
+      useHalfFloat =
+        halfFloatExt && model.openGLDataType === halfFloatExt.HALF_FLOAT_OES;
+    }
 
     if (!useHalfFloat) {
       return false;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
`gl.getExtension()` calls generally are very fast, but we can skip these calls entirely in webgl2 codepaths.

### Results
Slight perf improvement.

### Changes
- [x] OpenGLTexture now conditionally calls getExtension() in webgl2 code pathways. While the half_float extension result can technically be cached, I'm not going to introduce that here, since it's only relevant in webgl1 pathways. #2212 is related here.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
CI will run tests.

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
