### PR TITLE
Add null to findPokedRenderer return type

### DIFF
--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
@@ -193,8 +193,8 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
       selfRenderer.removeViewProp(model.actor);
 
       const renderWindow = model._interactor
-        .findPokedRenderer()
-        .getRenderWindow();
+        ?.findPokedRenderer()
+        ?.getRenderWindow();
       if (renderWindow) {
         renderWindow.removeRenderer(selfRenderer);
       }

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -1,4 +1,5 @@
 import { vtkObject, vtkSubscription } from "../../../interfaces";
+import { Nullable } from "../../../types";
 import vtkRenderer from "../Renderer";
 import { Axis, Device, Input } from "./Constants";
 
@@ -1152,7 +1153,7 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 	 * @param {Number} x 
 	 * @param {Number} y 
 	 */
-	findPokedRenderer(x: number, y: number): vtkRenderer;
+	findPokedRenderer(x: number, y: number): Nullable<vtkRenderer>;
 
 	/**
 	 * only render if we are not animating. If we are animating

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -811,7 +811,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     // The original order of renderers needs to remain as
     // the first one is the one we want to manipulate the camera on.
     const rc = model._view?.getRenderable()?.getRenderers();
-    if (!rc) {
+    if (!rc || rc.length === 0) {
       return null;
     }
     rc.sort((a, b) => a.getLayer() - b.getLayer());


### PR DESCRIPTION
Edit findPokedRenderer to handle a case when `rc` is an empt list (used to return undefined)
Edit typescript header as findPokedRenderer sometimes return null
Edit a call to this function in OrientationMarkerWidget accordingly, which sometimes caused errors

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
- [x] Run `npm run test`
