### PR TITLE
fix(reslicecursorwidget): fix ResliceCursorWidget small mouse wheel scroll

### DIFF
--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
@@ -281,9 +281,8 @@ function vtkMouseRangeManipulator(publicAPI, model) {
     processDelta(model.scrollListener, delta * model.scrollListener.step);
   };
 
-  publicAPI.onStartScroll = (payload) => {
+  publicAPI.onStartScroll = () => {
     model.interactionNetDelta = 0;
-    publicAPI.onScroll(payload);
   };
 }
 

--- a/Sources/Interaction/Style/InteractorStyleImage/index.js
+++ b/Sources/Interaction/Style/InteractorStyleImage/index.js
@@ -85,9 +85,8 @@ function vtkInteractorStyleImage(publicAPI, model) {
   };
 
   //--------------------------------------------------------------------------
-  publicAPI.handleStartMouseWheel = (callData) => {
+  publicAPI.handleStartMouseWheel = () => {
     publicAPI.startSlice();
-    publicAPI.handleMouseWheel(callData);
   };
 
   //--------------------------------------------------------------------------

--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -153,9 +153,8 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
   };
 
   //----------------------------------------------------------------------------
-  publicAPI.handleStartMouseWheel = (callData) => {
+  publicAPI.handleStartMouseWheel = () => {
     publicAPI.startDolly();
-    publicAPI.handleMouseWheel(callData);
   };
 
   //--------------------------------------------------------------------------

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -679,6 +679,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
 
     if (model.wheelTimeoutID === 0) {
       publicAPI.startMouseWheelEvent(callData);
+      publicAPI.mouseWheelEvent(callData);
     } else {
       publicAPI.mouseWheelEvent(callData);
       clearTimeout(model.wheelTimeoutID);

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -120,7 +120,7 @@ export default function widgetBehavior(publicAPI, model) {
    * @param {number} handleIndex 0, 1 or 2
    * @param {object} callData optional, see getHandleOrientation for details.
    */
-  function updateHandleOrientation(handleIndex, callData = null) {
+  function updateHandleOrientation(handleIndex) {
     const orientation = getHandleOrientation(Math.min(1, handleIndex));
     model.representations[handleIndex].setOrientation(orientation);
   }

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -4,7 +4,7 @@ import { vec3 } from 'gl-matrix';
 export default function widgetBehavior(publicAPI, model) {
   model.painting = model._factory.getPainting();
 
-  publicAPI.handleLeftButtonPress = (callData) => {
+  publicAPI.handleLeftButtonPress = () => {
     if (!model.activeState || !model.activeState.getActive()) {
       return macro.VOID;
     }

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -179,7 +179,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
   };
 
-  publicAPI.handleRightButtonRelease = (calldata) => {
+  publicAPI.handleRightButtonRelease = () => {
     if (
       model.widgetState.getScrollingMethod() ===
       ScrollingMethods.RIGHT_MOUSE_BUTTON
@@ -188,7 +188,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
   };
 
-  publicAPI.handleStartMouseWheel = (callData) => {
+  publicAPI.handleStartMouseWheel = () => {
     publicAPI.resetUpdateMethod();
     publicAPI.startInteraction();
   };
@@ -204,7 +204,7 @@ export default function widgetBehavior(publicAPI, model) {
     return macro.EVENT_ABORT;
   };
 
-  publicAPI.handleEndMouseWheel = (calldata) => {
+  publicAPI.handleEndMouseWheel = () => {
     publicAPI.endScrolling();
   };
 
@@ -217,7 +217,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
   };
 
-  publicAPI.handleMiddleButtonRelease = (calldata) => {
+  publicAPI.handleMiddleButtonRelease = () => {
     if (
       model.widgetState.getScrollingMethod() ===
       ScrollingMethods.MIDDLE_MOUSE_BUTTON


### PR DESCRIPTION
When doing a single mouse wheel scroll (for mouses with notches on their wheel) on one of the views of the widget, one can expect a single slice change. However, this does not occur since the startMouseWheel method of the widget does not call handleMouseWheel.
