### PR TITLE
fix: add loading data message to Scrolling2DMixedImages

### DIFF
--- a/Examples/Volume/Scrolling2DMixedImages/index.js
+++ b/Examples/Volume/Scrolling2DMixedImages/index.js
@@ -30,11 +30,22 @@ import vtkSphereSource from '@kitware/vtk.js/Filters/Sources/SphereSource';
 // to unzip data file
 import { unzipSync } from 'fflate';
 
+const rootBody = document.querySelector('body');
+rootBody.style.background = 'rgba(65, 86, 122, 1)';
+const labelSelector = document.createElement('label');
+labelSelector.style.fontWeight = 'bold';
+labelSelector.innerText = 'Loading input data, please wait ...';
+const progressContainer = document.createElement('div');
+progressContainer.appendChild(labelSelector);
+rootBody.appendChild(progressContainer);
+
 // ----------------------------------------------------------------------------
 // Standard rendering setup for image slice
 // ----------------------------------------------------------------------------
 const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
   background: [65 / 255, 86 / 255, 122 / 255],
+  rootContainer: rootBody,
+  containerStyle: { height: '100%', width: '100%', position: 'absolute' },
 });
 const renderer = fullScreenRenderer.getRenderer();
 renderer.getActiveCamera().setParallelProjection(true);
@@ -228,6 +239,7 @@ async function update() {
 
   if (imageArray.length > 0) {
     imageArray.map((elem) => collection.addItem(elem));
+    labelSelector.innerText = '';
     load(vtkImageMapper.SlicingMode.K);
   }
 }


### PR DESCRIPTION
Add a loading input data message for the initial loading of input data since it takes a while to load.
It may confuse the user if no message is displayed when the canvas is blank.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
