### PR TITLE
fix(RemoteMouse): send position in wheel event

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleRemoteMouse/index.js
+++ b/Sources/Interaction/Style/InteractorStyleRemoteMouse/index.js
@@ -109,29 +109,21 @@ function vtkInteractorStyleRemoteMouse(publicAPI, model) {
 
   //-------------------------------------------------------------------------
   publicAPI.handleStartMouseWheel = (callData) => {
-    const { spinY, altKey, controlKey, shiftKey } = callData;
     model._interactor.requestAnimation(publicAPI.handleStartMouseWheel);
     publicAPI.invokeStartInteractionEvent(START_INTERACTION_EVENT);
     publicAPI.invokeRemoteWheelEvent({
       type: 'StartMouseWheel',
-      spinY,
-      altKey,
-      controlKey,
-      shiftKey,
-      ...model.remoteEventAddOn,
+      ...createRemoteEvent(callData),
+      spinY: callData.spinY,
     });
   };
 
   //-------------------------------------------------------------------------
   publicAPI.handleMouseWheel = (callData) => {
-    const { spinY, altKey, controlKey, shiftKey } = callData;
     publicAPI.invokeRemoteWheelEvent({
       type: 'MouseWheel',
-      spinY,
-      altKey,
-      controlKey,
-      shiftKey,
-      ...model.remoteEventAddOn,
+      ...createRemoteEvent(callData),
+      spinY: callData.spinY,
     });
     publicAPI.invokeInteractionEvent(INTERACTION_EVENT);
   };


### PR DESCRIPTION
This modifies the remote mouse events to use `createRemoteEvent()` similarly to the other mouse events. One thing this adds is the `x` and `y` positions of the mouse, which can be used to determine which renderer the mouse is hovering over.

This is needed as a first step for fixing pyvista/pyvista#4020

The next step is to fix the web protocol to use the mouse position to determine which renderer the mouse is over.

I have tested this locally and it appears to work properly.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code