### PR TITLE
fix(linewidget): restore the hidden line in the LineWidget

### DIFF
--- a/Sources/Common/Core/CellArray/index.d.ts
+++ b/Sources/Common/Core/CellArray/index.d.ts
@@ -9,6 +9,10 @@ export interface ICellArrayInitialValues extends IDataArrayInitialValues {
 	empty?: boolean;
 }
 
+/**
+ * You are NOT allowed to modify the cell array via `getData()`.
+ * Only via `setData` or `insertNextCell`
+ */
 export interface vtkCellArray extends vtkDataArray {
 
 	/**

--- a/Sources/Common/Core/CellArray/index.js
+++ b/Sources/Common/Core/CellArray/index.js
@@ -66,6 +66,9 @@ function vtkCellArray(publicAPI, model) {
     return model.cellSizes;
   };
 
+  /**
+   * When `resize()` is being used, you then MUST use `insertNextCell()`.
+   */
   publicAPI.resize = (requestedNumTuples) => {
     const oldNumTuples = publicAPI.getNumberOfTuples();
     superClass.resize(requestedNumTuples);


### PR DESCRIPTION
The lines cell array did not contain any cell.

### Context
The linewidget example was not showing any line between the 2 handles.

### Results
The line is now visible in the LineWidget example.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] This change fixes an example
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 
  - **Browser**: Chrome
