### PR TITLE
feat(cameraFit): add view2DProxy option to fit camera to bounds

### DIFF
--- a/Sources/Common/Core/Math/index.d.ts
+++ b/Sources/Common/Core/Math/index.d.ts
@@ -776,6 +776,7 @@ export function areBoundsInitialized(bounds: Bounds): boolean;
  * @param {Vector3} point1 The coordinate of the first point.
  * @param {Vector3} point2 The coordinate of the second point.
  * @param {Bounds} bounds Output array that hold bounds, optionally empty.
+ * @deprecated please use vtkBoundingBox.addPoints(vtkBoundingBox.reset([]), points)
  */
 export function computeBoundsFromPoints(point1: Vector3, point2: Vector3, bounds: Bounds): Bounds;
 

--- a/Sources/Common/Core/Math/index.js
+++ b/Sources/Common/Core/Math/index.js
@@ -1969,6 +1969,9 @@ export function areBoundsInitialized(bounds) {
   return !(bounds[1] - bounds[0] < 0.0);
 }
 
+/**
+ * @deprecated please use vtkBoundingBox.addPoints(vtkBoundingBox.reset([]), points)
+ */
 export function computeBoundsFromPoints(point1, point2, bounds) {
   bounds[0] = Math.min(point1[0], point2[0]);
   bounds[1] = Math.max(point1[0], point2[0]);

--- a/Sources/Common/DataModel/BoundingBox/index.js
+++ b/Sources/Common/DataModel/BoundingBox/index.js
@@ -1,4 +1,5 @@
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import { vec3 } from 'gl-matrix';
 import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
 
 const INIT_BOUNDS = [
@@ -62,11 +63,11 @@ export function addPoints(bounds, points) {
   }
   if (Array.isArray(points[0])) {
     for (let i = 0; i < points.length; ++i) {
-      addPoint(bounds, points[i]);
+      addPoint(bounds, ...points[i]);
     }
   } else {
     for (let i = 0; i < points.length; i += 3) {
-      addPoint(bounds, points.slice(i, i + 3));
+      addPoint(bounds, ...points.slice(i, i + 3));
     }
   }
   return bounds;
@@ -265,6 +266,17 @@ export function computeCornerPoints(bounds, point1, point2) {
   point2[1] = bounds[3];
   point2[2] = bounds[5];
   return point1;
+}
+
+export function transformBounds(bounds, transform, out = []) {
+  if (out.length < 6) {
+    reset(out);
+  }
+  const corners = getCorners(bounds, []);
+  for (let i = 0; i < corners.length; ++i) {
+    vec3.transformMat4(corners[i], corners[i], transform);
+  }
+  return addPoints(out, corners);
 }
 
 export function computeScale3(bounds, scale3 = []) {
@@ -637,7 +649,7 @@ class BoundingBox {
   }
 
   addPoint(...xyz) {
-    return addPoint(this.bounds, xyz);
+    return addPoint(this.bounds, ...xyz);
   }
 
   addPoints(points) {
@@ -716,6 +728,10 @@ class BoundingBox {
     return computeLocalBounds(this.bounds, u, v, w);
   }
 
+  transformBounds(transform, out = []) {
+    return transformBounds(this.bounds, transform, out);
+  }
+
   computeScale3(scale3) {
     return computeScale3(this.bounds, scale3);
   }
@@ -784,6 +800,7 @@ export const STATIC = {
   getCorners,
   computeCornerPoints,
   computeLocalBounds,
+  transformBounds,
   computeScale3,
   cutWithPlane,
   intersectBox,

--- a/Sources/Common/DataModel/ImageData/index.js
+++ b/Sources/Common/DataModel/ImageData/index.js
@@ -186,27 +186,8 @@ function vtkImageData(publicAPI, model) {
   publicAPI.getBounds = () =>
     publicAPI.extentToBounds(publicAPI.getSpatialExtent());
 
-  publicAPI.extentToBounds = (ex) => {
-    // prettier-ignore
-    const corners = [
-      [ex[0], ex[2], ex[4]],
-      [ex[1], ex[2], ex[4]],
-      [ex[0], ex[3], ex[4]],
-      [ex[1], ex[3], ex[4]],
-      [ex[0], ex[2], ex[5]],
-      [ex[1], ex[2], ex[5]],
-      [ex[0], ex[3], ex[5]],
-      [ex[1], ex[3], ex[5]]
-    ];
-
-    const bounds = [...vtkBoundingBox.INIT_BOUNDS];
-    const vout = [];
-    for (let i = 0; i < 8; ++i) {
-      publicAPI.indexToWorld(corners[i], vout);
-      vtkBoundingBox.addPoint(bounds, ...vout);
-    }
-    return bounds;
-  };
+  publicAPI.extentToBounds = (ex) =>
+    vtkBoundingBox.transformBounds(ex, model.indexToWorld);
 
   publicAPI.getSpatialExtent = () =>
     vtkBoundingBox.inflate([...model.extent], 0.5);
@@ -244,31 +225,11 @@ function vtkImageData(publicAPI, model) {
   };
   publicAPI.worldToIndexVec3 = publicAPI.worldToIndex;
 
-  publicAPI.indexToWorldBounds = (bin, bout = []) => {
-    const in1 = [0, 0, 0];
-    const in2 = [0, 0, 0];
-    vtkBoundingBox.computeCornerPoints(bin, in1, in2);
+  publicAPI.indexToWorldBounds = (bin, bout = []) =>
+    vtkBoundingBox.transformBounds(bin, model.indexToWorld, bout);
 
-    const out1 = [0, 0, 0];
-    const out2 = [0, 0, 0];
-    vec3.transformMat4(out1, in1, model.indexToWorld);
-    vec3.transformMat4(out2, in2, model.indexToWorld);
-
-    return vtkMath.computeBoundsFromPoints(out1, out2, bout);
-  };
-
-  publicAPI.worldToIndexBounds = (bin, bout = []) => {
-    const in1 = [0, 0, 0];
-    const in2 = [0, 0, 0];
-    vtkBoundingBox.computeCornerPoints(bin, in1, in2);
-
-    const out1 = [0, 0, 0];
-    const out2 = [0, 0, 0];
-    vec3.transformMat4(out1, in1, model.worldToIndex);
-    vec3.transformMat4(out2, in2, model.worldToIndex);
-
-    return vtkMath.computeBoundsFromPoints(out1, out2, bout);
-  };
+  publicAPI.worldToIndexBounds = (bin, bout = []) =>
+    vtkBoundingBox.transformBounds(bin, model.worldToIndex, bout);
 
   // Make sure the transform is correct
   publicAPI.onModified(publicAPI.computeTransforms);

--- a/Sources/Proxy/Core/ProxyManager/example/index.js
+++ b/Sources/Proxy/Core/ProxyManager/example/index.js
@@ -1,0 +1,121 @@
+import '@kitware/vtk.js/favicon';
+
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import '@kitware/vtk.js/Rendering/Profiles/Volume';
+
+// Force the loading of HttpDataAccessHelper to support gzip decompression
+import '@kitware/vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+
+import vtkHttpDataSetReader from '@kitware/vtk.js/IO/Core/HttpDataSetReader';
+
+import vtkProxyManager from '@kitware/vtk.js/Proxy/Core/ProxyManager';
+import proxyConfiguration from './proxy';
+
+// ----------------------------------------------------------------------------
+// Use a vtkHttpDataSetReader to get a promise of vtkImageData
+// ----------------------------------------------------------------------------
+
+const imageDataPromise = vtkHttpDataSetReader
+  .newInstance({ fetchGzip: true })
+  .setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`)
+  .then((reader) => reader.loadData())
+  .then((reader) => reader.getOutputData());
+
+// ----------------------------------------------------------------------------
+// Create proxy manager
+// ----------------------------------------------------------------------------
+
+const proxyManager = vtkProxyManager.newInstance({ proxyConfiguration });
+
+// ----------------------------------------------------------------------------
+// Create DOM elements for the views
+// ----------------------------------------------------------------------------
+
+const mainContainer = document.createElement('div');
+document.body.appendChild(mainContainer);
+
+const view3DContainer = document.createElement('div');
+mainContainer.appendChild(view3DContainer);
+
+const view2DContainer = document.createElement('div');
+mainContainer.appendChild(view2DContainer);
+
+// Full screen main container
+document.documentElement.style.height = '100%';
+document.body.style.height = '100%';
+document.body.style.margin = '0';
+mainContainer.style.height = '100%';
+mainContainer.style.display = 'flex';
+
+// Half the screen for each container
+const viewContainerStyle = document.createElement('style');
+viewContainerStyle.innerHTML = `
+.viewContainer {
+  display: flex;
+  position: relative;
+  width: 50%;
+  padding: 5px;
+}
+`;
+document.head.appendChild(viewContainerStyle);
+
+view3DContainer.className = 'viewContainer';
+view2DContainer.className = 'viewContainer';
+
+// ----------------------------------------------------------------------------
+// Create view proxy for 3D
+// ----------------------------------------------------------------------------
+
+const view3DProxy = proxyManager.createProxy('Views', 'View3D');
+view3DProxy.setContainer(view3DContainer);
+view3DProxy
+  .getOpenGLRenderWindow()
+  .setSize([view3DContainer.clientWidth, view3DContainer.clientHeight]);
+
+// ----------------------------------------------------------------------------
+// Create view proxy for 2D
+// ----------------------------------------------------------------------------
+
+const view2DProxy = proxyManager.createProxy('Views', 'View2D', { axis: 2 });
+view2DProxy.setContainer(view2DContainer);
+view2DProxy
+  .getOpenGLRenderWindow()
+  .setSize([view2DContainer.clientWidth, view2DContainer.clientHeight]);
+
+// ----------------------------------------------------------------------------
+// Create source proxy
+// ----------------------------------------------------------------------------
+
+let representation3DProxy;
+let representation2DProxy;
+const sourceProxy = proxyManager.createProxy('Sources', 'TrivialProducer');
+imageDataPromise.then((imageData) => {
+  sourceProxy.setInputData(imageData);
+
+  // ----------------------------------------------------------------------------
+  // Create representation proxies for 2D and 3D views
+  // ----------------------------------------------------------------------------
+  // The representationProxy can be used to change properties, color by an array, set LUTs, etc...
+
+  representation3DProxy = proxyManager.getRepresentation(
+    sourceProxy,
+    view3DProxy
+  );
+  view3DProxy.resetCamera();
+
+  representation2DProxy = proxyManager.getRepresentation(
+    sourceProxy,
+    view2DProxy
+  );
+  view2DProxy.resetCamera();
+});
+
+global.mainContainer = mainContainer;
+global.view3DContainer = view3DContainer;
+global.view2DContainer = view2DContainer;
+global.proxyManager = proxyManager;
+global.sourceProxy = sourceProxy;
+global.view3DProxy = view3DProxy;
+global.view2DProxy = view2DProxy;
+global.representation3DProxy = representation3DProxy;
+global.representation2DProxy = representation2DProxy;

--- a/Sources/Proxy/Core/ProxyManager/example/proxy.js
+++ b/Sources/Proxy/Core/ProxyManager/example/proxy.js
@@ -1,0 +1,50 @@
+import vtkLookupTableProxy from '@kitware/vtk.js/Proxy/Core/LookupTableProxy';
+import vtkPiecewiseFunctionProxy from '@kitware/vtk.js/Proxy/Core/PiecewiseFunctionProxy';
+import vtkSourceProxy from '@kitware/vtk.js/Proxy/Core/SourceProxy';
+import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
+import vtkView2DProxy from '@kitware/vtk.js/Proxy/Core/View2DProxy';
+import vtkVolumeRepresentationProxy from '@kitware/vtk.js/Proxy/Representations/VolumeRepresentationProxy';
+import vtkIJKSliceRepresentationProxy from '@kitware/vtk.js/Proxy/Representations/SliceRepresentationProxy';
+
+export default {
+  definitions: {
+    Proxy: {
+      LookupTable: {
+        class: vtkLookupTableProxy,
+      },
+      PiecewiseFunction: {
+        class: vtkPiecewiseFunctionProxy,
+      },
+    },
+    Sources: {
+      TrivialProducer: {
+        class: vtkSourceProxy,
+      },
+    },
+    Representations: {
+      Volume: {
+        class: vtkVolumeRepresentationProxy,
+      },
+      ImageSlice: {
+        class: vtkIJKSliceRepresentationProxy,
+      },
+    },
+    Views: {
+      View3D: {
+        class: vtkViewProxy,
+      },
+      View2D: {
+        class: vtkView2DProxy,
+      },
+    },
+  },
+  representations: {
+    View3D: {
+      vtkImageData: { name: 'Volume' },
+    },
+    View2D: {
+      vtkImageData: { name: 'ImageSlice' },
+    },
+  },
+  filters: {},
+};

--- a/Sources/Proxy/Core/View2DProxy/example/index.js
+++ b/Sources/Proxy/Core/View2DProxy/example/index.js
@@ -1,0 +1,105 @@
+import '@kitware/vtk.js/favicon';
+
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import '@kitware/vtk.js/Rendering/Profiles/Volume';
+
+// Force the loading of HttpDataAccessHelper to support gzip decompression
+import '@kitware/vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+
+import vtkHttpDataSetReader from '@kitware/vtk.js/IO/Core/HttpDataSetReader';
+
+import vtkProxyManager from '@kitware/vtk.js/Proxy/Core/ProxyManager';
+import proxyConfiguration from './proxy';
+
+// ----------------------------------------------------------------------------
+// Use a vtkHttpDataSetReader to get a promise of vtkImageData
+// ----------------------------------------------------------------------------
+
+const imageDataPromise = vtkHttpDataSetReader
+  .newInstance({ fetchGzip: true })
+  .setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`)
+  .then((reader) => reader.loadData())
+  .then((reader) => reader.getOutputData());
+
+// ----------------------------------------------------------------------------
+// Create proxy manager
+// ----------------------------------------------------------------------------
+
+const proxyManager = vtkProxyManager.newInstance({ proxyConfiguration });
+
+// ----------------------------------------------------------------------------
+// Create DOM elements to use as container and a button
+// ----------------------------------------------------------------------------
+
+const mainContainer = document.createElement('div');
+document.body.appendChild(mainContainer);
+
+// Full screen main container
+document.documentElement.style.height = '100%';
+document.body.style.height = '100%';
+document.body.style.margin = '0';
+mainContainer.style.height = '100%';
+mainContainer.style.display = 'flex';
+
+const fitCameraButton = document.createElement('button');
+fitCameraButton.innerText = 'Toggle camera fitting';
+fitCameraButton.style.position = 'absolute';
+fitCameraButton.style.top = '10px';
+fitCameraButton.style.left = '10px';
+fitCameraButton.style.zIndex = '100';
+document.body.appendChild(fitCameraButton);
+
+const resetCameraButton = document.createElement('button');
+resetCameraButton.innerText = 'Reset Camera';
+resetCameraButton.style.position = 'absolute';
+resetCameraButton.style.top = '50px';
+resetCameraButton.style.left = '10px';
+resetCameraButton.style.zIndex = '100';
+document.body.appendChild(resetCameraButton);
+
+// ----------------------------------------------------------------------------
+// Create a 2D view proxy
+// ----------------------------------------------------------------------------
+
+const view2DProxy = proxyManager.createProxy('Views', 'View2D', {
+  axis: 2,
+  fitProps: true,
+});
+view2DProxy.setContainer(mainContainer);
+view2DProxy
+  .getOpenGLRenderWindow()
+  .setSize([mainContainer.clientWidth, mainContainer.clientHeight]);
+
+fitCameraButton.addEventListener('click', () => {
+  view2DProxy.setFitProps(!view2DProxy.getFitProps());
+  view2DProxy.resetCamera();
+});
+
+resetCameraButton.addEventListener('click', view2DProxy.resetCamera);
+
+// ----------------------------------------------------------------------------
+// Create source proxy
+// ----------------------------------------------------------------------------
+
+let representation2DProxy;
+const sourceProxy = proxyManager.createProxy('Sources', 'TrivialProducer');
+imageDataPromise.then((imageData) => {
+  sourceProxy.setInputData(imageData);
+
+  // ----------------------------------------------------------------------------
+  // Create representation proxy
+  // ----------------------------------------------------------------------------
+  // The representationProxy can be used to change properties, color by an array, set LUTs, etc...
+
+  representation2DProxy = proxyManager.getRepresentation(
+    sourceProxy,
+    view2DProxy
+  );
+  view2DProxy.resetCamera();
+});
+
+global.mainContainer = mainContainer;
+global.proxyManager = proxyManager;
+global.sourceProxy = sourceProxy;
+global.view2DProxy = view2DProxy;
+global.representation2DProxy = representation2DProxy;

--- a/Sources/Proxy/Core/View2DProxy/example/proxy.js
+++ b/Sources/Proxy/Core/View2DProxy/example/proxy.js
@@ -1,0 +1,29 @@
+import vtkSourceProxy from '@kitware/vtk.js/Proxy/Core/SourceProxy';
+import vtkView2DProxy from '@kitware/vtk.js/Proxy/Core/View2DProxy';
+import vtkIJKSliceRepresentationProxy from '@kitware/vtk.js/Proxy/Representations/SliceRepresentationProxy';
+
+export default {
+  definitions: {
+    Sources: {
+      TrivialProducer: {
+        class: vtkSourceProxy,
+      },
+    },
+    Representations: {
+      ImageSlice: {
+        class: vtkIJKSliceRepresentationProxy,
+      },
+    },
+    Views: {
+      View2D: {
+        class: vtkView2DProxy,
+      },
+    },
+  },
+  representations: {
+    View2D: {
+      vtkImageData: { name: 'ImageSlice' },
+    },
+  },
+  filters: {},
+};

--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -46,6 +46,11 @@ function vtkViewProxy(publicAPI, model) {
   model.interactorStyle3D = vtkInteractorStyleManipulator.newInstance();
   model.interactorStyle2D = vtkInteractorStyleManipulator.newInstance();
 
+  /**
+   * Internal function used by publicAPI.resetCamera()
+   */
+  model._resetCamera = (bounds = null) => model.renderer.resetCamera(bounds);
+
   // Apply default interaction styles
   InteractionPresets.applyPreset('3D', model.interactorStyle3D);
   InteractionPresets.applyPreset('2D', model.interactorStyle2D);
@@ -257,9 +262,36 @@ function vtkViewProxy(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
+  publicAPI.setCameraParameters = ({
+    position,
+    focalPoint,
+    bounds,
+    parallelScale,
+    viewAngle,
+  }) => {
+    if (position != null) {
+      model.camera.setPosition(...position);
+    }
+    if (focalPoint != null) {
+      model.camera.setFocalPoint(...focalPoint);
+    }
+    if (bounds != null) {
+      model.renderer.resetCameraClippingRange(bounds);
+    } else {
+      model.renderer.resetCameraClippingRange();
+    }
+    if (parallelScale != null) {
+      model.camera.setParallelScale(parallelScale);
+    }
+    if (viewAngle != null) {
+      model.camera.setViewAngle(viewAngle);
+    }
+  };
+
+  // --------------------------------------------------------------------------
+
   publicAPI.resetCamera = () => {
-    model.renderer.resetCamera();
-    model.renderer.resetCameraClippingRange();
+    model._resetCamera();
     model.interactorStyle2D.setCenterOfRotation(model.camera.getFocalPoint());
     model.interactorStyle3D.setCenterOfRotation(model.camera.getFocalPoint());
     publicAPI.renderLater();

--- a/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/behavior.js
@@ -208,7 +208,10 @@ export default function widgetBehavior(publicAPI, model) {
   // TODO: move to ShapeWidget/index.js
   publicAPI.getBounds = () =>
     model.point1 && model.point2
-      ? vtkMath.computeBoundsFromPoints(model.point1, model.point2, [])
+      ? vtkBoundingBox.addPoints(vtkBoundingBox.reset([]), [
+          model.point1,
+          model.point2,
+        ])
       : vtkMath.uninitializeBounds([]);
 
   // To be reimplemented by subclass
@@ -293,11 +296,10 @@ export default function widgetBehavior(publicAPI, model) {
       ...vtkBoundingBox.getMaxPoint(worldBounds),
       model._renderer
     );
-    const displayBounds = vtkMath.computeBoundsFromPoints(
+    const displayBounds = vtkBoundingBox.addPoints(vtkBoundingBox.reset([]), [
       minPoint,
       maxPoint,
-      []
-    );
+    ]);
 
     let planeOrigin = [];
     let p1 = [];
@@ -406,7 +408,10 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.updateTextPosition = (point1, point2) => {
-    const bounds = vtkMath.computeBoundsFromPoints(point1, point2, []);
+    const bounds = vtkBoundingBox.addPoints(vtkBoundingBox.reset([]), [
+      point1,
+      point2,
+    ]);
     const screenPosition = computeTextPosition(
       bounds,
       model.widgetState.getTextPosition(),


### PR DESCRIPTION
Add an option to fit camera to bounds

When this option is checked and the view is parallel, calling resetCamera will zoom until the bounds of the props fit as most as possible in the field of view
Works too when the camera is not aligned with the axes and with any prop

This can be easily extended to also work when the camera is not parallel, as visiblePoints remain valid (do not use viewBounds wihtout a parallel camera as it will be less precise)

### Context

See [this issue](https://github.com/Kitware/glance/issues/356) from glance

### Results

Without fitting:
![image](https://user-images.githubusercontent.com/90781029/214895127-da8d8b7f-5dcc-438f-91bc-7043b03b54c3.png)

With fitting:
![image](https://user-images.githubusercontent.com/90781029/214895189-e6e64f1f-4a1e-496e-8a16-22e255ea886a.png)

Because the fitting uses bounds, it is not always perfect.
For example, in the View2DProxy example, you can move the camera using these lines of code:
```
view2DProxy.getCamera().setViewUp([Math.sqrt(2), 0, -Math.sqrt(2)]);
view2DProxy
  .getCamera()
  .setDirectionOfProjection(Math.sqrt(3), Math.sqrt(3), Math.sqrt(3));
```

There is no bug, the bounding box of the slices is the bounding box of the volume.
You can see that by scrolling through the slices.
When you get to the end or the beginning of the volume, the slice matches the edge of the view.
Here is an illustration using the fitting option.

![image](https://user-images.githubusercontent.com/90781029/214907420-f7536020-f067-4877-8341-337ce064f7c0.png)

![image](https://user-images.githubusercontent.com/90781029/214907496-1cda3f00-3fd6-44ac-8435-6040eb35235f.png)

### Changes

Add the option in view2DProxy

Add examples for proxies in ProxyManager and View2DProxy

Fix addPoints in BoundingBox
Fix indexToWorldBounds and worldToIndexBounds in ImageData

Rewrite extentToBounds in ImageData using transformBounds

Delete vtkMath.computeBoundsFromPoints as it can be replaced by BoundingBox.addPoints

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
