### PR TITLE
feat(renderwindowinteractor): optionally bypass debounce on mouse scroll

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -60,6 +60,7 @@ export interface IRenderWindowInteractorInitialValues {
 	moveTimeoutID?: number;
 	preventDefaultOnPointerDown?: boolean;
 	preventDefaultOnPointerUp?: boolean;
+	mouseScrollDebounceByPass?: boolean;
 }
 
 interface IPosition {
@@ -163,6 +164,11 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 	 * @default false
 	 */
 	getPreventDefaultOnPointerUp(): boolean;
+
+	/**
+	 * @default false
+	 */
+	getMouseScrollDebounceByPass(): boolean;
 
 	/**
 	 * 
@@ -848,6 +854,13 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 	 * @param {Boolean} preventDefault
 	 */
 	setPreventDefaultOnPointerUp(preventDefault: boolean): boolean;
+
+	/**
+	 * Allow system to bypass scrolling debounce. This function must be called to allow the debounce to be bypassed
+	 * @param mouseScrollDebounceByPass
+	 */
+
+	setMouseScrollDebounceByPass(mouseScrollDebounceByPass:boolean): void;
 
    /**
 	 *

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -685,12 +685,18 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       clearTimeout(model.wheelTimeoutID);
     }
 
-    // start a timer to keep us animating while we get wheel events
-    model.wheelTimeoutID = setTimeout(() => {
+    if (model.mouseScrollDebounceByPass) {
       publicAPI.extendAnimation(600);
       publicAPI.endMouseWheelEvent();
       model.wheelTimeoutID = 0;
-    }, 200);
+    } else {
+      // start a timer to keep us animating while we get wheel events
+      model.wheelTimeoutID = setTimeout(() => {
+        publicAPI.extendAnimation(600);
+        publicAPI.endMouseWheelEvent();
+        model.wheelTimeoutID = 0;
+      }, 200);
+    }
   };
 
   publicAPI.handleMouseUp = (event) => {
@@ -1148,6 +1154,7 @@ const DEFAULT_VALUES = {
   lastGamepadValues: {},
   preventDefaultOnPointerDown: false,
   preventDefaultOnPointerUp: false,
+  mouseScrollDebounceByPass: false,
 };
 
 // ----------------------------------------------------------------------------
@@ -1187,6 +1194,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'picker',
     'preventDefaultOnPointerDown',
     'preventDefaultOnPointerUp',
+    'mouseScrollDebounceByPass',
   ]);
   macro.moveToProtected(publicAPI, model, ['view']);
 


### PR DESCRIPTION
Exposes a function to conditionally bypass the debounce of the mouse scroll. The bypass needs to be set explicitly.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
We were encountering an issue with the scroll events being debounced. Our back end wanted every scroll from the remote view.


### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
![in-code-test](https://user-images.githubusercontent.com/90642500/221124073-960cd40f-da9f-40e5-be6a-b6fa262a192b.png)

![in-browser-results](https://user-images.githubusercontent.com/90642500/221124087-50bb13ec-c3ac-40d8-ab9a-0a144172a230.png)

This change exposes a function that will allow the consumer to bypass the debounce. It must be called explicitly. This decision was made so that it would be impossible to accidentally turn off the debounce and potentially overload the server.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: master
  - **OS**: Ubuntu 22.04
  - **Browser**: Chrome 110.0.5481.100, FireFox 110.0

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
