### PR TITLE
fix(ViewProxy): in .d.ts change case of gl in getOpenGLRenderWindow

### DIFF
--- a/Sources/Proxy/Core/ViewProxy/index.d.ts
+++ b/Sources/Proxy/Core/ViewProxy/index.d.ts
@@ -66,7 +66,7 @@ export interface vtkViewProxy extends VtkProxy {
   getInteractor(): vtkRenderWindowInteractor;
   getInteractorStyle2D(): vtkInteractorStyle;
   getInteractorStyle3D(): vtkInteractorStyle;
-  getOpenglRenderWindow(): vtkOpenGLRenderWindow;
+  getOpenGLRenderWindow(): vtkOpenGLRenderWindow;
   getOrientationAxesType(): string;
   getPresetToOrientationAxes(): any;
   getRenderer(): vtkRenderer;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Typescript .d.ts mismatch on case of GL in ViewProxy::getOpenGLRenderWindow()

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Updates case of ViewProxy::getOpenGLRenderWindow() in .d.ts.


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code


<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
