### PR TITLE
feat: add (U)BigInt64 support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ module.exports = {
     },
   },
   env: {
+    es2020: true,
     es6: true,
     browser: true,
   },

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -97,8 +97,13 @@ TYPED_ARRAYS.Int16Array = Int16Array;
 TYPED_ARRAYS.Uint32Array = Uint32Array;
 TYPED_ARRAYS.Int32Array = Int32Array;
 TYPED_ARRAYS.Uint8ClampedArray = Uint8ClampedArray;
-// TYPED_ARRAYS.BigInt64Array = BigInt64Array;
-// TYPED_ARRAYS.BigUint64Array = BigUint64Array;
+
+try {
+  TYPED_ARRAYS.BigInt64Array = BigInt64Array;
+  TYPED_ARRAYS.BigUint64Array = BigUint64Array;
+} catch {
+  // ignore
+}
 
 export function newTypedArray(type, ...args) {
   return new (TYPED_ARRAYS[type] || Float64Array)(...args);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Adds BigInt64 support in order to handle converting `int64` datatypes from VTK.

### Results
- BigInt64 and UBigInt64 should now be supported.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] (U)BigInt64 support

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
