### PR TITLE
Fix LIC and translucency

### DIFF
--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -246,7 +246,7 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
     // TODO remove when webgl1 is deprecated and instead
     // have the forward pass use a texture backed zbuffer
     if (forwardPass.getOpaqueActorCount() > 0) {
-      forwardPass.setCurrentOperation('opaquePass');
+      forwardPass.setCurrentOperation('opaqueZBufferPass');
       renNode.traverse(forwardPass);
     }
 

--- a/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICInterface/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICInterface/index.js
@@ -408,19 +408,23 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
     model.geometryImage.activate();
     model.vectorImage.activate();
     model.maskVectorImage.activate();
+    // Don't use location 1 as it can be used by order independant translucent pass
+    // Translucent pass uses location 1 because of this line:
+    // gl_FragData[1].r = weight;
     fb.removeColorBuffer(0);
-    fb.removeColorBuffer(1);
     fb.removeColorBuffer(2);
+    fb.removeColorBuffer(3);
     fb.setColorBuffer(model.geometryImage, 0);
-    fb.setColorBuffer(model.vectorImage, 1);
-    fb.setColorBuffer(model.maskVectorImage, 2);
+    fb.setColorBuffer(model.vectorImage, 2);
+    fb.setColorBuffer(model.maskVectorImage, 3);
     fb.setDepthBuffer(model.depthTexture);
 
     const gl = model.context;
     gl.drawBuffers([
       gl.COLOR_ATTACHMENT0,
-      gl.COLOR_ATTACHMENT1,
+      gl.NONE,
       gl.COLOR_ATTACHMENT2,
+      gl.COLOR_ATTACHMENT3,
     ]);
     gl.viewport(0, 0, ...model.size);
     gl.scissor(0, 0, ...model.size);

--- a/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICMapper/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICMapper/index.js
@@ -32,8 +32,8 @@ function vtkOpenGLSurfaceLICMapper(publicAPI, model) {
     if (array && model.canDrawLIC) {
       FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::Output::Dec', [
         '//VTK::Output::Dec',
-        'layout(location = 1) out vec4 vectorTexture;',
-        'layout(location = 2) out vec4 maskVectorTexture;',
+        'layout(location = 2) out vec4 vectorTexture;',
+        'layout(location = 3) out vec4 maskVectorTexture;',
       ]).result;
 
       const arrayName = array.getName();


### PR DESCRIPTION
Order independant translucent pass uses draw buffer location 1.
Surface LIC was also using location 1 making it impossible to use in a scene with translucent objects.
Moved locations 1 and 2 to locations 2 and 3.

The order independant translucent pass used an 'opaquePass' to get the Z-buffer.
This pass doesn't work for objects rendered with LIC and is not optimized for Z buffer rendering (no need to compute colors, or render edges). As a result, translucent objects were renderd on top of LIC objects.
Replaced this 'opaquePass' with an 'opaqueZBufferPass'.