### PR TITLE
fix(reslicecursorwidget): fix line widget representation error when s…

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -80,21 +80,11 @@ export default function widgetBehavior(publicAPI, model) {
       ? 'point0'
       : 'point1';
 
-  // Reset "updateMethodName" attribute when no actors are selected
-  // Useful to update 'updateMethodeName' to the correct name which
-  // will be TranslateCenter by default
-  publicAPI.resetUpdateMethod = () => {
-    if (model.representations.length !== 0) {
-      model.representations[0].getSelectedState();
-    }
-  };
-
   publicAPI.startScrolling = (newPosition) => {
     if (newPosition) {
       previousPosition = newPosition;
     }
     isScrolling = true;
-    publicAPI.resetUpdateMethod();
     publicAPI.startInteraction();
   };
 
@@ -189,7 +179,6 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.handleStartMouseWheel = () => {
-    publicAPI.resetUpdateMethod();
     publicAPI.startInteraction();
   };
 


### PR DESCRIPTION
…crolling

Regression from 2dc7244409a175042750b4437ce522a56d210d22

### Context
When scrolling the ResliceCursorWidget example, an error was outputed and the RCW example was behaving oddly.
This is because there was some vtkResliceCursorWidgetRepresentation related code that remained in behavior.js

### Results
No more error in the RCW example when scrolling the views.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: latest Chrome
