### PR TITLE
Fix the issues where Chrome times out when running tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,5 +70,9 @@ module.exports = {
     '**/example_/*.js',
     // ignore js files in utilities
     'Utilities/**/*.js',
+    // ignore configs
+    'karma.conf.js',
+    'webpack.*.js',
+    '.eslintrc.js',
   ],
 };

--- a/Sources/Testing/index.js
+++ b/Sources/Testing/index.js
@@ -1,0 +1,13 @@
+/**
+ * The purpose of this file is to bundle all testing
+ * entrypoints into one chunk. This cuts down on extraneous
+ * code generation and addresses a race issue with the
+ * timer task queue.
+ */
+
+import './setupTestEnv';
+
+// webpack will include files that match the regex
+// '..' refers to the Sources/ dir
+const testsContext = require.context('..', true, /test[^/]*\.js$/);
+testsContext.keys().forEach(testsContext);

--- a/Sources/Testing/setupTestEnv.js
+++ b/Sources/Testing/setupTestEnv.js
@@ -43,6 +43,7 @@ function BufferedObjectPipe() {
   };
 
   const end = () => {
+    if (closed) return;
     closed = true;
     scheduleFlush();
   };
@@ -53,6 +54,7 @@ function BufferedObjectPipe() {
    */
   const setReader = (r) => {
     reader = r;
+    scheduleFlush();
   };
 
   return {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,14 +23,18 @@ module.exports = function init(config) {
     basePath: '',
     frameworks: ['tape-object-stream', 'webpack'],
     files: [
-      'Sources/Testing/setupTestEnv.js',
-      'Sources/**/test*.js',
+      'Sources/Testing/index.js',
+      {
+        pattern: 'Sources/**/*.js',
+        watched: true,
+        served: false,
+        included: false,
+      },
       { pattern: 'Data/**', watched: false, served: true, included: false },
     ],
 
     preprocessors: {
-      'Sources/Testing/setupTestEnv.js': ['webpack'],
-      'Sources/**/test*.js': ['webpack'],
+      'Sources/Testing/index.js': ['webpack'],
     },
 
     webpack: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,3 @@
-/* eslint-disable global-require */
 const path = require('path');
 
 const webpack = require('webpack');


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Chrome was hanging due to `window.__karma__.complete` not being called.
This had two root causes:

1. Chrome's timer task queue is no longer deprioritized to the end of
DOM loading (due to deprecation of a field test)
2. BufferedObjectPipe doesn't drain the existing buffer when the reader
is set. For some reason, Chrome sets the reader on the buffered pipe
later than Firefox does.

### Results
- Chrome should now report completed statuses when running the browser tests.
- Instead of editing `karma.conf.js` to modify the test targets, you now must edit `Sources/Testing/index.js`.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] karma testing configuration updated

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
Passing CI likely means this worked.