### PR TITLE
fix: use half float flag overrides norm16 flag

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -269,8 +269,10 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	 * @param {VtkDataTypes} vtktype 
 	 * @param {Number} numComps 
 	 * @param {Boolean} useFloat 
+	 * @param {unknown} oglNorm16Ext The WebGL EXT_texture_norm16 extension context
+	 * @param {Boolean} useHalfFloat
 	 */
-	getDefaultTextureInternalFormat(vtktype: VtkDataTypes, numComps: number, oglNorm16Ext?: unknown): void;
+	getDefaultTextureInternalFormat(vtktype: VtkDataTypes, numComps: number, oglNorm16Ext?: unknown, useHalfFloat?: boolean): void;
 
 	/**
 	 * 

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -533,7 +533,8 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   publicAPI.getDefaultTextureInternalFormat = (
     vtktype,
     numComps,
-    oglNorm16Ext = null
+    oglNorm16Ext = null,
+    useHalfFloat = false
   ) => {
     if (model.webgl2) {
       switch (vtktype) {
@@ -549,7 +550,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
             default:
               return model.context.RGBA8;
           }
-        case oglNorm16Ext && VtkDataTypes.UNSIGNED_SHORT:
+        case oglNorm16Ext && !useHalfFloat && VtkDataTypes.UNSIGNED_SHORT:
           switch (numComps) {
             case 1:
               return oglNorm16Ext.R16_EXT;
@@ -562,7 +563,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
               return oglNorm16Ext.RGBA16_EXT;
           }
         // prioritize norm16 over float
-        case oglNorm16Ext && VtkDataTypes.SHORT:
+        case oglNorm16Ext && !useHalfFloat && VtkDataTypes.SHORT:
           switch (numComps) {
             case 1:
               return oglNorm16Ext.R16_SNORM_EXT;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Fixes #2681, `preferSizeOverAccuracy` enables `halfFloat` use which overrides `norm16`

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Safari is able to use half float textures from uint16/int16 array buffers.
<img width="746" alt="image" src="https://user-images.githubusercontent.com/5455421/214022181-237f31c1-2b7a-45da-a60c-501e0e9911cd.png">

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: MacOS 13.1, iOS 14 -->
  - **Browser**: <!-- ex: Safari, iOS Safari -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
