### PR TITLE
fix(ImageMapper): TypeError in ImageMapper bindTexture

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -766,10 +766,6 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     const dataType = imgScalars.getDataType();
     const numComp = imgScalars.getNumberOfComponents();
 
-    // Re-allocate the texture because vtkOpenGLTexture uses texStorage2D
-    // which makes the texture immutable.
-    model.openGLTexture.releaseGraphicsResources(model._openGLRenderWindow);
-
     const actorProperty = actor.getProperty();
 
     // set interpolation on the texture based on property setting
@@ -1143,9 +1139,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   );
 
   model.tris = vtkHelper.newInstance();
-  model.openGLTexture = vtkOpenGLTexture.newInstance();
-  model.colorTexture = vtkOpenGLTexture.newInstance();
-  model.pwfTexture = vtkOpenGLTexture.newInstance();
+  model.openGLTexture = vtkOpenGLTexture.newInstance({ resizable: true });
+  model.colorTexture = vtkOpenGLTexture.newInstance({ resizable: true });
+  model.pwfTexture = vtkOpenGLTexture.newInstance({ resizable: true });
 
   model.imagemat = mat4.identity(new Float64Array(16));
   model.imagematinv = mat4.identity(new Float64Array(16));


### PR DESCRIPTION
This addresses issue #2710:
TypeError is thrown on call to `texture.bind()` due to releasing texture but not re-allocating it. A temporary fix is to use the resizable flag so that a delete/create of textures is not required (`ImageMapper` textures are no longer immutable).

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: Windows 11 <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: Chrome 109.0.5414.120 (Official Build) **(64-bit)** <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
