### PR TITLE
Fix texture from image cropping when size is not a power of two

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1071,8 +1071,6 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     model.target = model.context.TEXTURE_2D;
     model.components = 4;
-    model.width = image.width;
-    model.height = image.height;
     model.depth = 1;
     model.numberOfDimensions = 2;
     model._openGLRenderWindow.activateTexture(publicAPI);
@@ -1085,7 +1083,9 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     // Scale up the texture to the next highest power of two dimensions (if needed) and flip y.
     const needNearestPowerOfTwo =
-      !vtkMath.isPowerOfTwo(image.width) || !vtkMath.isPowerOfTwo(image.height);
+      !model._openGLRenderWindow.getWebgl2() &&
+      (!vtkMath.isPowerOfTwo(image.width) ||
+        !vtkMath.isPowerOfTwo(image.height));
     const canvas = document.createElement('canvas');
     canvas.width = needNearestPowerOfTwo
       ? vtkMath.nearestPowerOfTwo(image.width)
@@ -1093,6 +1093,10 @@ function vtkOpenGLTexture(publicAPI, model) {
     canvas.height = needNearestPowerOfTwo
       ? vtkMath.nearestPowerOfTwo(image.height)
       : image.height;
+
+    model.width = canvas.width;
+    model.height = canvas.height;
+
     const ctx = canvas.getContext('2d');
     ctx.translate(0, canvas.height);
     ctx.scale(1, -1);


### PR DESCRIPTION
When creating a texture from an image which dimensions are not powers of 2, vtk.js used to:
- create a canvas bigger than the image, which dimensions are powers of 2
- paint and stretch the image to fill the canvas
- use as texture a piece of the canvas which has the same size as the image

Fixed this behaviour by using the size of the canvas instead of the size of the image to create the texture.

To illustrate the bug, here is an example with a 1500x700 image applied to a plane
Before the fix, the image was stretched to 2048x1024 and then cropped to 1500x700

Before

![image](https://user-images.githubusercontent.com/90781029/217310345-754bc514-50a0-44e6-91c0-b5ca8c0e1755.png)


After

![image](https://user-images.githubusercontent.com/90781029/217310059-37284897-795c-4be2-b670-b2c83bb02ba6.png)
