### PR TITLE
fix(WebXR): XRWebGLLayer needs unproxied context

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/ContextProxy.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/ContextProxy.js
@@ -1,3 +1,6 @@
+// This is used to access the underlying 3D context
+export const GET_UNDERLYING_CONTEXT = '__getUnderlyingContext';
+
 export function createContextProxyHandler() {
   const cache = new Map();
 
@@ -42,6 +45,7 @@ export function createContextProxyHandler() {
 
   return {
     get(gl, prop, receiver) {
+      if (prop === GET_UNDERLYING_CONTEXT) return () => gl;
       let value = Reflect.get(gl, prop, gl);
       if (value instanceof Function) {
         // prevents Illegal Invocation errors

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -8,7 +8,10 @@ import vtkOpenGLTextureUnitManager from 'vtk.js/Sources/Rendering/OpenGL/Texture
 import vtkOpenGLViewNodeFactory from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
 import vtkRenderPass from 'vtk.js/Sources/Rendering/SceneGraph/RenderPass';
 import vtkRenderWindowViewNode from 'vtk.js/Sources/Rendering/SceneGraph/RenderWindowViewNode';
-import { createContextProxyHandler } from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow/ContextProxy';
+import {
+  createContextProxyHandler,
+  GET_UNDERLYING_CONTEXT,
+} from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow/ContextProxy';
 
 const { vtkDebugMacro, vtkErrorMacro } = macro;
 
@@ -325,7 +328,11 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       const gl = publicAPI.get3DContext();
       await gl.makeXRCompatible();
 
-      const glLayer = new global.XRWebGLLayer(model.xrSession, gl);
+      const glLayer = new global.XRWebGLLayer(
+        model.xrSession,
+        // constructor needs unproxied context
+        gl[GET_UNDERLYING_CONTEXT]()
+      );
       publicAPI.setSize(glLayer.framebufferWidth, glLayer.framebufferHeight);
 
       model.xrSession.updateRenderState({


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Fixes #2650. XRWebGLLayer requires a non-proxied context.

### Results
XR examples should work again.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: latest
  - **OS**: Android
  - **Browser**: Chrome

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
