### PR TITLE
fix(SynchronizableRenderWindow): Handle vtkOrientationMarkerWidget

### DIFF
--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/BehaviorManager/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/BehaviorManager/index.js
@@ -2,6 +2,52 @@ import vtkCameraSynchronizer from './CameraSynchronizer';
 
 const BEHAVIORS = {};
 
+class CameraSync {
+  constructor(ctx, config) {
+    this.ctx = ctx;
+    this.behavior = vtkCameraSynchronizer.newInstance(
+      this.getProperties(config)
+    );
+    this.behavior.update();
+  }
+
+  getProperties({ actorBounds, srcRenderer, dstRenderer }) {
+    const distance =
+      3.4 *
+      Math.max(
+        actorBounds[1] - actorBounds[0],
+        actorBounds[3] - actorBounds[2],
+        actorBounds[5] - actorBounds[4]
+      );
+    const focalPoint = [
+      0.5 * (actorBounds[0] + actorBounds[1]),
+      0.5 * (actorBounds[2] + actorBounds[3]),
+      0.5 * (actorBounds[4] + actorBounds[5]),
+    ];
+    const mode = vtkCameraSynchronizer.SynchronizationMode.MODE_ORIENTATION;
+    return {
+      distance,
+      focalPoint,
+      mode,
+      srcRenderer: this.ctx.getInstance(srcRenderer),
+      dstRenderer: this.ctx.getInstance(dstRenderer),
+    };
+  }
+
+  update(config) {
+    this.behavior.set(this.getProperties(config));
+    this.behavior.update();
+  }
+
+  delete() {
+    this.behavior.delete();
+  }
+}
+
+const BEHAVIORS_TYPES = {
+  CameraSync,
+};
+
 export function applyBehaviors(renderWindow, state, context) {
   if (!state.behaviors || !renderWindow.getSynchronizedViewId) {
     return;
@@ -39,8 +85,29 @@ export function applyBehaviors(renderWindow, state, context) {
     }
   }
 
-  // Process remaining behaviors...
-  // TODO - widgets(orientation, ...)
+  const currentSets = Object.keys(state.behaviors);
+  const existingSets = Object.keys(localBehaviors);
+  for (let i = 0; i < currentSets.length; i++) {
+    const key = currentSets[i];
+    if (!localBehaviors[key]) {
+      const config = state.behaviors[key];
+      if (BEHAVIORS_TYPES[config.type]) {
+        localBehaviors[key] = new BEHAVIORS_TYPES[config.type](context, config);
+      } else {
+        console.log('No mapping for', config);
+      }
+    } else {
+      localBehaviors[key].update(state.behaviors[key]);
+    }
+  }
+  for (let i = 0; i < existingSets.length; i++) {
+    const key = currentSets[i];
+    if (!state.behaviors[key]) {
+      // Need to delete previously created behavior
+      localBehaviors[key].delete();
+      delete localBehaviors[key];
+    }
+  }
 }
 
 export default { applyBehaviors };

--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
@@ -412,8 +412,6 @@ function vtkRenderWindowUpdater(instance, state, context) {
             }
             context.unregisterInstance(context.getInstanceId(viewProp));
           });
-          // Now just remove all the view props
-          renderer.removeAllViewProps();
         });
       });
   }

--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/index.js
@@ -118,6 +118,7 @@ function createInstanceMap() {
 
   function registerInstance(id, instance) {
     instances[id] = instance;
+    instance.set({ remoteId: id }, true, true);
   }
 
   function unregisterInstance(id) {


### PR DESCRIPTION
Now remote VTK renderer can be synchronized with vtk.js to show vtkOrientationMarkerWidget. 
This is mainly for __trame__ with examples like https://github.com/Kitware/trame-vtk/pull/34/files#diff-f3098b8f9ebd4e483da691b3f1272b8300903ba316978ee1c04c680cfc8ec2e6