### PR TITLE
fix(MouseRangeManipulator): asymmetric scroll wheel behaviour

### DIFF
--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/example/index.js
@@ -72,7 +72,7 @@ const rangeManipulator = Manipulators.vtkMouseRangeManipulator.newInstance({
 });
 rangeManipulator.setVerticalListener(wMin, wMax, 1, wGet, wSet, 1);
 rangeManipulator.setHorizontalListener(lMin, lMax, 1, lGet, lSet, 1);
-rangeManipulator.setScrollListener(kMin, kMax, 1, kGet, kSet, 1);
+rangeManipulator.setScrollListener(kMin, kMax, 1, kGet, kSet, -0.5);
 
 const iStyle = vtkInteractorStyleManipulator.newInstance();
 iStyle.addMouseManipulator(rangeManipulator);

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/test/testMouseRangeManipulator.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/test/testMouseRangeManipulator.js
@@ -41,5 +41,59 @@ test('Test MouseRangeManipulator addition/removal', (t) => {
     'Vertical listener removed'
   );
 
+  let sliceValue = 5;
+  manip.setScrollListener(
+    0,
+    10,
+    1,
+    () => sliceValue,
+    (x) => {
+      sliceValue = x;
+    },
+    0.5
+  );
+
+  manip.onScroll(null, null, 1);
+  t.isEqual(sliceValue, 5, 'Scrolling to larger value, attempt-1.');
+
+  manip.onScroll(null, null, 1);
+  t.isEqual(sliceValue, 6, 'Scrolling to larger value, attempt-2.');
+
+  manip.onScroll(null, null, -1);
+  t.isEqual(sliceValue, 6, 'Scrolling to smaller value, attempt-1.');
+
+  manip.onScroll(null, null, -1);
+  t.isEqual(sliceValue, 5, 'Scrolling to smaller value, attempt-2.');
+
+  manip.removeScrollListener();
+  sliceValue = 0;
+  manip.setScrollListener(
+    -5,
+    7,
+    2,
+    () => sliceValue,
+    (x) => {
+      sliceValue = x;
+    },
+    1.0
+  );
+
+  manip.onScroll(null, null, 1);
+  t.isEqual(sliceValue, 2, 'Scrolling to larger value with step=2.');
+
+  manip.onScroll(null, null, -1);
+  t.isEqual(
+    sliceValue,
+    0,
+    'Scrolling to smaller value with step=2, attempt-1.'
+  );
+
+  manip.onScroll(null, null, -1);
+  t.isEqual(
+    sliceValue,
+    -2,
+    'Scrolling to smaller value with step=2, attempt-2.'
+  );
+
   t.end();
 });


### PR DESCRIPTION
Fix a bug where the `scrollListener` behaves in an asymmetric manner when comparing increasing value against decreasing value. This specifically occurs when using fractional `scale` values such as `0.5`. Bug is due to the use of `Math.round()` function and its application to the independently calculated `newValue`. Additionally, `Math.round()` also behaves asymmetrically when applied to the value of 0.5, as it always rounds towards `+infinity`.

The correct approach is to calculate the number of accumulated steps from the `newDelta` and round down to the closest lower integer using `Math.floor()`. This new approach also requires that the `listener.step` value be always positive. A required check has been added to the input value. If the caller needs to flip the scroll wheel direction, they should use negative `scale` values instead.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) --> latest master
  - **OS**: <!-- ex: Windows 10, iOS 13.6 --> Windows 11 Pro, 22H2 22621.1265
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 --> Firefox 110.0.1 (64-bit)

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
