### PR TITLE
fix(glyphrepresentation): fix widgets representation when no visible …

### DIFF
--- a/Examples/Widgets/Box/BoxWidget.js
+++ b/Examples/Widgets/Box/BoxWidget.js
@@ -52,10 +52,10 @@ function widgetBehavior(publicAPI, model) {
       model.activeState &&
       model.activeState.getActive()
     ) {
-      model.manipulator.setNormal(model.camera.getDirectionOfProjection());
+      // model.manipulator.setNormal(model.camera.getDirectionOfProjection());
       const worldCoords = model.manipulator.handleEvent(
         callData,
-        model.apiSpecificRenderWindow
+        model._apiSpecificRenderWindow
       );
 
       if (worldCoords.length) {
@@ -85,6 +85,7 @@ function vtkBoxWidget(publicAPI, model) {
   // --- Widget Requirement ---------------------------------------------------
   model.behavior = widgetBehavior;
 
+  model.methodsToLink = ['scaleInPixels'];
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
       case ViewTypes.DEFAULT:

--- a/Examples/Widgets/Box/index.js
+++ b/Examples/Widgets/Box/index.js
@@ -2,6 +2,7 @@ import '@kitware/vtk.js/favicon';
 
 // Load the rendering pieces we want to use (for both WebGL and WebGPU)
 import '@kitware/vtk.js/Rendering/Profiles/Geometry';
+import '@kitware/vtk.js/Rendering/Profiles/Glyph';
 
 import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
@@ -49,6 +50,7 @@ function widgetRegistration(e) {
   const action = e ? e.currentTarget.dataset.action : 'addWidget';
   const viewWidget = widgetManager[action](widget);
   if (viewWidget) {
+    viewWidget.setScaleInPixels(false);
     viewWidget.setDisplayCallback((coords) => {
       overlay.style.left = '-100px';
       if (coords) {

--- a/Sources/Widgets/Manipulators/AbstractManipulator/index.d.ts
+++ b/Sources/Widgets/Manipulators/AbstractManipulator/index.d.ts
@@ -58,7 +58,7 @@ export interface vtkAbstractManipulator extends vtkObject {
     /* ------------------------------------------------------------------- */
 
     /**
-     * Set the user normal. 
+     * Set the user normal.
      * This normal take precedence on the handleNormal and the widgetNormal.
      * This normal should not be set within the widget internal code.
      * @param {Vector3} normal The normal coordinate.

--- a/Sources/Widgets/Representations/GlyphRepresentation/index.js
+++ b/Sources/Widgets/Representations/GlyphRepresentation/index.js
@@ -188,7 +188,7 @@ function vtkGlyphRepresentation(publicAPI, model) {
   publicAPI.getRepresentationStates = (input = model.inputData[0]) =>
     superClass
       .getRepresentationStates(input)
-      .filter((state) => state.getOrigin?.() && state.isVisible?.());
+      .filter((state) => state.getOrigin?.() && (state.isVisible?.() ?? true));
 
   // --------------------------------------------------------------------------
   publicAPI.getMixins = (states) => {


### PR DESCRIPTION
…mixin is added

fix #2428

### Context
The Box example was broken, the sphere handles did not show up.

### Results
Sphere handles in the Box example are now visible.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: latest Chrome
