### PR TITLE
feat(SphereMapper): add scaleFactor to scale radius of sphere

### DIFF
--- a/Sources/Rendering/Core/SphereMapper/example/controlPanel.html
+++ b/Sources/Rendering/Core/SphereMapper/example/controlPanel.html
@@ -11,4 +11,10 @@
       <input class='yResolution' type="range" min="1" max="25" step="1" value="10" />
     </td>
   </tr>
+  <tr>
+    <td>Scale Factor</td>
+    <td>
+      <input class='scaleFactor' type="range" min="0.1" max="5" step="0.1" value="1.0" />
+    </td>
+  </tr>
 </table>

--- a/Sources/Rendering/Core/SphereMapper/example/index.js
+++ b/Sources/Rendering/Core/SphereMapper/example/index.js
@@ -100,6 +100,12 @@ fullScreenRenderer.addController(controlPanel);
   });
 });
 
+document.querySelector('.scaleFactor').addEventListener('input', (e) => {
+  const value = Number(e.target.value);
+  mapper.setScaleFactor(value);
+  renderWindow.render();
+});
+
 // -----------------------------------------------------------
 // Make some variables global so that you can inspect and
 // modify objects in your browser's developer console:

--- a/Sources/Rendering/Core/SphereMapper/index.d.ts
+++ b/Sources/Rendering/Core/SphereMapper/index.d.ts
@@ -18,6 +18,11 @@ export interface vtkSphereMapper extends vtkMapper {
 
 	/**
 	 * 
+	 */
+	getScaleFactor(): number;
+
+	/**
+	 * 
 	 * @param {Number} radius 
 	 */
 	setRadius(radius: number): boolean;
@@ -27,6 +32,13 @@ export interface vtkSphereMapper extends vtkMapper {
 	 * @param scaleArray 
 	 */
 	setScaleArray(scaleArray: any): boolean;
+
+/**
+	 * Factor multiplied with scale array elements. Radius is used when no scale array is given.
+	 * @param scaleFactor number to multiply with when a scale array is provided. 1 by default.
+	 * @see getScaleFactor(), setScaleArray(), setRadius()
+	 */ 
+	setScaleFactor(scaleFactor: number): boolean;
 }
 
 /**

--- a/Sources/Rendering/Core/SphereMapper/index.js
+++ b/Sources/Rendering/Core/SphereMapper/index.js
@@ -17,6 +17,7 @@ function vtkSphereMapper(publicAPI, model) {
 const DEFAULT_VALUES = {
   scaleArray: null,
   radius: 0.05,
+  scaleFactor: 1.0,
 };
 
 // ----------------------------------------------------------------------------
@@ -27,7 +28,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Inheritance
   vtkMapper.extend(publicAPI, model, initialValues);
 
-  macro.setGet(publicAPI, model, ['radius', 'scaleArray']);
+  macro.setGet(publicAPI, model, ['radius', 'scaleArray', 'scaleFactor']);
 
   // Object methods
   vtkSphereMapper(publicAPI, model);

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -173,6 +173,21 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
         .getProgram()
         .setUniformf('invertedDepth', model.invert ? -1.0 : 1.0);
     }
+    if (cellBO.getProgram().isUniformUsed('scaleFactor')) {
+      // apply scaling factor only if a scale array has been provided.
+      const poly = model.currentInput;
+      const pointData = poly.getPointData();
+      if (
+        model.renderable.getScaleArray() != null &&
+        pointData.hasArray(model.renderable.getScaleArray())
+      ) {
+        cellBO
+          .getProgram()
+          .setUniformf('scaleFactor', model.renderable.getScaleFactor());
+      } else {
+        cellBO.getProgram().setUniformf('scaleFactor', 1.0);
+      }
+    }
 
     superClass.setMapperShaderParameters(cellBO, ren, actor);
   };

--- a/Sources/Rendering/OpenGL/glsl/vtkSphereMapperVS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkSphereMapperVS.glsl
@@ -41,6 +41,7 @@ varying float radiusVCVSOutput;
 varying vec3 centerVCVSOutput;
 
 uniform int cameraParallel;
+uniform float scaleFactor;
 
 void main()
 {
@@ -53,9 +54,10 @@ void main()
   //VTK::Clip::Impl
 
   // compute the projected vertex position
+  vec2 scaledOffsetMC = scaleFactor * offsetMC;
   vertexVCVSOutput = MCVCMatrix * vertexMC;
   centerVCVSOutput = vertexVCVSOutput.xyz;
-  radiusVCVSOutput = length(offsetMC)*0.5;
+  radiusVCVSOutput = length(scaledOffsetMC)*0.5;
 
   // make the triangle face the camera
   if (cameraParallel == 0)
@@ -63,12 +65,12 @@ void main()
     vec3 dir = normalize(-vertexVCVSOutput.xyz);
     vec3 base2 = normalize(cross(dir,vec3(1.0,0.0,0.0)));
     vec3 base1 = cross(base2,dir);
-    vertexVCVSOutput.xyz = vertexVCVSOutput.xyz + offsetMC.x*base1 + offsetMC.y*base2;
+    vertexVCVSOutput.xyz = vertexVCVSOutput.xyz + scaledOffsetMC.x*base1 + scaledOffsetMC.y*base2;
     }
   else
     {
     // add in the offset
-    vertexVCVSOutput.xy = vertexVCVSOutput.xy + offsetMC;
+    vertexVCVSOutput.xy = vertexVCVSOutput.xy + scaledOffsetMC;
     }
 
   gl_Position = VCPCMatrix * vertexVCVSOutput;

--- a/Sources/Rendering/WebGPU/SphereMapper/index.js
+++ b/Sources/Rendering/WebGPU/SphereMapper/index.js
@@ -237,7 +237,7 @@ function vtkWebGPUSphereMapper(publicAPI, model) {
         for (let id = 0; id < numPoints; ++id) {
           let radius = model.renderable.getRadius();
           if (scales) {
-            radius = scales[id];
+            radius = scales[id] * model.renderable.getScaleFactor();
           }
           tmpVBO[vboIdx++] = -2.0 * radius * cos30;
           tmpVBO[vboIdx++] = -radius;


### PR DESCRIPTION
### Context
- fix #2036 

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
- Added `scaleFactor` property in `SphereMapper`
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
Run the `SphereMapper` example, try to modify `ScaleFactor` and observe the sphere radii change.
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: ubuntu
  - **Browser**: Chrome 107.0.5304.121
