### PR TITLE
fix(imagemarchingcubes): fix vtkImageMarchingCubes filter multiple re…

### DIFF
--- a/Sources/Filters/General/ImageMarchingCubes/index.js
+++ b/Sources/Filters/General/ImageMarchingCubes/index.js
@@ -338,6 +338,7 @@ function vtkImageMarchingCubes(publicAPI, model) {
         }
       }
     }
+    edgeLocator.initialize();
 
     // Update output
     const polydata = vtkPolyData.newInstance();


### PR DESCRIPTION
…questData calls

The edge locator must be reset each time requestData is called.

fix #2753


### Context
The VolumeContour example was broken when changing iso value.

### Results
This PR fixes the VolumeContour example.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes
- [x] vtkImageMarchingCubes can be run multiple times

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome
