### PR TITLE
fix: Enable BigInt64Array and BigUint64Array

### DIFF
--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -97,8 +97,10 @@ TYPED_ARRAYS.Int16Array = Int16Array;
 TYPED_ARRAYS.Uint32Array = Uint32Array;
 TYPED_ARRAYS.Int32Array = Int32Array;
 TYPED_ARRAYS.Uint8ClampedArray = Uint8ClampedArray;
-TYPED_ARRAYS.BigInt64Array = BigInt64Array;
-TYPED_ARRAYS.BigUint64Array = BigUint64Array;
+try {
+  TYPED_ARRAYS.BigInt64Array = BigInt64Array;
+  TYPED_ARRAYS.BigUint64Array = BigUint64Array;
+} catch (error) {}
 
 export function newTypedArray(type, ...args) {
   return new (TYPED_ARRAYS[type] || Float64Array)(...args);

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -97,8 +97,8 @@ TYPED_ARRAYS.Int16Array = Int16Array;
 TYPED_ARRAYS.Uint32Array = Uint32Array;
 TYPED_ARRAYS.Int32Array = Int32Array;
 TYPED_ARRAYS.Uint8ClampedArray = Uint8ClampedArray;
-// TYPED_ARRAYS.BigInt64Array = BigInt64Array;
-// TYPED_ARRAYS.BigUint64Array = BigUint64Array;
+TYPED_ARRAYS.BigInt64Array = BigInt64Array;
+TYPED_ARRAYS.BigUint64Array = BigUint64Array;
 
 export function newTypedArray(type, ...args) {
   return new (TYPED_ARRAYS[type] || Float64Array)(...args);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Resolves #2693 

I have no idea if more is needed but here's a start!

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
