### PR TITLE
fix(ProxyManager): export usable type

### DIFF
--- a/Sources/Proxy/Core/ProxyManager/index.d.ts
+++ b/Sources/Proxy/Core/ProxyManager/index.d.ts
@@ -6,7 +6,7 @@ import vtkLookupTableProxy from '../LookupTableProxy';
 import vtkPiecewiseFunctionProxy from '../PiecewiseFunctionProxy';
 import { VtkProxy } from '../../../macros';
 
-export type ProxyConfiguration = Object;
+export type ProxyConfiguration = object;
 
 export interface ProxyRegistrationChangeInfo {
   action: 'register' | 'unregister';
@@ -14,6 +14,10 @@ export interface ProxyRegistrationChangeInfo {
   proxyName: string;
   proxyGroup: string;
   proxy: VtkProxy;
+}
+
+export interface IProxyManagerInitialValues {
+  proxyConfiguration?: ProxyConfiguration;
 }
 
 export interface vtkProxyManager extends vtkObject {
@@ -77,5 +81,35 @@ export interface vtkProxyManager extends vtkObject {
     dataRange: [number, number]
   ): void;
 }
+
+/**
+ * Decorates a given publicAPI + model with vtkProxyManager characteristics.
+ *
+ * @param publicAPI
+ * @param model
+ * @param {IProxyManagerInitialValues} [initialValues]
+ */
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: IProxyManagerInitialValues
+): void;
+
+/**
+ * Creates a vtkProxyManager.
+ * @param {IProxyManagerInitialValues} [initialValues]
+ */
+export function newInstance(
+  initialValues?: IProxyManagerInitialValues
+): vtkProxyManager;
+
+/**
+ * vtkProxyManager is the central manager for managing proxy resources
+ * in vtk.js.
+ */
+export declare const vtkProxyManager: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+};
 
 export default vtkProxyManager;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
`vtkProxyManager` is only exported as a type. [See this reporting issue](https://discourse.vtk.org/t/vtkproxymanager-is-a-type-and-must-be-imported-using-a-type-only-import/11040/2)

### Results
`vtkProxyManager` is properly exported.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code
