### PR TITLE
fix(lights): do not add duplicate lights

### DIFF
--- a/Sources/Rendering/Core/Renderer/index.d.ts
+++ b/Sources/Rendering/Core/Renderer/index.d.ts
@@ -64,6 +64,12 @@ export interface vtkRenderer extends vtkViewport {
 	addActor(actor: vtkProp): boolean;
 
 	/**
+	 * Check if the renderer already has the specified light.
+	 * @param {vtkLight} light The vtkLight instance.
+	 */
+	hasLight(light: vtkLight): boolean;
+
+	/**
 	 * Add a light to the list of lights.
 	 * @param {vtkLight} light The vtkLight instance.
 	 */

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -181,11 +181,10 @@ function vtkRenderer(publicAPI, model) {
     publicAPI.modified();
   };
 
-  publicAPI.hasLight = (light) =>
-    !!model.lights.filter((item) => item === light).length;
+  publicAPI.hasLight = (light) => model.lights.includes(light);
   publicAPI.addLight = (light) => {
     if (light && !publicAPI.hasLight(light)) {
-      model.lights = model.lights.concat(light);
+      model.lights.push(light);
       publicAPI.modified();
     }
   };

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -181,9 +181,13 @@ function vtkRenderer(publicAPI, model) {
     publicAPI.modified();
   };
 
+  publicAPI.hasLight = (light) =>
+    !!model.lights.filter((item) => item === light).length;
   publicAPI.addLight = (light) => {
-    model.lights = [].concat(model.lights, light);
-    publicAPI.modified();
+    if (light && !publicAPI.hasLight(light)) {
+      model.lights = model.lights.concat(light);
+      publicAPI.modified();
+    }
   };
   publicAPI.removeLight = (light) => {
     model.lights = model.lights.filter((l) => l !== light);

--- a/Sources/Rendering/Core/Viewport/index.js
+++ b/Sources/Rendering/Core/Viewport/index.js
@@ -16,11 +16,10 @@ function vtkViewport(publicAPI, model) {
 
   // Public API methods
   publicAPI.getViewProps = () => model.props;
-  publicAPI.hasViewProp = (prop) =>
-    !!model.props.filter((item) => item === prop).length;
+  publicAPI.hasViewProp = (prop) => model.props.includes(prop);
   publicAPI.addViewProp = (prop) => {
     if (prop && !publicAPI.hasViewProp(prop)) {
-      model.props = model.props.concat(prop);
+      model.props.push(prop);
     }
   };
 


### PR DESCRIPTION
In trame-vtk, we have a call to [add a light](https://github.com/Kitware/trame-vtk/blob/e2c09edfbfc28ce57959174d72e1eaa6527d4f86/trame_vtk/modules/vtk/serializers/render_windows.py#L48-L50).

Sometimes, this would be triggered multiple times, like if the user toggled
local view on/off.

It doesn't really make sense to add the same light twice (you can just modify
the intensity instead). So, similar to [the view prop check](https://github.com/Kitware/vtk-js/blob/24d26e040e3454f61b882ab7d95982d084f03a9d/Sources/Rendering/Core/Viewport/index.js#L19-L25),
add a check to prevent the same light from being added twice.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code