### PR TITLE
perf(rendering): only allocate texture buffers when data is available

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -815,24 +815,26 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
 
     if (model._openGLRenderWindow.getWebgl2()) {
-      model.context.texStorage2D(
-        model.target,
-        1,
-        model.internalFormat,
-        model.width,
-        model.height
-      );
-      model.context.texSubImage2D(
-        model.target,
-        0,
-        0,
-        0,
-        model.width,
-        model.height,
-        model.format,
-        model.openGLDataType,
-        scaledData[0]
-      );
+      if (scaledData[0] != null) {
+        model.context.texStorage2D(
+          model.target,
+          1,
+          model.internalFormat,
+          model.width,
+          model.height
+        );
+        model.context.texSubImage2D(
+          model.target,
+          0,
+          0,
+          0,
+          model.width,
+          model.height,
+          model.format,
+          model.openGLDataType,
+          scaledData[0]
+        );
+      }
     } else {
       model.context.texImage2D(
         model.target,
@@ -938,17 +940,19 @@ function vtkOpenGLTexture(publicAPI, model) {
           tempData = invertedData[6 * j + i];
         }
         if (model._openGLRenderWindow.getWebgl2()) {
-          model.context.texSubImage2D(
-            model.context.TEXTURE_CUBE_MAP_POSITIVE_X + i,
-            j,
-            0,
-            0,
-            w,
-            h,
-            model.format,
-            model.openGLDataType,
-            tempData
-          );
+          if (tempData != null) {
+            model.context.texSubImage2D(
+              model.context.TEXTURE_CUBE_MAP_POSITIVE_X + i,
+              j,
+              0,
+              0,
+              w,
+              h,
+              model.format,
+              model.openGLDataType,
+              tempData
+            );
+          }
         } else {
           model.context.texImage2D(
             model.context.TEXTURE_CUBE_MAP_POSITIVE_X + i,
@@ -1010,24 +1014,26 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
 
     if (model._openGLRenderWindow.getWebgl2()) {
-      model.context.texStorage2D(
-        model.target,
-        1,
-        model.internalFormat,
-        model.width,
-        model.height
-      );
-      model.context.texSubImage2D(
-        model.target,
-        0,
-        0,
-        0,
-        model.width,
-        model.height,
-        model.format,
-        model.openGLDataType,
-        data
-      );
+      if (data != null) {
+        model.context.texStorage2D(
+          model.target,
+          1,
+          model.internalFormat,
+          model.width,
+          model.height
+        );
+        model.context.texSubImage2D(
+          model.target,
+          0,
+          0,
+          0,
+          model.width,
+          model.height,
+          model.format,
+          model.openGLDataType,
+          data
+        );
+      }
     } else {
       model.context.texImage2D(
         model.target,
@@ -1102,24 +1108,26 @@ function vtkOpenGLTexture(publicAPI, model) {
     const safeImage = canvas;
 
     if (model._openGLRenderWindow.getWebgl2()) {
-      model.context.texStorage2D(
-        model.target,
-        1,
-        model.internalFormat,
-        model.width,
-        model.height
-      );
-      model.context.texSubImage2D(
-        model.target,
-        0,
-        0,
-        0,
-        model.width,
-        model.height,
-        model.format,
-        model.openGLDataType,
-        safeImage
-      );
+      if (safeImage != null) {
+        model.context.texStorage2D(
+          model.target,
+          1,
+          model.internalFormat,
+          model.width,
+          model.height
+        );
+        model.context.texSubImage2D(
+          model.target,
+          0,
+          0,
+          0,
+          model.width,
+          model.height,
+          model.format,
+          model.openGLDataType,
+          safeImage
+        );
+      }
     } else {
       model.context.texImage2D(
         model.target,
@@ -1577,24 +1585,26 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
 
     if (model._openGLRenderWindow.getWebgl2()) {
-      model.context.texStorage2D(
-        model.target,
-        1,
-        model.internalFormat,
-        model.width,
-        model.height
-      );
-      model.context.texSubImage2D(
-        model.target,
-        0,
-        0,
-        0,
-        model.width,
-        model.height,
-        model.format,
-        model.openGLDataType,
-        newArray
-      );
+      if (newArray != null) {
+        model.context.texStorage2D(
+          model.target,
+          1,
+          model.internalFormat,
+          model.width,
+          model.height
+        );
+        model.context.texSubImage2D(
+          model.target,
+          0,
+          0,
+          0,
+          model.width,
+          model.height,
+          model.format,
+          model.openGLDataType,
+          newArray
+        );
+      }
     } else {
       model.context.texImage2D(
         model.target,


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->
<!--
### Context

Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
<!--
### Results

Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
<!--

### Testing
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
