### PR TITLE
Avoid side effects of getNeedToRebuildShaders

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -110,6 +110,10 @@ function vtkOpenGLImageMapper(publicAPI, model) {
   publicAPI.buildShaders = (shaders, ren, actor) => {
     publicAPI.getShaderTemplate(shaders, ren, actor);
 
+    model.lastRenderPassShaderReplacement = model.currentRenderPass
+      ? model.currentRenderPass.getShaderReplacement()
+      : null;
+
     // apply any renderPassReplacements
     if (model.lastRenderPassShaderReplacement) {
       model.lastRenderPassShaderReplacement(shaders);
@@ -395,23 +399,19 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     // property modified (representation interpolation and lighting)
     // input modified
     // light complexity changed
+    // render pass shader replacement changed
 
     const tNumComp = model.openGLTexture.getComponents();
     const iComp = actor.getProperty().getIndependentComponents();
 
     // has the render pass shader replacement changed? Two options
     let needRebuild = false;
-    if (!model.currentRenderPass && model.lastRenderPassShaderReplacement) {
-      needRebuild = true;
-      model.lastRenderPassShaderReplacement = null;
-    }
     if (
-      model.currentRenderPass &&
-      model.currentRenderPass.getShaderReplacement() !==
-        model.lastRenderPassShaderReplacement
+      (!model.currentRenderPass && model.lastRenderPassShaderReplacement) ||
+      (model.currentRenderPass &&
+        model.currentRenderPass.getShaderReplacement() !==
+          model.lastRenderPassShaderReplacement)
     ) {
-      model.lastRenderPassShaderReplacement =
-        model.currentRenderPass.getShaderReplacement();
       needRebuild = true;
     }
 

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -101,6 +101,10 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
   publicAPI.buildShaders = (shaders, ren, actor) => {
     publicAPI.getShaderTemplate(shaders, ren, actor);
 
+    model.lastRenderPassShaderReplacement = model.currentRenderPass
+      ? model.currentRenderPass.getShaderReplacement()
+      : null;
+
     // apply any renderPassReplacements
     if (model.lastRenderPassShaderReplacement) {
       model.lastRenderPassShaderReplacement(shaders);
@@ -1139,17 +1143,12 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     }
 
     // has the render pass shader replacement changed? Two options
-    if (!model.currentRenderPass && model.lastRenderPassShaderReplacement) {
-      needRebuild = true;
-      model.lastRenderPassShaderReplacement = null;
-    }
     if (
-      model.currentRenderPass &&
-      model.currentRenderPass.getShaderReplacement() !==
-        model.lastRenderPassShaderReplacement
+      (!model.currentRenderPass && model.lastRenderPassShaderReplacement) ||
+      (model.currentRenderPass &&
+        model.currentRenderPass.getShaderReplacement() !==
+          model.lastRenderPassShaderReplacement)
     ) {
-      model.lastRenderPassShaderReplacement =
-        model.currentRenderPass.getShaderReplacement();
       needRebuild = true;
     }
 
@@ -1158,6 +1157,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     // property modified (representation interpolation and lighting)
     // input modified
     // light complexity changed
+    // render pass shader replacement changed
     if (
       model.lastHaveSeenDepthRequest !== model.haveSeenDepthRequest ||
       cellBO.getShaderSourceTime().getMTime() < model.renderable.getMTime() ||


### PR DESCRIPTION
In PolyDataMapper and ImageMapper, `lastRenderPassShaderReplacement` was sometimes not updated.

It should have been updated in `getNeedToRebuildShaders`, but when this function was not called, the update didn't occur.

Fixed this behaviour by moving the update of `lastRenderPassShaderReplacement` in the render function.