### PR TITLE
Fix widgets

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -8,7 +8,7 @@ takes an axis name (string, e.g. 'XinY') instead of a substate. `enableRotation`
   - `widgetState.setSphereRadius()` is replaced by `widgetState.getCenterHandle().setScale1()` and `widgetState.getStatesWithLabel('rotation').forEach((handle) => handle.setScale1())`
   - `widgetState.setLineThickness(t)` is replaced by `widgetState.getStatesWithLabel('line').forEach((handle) => handle.setScale3(t,t,t))`
   - `setScaleInPixels()` should now be set on the widget instead of the `widgetInView`.
-  - `widgetState.setOpacity()` has not yet been replaced.
+  - `widgetState.setOpacity()` is replaced by `widgetState.getStatesWithLabel('handles').forEach((handle) => handle.setOpacity())`
 - SVGRepresentation and SVG widget support has been fully removed.
 
 ## From 24.x to 25

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -4,6 +4,11 @@
 Instead, a `vtkSphereHandleRepresentation` is used for `rotation` and `center` handles,
 and a `vtkLineHandleRepresenttion` is used for the axes. `rotateLineInView()` now
 takes an axis name (string, e.g. 'XinY') instead of a substate. `enableRotation`, `enableTranslation` and `keepOrthogonality` in widgetState are replaced by widget behavior accessors (e.g. `widgetInView.setEnableRotation(false)`). See RCW example.
+  - `widgetState.setShowCenter()` is replaced by `widgetState.getCenterHandle.setVisible()`
+  - `widgetState.setSphereRadius()` is replaced by `widgetState.getCenterHandle().setScale1()` and `widgetState.getStatesWithLabel('rotation').forEach((handle) => handle.setScale1())`
+  - `widgetState.setLineThickness(t)` is replaced by `widgetState.getStatesWithLabel('line').forEach((handle) => handle.setScale3(t,t,t))`
+  - `setScaleInPixels()` should now be set on the widget instead of the `widgetInView`.
+  - `widgetState.setOpacity()` has not yet been replaced.
 - SVGRepresentation and SVG widget support has been fully removed.
 
 ## From 24.x to 25

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -3,7 +3,7 @@
 - **ResliceCursorWidget**: vtkResliceCursorContextRepresentation is deprecated and removed.
 Instead, a `vtkSphereHandleRepresentation` is used for `rotation` and `center` handles,
 and a `vtkLineHandleRepresenttion` is used for the axes. `rotateLineInView()` now
-takes an axis name (string, e.g. 'XinY') instead of a substate.
+takes an axis name (string, e.g. 'XinY') instead of a substate. `enableRotation`, `enableTranslation` and `keepOrthogonality` in widgetState are replaced by widget behavior accessors (e.g. `widgetInView.setEnableRotation(false)`). See RCW example.
 - SVGRepresentation and SVG widget support has been fully removed.
 
 ## From 24.x to 25

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -133,11 +133,6 @@ function vtkDataArray(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkDataArray');
 
-  function dataChange() {
-    model.ranges = null;
-    publicAPI.modified();
-  }
-
   /**
    * Resize model.values and copy the old values to the new array.
    * @param {Number} requestedNumTuples Final expected number of tuples; must be >= 0
@@ -170,18 +165,23 @@ function vtkDataArray(publicAPI, model) {
     // Requested size is smaller than currently allocated size
     if (model.size > requestedNumTuples * numComps) {
       model.size = requestedNumTuples * numComps;
-      dataChange();
+      publicAPI.dataChange();
     }
 
     return true;
   }
+
+  publicAPI.dataChange = () => {
+    model.ranges = null;
+    publicAPI.modified();
+  };
 
   publicAPI.resize = (requestedNumTuples) => {
     resize(requestedNumTuples);
     const newSize = requestedNumTuples * publicAPI.getNumberOfComponents();
     if (model.size !== newSize) {
       model.size = newSize;
-      dataChange();
+      publicAPI.dataChange();
       return true;
     }
     return false;
@@ -209,7 +209,7 @@ function vtkDataArray(publicAPI, model) {
   publicAPI.setComponent = (tupleIdx, compIdx, value) => {
     if (value !== model.values[tupleIdx * model.numberOfComponents + compIdx]) {
       model.values[tupleIdx * model.numberOfComponents + compIdx] = value;
-      dataChange();
+      publicAPI.dataChange();
     }
   };
 
@@ -382,7 +382,7 @@ function vtkDataArray(publicAPI, model) {
     if (model.size % model.numberOfComponents !== 0) {
       model.numberOfComponents = 1;
     }
-    dataChange();
+    publicAPI.dataChange();
   };
 
   // Override serialization support

--- a/Sources/Common/Core/ScalarsToColors/index.d.ts
+++ b/Sources/Common/Core/ScalarsToColors/index.d.ts
@@ -124,9 +124,17 @@ export interface vtkScalarsToColors extends vtkObject {
 	getVectorSize(): number;
 
 	/**
-	 * 
+	 * @see areScalarsOpaque
 	 */
 	isOpaque(): boolean;
+
+	/**
+	 * Returns false if scalars are Uint8 LA or RGBA with A < 255,
+	 * otherwise rely on getAlpha() in case of direct mapping,
+	 * otherwise return isOpaque()
+	 * @see isOpaque, getAlpha
+	 */
+	areScalarsOpaque(scalars, colorMode, componentIn): boolean;
 
 	/**
 	 * 

--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -511,6 +511,32 @@ function vtkScalarsToColors(publicAPI, model) {
 
   publicAPI.setRange = (min, max) => publicAPI.setMappingRange(min, max);
   publicAPI.getRange = () => publicAPI.getMappingRange();
+
+  publicAPI.areScalarsOpaque = (scalars, colorMode, componentIn) => {
+    if (!scalars) {
+      return publicAPI.isOpaque();
+    }
+
+    const numberOfComponents = scalars.getNumberOfComponents();
+
+    // map scalars through lookup table only if needed
+    if (
+      (colorMode === ColorMode.DEFAULT &&
+        scalars.getDataType() === VtkDataTypes.UNSIGNED_CHAR) ||
+      colorMode === ColorMode.DIRECT_SCALARS
+    ) {
+      // we will be using the scalars directly, so look at the number of
+      // components and the range
+      if (numberOfComponents === 3 || numberOfComponents === 1) {
+        return model.alpha >= 1.0;
+      }
+      // otherwise look at the range of the alpha channel
+      const range = scalars.getRange(numberOfComponents - 1);
+      return range[0] === 255;
+    }
+
+    return true;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -403,11 +403,24 @@ function vtkMapper(publicAPI, model) {
   };
 
   publicAPI.getIsOpaque = () => {
+    const input = publicAPI.getInputData();
+    const gasResult = publicAPI.getAbstractScalars(
+      input,
+      model.scalarMode,
+      model.arrayAccessMode,
+      model.arrayId,
+      model.colorByArrayName
+    );
+    const scalars = gasResult.scalars;
+    if (!model.scalarVisibility || scalars == null) {
+      // No scalar colors.
+      return true;
+    }
     const lut = publicAPI.getLookupTable();
     if (lut) {
       // Ensure that the lookup table is built
       lut.build();
-      return lut.isOpaque();
+      return lut.areScalarsOpaque(scalars, model.colorMode, -1);
     }
     return true;
   };

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1283,6 +1283,20 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     publicAPI.setViewStream,
     deleteGLContext
   );
+
+  // Do not trigger modified for performance reasons
+  publicAPI.setActiveFramebuffer = (newActiveFramebuffer) => {
+    model.activeFramebuffer = newActiveFramebuffer;
+  };
+
+  const superSetSize = publicAPI.setSize;
+  publicAPI.setSize = (width, height) => {
+    const modified = superSetSize(width, height);
+    if (modified) {
+      publicAPI.invokeWindowResizeEvent({ width, height });
+    }
+    return modified;
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -1364,6 +1378,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'vrDisplay',
     'useBackgroundImage',
     'xrSupported',
+    'activeFramebuffer',
   ]);
 
   macro.setGet(publicAPI, model, [
@@ -1375,14 +1390,10 @@ export function extend(publicAPI, model, initialValues = {}) {
     'defaultToWebgl2',
     'cursor',
     'useOffScreen',
-    // might want to make this not call modified as
-    // we change the active framebuffer a lot. Or maybe
-    // only mark modified if the size or depth
-    // of the buffer has changed
-    'activeFramebuffer',
   ]);
 
   macro.setGetArray(publicAPI, model, ['size'], 2);
+  macro.event(publicAPI, model, 'windowResizeEvent');
 
   // Object methods
   vtkOpenGLRenderWindow(publicAPI, model);

--- a/Sources/Widgets/Core/AbstractWidget/index.js
+++ b/Sources/Widgets/Core/AbstractWidget/index.js
@@ -75,10 +75,7 @@ function vtkAbstractWidget(publicAPI, model) {
     }
   };
 
-  publicAPI.getViewWidgets = () =>
-    model._factory
-      .getViewIds()
-      .map((viewId) => model._factory.getWidgetForView({ viewId }));
+  publicAPI.getViewWidgets = () => model._factory.getViewWidgets();
 
   // --------------------------------------------------------------------------
   // Initialization calls

--- a/Sources/Widgets/Core/AbstractWidgetFactory/index.d.ts
+++ b/Sources/Widgets/Core/AbstractWidgetFactory/index.d.ts
@@ -28,6 +28,11 @@ export interface vtkAbstractWidgetFactory {
   getViewIds(): string[];
 
   /**
+   * Get a list of all the instances of the widget.
+   */
+  getViewWidgets(): vtkAbstractWidget[];
+
+  /**
    * Set the visiblity on each underlying view widget.
    * 
    * @param {Boolean} visible

--- a/Sources/Widgets/Core/AbstractWidgetFactory/index.js
+++ b/Sources/Widgets/Core/AbstractWidgetFactory/index.js
@@ -125,6 +125,8 @@ function vtkAbstractWidgetFactory(publicAPI, model) {
   // List of all the views the widget has been registered to.
   publicAPI.getViewIds = () => Object.keys(viewToWidget);
 
+  publicAPI.getViewWidgets = () => Object.values(viewToWidget);
+
   // --------------------------------------------------------------------------
   // Widget visibility / enable
   // --------------------------------------------------------------------------

--- a/Sources/Widgets/Core/StateBuilder/color3Mixin.js
+++ b/Sources/Widgets/Core/StateBuilder/color3Mixin.js
@@ -5,6 +5,7 @@ import macro from 'vtk.js/Sources/macros';
  */
 const DEFAULT_VALUES = {
   color3: [255, 255, 255],
+  opacity: 255,
 };
 
 // ----------------------------------------------------------------------------
@@ -12,6 +13,7 @@ const DEFAULT_VALUES = {
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
   macro.setGetArray(publicAPI, model, ['color3'], 3, 255);
+  macro.setGet(publicAPI, model, ['opacity']);
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Widgets/Core/StateBuilder/originMixin.js
+++ b/Sources/Widgets/Core/StateBuilder/originMixin.js
@@ -1,25 +1,52 @@
 import macro from 'vtk.js/Sources/macros';
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import { getPixelWorldHeightAtCoord } from 'vtk.js/Sources/Widgets/Core/WidgetManager';
 
 // ----------------------------------------------------------------------------
 
 function vtkOriginMixin(publicAPI, model) {
+  const superClass = { ...publicAPI };
   publicAPI.translate = (dx, dy, dz) => {
     const [x, y, z] = publicAPI.getOriginByReference();
     publicAPI.setOrigin(x + dx, y + dy, z + dz);
   };
+  publicAPI.getOrigin = (displayScaleParams) => {
+    const origin = superClass.getOrigin();
+    if (!model.offset) {
+      return origin;
+    }
+    if (!displayScaleParams) {
+      return vtkMath.add(origin, model.offset, origin);
+    }
+    const pixelWorldHeight = getPixelWorldHeightAtCoord(
+      origin,
+      displayScaleParams
+    );
+    const { rendererPixelDims } = displayScaleParams;
+    const totalSize = Math.min(rendererPixelDims[0], rendererPixelDims[1]);
+    return vtkMath.multiplyAccumulate(
+      origin,
+      model.offset,
+      totalSize * pixelWorldHeight,
+      origin
+    );
+  };
 }
 
 // ----------------------------------------------------------------------------
-
+/**
+ * offset: optional offset that can be scaled to pixel screen space.
+ */
 const DEFAULT_VALUES = {
   origin: null,
+  offset: null,
 };
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
-  macro.setGetArray(publicAPI, model, ['origin'], 3);
+  macro.setGetArray(publicAPI, model, ['origin', 'offset'], 3);
   vtkOriginMixin(publicAPI, model);
 }
 

--- a/Sources/Widgets/Core/WidgetManager/index.d.ts
+++ b/Sources/Widgets/Core/WidgetManager/index.d.ts
@@ -37,6 +37,14 @@ export interface IRenderingComponents {
  */
 export function extractRenderingComponents(renderer: vtkRenderer): IRenderingComponents;
 
+/**
+ * This method returns the world distance that corresponds to the height of a
+ * single display pixel at a given coordinate. For example, to determine the
+ * (vertical) distance that matches a display distance of 30px for a coordinate
+ * `coord`, you would compute `30 * getPixelWorldHeightAtCoord(coord)`.
+ */
+export function getPixelWorldHeightAtCoord(coord: []): Number;
+
 export interface vtkWidgetManager extends vtkObject {
   /**
    * The the captureOn value. 

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -1,4 +1,4 @@
-import { radiansFromDegrees } from 'vtk.js/Sources/Common/Core/Math';
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import { FieldAssociations } from 'vtk.js/Sources/Common/DataModel/DataSet/Constants';
 import macro from 'vtk.js/Sources/macros';
 import Constants from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
@@ -27,6 +27,26 @@ export function extractRenderingComponents(renderer) {
   };
 }
 
+export function getPixelWorldHeightAtCoord(worldCoord, displayScaleParams) {
+  const {
+    dispHeightFactor,
+    cameraPosition,
+    cameraDir,
+    isParallel,
+    rendererPixelDims,
+  } = displayScaleParams;
+  let scale = 1;
+  if (isParallel) {
+    scale = dispHeightFactor;
+  } else {
+    const worldCoordToCamera = [...worldCoord];
+    vtkMath.subtract(worldCoordToCamera, cameraPosition, worldCoordToCamera);
+    scale = vtkMath.dot(worldCoordToCamera, cameraDir) * dispHeightFactor;
+  }
+
+  const rHeight = rendererPixelDims[1];
+  return scale / rHeight;
+}
 // ----------------------------------------------------------------------------
 // vtkWidgetManager methods
 // ----------------------------------------------------------------------------
@@ -85,7 +105,7 @@ function vtkWidgetManager(publicAPI, model) {
       const isParallel = _camera.getParallelProjection();
       const dispHeightFactor = isParallel
         ? 2 * _camera.getParallelScale()
-        : 2 * Math.tan(radiansFromDegrees(_camera.getViewAngle()) / 2);
+        : 2 * Math.tan(vtkMath.radiansFromDegrees(_camera.getViewAngle()) / 2);
 
       model.widgets.forEach((w) => {
         w.getNestedProps().forEach((r) => {
@@ -500,4 +520,4 @@ export const newInstance = macro.newInstance(extend, 'vtkWidgetManager');
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend, Constants };
+export default { newInstance, extend, Constants, getPixelWorldHeightAtCoord };

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -251,7 +251,9 @@ function vtkWidgetManager(publicAPI, model) {
     );
 
     subscriptions.push(
-      model._apiSpecificRenderWindow.onModified(updateDisplayScaleParams)
+      model._apiSpecificRenderWindow.onWindowResizeEvent(
+        updateDisplayScaleParams
+      )
     );
     subscriptions.push(model._camera.onModified(updateDisplayScaleParams));
     updateDisplayScaleParams();

--- a/Sources/Widgets/Representations/GlyphRepresentation/index.js
+++ b/Sources/Widgets/Representations/GlyphRepresentation/index.js
@@ -40,13 +40,14 @@ export function noPosition(publicAPI, model) {
 export function color3(publicAPI, model) {
   return (polyData, states) => {
     model._pipeline.mapper.setColorByArrayName('color');
-    const colors = allocateArray(
+    const colorArray = allocateArray(
       polyData,
       'color',
       states.length,
-      'Uint8Array', // RGB
-      3
-    ).getData();
+      'Uint8Array', // RGBA
+      4
+    );
+    const colors = colorArray.getData();
     let j = 0;
     for (let i = 0; i < states.length; ++i) {
       let c3 = states[i].getColor3();
@@ -56,7 +57,9 @@ export function color3(publicAPI, model) {
       colors[j++] = c3[0];
       colors[j++] = c3[1];
       colors[j++] = c3[2];
+      colors[j++] = states[i].getOpacity();
     }
+    colorArray.dataChange();
   };
 }
 export function color(publicAPI, model) {

--- a/Sources/Widgets/Representations/GlyphRepresentation/index.js
+++ b/Sources/Widgets/Representations/GlyphRepresentation/index.js
@@ -7,8 +7,9 @@ import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 
 import { ScalarMode } from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
+import { getPixelWorldHeightAtCoord } from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+
 import vtkWidgetRepresentation, {
-  getPixelWorldHeightAtCoord,
   allocateArray,
 } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 import { Behavior } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation/Constants';
@@ -22,7 +23,9 @@ export function origin(publicAPI, model) {
     const points = allocateArray(polyData, 'points', states.length).getData();
     let j = 0;
     for (let i = 0; i < states.length; ++i) {
-      const coord = states[i].getOrigin();
+      const coord = states[i].getOrigin(
+        model.scaleInPixels && model.displayScaleParams
+      );
       points[j++] = coord[0];
       points[j++] = coord[1];
       points[j++] = coord[2];

--- a/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
+++ b/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
@@ -11,9 +11,8 @@ import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
 import vtkStateBuilder from 'vtk.js/Sources/Widgets/Core/StateBuilder';
-import vtkWidgetRepresentation, {
-  getPixelWorldHeightAtCoord,
-} from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
+import { getPixelWorldHeightAtCoord } from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkWidgetRepresentation from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 
 import WidgetManagerConst from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 import PropertyConst from 'vtk.js/Sources/Rendering/Core/Property/Constants';

--- a/Sources/Widgets/Representations/PolyLineRepresentation/index.js
+++ b/Sources/Widgets/Representations/PolyLineRepresentation/index.js
@@ -4,8 +4,8 @@ import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import vtkTubeFilter from 'vtk.js/Sources/Filters/General/TubeFilter';
+import { getPixelWorldHeightAtCoord } from 'vtk.js/Sources/Widgets/Core/WidgetManager';
 import vtkWidgetRepresentation, {
-  getPixelWorldHeightAtCoord,
   allocateArray,
 } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation';
 import { RenderingTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';

--- a/Sources/Widgets/Representations/WidgetRepresentation/api.md
+++ b/Sources/Widgets/Representations/WidgetRepresentation/api.md
@@ -22,9 +22,3 @@ that match the target labels.
 
 Should be used when creating an actor for the representation. It will apply widget-wide configuration such as coincident topology parameters to the mapper.
 
-## getPixelWorldHeightAtCoord(coord)
-
-This method returns the world distance that corresponds to the height of a
-single display pixel at a given coordinate. For example, to determine the
-(vertical) distance that matches a display distance of 30px for a coordinate
-`coord`, you would compute `30 * getPixelWorldHeightAtCoord(coord)`.

--- a/Sources/Widgets/Representations/WidgetRepresentation/index.js
+++ b/Sources/Widgets/Representations/WidgetRepresentation/index.js
@@ -1,6 +1,5 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkProp from 'vtk.js/Sources/Rendering/Core/Prop';
-import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
 import vtkCellArray from 'vtk.js/Sources/Common/Core/CellArray';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
@@ -84,27 +83,6 @@ export function connectPipeline(pipeline) {
     pipeline.mapper.setInputConnection(pipeline.glyph.getOutputPort(), 1);
   }
   pipeline.actor.setMapper(pipeline.mapper);
-}
-
-export function getPixelWorldHeightAtCoord(worldCoord, displayScaleParams) {
-  const {
-    dispHeightFactor,
-    cameraPosition,
-    cameraDir,
-    isParallel,
-    rendererPixelDims,
-  } = displayScaleParams;
-  let scale = 1;
-  if (isParallel) {
-    scale = dispHeightFactor;
-  } else {
-    const worldCoordToCamera = [...worldCoord];
-    vtkMath.subtract(worldCoordToCamera, cameraPosition, worldCoordToCamera);
-    scale = vtkMath.dot(worldCoordToCamera, cameraDir) * dispHeightFactor;
-  }
-
-  const rHeight = rendererPixelDims[1];
-  return scale / rHeight;
 }
 
 // Internal convenient function to create a data array:
@@ -343,7 +321,11 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Object methods
   vtkProp.extend(publicAPI, model, defaultValues(initialValues));
   macro.algo(publicAPI, model, 1, 1);
-  macro.get(publicAPI, model, ['labels']);
+  macro.get(publicAPI, model, [
+    'labels',
+    'displayScaleParams',
+    'coincidentTopologyParameters',
+  ]);
   macro.set(publicAPI, model, [
     { type: 'object', name: 'displayScaleParams' },
     { type: 'object', name: 'coincidentTopologyParameters' },
@@ -366,5 +348,4 @@ export default {
   mergeStyles,
   applyStyles,
   connectPipeline,
-  getPixelWorldHeightAtCoord,
 };

--- a/Sources/Widgets/Widgets3D/LineWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/example/index.js
@@ -48,7 +48,7 @@ widgetManager.setRenderer(renderer);
 let widget = null;
 
 let lineWidget = null;
-let selectedWidgetIndex = 0;
+let selectedWidgetIndex = null;
 
 let getHandle = {};
 
@@ -176,7 +176,29 @@ function updateHandleShape(handleId) {
 function setWidgetColor(currentWidget, color) {
   currentWidget.getWidgetState().getHandle1().setColor(color);
   currentWidget.getWidgetState().getHandle2().setColor(color);
-  currentWidget.getWidgetState().getMoveHandle().setColor(color);
+
+  currentWidget.setUseActiveColor(false);
+  currentWidget.getWidgetState().getMoveHandle().setColor(0.3);
+}
+
+// Restore color
+function unselectWidget(index) {
+  if (index != null) {
+    const widgetToUnselect = widgetManager.getWidgets()[selectedWidgetIndex];
+    setWidgetColor(widgetToUnselect, 0.5); // green
+  }
+  if (index === selectedWidgetIndex) {
+    selectedWidgetIndex = null;
+  }
+}
+
+function selectWidget(index) {
+  unselectWidget(selectedWidgetIndex);
+  if (index != null) {
+    const widgetToSelect = widgetManager.getWidgets()[index];
+    setWidgetColor(widgetToSelect, 0.2); // yellow
+  }
+  selectedWidgetIndex = index;
 }
 
 const inputHandle1 = document.getElementById('idh1');
@@ -228,6 +250,7 @@ document.querySelector('#addWidget').addEventListener('click', () => {
   currentHandle = widgetManager.addWidget(widget);
   lineWidget = currentHandle;
 
+  selectWidget(widgetManager.getWidgets().length - 1);
   setupSVG(widget);
 
   getHandle = {
@@ -252,9 +275,7 @@ document.querySelector('#addWidget').addEventListener('click', () => {
       1: currentHandle.getWidgetState().getHandle1(),
       2: currentHandle.getWidgetState().getHandle2(),
     };
-    setWidgetColor(widgetManager.getWidgets()[selectedWidgetIndex], 0.5);
-    setWidgetColor(widgetManager.getWidgets()[index], 0.2);
-    selectedWidgetIndex = index;
+    selectWidget(index);
     lineWidget = currentHandle;
     document.getElementById('idh1').value =
       getHandle[1].getShape() === '' ? 'sphere' : getHandle[1].getShape();
@@ -276,10 +297,11 @@ document.querySelector('#addWidget').addEventListener('click', () => {
 });
 
 document.querySelector('#removeWidget').addEventListener('click', () => {
+  unselectWidget(selectedWidgetIndex);
   widgetManager.removeWidget(widgetManager.getWidgets()[selectedWidgetIndex]);
   if (svgCleanupCallbacks.length) svgCleanupCallbacks.pop()();
   if (widgetManager.getWidgets().length !== 0) {
-    selectedWidgetIndex = widgetManager.getWidgets().length - 1;
+    selectWidget(widgetManager.getWidgets().length - 1);
     setWidgetColor(widgetManager.getWidgets()[selectedWidgetIndex], 0.2);
   }
 });

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/api.md
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/api.md
@@ -30,15 +30,7 @@ These sub states contain :
 
 - sphereRadius: Manages the radius of the rotation points
 
-- showCenter: Defines if the reslice cursor center is displayed or not. If not, it's still possible to move the center. The cursor mouse will be turned into 'move' cursor when you can translate the center.
-
 - Planes: Contains the normal and viewUp of the YZ_, XZ_ and XY_PLANE views (which is updated when a rotation is applied). It's used to compute the resliced image
-
-- enableRotation: if false, then remove the rotation points and disable the line rotation
-
-- enableTranslation: if false, disable the translation of the axis
-
-- keepOrthogonality: if false, then rotation are totally free. Else, if one axis is rotated, then the associated one if rotating the same axis in order to keep orthogonality
 
 - scrollingMethod: Define which mouse button is used to scroll (use [Contants.js](https://github.com/Kitware/vtk-js/blob/master/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants.js)):
   * MIDDLE_MOUSE_BUTTON : Default

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -25,6 +25,17 @@ export default function widgetBehavior(publicAPI, model) {
   let isScrolling = false;
   let previousPosition;
 
+  macro.setGet(publicAPI, model, ['keepOrthogonality']);
+
+  publicAPI.setEnableTranslation = (enable) => {
+    model.representations[0].setPickable(enable); // line handle
+    model.representations[2].setPickable(enable); // center handle
+  };
+
+  publicAPI.setEnableRotation = (enable) => {
+    model.representations[1].setPickable(enable); // rotation handle
+  };
+
   // FIXME: label information should be accessible from activeState instead of parent state.
   publicAPI.getActiveInteraction = () => {
     if (
@@ -406,7 +417,7 @@ export default function widgetBehavior(publicAPI, model) {
     const planeNormal = model.widgetState.getPlanes()[inViewType].normal;
     publicAPI.rotatePlane(viewType, radianAngle, planeNormal);
 
-    if (model.widgetState.getKeepOrthogonality()) {
+    if (publicAPI.getKeepOrthogonality()) {
       const otherLineName = getOtherLineName(lineName);
       const otherPlaneName = getLinePlaneName(otherLineName);
       publicAPI.rotatePlane(

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -287,7 +287,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.setCenter(newCenter);
     updateState(
       model.widgetState,
-      model._factory.getDisplayScaleParams(),
+      model._factory.getScaleInPixels(),
       model._factory.getRotationHandlePosition()
     );
   };
@@ -345,7 +345,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.setCenter(newOrigin);
     updateState(
       model.widgetState,
-      model._factory.getDisplayScaleParams(),
+      model._factory.getScaleInPixels(),
       model._factory.getRotationHandlePosition()
     );
   };
@@ -373,7 +373,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.setCenter(newCenter);
     updateState(
       model.widgetState,
-      model._factory.getDisplayScaleParams(),
+      model._factory.getScaleInPixels(),
       model._factory.getRotationHandlePosition()
     );
   };
@@ -389,7 +389,7 @@ export default function widgetBehavior(publicAPI, model) {
     const center = model.widgetState.getCenter();
     const previousLineDirection = activeLineHandle.getDirection();
     vtkMath.normalize(previousLineDirection);
-    if (publicAPI.getActiveRotationPointName() === 'point0') {
+    if (publicAPI.getActiveRotationPointName() === 'point1') {
       vtkMath.multiplyScalar(previousLineDirection, -1);
     }
 
@@ -428,7 +428,7 @@ export default function widgetBehavior(publicAPI, model) {
     }
     updateState(
       model.widgetState,
-      model._factory.getDisplayScaleParams(),
+      model._factory.getScaleInPixels(),
       model._factory.getRotationHandlePosition()
     );
   };

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
@@ -30,6 +30,11 @@
     </td>
   </tr>
   <tr>
+    <td>Opacity :</td>
+    <td><input id='opacity' type="range" min="0" max="255" step="1" value="255" style="width: 100px;"/></td>
+    <td id='opacityValue'>255</td>
+  </tr>
+  <tr>
     <td>Slab Mode :</td>
     <td>
       <select id="slabMode">

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
@@ -55,6 +55,12 @@
     </td>
   </tr>
   <tr>
+    <td>Window Level:</td>
+    <td>
+      <input type="checkbox" id="checkboxWindowLevel" checked>
+    </td>
+  </tr>
+  <tr>
     <td>
       <button id="buttonReset">Reset views</button>
     </td>

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/controlPanel.html
@@ -1,8 +1,14 @@
 <table>
   <tr>
-    <td>Keep orthogonality:</td>
+    <td>Allow translation:</td>
     <td>
-      <input type="checkbox" id="checkboxOrthogality" checked>
+      <input type="checkbox" id="checkboxTranslation" checked>
+    </td>
+  </tr>
+  <tr>
+    <td>Show rotation:</td>
+    <td>
+      <input type="checkbox" id="checkboxShowRotation" checked>
     </td>
   </tr>
   <tr>
@@ -12,9 +18,9 @@
     </td>
   </tr>
   <tr>
-    <td>Allow translation:</td>
+    <td>Keep orthogonality:</td>
     <td>
-      <input type="checkbox" id="checkboxTranslation" checked>
+      <input type="checkbox" id="checkboxOrthogonality" checked>
     </td>
   </tr>
   <tr>

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -425,8 +425,8 @@ checkboxOrthogonality.addEventListener('change', (ev) => {
 
 const checkboxScaleInPixels = document.getElementById('checkboxScaleInPixels');
 checkboxScaleInPixels.addEventListener('change', (ev) => {
+  widget.setScaleInPixels(checkboxScaleInPixels.checked);
   viewAttributes.forEach((obj) => {
-    obj.widgetInstance.setScaleInPixels(checkboxScaleInPixels.checked);
     obj.interactor.render();
   });
 });
@@ -470,4 +470,17 @@ selectInterpolationMode.addEventListener('change', (ev) => {
     obj.reslice.setInterpolationMode(Number(ev.target.selectedIndex));
   });
   updateViews();
+});
+
+const checkboxWindowLevel = document.getElementById('checkboxWindowLevel');
+checkboxWindowLevel.addEventListener('change', (ev) => {
+  viewAttributes.forEach((obj, index) => {
+    if (index < 3) {
+      obj.interactor.setInteractorStyle(
+        checkboxWindowLevel.checked
+          ? vtkInteractorStyleImage.newInstance()
+          : vtkInteractorStyleTrackballCamera.newInstance()
+      );
+    }
+  });
 });

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -46,7 +46,6 @@ const viewColors = [
 const viewAttributes = [];
 const widget = vtkResliceCursorWidget.newInstance();
 const widgetState = widget.getWidgetState();
-widgetState.setKeepOrthogonality(true);
 widgetState.setOpacity(0.6);
 // Set size in CSS pixel space because scaleInPixels defaults to true
 widgetState.setSphereRadius(10);
@@ -62,6 +61,10 @@ const container = document.querySelector('body');
 const controlContainer = document.createElement('div');
 controlContainer.innerHTML = controlPanel;
 container.appendChild(controlContainer);
+const checkboxTranslation = document.getElementById('checkboxTranslation');
+const checkboxShowRotation = document.getElementById('checkboxShowRotation');
+const checkboxRotation = document.getElementById('checkboxRotation');
+const checkboxOrthogonality = document.getElementById('checkboxOrthogonality');
 
 // ----------------------------------------------------------------------------
 // Setup rendering code
@@ -145,6 +148,7 @@ for (let i = 0; i < 4; i++) {
     obj.interactor.setInteractorStyle(vtkInteractorStyleImage.newInstance());
     obj.widgetInstance = obj.widgetManager.addWidget(widget, xyzToViewType[i]);
     obj.widgetInstance.setScaleInPixels(true);
+    obj.widgetInstance.setKeepOrthogonality(checkboxOrthogonality.checked);
     obj.widgetManager.enablePicking();
     // Use to update all renderers buffer when actors are moved
     obj.widgetManager.setCaptureOn(CaptureOn.MOUSE_MOVE);
@@ -387,19 +391,36 @@ function updateViews() {
   view3D.renderer.resetCameraClippingRange();
 }
 
-const checkboxOrthogonality = document.getElementById('checkboxOrthogality');
-checkboxOrthogonality.addEventListener('change', (ev) => {
-  widgetState.setKeepOrthogonality(checkboxOrthogonality.checked);
-});
-
-const checkboxRotation = document.getElementById('checkboxRotation');
-checkboxRotation.addEventListener('change', (ev) => {
-  widgetState.setEnableRotation(checkboxRotation.checked);
-});
-
-const checkboxTranslation = document.getElementById('checkboxTranslation');
 checkboxTranslation.addEventListener('change', (ev) => {
-  widgetState.setEnableTranslation(checkboxTranslation.checked);
+  viewAttributes.forEach((obj) =>
+    obj.widgetInstance.setEnableTranslation(checkboxTranslation.checked)
+  );
+});
+
+checkboxShowRotation.addEventListener('change', (ev) => {
+  widgetState
+    .getStatesWithLabel('rotation')
+    .forEach((handle) => handle.setVisible(checkboxShowRotation.checked));
+  viewAttributes.forEach((obj) => {
+    obj.interactor.render();
+  });
+  checkboxRotation.checked = checkboxShowRotation.checked;
+  checkboxRotation.disabled = !checkboxShowRotation.checked;
+  checkboxRotation.dispatchEvent(new Event('change'));
+});
+
+checkboxRotation.addEventListener('change', (ev) => {
+  viewAttributes.forEach((obj) =>
+    obj.widgetInstance.setEnableRotation(checkboxRotation.checked)
+  );
+  checkboxOrthogonality.disabled = !checkboxRotation.checked;
+  checkboxOrthogonality.dispatchEvent(new Event('change'));
+});
+
+checkboxOrthogonality.addEventListener('change', (ev) => {
+  viewAttributes.forEach((obj) =>
+    obj.widgetInstance.setKeepOrthogonality(checkboxOrthogonality.checked)
+  );
 });
 
 const checkboxScaleInPixels = document.getElementById('checkboxScaleInPixels');

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -46,11 +46,10 @@ const viewColors = [
 const viewAttributes = [];
 const widget = vtkResliceCursorWidget.newInstance();
 const widgetState = widget.getWidgetState();
-widgetState.setOpacity(0.6);
 // Set size in CSS pixel space because scaleInPixels defaults to true
-widgetState.setSphereRadius(10);
-widgetState.setLineThickness(5);
-
+widgetState
+  .getStatesWithLabel('sphere')
+  .forEach((handle) => handle.setScale1(20));
 const showDebugActors = true;
 
 // ----------------------------------------------------------------------------
@@ -426,6 +425,19 @@ checkboxOrthogonality.addEventListener('change', (ev) => {
 const checkboxScaleInPixels = document.getElementById('checkboxScaleInPixels');
 checkboxScaleInPixels.addEventListener('change', (ev) => {
   widget.setScaleInPixels(checkboxScaleInPixels.checked);
+  viewAttributes.forEach((obj) => {
+    obj.interactor.render();
+  });
+});
+
+const opacity = document.getElementById('opacity');
+opacity.addEventListener('input', (ev) => {
+  const opacityValue = document.getElementById('opacityValue');
+  opacityValue.innerHTML = ev.target.value;
+  widget
+    .getWidgetState()
+    .getStatesWithLabel('handles')
+    .forEach((handle) => handle.setOpacity(ev.target.value));
   viewAttributes.forEach((obj) => {
     obj.interactor.render();
   });

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -14,6 +14,8 @@ import {
   updateState,
   transformPlane,
 } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';
+import { viewTypeToPlaneName } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/Constants';
+
 import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 
 import { mat4 } from 'gl-matrix';
@@ -265,51 +267,26 @@ function vtkResliceCursorWidget(publicAPI, model) {
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
       case ViewTypes.XY_PLANE:
-        return [
-          {
-            builder: vtkLineHandleRepresentation,
-            labels: ['lineInZ'],
-            initialValues: {
-              useActiveColor: false,
-            },
-          },
-          {
-            builder: vtkSphereHandleRepresentation,
-            labels: ['rotationInZ', 'center'],
-            initialValues: {
-              useActiveColor: false,
-            },
-          },
-        ];
       case ViewTypes.XZ_PLANE:
-        return [
-          {
-            builder: vtkLineHandleRepresentation,
-            labels: ['lineInY'],
-            initialValues: {
-              useActiveColor: false,
-            },
-          },
-          {
-            builder: vtkSphereHandleRepresentation,
-            labels: ['rotationInY', 'center'],
-            initialValues: {
-              useActiveColor: false,
-            },
-          },
-        ];
       case ViewTypes.YZ_PLANE:
         return [
           {
             builder: vtkLineHandleRepresentation,
-            labels: ['lineInX'],
+            labels: [`lineIn${viewTypeToPlaneName[viewType]}`],
             initialValues: {
               useActiveColor: false,
             },
           },
           {
             builder: vtkSphereHandleRepresentation,
-            labels: ['rotationInX', 'center'],
+            labels: [`rotationIn${viewTypeToPlaneName[viewType]}`],
+            initialValues: {
+              useActiveColor: false,
+            },
+          },
+          {
+            builder: vtkSphereHandleRepresentation,
+            labels: ['center'],
             initialValues: {
               useActiveColor: false,
             },

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -250,14 +250,15 @@ function vtkResliceCursorWidget(publicAPI, model) {
   /**
    * Convenient function to return the ResliceCursorRepresentation for a given viewType
    * @param {string} viewType
-   * @returns
+   * @returns an array of 3 representations (for line handles, rotation handles, center handle)
+   * or an empty array if the widget has not yet been added to the view type.
    */
   function findRepresentationsForViewType(viewType) {
     const widgetForViewType = publicAPI
       .getViewIds()
       .map((viewId) => publicAPI.getWidgetForView({ viewId }))
       .find((widget) => widget.getViewType() === viewType);
-    return widgetForViewType.getRepresentations();
+    return widgetForViewType ? widgetForViewType.getRepresentations() : [];
   }
 
   // --------------------------------------------------------------------------
@@ -591,7 +592,9 @@ function vtkResliceCursorWidget(publicAPI, model) {
     [ViewTypes.YZ_PLANE, ViewTypes.XZ_PLANE, ViewTypes.XY_PLANE].reduce(
       (res, viewType) => {
         res[viewType] =
-          findRepresentationsForViewType(viewType)[0].getDisplayScaleParams?.();
+          findRepresentationsForViewType(
+            viewType
+          )[0]?.getDisplayScaleParams?.();
         return res;
       },
       {}

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
@@ -15,11 +15,8 @@ export default function generateState() {
   const state = vtkStateBuilder
     .createBuilder()
     .addField({ name: 'center', initialValue: [0, 0, 0] })
-    .addField({ name: 'opacity', initialValue: 1 })
     .addField({ name: 'image', initialValue: null })
     .addField({ name: 'activeViewType', initialValue: null })
-    .addField({ name: 'lineThickness', initialValue: 2 })
-    .addField({ name: 'sphereRadius', initialValue: 5 })
     .addField({
       name: 'planes',
       initialValue: {
@@ -35,7 +32,7 @@ export default function generateState() {
     .addField({ name: 'cameraOffsets', initialValue: {} })
     .addField({ name: 'viewUpFromViewType', initialValue: {} })
     .addStateFromMixin({
-      labels: ['handles', 'center'],
+      labels: ['handles', 'sphere', 'center'],
       mixins: ['origin', 'color3', 'scale1', 'visible', 'manipulator'],
       name: 'centerHandle',
       initialValues: {
@@ -71,6 +68,7 @@ export default function generateState() {
             axisState.addStateFromMixin({
               labels: [
                 'handles',
+                'sphere',
                 'rotation',
                 `rotationIn${view}`,
                 `${axis}in${view}`,

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/state.js
@@ -20,7 +20,6 @@ export default function generateState() {
     .addField({ name: 'activeViewType', initialValue: null })
     .addField({ name: 'lineThickness', initialValue: 2 })
     .addField({ name: 'sphereRadius', initialValue: 5 })
-    .addField({ name: 'showCenter', initialValue: true })
     .addField({
       name: 'planes',
       initialValue: {
@@ -29,9 +28,6 @@ export default function generateState() {
         [ViewTypes.XY_PLANE]: { normal: [0, 0, -1], viewUp: [0, -1, 0] },
       },
     })
-    .addField({ name: 'enableRotation', initialValue: true })
-    .addField({ name: 'enableTranslation', initialValue: true })
-    .addField({ name: 'keepOrthogonality', initialValue: false })
     .addField({
       name: 'scrollingMethod',
       initialValue: ScrollingMethods.MIDDLE_MOUSE_BUTTON,

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testMultipleRotationPlanes.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testMultipleRotationPlanes.js
@@ -62,8 +62,9 @@ function createView(gc, viewType, widget) {
     gc.registerResource(vtkInteractorStyleImage.newInstance())
   );
   obj.widgetInstance = gc.registerResource(
-    obj.widgetManager.addWidget(widget, viewType)
+    obj.widgetManager.addWidget(widget, viewType, { keepOrthogonality: true })
   );
+
   obj.widgetManager.enablePicking();
   // Use to update all renderers buffer when actors are moved
   obj.widgetManager.setCaptureOn(CaptureOn.MOUSE_MOVE);
@@ -100,7 +101,6 @@ test('Test rendering when several rotations plane', (t) => {
   // --------------------------------------------------------------------------
 
   const widget = gc.registerResource(vtkResliceCursorWidget.newInstance());
-  widget.getWidgetState().setKeepOrthogonality(true);
   const viewAttributes = [];
 
   /**


### PR DESCRIPTION
### Context
Improve the ResliceCursorWidget following the recent breaking change in v26

### Results
Allow fine control over visiblity and pickability of the ResliceCursorWidget handles.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome latest