### PR TITLE
perf(vtkOpenGLTexture): use fastComputeRange in computeScaleOffsets

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1,7 +1,9 @@
 import Constants from 'vtk.js/Sources/Rendering/OpenGL/Texture/Constants';
 import HalfFloat from 'vtk.js/Sources/Common/Core/HalfFloat';
 import * as macro from 'vtk.js/Sources/macros';
-import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkDataArray, {
+  STATIC as dataArrayHelpers,
+} from 'vtk.js/Sources/Common/Core/DataArray';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
 
@@ -1188,22 +1190,13 @@ function vtkOpenGLTexture(publicAPI, model) {
     // compute min and max values per component
     const min = [];
     const max = [];
+
     for (let c = 0; c < numComps; ++c) {
-      min[c] = data[c];
-      max[c] = data[c];
+      const range = dataArrayHelpers.fastComputeRange(data, c, numComps);
+      min[c] = range.min;
+      max[c] = range.max;
     }
-    let count = 0;
-    for (let i = 0; i < numPixelsIn; ++i) {
-      for (let c = 0; c < numComps; ++c) {
-        if (data[count] < min[c]) {
-          min[c] = data[count];
-        }
-        if (data[count] > max[c]) {
-          max[c] = data[count];
-        }
-        count++;
-      }
-    }
+
     const offset = [];
     const scale = [];
     for (let c = 0; c < numComps; ++c) {


### PR DESCRIPTION
### Context
Computing scale offsets in vtkOpenGLTexture can be slow for 3d textures.
Using the fastComputeRange utility from vtkDataArray makes it faster.

### Results
Usually yields a +50% speedup.
See https://github.com/Julesdevops/texture-test/blob/master/src/index.ts

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: 26.9.12
  - **OS**: linux
  - **Browser**: Firefox 111
