### PR TITLE
fix(scalarstocolors): support changing the number of color in the CTF…

### DIFF
--- a/Sources/Common/Core/LookupTable/index.js
+++ b/Sources/Common/Core/LookupTable/index.js
@@ -61,7 +61,7 @@ function vtkLookupTable(publicAPI, model) {
   publicAPI.usingLogScale = () => false;
 
   //----------------------------------------------------------------------------
-  publicAPI.getNumberOfAvailableColors = () => model.table.length;
+  publicAPI.getNumberOfAvailableColors = () => model.table.length / 4;
 
   //----------------------------------------------------------------------------
   // Apply shift/scale to the scalar value v and return the index.
@@ -92,12 +92,7 @@ function vtkLookupTable(publicAPI, model) {
       index = publicAPI.linearIndexLookup(v, p);
     }
     const offset = 4 * index;
-    return [
-      table[offset],
-      table[offset + 1],
-      table[offset + 2],
-      table[offset + 3],
-    ];
+    return table.slice(offset, offset + 4);
   };
 
   publicAPI.indexedLookupFunction = (v, table, p) => {
@@ -199,6 +194,8 @@ function vtkLookupTable(publicAPI, model) {
       ainc = (model.alphaRange[1] - model.alphaRange[0]) / maxIndex;
     }
 
+    model.table.length = 4 * maxIndex + 16;
+
     const hsv = [];
     const rgba = [];
     for (let i = 0; i <= maxIndex; i++) {
@@ -232,6 +229,7 @@ function vtkLookupTable(publicAPI, model) {
     }
     model.numberOfColors = table.getNumberOfTuples();
     const data = table.getData();
+    model.table.length = data.length;
     for (let i = 0; i < data.length; i++) {
       model.table[i] = data[i];
     }

--- a/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
+++ b/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
@@ -41,4 +41,34 @@
       <input type="checkbox" id="drawAboveRangeSwatch" checked>
     </td>
   </tr>
+  <tr>
+    <td><b>Mapper</b></td>
+  </tr>
+  <tr>
+    <td>Interpolate Scalars:</td>
+    <td>
+      <input type="checkbox" id="interpolateScalars">
+    </td>
+  </tr>
+  <tr>
+    <td>Use ColorTransferFunction:</td>
+    <td>
+      <input type="checkbox" id="useColorTransferFunction">
+    </td>
+  </tr>
+  <tr>
+    <td><b>ScalarsToColors</b></td>
+  </tr>
+  <tr>
+    <td>Discretize:</td>
+    <td>
+      <input type="checkbox" id="discretize">
+    </td>
+  </tr>
+  <tr>
+    <td>Number of colors:</td>
+    <td>
+      <input type="number" id="numberOfColors" value="256" min="1"></input>
+    </td>
+  </tr>
 </table>

--- a/Sources/Rendering/Core/ScalarBarActor/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/index.js
@@ -403,7 +403,7 @@ function vtkScalarBarActorHelper(publicAPI, model) {
   };
 
   // based on all the settins compute a barSegments array
-  // containing the segments opf the scalar bar
+  // containing the segments of the scalar bar
   // each segment contains
   //   corners[4][2]
   //   title - e.g. NaN, Above, ticks
@@ -854,7 +854,7 @@ const newScalarBarActorHelper = macro.newInstance(
     model.tmPolyData = vtkPolyData.newInstance();
     model.tmMapper = vtkMapper.newInstance();
     model.tmMapper.setInputData(model.tmPolyData);
-    model.tmTexture = vtkTexture.newInstance();
+    model.tmTexture = vtkTexture.newInstance({ resizable: true });
     model.tmTexture.setInterpolate(false);
     model.tmActor = vtkActor.newInstance({ parentProp: publicAPI });
     model.tmActor.setMapper(model.tmMapper);

--- a/Sources/Rendering/Core/Texture/index.d.ts
+++ b/Sources/Rendering/Core/Texture/index.d.ts
@@ -1,11 +1,16 @@
 import { vtkAlgorithm } from "../../../interfaces";
 
+/**
+ * 
+ * @param {boolean} [resizable] Must be set to true if texture can be resized at run time (default: false)
+ */
 export interface ITextureInitialValues {
 	repeat?: boolean;
 	interpolate?: boolean;
 	edgeClamp?: boolean;
 	imageLoaded?: boolean;
 	mipLevel?: number;
+	resizable?: boolean;
 }
 
 export interface vtkTexture extends vtkAlgorithm {

--- a/Sources/Rendering/Core/Texture/index.js
+++ b/Sources/Rendering/Core/Texture/index.js
@@ -249,6 +249,7 @@ const DEFAULT_VALUES = {
   interpolate: false,
   edgeClamp: false,
   mipLevel: 0,
+  resizable: false, // must be set at construction time if the texture can be resizable
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1900,7 +1900,9 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     if (model.renderable.getColorCoordinates()) {
       tcoords = model.renderable.getColorCoordinates();
       if (!model.internalColorTexture) {
-        model.internalColorTexture = vtkOpenGLTexture.newInstance();
+        model.internalColorTexture = vtkOpenGLTexture.newInstance({
+          resizable: true,
+        });
       }
       const tex = model.internalColorTexture;
       // the following 4 lines allow for NPOT textures

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -814,7 +814,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     model.context.pixelStorei(model.context.UNPACK_FLIP_Y_WEBGL, flip);
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
 
-    if (model._openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2() && !model.resizable) {
       model.context.texStorage2D(
         model.target,
         1,
@@ -916,7 +916,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     // Source texture data from the PBO.
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
 
-    if (model._openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2() && !model.resizable) {
       model.context.texStorage2D(
         model.target,
         6,
@@ -939,7 +939,7 @@ function vtkOpenGLTexture(publicAPI, model) {
         if (j <= model.maxLevel) {
           tempData = invertedData[6 * j + i];
         }
-        if (model._openGLRenderWindow.getWebgl2()) {
+        if (model._openGLRenderWindow.getWebgl2() && !model.resizable) {
           if (tempData != null) {
             model.context.texSubImage2D(
               model.context.TEXTURE_CUBE_MAP_POSITIVE_X + i,
@@ -1013,7 +1013,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     // model.context.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
 
-    if (model._openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2() && !model.resizable) {
       model.context.texStorage2D(
         model.target,
         1,
@@ -1107,7 +1107,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     );
     const safeImage = canvas;
 
-    if (model._openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2() && !model.resizable) {
       model.context.texStorage2D(
         model.target,
         1,
@@ -1586,7 +1586,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     // model.context.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     model.context.pixelStorei(model.context.UNPACK_ALIGNMENT, 1);
 
-    if (model._openGLRenderWindow.getWebgl2()) {
+    if (model._openGLRenderWindow.getWebgl2() && !model.resizable) {
       model.context.texStorage2D(
         model.target,
         1,


### PR DESCRIPTION
… and LUT

The texture used to display the CTF/LUT was not being resized when reducing the number of discrete colors.

This is because texStorage2D sets a permanent texture size.

### Context
Changing the number of values of a vtkColorTransferFunction was not correctly updating the vtkScalarBarActor color legend.

### Results
The scalarbaractor color legend is now correctly updated.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] This change improves an example
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome
