### PR TITLE
fix(renderwindowinteractor): adjust the threshold for spinY values when detecting trackpads

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -687,9 +687,10 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     // Here the first spin value is "recorded", and used to normalize
     // all the following mouse wheel events.
     if (model.wheelTimeoutID === 0) {
-      // 0.4 is roughly half-way between a large trackpad first event and small
-      // mouse wheel first event.
-      if (Math.abs(callData.spinY) > 0.4) {
+      // we attempt to distinguish between trackpads and mice
+      // .3 will be larger than the first trackpad event,
+      // but small enough to detect some common edge case mice
+      if (Math.abs(callData.spinY) >= 0.3) {
         // Event is coming from mouse wheel
         wheelCoefficient = Math.abs(callData.spinY);
       } else {


### PR DESCRIPTION
Discussion here: https://github.com/Kitware/vtk-js/pull/2680

### Context
vtkjs uses a spinY threshold of `> .4 ` to decide if a wheel event is sent from the trackpad. 
Instead we want it to use `>=.3` to detect some common logitech mice

### Results
Wheel scroll on logitech mice now allows slice by slice scrolling

### Changes
a change to a hardcoded value in the conditional logic of RenderWindowInteractor


### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
Test various mice to make sure that scroll still feels responsive. I have tested a logitech mx ergo (the culprit), a logitech g305, a logitech g203, and an apple magic trackpad.

### Funding
This contribution is funded by [Sirona Medical](https://sironamedical.com/).
