### PR TITLE
fix(polydatanormals): prevent vtkPolyDataNormals from modifying input…

### DIFF
--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.js
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.js
@@ -52,12 +52,18 @@ function vtkFieldData(publicAPI, model) {
     model.arrays = [];
   };
   publicAPI.removeArray = (arrayName) => {
-    model.arrays = model.arrays.filter(
-      (entry) => arrayName !== entry.data.getName()
+    const index = model.arrays.findIndex(
+      (array) => array.getName() === arrayName
     );
+    return publicAPI.removeArrayByIndex(index);
   };
   publicAPI.removeArrayByIndex = (arrayIdx) => {
-    model.arrays = model.arrays.filter((entry, idx) => idx !== arrayIdx);
+    if (arrayIdx !== -1 && arrayIdx < model.arrays.length) {
+      model.arrays.splice(arrayIdx, 1);
+      // TBD modified() ?
+      return true;
+    }
+    return false;
   };
   publicAPI.getArrays = () => model.arrays.map((entry) => entry.data);
   publicAPI.getArray = (arraySpec) =>
@@ -69,14 +75,12 @@ function vtkFieldData(publicAPI, model) {
       (a, b, i) => (b.data.getName() === arrayName ? b.data : a),
       null
     );
-  publicAPI.getArrayWithIndex = (arrayName) =>
-    model.arrays.reduce(
-      (a, b, i) =>
-        b.data && b.data.getName() === arrayName
-          ? { array: b.data, index: i }
-          : a,
-      { array: null, index: -1 }
+  publicAPI.getArrayWithIndex = (arrayName) => {
+    const index = model.arrays.findIndex(
+      (array) => array.data.getName() === arrayName
     );
+    return { array: index !== -1 ? model.arrays[index].data : null, index };
+  };
   publicAPI.getArrayByIndex = (idx) =>
     idx >= 0 && idx < model.arrays.length ? model.arrays[idx].data : null;
   publicAPI.hasArray = (arrayName) =>

--- a/Sources/Common/DataModel/DataSetAttributes/index.js
+++ b/Sources/Common/DataModel/DataSetAttributes/index.js
@@ -39,6 +39,7 @@ function vtkDataSetAttributes(publicAPI, model) {
 
   // Set our className
   model.classHierarchy.push('vtkDataSetAttributes');
+  const superClass = { ...publicAPI };
 
   publicAPI.checkNumberOfComponents = (x) => true; // TODO
 
@@ -65,6 +66,7 @@ function vtkDataSetAttributes(publicAPI, model) {
       if (model.arrays[currentAttribute] === arr) {
         return currentAttribute;
       }
+      // FIXME setting an array actually changes its index
       publicAPI.removeArrayByIndex(currentAttribute);
     }
 
@@ -127,36 +129,24 @@ function vtkDataSetAttributes(publicAPI, model) {
 
   // Override to allow proper handling of active attributes
   publicAPI.removeAllArrays = () => {
-    model.arrays = [];
     attrTypes.forEach((attType) => {
       model[`active${attType}`] = -1;
     });
-  };
-
-  // Override to allow proper handling of active attributes
-  publicAPI.removeArray = (arrayName) => {
-    model.arrays = model.arrays.filter((entry, idx) => {
-      if (arrayName === entry.data.getName()) {
-        // Found the array to remove, but is it an active attribute?
-        attrTypes.forEach((attType) => {
-          if (idx === model[`active${attType}`]) {
-            model[`active${attType}`] = -1;
-          }
-        });
-        return false;
-      }
-      return true;
-    });
+    superClass.removeAllArrays();
   };
 
   // Override to allow proper handling of active attributes
   publicAPI.removeArrayByIndex = (arrayIdx) => {
-    model.arrays = model.arrays.filter((entry, idx) => idx !== arrayIdx);
-    attrTypes.forEach((attType) => {
-      if (arrayIdx === model[`active${attType}`]) {
-        model[`active${attType}`] = -1;
-      }
-    });
+    if (arrayIdx !== -1) {
+      attrTypes.forEach((attType) => {
+        if (arrayIdx === model[`active${attType}`]) {
+          model[`active${attType}`] = -1;
+        } else if (arrayIdx < model[`active${attType}`]) {
+          model[`active${attType}`] -= 1;
+        }
+      });
+    }
+    return superClass.removeArrayByIndex(arrayIdx);
   };
 
   attrTypes.forEach((value) => {

--- a/Sources/Filters/Core/PolyDataNormals/index.js
+++ b/Sources/Filters/Core/PolyDataNormals/index.js
@@ -94,14 +94,15 @@ function vtkPolyDataNormals(publicAPI, model) {
       values: outputNormalsData,
     });
 
-    output.setPointData(input.getPointData());
-    output.setCellData(input.getCellData());
-    output.setFieldData(input.getFieldData());
     output.setPoints(input.getPoints());
     output.setVerts(input.getVerts());
     output.setLines(input.getLines());
     output.setPolys(input.getPolys());
     output.setStrips(input.getStrips());
+
+    output.getPointData().passData(input.getPointData());
+    output.getCellData().passData(input.getCellData());
+    output.getFieldData().passData(input.getFieldData());
 
     output.getPointData().setNormals(outputNormals);
 

--- a/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
+++ b/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
@@ -1,0 +1,26 @@
+import test from 'tape-catch';
+
+import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
+import vtkPolyDataNormals from 'vtk.js/Sources/Filters/Core/PolyDataNormals';
+
+test('Test vtkPolyDataNormals passData', (t) => {
+  const cube = vtkCubeSource.newInstance();
+  const input = cube.getOutputData();
+  input.getPointData().setNormals(null);
+
+  const normals = vtkPolyDataNormals.newInstance();
+  normals.setInputData(input);
+  normals.update();
+  const output = normals.getOutputData();
+
+  t.equal(input.getPointData().getNormals(), null);
+  t.ok(input.getPointData().getTCoords() != null);
+
+  t.ok(output.getPointData().getNormals() != null);
+  t.equal(
+    output.getPointData().getTCoords(),
+    input.getPointData().getTCoords()
+  );
+
+  t.end();
+});


### PR DESCRIPTION
… polydata

fix #2762

### Context
output.setPointData(input.getPointData()) is copying references and not doing deep copy.

### Results
The input polydata is no longer modified.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome latest
