### PR TITLE
Clean OpenGL RenderWindow eventListeners

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -1101,6 +1101,9 @@ function vtkRenderWindowInteractor(publicAPI, model) {
         publicAPI.handleVisibilityChange
       );
     }
+    if (model.container) {
+      publicAPI.unbindEvents();
+    }
     superDelete();
   };
 

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -86,6 +86,10 @@ export function popMonitorGLContextCount(cb) {
   return GL_CONTEXT_LISTENERS.pop();
 }
 
+function _preventDefault(e) {
+  e.preventDefault();
+}
+
 // ----------------------------------------------------------------------------
 // vtkOpenGLRenderWindow methods
 // ----------------------------------------------------------------------------
@@ -99,13 +103,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   publicAPI.getViewNodeFactory = () => model.myFactory;
 
   // prevent default context lost handler
-  model.canvas.addEventListener(
-    'webglcontextlost',
-    (event) => {
-      event.preventDefault();
-    },
-    false
-  );
+  model.canvas.addEventListener('webglcontextlost', _preventDefault, false);
 
   model.canvas.addEventListener(
     'webglcontextrestored',
@@ -1252,7 +1250,16 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     return ret;
   };
 
+  function clearEvents() {
+    model.canvas.removeEventListener('webglcontextlost', _preventDefault);
+    model.canvas.removeEventListener(
+      'webglcontextrestored',
+      publicAPI.restoreContext
+    );
+  }
+
   publicAPI.delete = macro.chain(
+    clearEvents,
     publicAPI.delete,
     publicAPI.setViewStream,
     deleteGLContext


### PR DESCRIPTION
Remove `webglcontextlost` and `webglcontextrestored` eventListeners added for canvas when deleting the RenderWindow.


<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

fix #2670

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
It is no longer leaking memory through these event listeners.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
No changes to API, clean up internally.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [X] Tested environment:
 - **vtk.js**: 25.8.5
- **OS**: 12.6.2
- **Browser**: Chrome 108.0.5359.124


<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
