### PR TITLE
Rename opaqueZBufferPass to zBufferPass and create a real opaqueZBufferPass

### DIFF
--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -44,7 +44,8 @@ function vtkOpenGLActor(publicAPI, model) {
     }
   };
 
-  publicAPI.traverseOpaqueZBufferPass = (renderPass) => {
+  // render both opaque and translucent actors
+  publicAPI.traverseZBufferPass = (renderPass) => {
     if (
       !model.renderable ||
       !model.renderable.getNestedVisibility() ||
@@ -59,6 +60,10 @@ function vtkOpenGLActor(publicAPI, model) {
 
     publicAPI.apply(renderPass, false);
   };
+
+  // only render opaque actors
+  publicAPI.traverseOpaqueZBufferPass = (renderPass) =>
+    publicAPI.traverseOpaquePass(renderPass);
 
   // we draw textures, then mapper, then post pass textures
   publicAPI.traverseOpaquePass = (renderPass) => {
@@ -126,6 +131,9 @@ function vtkOpenGLActor(publicAPI, model) {
       }
     }
   };
+
+  publicAPI.zBufferPass = (prepass, renderPass) =>
+    publicAPI.opaquePass(prepass, renderPass);
 
   publicAPI.opaqueZBufferPass = (prepass, renderPass) =>
     publicAPI.opaquePass(prepass, renderPass);

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -41,6 +41,7 @@ function vtkOpenGLCamera(publicAPI, model) {
     }
   };
   publicAPI.translucentPass = publicAPI.opaquePass;
+  publicAPI.zBufferPass = publicAPI.opaquePass;
   publicAPI.opaqueZBufferPass = publicAPI.opaquePass;
   publicAPI.volumePass = publicAPI.opaquePass;
 

--- a/Sources/Rendering/OpenGL/ForwardPass/index.js
+++ b/Sources/Rendering/OpenGL/ForwardPass/index.js
@@ -46,7 +46,8 @@ function vtkForwardPass(publicAPI, model) {
 
           // do we need to capture a zbuffer?
           if (
-            (model.opaqueActorCount > 0 && model.volumeCount > 0) ||
+            ((model.opaqueActorCount > 0 || model.translucentActorCount > 0) &&
+              model.volumeCount > 0) ||
             model.depthRequested
           ) {
             const size = viewNode.getFramebufferSize();
@@ -66,7 +67,10 @@ function vtkForwardPass(publicAPI, model) {
               model.framebuffer.populateFramebuffer();
             }
             model.framebuffer.bind();
-            publicAPI.setCurrentOperation('opaqueZBufferPass');
+            // opaqueZBufferPass only renders opaque actors
+            // zBufferPass renders both translucent and opaque actors
+            // we want to be able to pick translucent actors
+            publicAPI.setCurrentOperation('zBufferPass');
             renNode.traverse(publicAPI);
             model.framebuffer.restorePreviousBindingsAndBuffers();
 

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -81,7 +81,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     }
   };
 
-  publicAPI.opaqueZBufferPass = (prepass) => {
+  publicAPI.zBufferPass = (prepass) => {
     if (prepass) {
       model.haveSeenDepthRequest = true;
       model.renderDepth = true;
@@ -89,6 +89,8 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model.renderDepth = false;
     }
   };
+
+  publicAPI.opaqueZBufferPass = (prepass) => publicAPI.zBufferPass(prepass);
 
   publicAPI.opaquePass = (prepass) => {
     if (prepass) {

--- a/Sources/Rendering/OpenGL/ImageSlice/index.js
+++ b/Sources/Rendering/OpenGL/ImageSlice/index.js
@@ -34,9 +34,25 @@ function vtkOpenGLImageSlice(publicAPI, model) {
     }
   };
 
-  publicAPI.traverseOpaqueZBufferPass = (renderPass) => {
-    publicAPI.traverseOpaquePass(renderPass);
+  publicAPI.traverseZBufferPass = (renderPass) => {
+    if (
+      !model.renderable ||
+      !model.renderable.getNestedVisibility() ||
+      (model._openGLRenderer.getSelector() &&
+        !model.renderable.getNestedPickable())
+    ) {
+      return;
+    }
+
+    publicAPI.apply(renderPass, true);
+    model.children.forEach((child) => {
+      child.traverse(renderPass);
+    });
+    publicAPI.apply(renderPass, false);
   };
+
+  publicAPI.traverseOpaqueZBufferPass = (renderPass) =>
+    publicAPI.traverseOpaquePass(renderPass);
 
   // we draw textures, then mapper, then post pass textures
   publicAPI.traverseOpaquePass = (renderPass) => {
@@ -88,6 +104,9 @@ function vtkOpenGLImageSlice(publicAPI, model) {
       }
     }
   };
+
+  publicAPI.zBufferPass = (prepass, renderPass) =>
+    publicAPI.opaquePass(prepass, renderPass);
 
   publicAPI.opaqueZBufferPass = (prepass, renderPass) =>
     publicAPI.opaquePass(prepass, renderPass);

--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -246,6 +246,7 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
     // TODO remove when webgl1 is deprecated and instead
     // have the forward pass use a texture backed zbuffer
     if (forwardPass.getOpaqueActorCount() > 0) {
+      // Don't use zBufferPass as it will also render the depth of translucent actors
       forwardPass.setCurrentOperation('opaqueZBufferPass');
       renNode.traverse(forwardPass);
     }

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -70,7 +70,7 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     }
   };
 
-  publicAPI.opaqueZBufferPass = (prepass) => {
+  publicAPI.zBufferPass = (prepass) => {
     if (prepass) {
       model.haveSeenDepthRequest = true;
       model.renderDepth = true;
@@ -78,6 +78,8 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       model.renderDepth = false;
     }
   };
+
+  publicAPI.opaqueZBufferPass = (prepass) => publicAPI.zBufferPass(prepass);
 
   publicAPI.opaquePass = (prepass) => {
     if (prepass) {

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -47,7 +47,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
     return count;
   };
 
-  publicAPI.opaqueZBufferPass = (prepass) => {
+  publicAPI.zBufferPass = (prepass) => {
     if (prepass) {
       let clearMask = 0;
       const gl = model.context;
@@ -74,6 +74,8 @@ function vtkOpenGLRenderer(publicAPI, model) {
       gl.enable(gl.DEPTH_TEST);
     }
   };
+
+  publicAPI.opaqueZBufferPass = (prepass) => publicAPI.zBufferPass(prepass);
 
   // Renders myself
   publicAPI.cameraPass = (prepass) => {

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -55,7 +55,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
   // ohh someone is doing a zbuffer pass, use that for
   // intermixed volume rendering
-  publicAPI.opaqueZBufferPass = (prepass, renderPass) => {
+  publicAPI.zBufferPass = (prepass, renderPass) => {
     if (prepass) {
       const zbt = renderPass.getZBufferTexture();
       if (zbt !== model.zBufferTexture) {
@@ -63,6 +63,9 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       }
     }
   };
+
+  publicAPI.opaqueZBufferPass = (prepass, renderPass) =>
+    publicAPI.zBufferPass(prepass, renderPass);
 
   // Renders myself
   publicAPI.volumePass = (prepass, renderPass) => {


### PR DESCRIPTION
The old opaqueZBufferPass rendered the depth of translucent actors too
Renamed it zBufferPass and created a new opaqueZBufferPass which only renders the depth of opaque actors

opaqueZBufferPass is used by the OrderIndependantTranslucentPass to occlude fragments hidden by opaque actors
zBufferPass is used when picking or rendering depth for volume occlusion
