### PR TITLE
fix(radon): fix radon transform following half-float support

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -1438,7 +1438,7 @@ void applyBlend(vec3 posIS, vec3 endIS, vec3 tdims)
     {
       tValue = getTextureValue(posIS);
       normalizedRayIntensity = normalizedRayIntensity - sampleDistance*texture2D(otexture, vec2(tValue.r * oscale0 + oshift0, 0.5)).r;
-      gl_FragData[0] = texture2D(ctexture, vec2(normalizedRayIntensity * cscale0 + cshift0, 0.5));
+      gl_FragData[0] = texture2D(ctexture, vec2(normalizedRayIntensity, 0.5));
       return;
     }
 
@@ -1459,7 +1459,7 @@ void applyBlend(vec3 posIS, vec3 endIS, vec3 tdims)
     }
 
     // map normalizedRayIntensity to color
-    gl_FragData[0] = texture2D(ctexture, vec2(normalizedRayIntensity * cscale0 + cshift0, 0.5));
+    gl_FragData[0] = texture2D(ctexture, vec2(normalizedRayIntensity , 0.5));
 
   #endif
 }


### PR DESCRIPTION
Regression from a6d9d32d. Closes #2658

fix #2658

### Context
Radon transform example was displaying a fully white volume.

### Results
With change the volume is now back to a grayscale volume.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome
