### PR TITLE
refactor(macros): add support for _onPropChanged callback

### DIFF
--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
@@ -35,6 +35,8 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
     }
   }
 
+  model._onParentRendererChanged = () => publicAPI.updateViewport();
+
   publicAPI.computeViewport = () => {
     const parentRen =
       model.parentRenderer || model._interactor.getCurrentRenderer();
@@ -232,14 +234,6 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
     publicAPI.setEnabled(false);
     model.actor = actor;
     publicAPI.setEnabled(previousState);
-  };
-
-  publicAPI.setParentRenderer = (ren) => {
-    const changed = superClass.setParentRenderer(ren);
-    if (changed) {
-      publicAPI.updateViewport();
-    }
-    return changed;
   };
 
   publicAPI.getRenderer = () => selfRenderer;

--- a/Sources/Testing/testMacro.js
+++ b/Sources/Testing/testMacro.js
@@ -30,12 +30,24 @@ const DEFAULT_VALUES = {
   myProp6: [0.1, 0.2, 0.3, 0.4, 0.5],
   myProp7: MY_ENUM.FIRST,
   myProp8: [1, 2, 3],
+  _onMyProp8Changed: (publicAPI, model) => {
+    ++model._onMyProp8ChangedCallsCount;
+  },
+  _onMyProp8ChangedCallsCount: 0,
   myProp9: null,
   // myProp10: null,
   myProp11: 11,
+  _onMyProp11Changed: (publicAPI, model) => {
+    ++model._onMyProp11ChangedCallsCount;
+  },
+  _onMyProp11ChangedCallsCount: 0,
   _myProp12: [12],
   _myProp13: 13,
   myObjectProp: { foo: 1 },
+  _onMyObjectPropChanged: (publicAPI, model) => {
+    ++model._onMyObjectPropChangedCallsCount;
+  },
+  _onMyObjectPropChangedCallsCount: 0,
 };
 
 // ----------------------------------------------------------------------------
@@ -501,6 +513,33 @@ test('Macro methods object tests', (t) => {
 
   t.doesNotThrow(() => myTestClass.delete());
   t.notOk(myTestClass.getMyProp4(), 'All calls should do nothing after delete');
+
+  t.end();
+});
+
+test('Macro methods _onPropChanged tests', (t) => {
+  const myTestClass = newInstance();
+
+  myTestClass.setMyProp8([3, 2, 1]);
+  t.equal(myTestClass.get()._onMyProp8ChangedCallsCount, 1);
+  myTestClass.setMyProp8([3, 2, 1]);
+  t.equal(myTestClass.get()._onMyProp8ChangedCallsCount, 1);
+  myTestClass.setMyProp8([2, 3, 1]);
+  t.equal(myTestClass.get()._onMyProp8ChangedCallsCount, 2);
+
+  myTestClass.setMyProp11(42);
+  t.equal(myTestClass.get()._onMyProp11ChangedCallsCount, 1);
+  myTestClass.setMyProp11(42);
+  t.equal(myTestClass.get()._onMyProp11ChangedCallsCount, 1);
+  myTestClass.setMyProp11(43);
+  t.equal(myTestClass.get()._onMyProp11ChangedCallsCount, 2);
+
+  myTestClass.setMyObjectProp({ foo: 10 });
+  t.equal(myTestClass.get()._onMyObjectPropChangedCallsCount, 1);
+  myTestClass.setMyObjectProp({ foo: 10 });
+  t.equal(myTestClass.get()._onMyObjectPropChangedCallsCount, 1);
+  myTestClass.setMyObjectProp({ bar: 10 });
+  t.equal(myTestClass.get()._onMyObjectPropChangedCallsCount, 2);
 
   t.end();
 });

--- a/Sources/Widgets/Widgets3D/AngleWidget/index.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/index.js
@@ -17,8 +17,6 @@ import { ViewTypes } from 'vtk.js/Sources/Widgets/Core/WidgetManager/Constants';
 function vtkAngleWidget(publicAPI, model) {
   model.classHierarchy.push('vtkAngleWidget');
 
-  const superClass = { ...publicAPI };
-
   // --- Widget Requirement ---------------------------------------------------
 
   model.methodsToLink = [
@@ -29,6 +27,13 @@ function vtkAngleWidget(publicAPI, model) {
     'defaultScale',
     'scaleInPixels',
   ];
+
+  model._onManipulatorChanged = () => {
+    model.widgetState.getMoveHandle().setManipulator(model.manipulator);
+    model.widgetState.getHandleList().forEach((handle) => {
+      handle.setManipulator(model.manipulator);
+    });
+  };
 
   publicAPI.getRepresentationsForViewType = (viewType) => {
     switch (viewType) {
@@ -70,14 +75,6 @@ function vtkAngleWidget(publicAPI, model) {
     vtkMath.subtract(handles[0].getOrigin(), handles[1].getOrigin(), vec1);
     vtkMath.subtract(handles[2].getOrigin(), handles[1].getOrigin(), vec2);
     return vtkMath.angleBetweenVectors(vec1, vec2);
-  };
-
-  publicAPI.setManipulator = (manipulator) => {
-    superClass.setManipulator(manipulator);
-    model.widgetState.getMoveHandle().setManipulator(manipulator);
-    model.widgetState.getHandleList().forEach((handle) => {
-      handle.setManipulator(manipulator);
-    });
   };
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
By adding a function _onPropChanged into the model, the function will be called each time prop is changed but before modified() is called.

### Context
Sometimes it is useful to call extra code whenever a prop changes.

### Results
Each time an XXX prop is modified via the `macro.set`, `macro.setGet` or `macro.setArray` and if `model` contains `_onXXXChanged`, then it will be called automatically after changing the value but before `modified` is called.

Closes #2765 

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome latest

