### PR TITLE
docs(geometryviewer): add option to not map scalars to colors in Geom…

### DIFF
--- a/Examples/Applications/GeometryViewer/index.js
+++ b/Examples/Applications/GeometryViewer/index.js
@@ -330,12 +330,15 @@ function createPipeline(fileName, fileContents) {
           lut.setVectorModeToMagnitude();
         }
         componentSelector.style.display = 'block';
-        const compOpts = ['Magnitude'];
+        const compOpts = [['Magnitude', -1]];
         while (compOpts.length <= numberOfComponents) {
-          compOpts.push(`Component ${compOpts.length}`);
+          compOpts.push([`Component ${compOpts.length}`, compOpts.length - 1]);
+        }
+        if (numberOfComponents === 3 || numberOfComponents === 4) {
+          compOpts.push([`Use direct mapping`, -2]);
         }
         componentSelector.innerHTML = compOpts
-          .map((t, index) => `<option value="${index - 1}">${t}</option>`)
+          .map((t) => `<option value="${t[1]}">${t[0]}</option>`)
           .join('');
       } else {
         componentSelector.style.display = 'none';
@@ -361,7 +364,10 @@ function createPipeline(fileName, fileContents) {
   function updateColorByComponent(event) {
     if (mapper.getLookupTable()) {
       const lut = mapper.getLookupTable();
-      if (event.target.value === -1) {
+      mapper.setColorModeToMapScalars();
+      if (event.target.value === '-2') {
+        mapper.setColorModeToDirectScalars();
+      } else if (event.target.value === '-1') {
         lut.setVectorModeToMagnitude();
       } else {
         lut.setVectorModeToComponent();


### PR DESCRIPTION
…etryViewer example

### Context
Expose the MapScalarsToColors option in the Geometry viewer.

### Results
It is then possible to use a scalar point data array that is RGB or RGBA.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master -->
  - **OS**: Windows 11
  - **Browser**: Chrome
