### PR TITLE
fix(glyphrepresentation): support overriding pipeline in glyph repres…

### DIFF
--- a/Sources/Widgets/Representations/GlyphRepresentation/index.js
+++ b/Sources/Widgets/Representations/GlyphRepresentation/index.js
@@ -244,22 +244,22 @@ function defaultValues(publicAPI, model, initialValues) {
     defaultScale: 1,
     ...initialValues,
     _pipeline: {
-      source: initialValues.pipeline?.source ?? publicAPI,
+      source: initialValues._pipeline?.source ?? publicAPI,
       glyph:
-        initialValues.pipeline?.glyph ?? // in case glyph was provided
+        initialValues._pipeline?.glyph ?? // in case glyph was provided
         vtkSphereSource.newInstance({
           phiResolution: 8,
           thetaResolution: 8,
         }),
       mapper:
-        initialValues.pipeline?.mapper ?? // in case mapper was provided
+        initialValues._pipeline?.mapper ?? // in case mapper was provided
         vtkGlyph3DMapper.newInstance({
           scalarMode: ScalarMode.USE_POINT_FIELD_DATA,
         }),
       actor:
-        initialValues.pipeline?.actor ?? // in case actor was provided
+        initialValues._pipeline?.actor ?? // in case actor was provided
         vtkActor.newInstance({ parentProp: publicAPI }),
-      ...initialValues.pipeline, // in case there is something else to add to pipeline
+      ...initialValues._pipeline, // in case there is something else to add to pipeline
     },
     applyMixin: {
       origin: initialValues.applyMixin?.origin ?? origin(publicAPI, model),


### PR DESCRIPTION
…entation subclasses

### Context
Shape widget example was broken since v26.0.0.

### Results
vtkGlyphRepresentation subclasses are now able to override the default pipeline.

### Changes
Rename pipeline with _pipeline.

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes an example
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
