### PR TITLE
fix(sources/macros.d.ts): add explicit type to function parameter in…

### DIFF
--- a/Sources/macros.d.ts
+++ b/Sources/macros.d.ts
@@ -290,7 +290,7 @@ export interface VtkChangeEvent {
    * @param VtkCallback
    * @param priority (default 0.0)
    */
-  onChange(VtkCallback, priority?: number): vtkSubscription;
+  onChange(VtkCallback: (...args: any) => void | symbol, priority?: number): vtkSubscription;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
… Sources/macros.d.ts

This is needed to be compliant with "noImplicitAny" flag


### Context
If the library is used by a project which has the "noImplicitAny" ts-compilier flag set to true (which is the default), the following error is thrown.

`Error: node_modules/@kitware/vtk.js/macros.d.ts:293:12 - error TS7006: Parameter 'VtkCallback' implicitly has an 'any' type.`

### Results
After the the addition of the explicit type, the error is not thrown anymore and the project can be compiled.

### Changes
--Addition of the parameter type.

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
Import vtk library into a project which has set "noImplicitAny" type to true. Should compile without errors.

