### PR TITLE
build(package.json): add missing fast-deep-equal dependency

### DIFF
--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -2,7 +2,7 @@
  * macros.js is the old macro.js.
  * The name change is so we do not get eaten by babel-plugin-macros.
  */
-import DeepEqual from 'deep-equal';
+import DeepEqual from 'fast-deep-equal';
 import vtk, { vtkGlobal } from './vtk';
 import ClassHierarchy from './Common/Core/ClassHierarchy';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/runtime": "7.17.9",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
+        "fast-deep-equal": "^3.1.3",
         "fflate": "0.7.3",
         "gl-matrix": "3.4.3",
         "globalthis": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/runtime": "7.17.9",
     "commander": "9.2.0",
     "d3-scale": "4.0.2",
+    "fast-deep-equal": "^3.1.3",
     "fflate": "0.7.3",
     "gl-matrix": "3.4.3",
     "globalthis": "1.0.3",


### PR DESCRIPTION

### Context
Transpilation error due to missing deep-equal dependency.

### Results
Switch to a faster deep-equal module: fast-deep-equal.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**:  master
  - **OS**: Windows 10
  - **Browser**: Chrome
