### PR TITLE
Volume local ambient occlusion combined with gradient shading

### DIFF
--- a/Sources/Rendering/Core/VolumeMapper/example/controller.html
+++ b/Sources/Rendering/Core/VolumeMapper/example/controller.html
@@ -1,1 +1,11 @@
-<button onClick="toggleParallel()">toggle Parallel projection: <i class="text">(off)</i></button>
+<form>
+  <input class='toggleParallel' type='checkbox'>Parallel Projection</input></br>
+  <input class='toggleShade' type='checkbox'>Lighting</input></br>
+  <fieldset class='shade'>
+    <legend>Lighting</legend>
+    <input class='lao' id='lao' type='checkbox'/>
+    <label for='lao'>Toggle LAO <i class='text'>(off)</label><br></br>
+    <label for='scattering'>Volumetric Scattering: <i class='stext'>(off)</i></label>
+    <input class='scattering' id='scattering' type='range' min='0' max='10' value='0'/><br></br>
+  </fieldset>
+</form>

--- a/Sources/Rendering/Core/VolumeMapper/example/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/example/index.js
@@ -2,11 +2,19 @@ import '@kitware/vtk.js/favicon';
 
 // Load the rendering pieces we want to use (for both WebGL and WebGPU)
 import '@kitware/vtk.js/Rendering/Profiles/Volume';
+import '@kitware/vtk.js/Rendering/Profiles/Geometry';
 
+import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
 import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkConeSource from '@kitware/vtk.js/Filters/Sources/ConeSource';
 import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
 import vtkHttpDataSetReader from '@kitware/vtk.js/IO/Core/HttpDataSetReader';
+import vtkLight from '@kitware/vtk.js/Rendering/Core/Light';
+import vtkMapper from '@kitware/vtk.js/Rendering/Core/Mapper';
+import vtkMath from '@kitware/vtk.js/Common/Core/Math';
 import vtkPiecewiseFunction from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkProperty from '@kitware/vtk.js/Rendering/Core/Property';
+import vtkSphereSource from '@kitware/vtk.js/Filters/Sources/SphereSource';
 import vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
 import vtkVolumeMapper from '@kitware/vtk.js/Rendering/Core/VolumeMapper';
 
@@ -14,6 +22,8 @@ import vtkVolumeMapper from '@kitware/vtk.js/Rendering/Core/VolumeMapper';
 import '@kitware/vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
 
 import controlPanel from './controller.html';
+
+const { Representation, Shading } = vtkProperty;
 
 // ----------------------------------------------------------------------------
 // Standard rendering code setup
@@ -24,8 +34,7 @@ const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
 });
 const renderer = fullScreenRenderer.getRenderer();
 const renderWindow = fullScreenRenderer.getRenderWindow();
-
-fullScreenRenderer.addController(controlPanel);
+renderer.setTwoSidedLighting(false);
 
 // ----------------------------------------------------------------------------
 // Example code
@@ -38,61 +47,154 @@ const reader = vtkHttpDataSetReader.newInstance({ fetchGzip: true });
 
 const actor = vtkVolume.newInstance();
 const mapper = vtkVolumeMapper.newInstance();
-mapper.setSampleDistance(1.3);
+mapper.setSampleDistance(0.7);
+mapper.setVolumetricScatteringBlending(0);
+mapper.setLocalAmbientOcclusion(0);
+mapper.setLAOKernelSize(10);
+mapper.setLAOKernelRadius(5);
+mapper.setComputeNormalFromOpacity(true);
 actor.setMapper(mapper);
 
 // create color and opacity transfer functions
 const ctfun = vtkColorTransferFunction.newInstance();
-ctfun.addRGBPoint(0, 85 / 255.0, 0, 0);
+ctfun.addRGBPoint(0, 0, 0, 0);
 ctfun.addRGBPoint(95, 1.0, 1.0, 1.0);
 ctfun.addRGBPoint(225, 0.66, 0.66, 0.5);
-ctfun.addRGBPoint(255, 0.3, 1.0, 0.5);
+ctfun.addRGBPoint(255, 0.3, 0.3, 0.5);
 const ofun = vtkPiecewiseFunction.newInstance();
-ofun.addPoint(0.0, 0.0);
+ofun.addPoint(0.0, 0.1);
 ofun.addPoint(255.0, 1.0);
 actor.getProperty().setRGBTransferFunction(0, ctfun);
 actor.getProperty().setScalarOpacity(0, ofun);
-actor.getProperty().setScalarOpacityUnitDistance(0, 3.0);
 actor.getProperty().setInterpolationTypeToLinear();
 actor.getProperty().setUseGradientOpacity(0, true);
 actor.getProperty().setGradientOpacityMinimumValue(0, 2);
 actor.getProperty().setGradientOpacityMinimumOpacity(0, 0.0);
 actor.getProperty().setGradientOpacityMaximumValue(0, 20);
 actor.getProperty().setGradientOpacityMaximumOpacity(0, 1.0);
+actor.getProperty().setScalarOpacityUnitDistance(0, 2.955);
 actor.getProperty().setShade(true);
-actor.getProperty().setAmbient(0.2);
+actor.getProperty().setAmbient(0.5);
 actor.getProperty().setDiffuse(0.7);
-actor.getProperty().setSpecular(0.3);
-actor.getProperty().setSpecularPower(8.0);
+actor.getProperty().setSpecular(0.0);
 
 mapper.setInputConnection(reader.getOutputPort());
+renderer.addVolume(actor);
+
+renderer.removeAllLights();
+const light = vtkLight.newInstance();
+light.setLightTypeToSceneLight();
+light.setPositional(true);
+light.setPosition(450, 300, 200);
+light.setFocalPoint(0, 0, 0);
+light.setColor(0, 0.45, 0.45);
+light.setConeAngle(25);
+light.setIntensity(1.0);
+renderer.addLight(light);
+
+// Visualize the light source
+if (light.getPositional()) {
+  const ls = vtkSphereSource.newInstance({
+    center: light.getPosition(),
+    radius: 5.0,
+  });
+  const lm = vtkMapper.newInstance();
+  lm.setInputConnection(ls.getOutputPort());
+  const la = vtkActor.newInstance({ mapper: lm });
+  la.getProperty().setColor(1, 1, 1);
+  la.getProperty().setRepresentation(Representation.WIREFRAME);
+  la.getProperty().setInterpolation(Shading.FLAT);
+  la.getProperty().setColor(light.getColor());
+  la.getProperty().setLineWidth(2.0);
+  renderer.addActor(la);
+
+  const lightDir = [0, 0, 0];
+  vtkMath.subtract(light.getFocalPoint(), light.getPosition(), lightDir);
+  vtkMath.normalize(lightDir);
+  const frustumCenter = light.getPosition();
+  const frustumHeight = 80;
+  const frustumRadius =
+    frustumHeight * Math.tan((light.getConeAngle() * 1.0 * Math.PI) / 180);
+  const halfDir = [0, 0, 0];
+  vtkMath.add(
+    frustumCenter,
+    vtkMath.multiplyScalar(lightDir, frustumHeight * 0.5),
+    halfDir
+  );
+  vtkMath.multiplyScalar(lightDir, -1, lightDir);
+  const lc = vtkConeSource.newInstance({
+    center: halfDir,
+    radius: frustumRadius,
+    height: frustumHeight,
+    direction: lightDir,
+    resolution: 6,
+  });
+  const lcm = vtkMapper.newInstance();
+  lcm.setInputConnection(lc.getOutputPort());
+  const lca = vtkActor.newInstance({ mapper: lcm });
+  lca.getProperty().setColor(1, 1, 1);
+  lca.getProperty().setRepresentation(Representation.WIREFRAME);
+  lca.getProperty().setInterpolation(Shading.FLAT);
+  lca.getProperty().setColor(light.getColor());
+  lca.getProperty().setLineWidth(2.0);
+  renderer.addActor(lca);
+}
 
 reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
   reader.loadData().then(() => {
-    renderer.addVolume(actor);
     const interactor = renderWindow.getInteractor();
     interactor.setDesiredUpdateRate(15.0);
-    renderer.resetCamera();
-    renderer.getActiveCamera().zoom(1.5);
-    renderer.getActiveCamera().elevation(70);
+    renderer.getActiveCamera().azimuth(90);
+    renderer.getActiveCamera().roll(90);
+    renderer.getActiveCamera().azimuth(-60);
     renderer.resetCamera();
     renderWindow.render();
   });
 });
 
-// TEST PARALLEL ==============
+// TEST  ==============
 
-let isParallel = false;
+fullScreenRenderer.addController(controlPanel);
+let isLAO = false;
 const button = document.querySelector('.text');
 
-function toggleParallel() {
-  isParallel = !isParallel;
-
-  renderer.getActiveCamera().setParallelProjection(isParallel);
-
-  button.innerText = `(${isParallel ? 'on' : 'off'})`;
+const lao = document.querySelector('.lao');
+lao.addEventListener('click', (e) => {
+  isLAO = !isLAO;
+  mapper.setLocalAmbientOcclusion(isLAO);
+  button.innerText = `(${isLAO ? 'on' : 'off'})`;
   renderWindow.render();
-}
+});
+
+const vs = document.querySelector('.scattering');
+vs.addEventListener('input', (e) => {
+  const b = (0.1 * Number(e.target.value)).toPrecision(1);
+  const sbutton = document.querySelector('.stext');
+  sbutton.innerText = `(${b > 0 ? b : 'off'})`;
+  mapper.setVolumetricScatteringBlending(b);
+  renderWindow.render();
+});
+
+const toggleShade = document.querySelector('.toggleShade');
+toggleShade.addEventListener('click', () => {
+  const shadeFieldSet = document.querySelector('.shade');
+  if (shadeFieldSet.disabled) {
+    shadeFieldSet.disabled = false;
+    actor.getProperty().setShade(true);
+    renderWindow.render();
+  } else {
+    shadeFieldSet.disabled = true;
+    actor.getProperty().setShade(false);
+    renderWindow.render();
+  }
+});
+
+const toggleParallel = document.querySelector('.toggleParallel');
+toggleParallel.addEventListener('click', () => {
+  const cam = renderer.getActiveCamera();
+  cam.setParallelProjection(!cam.getParallelProjection());
+  renderWindow.render();
+});
 
 // -----------------------------------------------------------
 // Make some variables global so that you can inspect and
@@ -106,4 +208,3 @@ global.ctfun = ctfun;
 global.ofun = ofun;
 global.renderer = renderer;
 global.renderWindow = renderWindow;
-global.toggleParallel = toggleParallel;

--- a/Sources/Rendering/Core/VolumeMapper/index.d.ts
+++ b/Sources/Rendering/Core/VolumeMapper/index.d.ts
@@ -4,16 +4,23 @@ import vtkAbstractMapper, { IAbstractMapperInitialValues } from "../AbstractMapp
 import { BlendMode, FilterMode } from "./Constants";
 
 /**
- * 
+ *
  */
 export interface IVolumeMapperInitialValues extends IAbstractMapperInitialValues {
-	bounds?: Bounds;
-	blendMode?: BlendMode;
-	sampleDistance?: number;
-	imageSampleDistance?: number;
-	maximumSamplesPerRay?: number;
+	anisotropy?: number;
 	autoAdjustSampleDistances?: boolean;
 	averageIPScalarRange?: Range;
+	blendMode?: BlendMode;
+	bounds?: Bounds;
+	computeNormalFromOpacity?: boolean;
+	getVolumeShadowSamplingDistFactor?: number;
+	globalIlluminationReach?: number;
+	imageSampleDistance?: number;
+	localAmbientOcclusion?: boolean;
+	maximumSamplesPerRay?: number;
+	sampleDistance?: number;
+	LAOKernelRadius?: number;
+	LAOKernelSize?: number;
 }
 
 export interface vtkVolumeMapper extends vtkAbstractMapper {
@@ -25,12 +32,12 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	getBounds(): Bounds;
 
 	/**
-	 * 
+	 *
 	 */
 	getBlendMode(): BlendMode;
 
 	/**
-	 * 
+	 *
 	 */
 	getBlendModeAsString(): string;
 
@@ -42,32 +49,32 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	getSampleDistance(): number;
 
 	/**
-	 * Sampling distance in the XY image dimensions. 
-	 * Default value of 1 meaning 1 ray cast per pixel. If set to 0.5, 4 rays will be cast per pixel. 
+	 * Sampling distance in the XY image dimensions.
+	 * Default value of 1 meaning 1 ray cast per pixel. If set to 0.5, 4 rays will be cast per pixel.
 	 * If set to 2.0, 1 ray will be cast for every 4 (2 by 2) pixels. T
 	 * @default 1.0
 	 */
 	getImageSampleDistance(): number;
 
 	/**
-	 * 
+	 *
 	 * @default 1000
 	 */
 	getMaximumSamplesPerRay(): number;
 
 	/**
-	 * 
+	 *
 	 * @default true
 	 */
 	getAutoAdjustSampleDistances(): boolean;
 
 	/**
-	 * 
+	 *
 	 */
 	getAverageIPScalarRange(): Range;
 
 	/**
-	 * 
+	 *
 	 */
 	getAverageIPScalarRangeByReference(): Range;
 
@@ -114,21 +121,21 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	getLAOKernelRadius(): number;
 
 	/**
-	 * 
-	 * @param x 
-	 * @param y 
+	 *
+	 * @param x
+	 * @param y
 	 */
 	setAverageIPScalarRange(x: number, y: number): boolean;
 
 	/**
-	 * 
-	 * @param {Range} averageIPScalarRange 
+	 *
+	 * @param {Range} averageIPScalarRange
 	 */
 	setAverageIPScalarRangeFrom(averageIPScalarRange: Range): boolean;
 
 	/**
 	 * Set blend mode to COMPOSITE_BLEND
-	 * @param {BlendMode} blendMode 
+	 * @param {BlendMode} blendMode
 	 */
 	setBlendMode(blendMode: BlendMode): void;
 
@@ -159,27 +166,38 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 
 	/**
 	 * Get the distance between samples used for rendering
-	 * @param sampleDistance 
+	 * @param sampleDistance
 	 */
 	setSampleDistance(sampleDistance: number): boolean;
 
 	/**
-	 * 
-	 * @param imageSampleDistance 
+	 *
+	 * @param imageSampleDistance
 	 */
 	setImageSampleDistance(imageSampleDistance: number): boolean;
 
 	/**
-	 * 
-	 * @param maximumSamplesPerRay 
+	 *
+	 * @param maximumSamplesPerRay
 	 */
 	setMaximumSamplesPerRay(maximumSamplesPerRay: number): boolean;
 
 	/**
-	 * 
-	 * @param autoAdjustSampleDistances 
+	 *
+	 * @param autoAdjustSampleDistances
 	 */
 	setAutoAdjustSampleDistances(autoAdjustSampleDistances: boolean): boolean;
+
+	/**
+	 * Set the normal computation to be dependent on the transfer function.
+	 * By default, the mapper relies on the scalar gradient for computing normals at sample locations
+	 * for lighting calculations. This is an approximation and can lead to inaccurate results.
+	 * When enabled, this property makes the mapper compute normals based on the accumulated opacity
+	 * at sample locations. This can generate a more accurate representation of edge structures in the
+	 * data but adds an overhead and drops frame rate.
+	 * @param computeNormalFromOpacity
+	 */
+	setComputeNormalFromOpacity(computeNormalFromOpacity: boolean): boolean;
 
 	/**
 	 * Set the blending coefficient that determines the interpolation between surface and volume rendering.
@@ -234,7 +252,7 @@ export interface vtkVolumeMapper extends vtkAbstractMapper {
 	setLAOKernelRadius(LAOKernelRadius: number): void;
 
 	/**
-	 * 
+	 *
 	 */
 	update(): void;
 }
@@ -279,11 +297,11 @@ export function createRadonTransferFunction(
 export function extend(publicAPI: object, model: object, initialValues?: IVolumeMapperInitialValues): void;
 
 /**
- * Method use to create a new instance of vtkVolumeMapper 
+ * Method use to create a new instance of vtkVolumeMapper
  */
 export function newInstance(initialValues?: IVolumeMapperInitialValues): vtkVolumeMapper;
 
-/** 
+/**
  * vtkVolumeMapper inherits from vtkMapper.
  * A volume mapper that performs ray casting on the GPU using fragment programs.
  */

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -211,7 +211,6 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         ).result;
       }
       if (
-        model.renderable.getVolumetricScatteringBlending() === 0.0 &&
         model.renderable.getLocalAmbientOcclusion() &&
         actor.getProperty().getAmbient() > 0.0
       ) {
@@ -341,7 +340,6 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       ).result;
     }
     if (
-      model.renderable.getVolumetricScatteringBlending() === 0.0 &&
       model.renderable.getLocalAmbientOcclusion() &&
       actor.getProperty().getAmbient() > 0.0
     ) {
@@ -936,7 +934,6 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       );
     }
     if (
-      model.renderable.getVolumetricScatteringBlending() === 0.0 &&
       model.renderable.getLocalAmbientOcclusion() &&
       actor.getProperty().getAmbient() > 0.0
     ) {

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -765,9 +765,9 @@ mat3 zBaseRotationalMatrix(vec3 startDir){
   return matrix;
 }
 
-float computeLAO(vec3 posIS, float opacity, vec3 lightDir, vec4 normal){
+float computeLAO(vec3 posIS, float op, vec3 lightDir, vec4 normal){
   // apply LAO only at selected locations, otherwise return full brightness
-  if (normal.w > 0.0 && opacity > 0.05){
+  if (normal.w > 0.0 && op > 0.05){
     float total_transmittance = 0.0;
     mat3 inverseRotateBasis = inverse(zBaseRotationalMatrix(normalize(-normal.xyz)));
     vec3 currPos, randomDirStep;

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -314,9 +314,9 @@ vec4 getTextureValue(vec3 ijk)
 #if vtkLightComplexity > 0
 vec3 IStoVC(vec3 posIS){
   vec3 posVC = posIS / vVCToIJK;
-  return posVC.x * vPlaneNormal0 + 
-         posVC.y * vPlaneNormal2 + 
-         posVC.z * vPlaneNormal4 + 
+  return posVC.x * vPlaneNormal0 +
+         posVC.y * vPlaneNormal2 +
+         posVC.z * vPlaneNormal4 +
          vOriginVC;
 }
 
@@ -326,7 +326,7 @@ vec3 VCtoIS(vec3 posVC){
   posVC = vec3(
     dot(posVC, vPlaneNormal0),
     dot(posVC, vPlaneNormal2),
-    dot(posVC, vPlaneNormal4));  
+    dot(posVC, vPlaneNormal4));
   return posVC * vVCToIJK;
 }
 #endif
@@ -346,7 +346,7 @@ vec3 rotateToIDX(vec3 dirVC){
   dirIS.xyz = vec3(
     dot(dirVC, vPlaneNormal0),
     dot(dirVC, vPlaneNormal2),
-    dot(dirVC, vPlaneNormal4));  
+    dot(dirVC, vPlaneNormal4));
   return dirIS;
 }
 #endif
@@ -412,11 +412,11 @@ float computeGradientOpacityFactor(
         if (gradientMag >= 0.0){
           opacity *= computeGradientOpacityFactor(gradientMag, goscale0, goshift0, gomin0, gomax0);
         }
-        opacityInterp.x = texture2D(otexture, vec2(scalarInterp[0][0] * oscale0 + oshift0, 0.5)).r; 
+        opacityInterp.x = texture2D(otexture, vec2(scalarInterp[0][0] * oscale0 + oshift0, 0.5)).r;
         if (secondaryGradientMag.x >= 0.0){
           opacityInterp.x *= computeGradientOpacityFactor(secondaryGradientMag.x, goscale0, goshift0, gomin0, gomax0);
         }
-    
+
         opacityInterp.y = texture2D(otexture, vec2(scalarInterp[0][1] * oscale0 + oshift0, 0.5)).r;
         if (secondaryGradientMag.y >= 0.0){
           opacityInterp.y *= computeGradientOpacityFactor(secondaryGradientMag.y, goscale0, goshift0, gomin0, gomax0);
@@ -432,73 +432,73 @@ float computeGradientOpacityFactor(
         opacityG.xyz /= vSpacing;
         opacityG.w = length(opacityG.xyz);
         rotateToViewCoord(opacityG.xyz);
-        if (length(opacityG.xyz) > 0.0) {  
+        if (length(opacityG.xyz) > 0.0) {
           return vec4(normalize(opacityG.xyz),opacityG.w);
         } else {
           return vec4(0.0);
         }
-      } 
+      }
 
     #else
     //if gradient opacity not on but using density gradient
-      vec4 computeDensityNormal(float scalar, vec3 scalarInterp) 
-      { 
-        vec4 opacityG; 
-        float opacity = texture2D(otexture, vec2(scalar * oscale0 + oshift0, 0.5)).r; 
-        opacityG.x = texture2D(otexture, vec2(scalarInterp.x * oscale0 + oshift0, 0.5)).r - opacity; 
-        opacityG.y = texture2D(otexture, vec2(scalarInterp.y * oscale0 + oshift0, 0.5)).r - opacity; 
-        opacityG.z = texture2D(otexture, vec2(scalarInterp.z * oscale0 + oshift0, 0.5)).r - opacity; 
-        // divide by spacing 
-        opacityG.xyz /= vSpacing; 
-        opacityG.w = length(opacityG.xyz); 
-        // rotate to View Coords 
+      vec4 computeDensityNormal(float scalar, vec3 scalarInterp)
+      {
+        vec4 opacityG;
+        float opacity = texture2D(otexture, vec2(scalar * oscale0 + oshift0, 0.5)).r;
+        opacityG.x = texture2D(otexture, vec2(scalarInterp.x * oscale0 + oshift0, 0.5)).r - opacity;
+        opacityG.y = texture2D(otexture, vec2(scalarInterp.y * oscale0 + oshift0, 0.5)).r - opacity;
+        opacityG.z = texture2D(otexture, vec2(scalarInterp.z * oscale0 + oshift0, 0.5)).r - opacity;
+        // divide by spacing
+        opacityG.xyz /= vSpacing;
+        opacityG.w = length(opacityG.xyz);
+        // rotate to View Coords
         rotateToViewCoord(opacityG.xyz);
-        if (length(opacityG.xyz) > 0.0) {     
-          return vec4(normalize(opacityG.xyz),opacityG.w); 
-        } else { 
-          return vec4(0.0); 
-        } 
-      } 
-      vec4 computeNormalForDensity(vec3 pos, float scalar, vec3 tstep, out vec3 scalarInterp) 
-      { 
-        vec4 result; 
-        scalarInterp.x = getTextureValue(pos + vec3(tstep.x, 0.0, 0.0)).a; 
-        scalarInterp.y = getTextureValue(pos + vec3(0.0, tstep.y, 0.0)).a; 
-        scalarInterp.z = getTextureValue(pos + vec3(0.0, 0.0, tstep.z)).a; 
-        result.x = scalarInterp.x - scalar; 
-        result.y = scalarInterp.y - scalar; 
-        result.z = scalarInterp.z - scalar;   
+        if (length(opacityG.xyz) > 0.0) {
+          return vec4(normalize(opacityG.xyz),opacityG.w);
+        } else {
+          return vec4(0.0);
+        }
+      }
+      vec4 computeNormalForDensity(vec3 pos, float scalar, vec3 tstep, out vec3 scalarInterp)
+      {
+        vec4 result;
+        scalarInterp.x = getTextureValue(pos + vec3(tstep.x, 0.0, 0.0)).a;
+        scalarInterp.y = getTextureValue(pos + vec3(0.0, tstep.y, 0.0)).a;
+        scalarInterp.z = getTextureValue(pos + vec3(0.0, 0.0, tstep.z)).a;
+        result.x = scalarInterp.x - scalar;
+        result.y = scalarInterp.y - scalar;
+        result.z = scalarInterp.z - scalar;
         // divide by spacing
         result.xyz /= vSpacing;
-        result.w = length(result.xyz); 
-        // rotate to View Coords 
-        rotateToViewCoord(result.xyz);      
-        if (length(result.xyz) > 0.0) {     
-          return vec4(normalize(result.xyz),result.w); 
-        } else { 
-          return vec4(0.0); 
-        } 
-      }           
+        result.w = length(result.xyz);
+        // rotate to View Coords
+        rotateToViewCoord(result.xyz);
+        if (length(result.xyz) > 0.0) {
+          return vec4(normalize(result.xyz),result.w);
+        } else {
+          return vec4(0.0);
+        }
+      }
     #endif
   #endif
   // compute scalar density
-  vec4 computeNormal(vec3 pos, float scalar, vec3 tstep)  
-  {  
-    vec4 result;  
-    result.x = getTextureValue(pos + vec3(tstep.x, 0.0, 0.0)).a - scalar;  
-    result.y = getTextureValue(pos + vec3(0.0, tstep.y, 0.0)).a - scalar;  
-    result.z = getTextureValue(pos + vec3(0.0, 0.0, tstep.z)).a - scalar;  
-    // divide by spacing  
-    result.xyz /= vSpacing;  
+  vec4 computeNormal(vec3 pos, float scalar, vec3 tstep)
+  {
+    vec4 result;
+    result.x = getTextureValue(pos + vec3(tstep.x, 0.0, 0.0)).a - scalar;
+    result.y = getTextureValue(pos + vec3(0.0, tstep.y, 0.0)).a - scalar;
+    result.z = getTextureValue(pos + vec3(0.0, 0.0, tstep.z)).a - scalar;
+    // divide by spacing
+    result.xyz /= vSpacing;
     result.w = length(result.xyz);
     if (result.w > 0.0){
-      // rotate to View Coords  
+      // rotate to View Coords
       rotateToViewCoord(result.xyz);
-      return vec4(normalize(result.xyz),result.w);  
+      return vec4(normalize(result.xyz),result.w);
     } else {
       return vec4(0.0);
     }
-  }  
+  }
 #endif
 
 #ifdef vtkImageLabelOutlineOn
@@ -514,7 +514,7 @@ vec3 fragCoordToIndexSpace(vec4 fragCoord) {
 
   vec3 index = (vWCtoIDX * vertex).xyz;
 
-  // half voxel fix for labelmapOutline 
+  // half voxel fix for labelmapOutline
   return (index + vec3(0.5)) / vec3(volumeDimensions);
 }
 #endif
@@ -589,7 +589,7 @@ mat4 computeMat4Normal(vec3 pos, vec4 tValue, vec3 tstep)
 // global shadow - secondary ray
 #if defined(VolumeShadowOn) || defined(localAmbientOcclusionOn)
 float random()
-{ 
+{
   float rand = fract(sin(dot(gl_FragCoord.xy,vec2(12.9898,78.233)))*43758.5453123);
   float jitter=texture2D(jtexture,gl_FragCoord.xy/32.).r;
   uint pcg_state = floatBitsToUint(jitter);
@@ -654,18 +654,18 @@ float volume_shadow(vec3 posIS, vec3 lightDirNormIS)
   // modify sample distance with a random number between 1.5 and 3.0
   float sampleDistanceISVS_jitter = sampleDistanceISVS * mix(1.5, 3.0, random());
   float opacityPrev = texture2D(otexture, vec2(getTextureValue(posIS).r * oscale0 + oshift0, 0.5)).r;
-  
-  // in case the first sample near surface has a very tiled light ray, we need to offset start position 
-  posIS += sampleDistanceISVS_jitter * lightDirNormIS;  
+
+  // in case the first sample near surface has a very tiled light ray, we need to offset start position
+  posIS += sampleDistanceISVS_jitter * lightDirNormIS;
 
   // compute the start and end points for the ray
   Ray ray;
-  Hit hit;  
+  Hit hit;
   ray.origin = posIS;
   ray.dir = lightDirNormIS;
   safe_0_vector(ray);
   ray.invDir = 1.0/ray.dir;
-  
+
   if(!BBoxIntersect(vec3(0.0),vec3(1.0), ray, hit))
   {
     return 1.0;
@@ -693,10 +693,10 @@ float volume_shadow(vec3 posIS, vec3 lightDirNormIS)
   {
     scalar = getTextureValue(posIS);
     opacity = texture2D(otexture, vec2(scalar.r * oscale0 + oshift0, 0.5)).r;
-    #ifdef vtkGradientOpacityOn 
-      normal = computeNormal(posIS, scalar.a, vec3(1.0/vec3(volumeDimensions))); 
+    #ifdef vtkGradientOpacityOn
+      normal = computeNormal(posIS, scalar.a, vec3(1.0/vec3(volumeDimensions)));
       opacity *= computeGradientOpacityFactor(normal.w, goscale0, goshift0, gomin0, gomax0);
-    #endif    
+    #endif
     shadow *= 1.0 - opacity;
 
     // optimization: early termination
@@ -736,9 +736,9 @@ vec3 applyShadowRay(vec3 tColor, vec3 posIS, vec3 viewDirectionVC)
       phase_attenuation = phase_function(dDotL);
     }
     float vol_shadow = volume_shadow(posIS, normalize(rotateToIDX(vertLight)));
-    secondary_contrib += tColor * vDiffuse * lightColor[i] * vol_shadow * phase_attenuation;     
+    secondary_contrib += tColor * vDiffuse * lightColor[i] * vol_shadow * phase_attenuation;
     secondary_contrib += tColor * vAmbient;
-  } 
+  }
   return secondary_contrib;
 }
 #endif
@@ -800,7 +800,7 @@ float computeLAO(vec3 posIS, float op, vec3 lightDir, vec4 normal){
       }
     }
     // average transmittance and reduce variance
-    return clamp(total_transmittance / float(kernelSize), 0.3, 1.0); 
+    return clamp(total_transmittance / float(kernelSize), 0.3, 1.0);
   } else {
     return 1.0;
   }
@@ -832,7 +832,7 @@ float computeLAO(vec3 posIS, float op, vec3 lightDir, vec4 normal){
       vec3 specular = vec3(0.0);
       #ifdef localAmbientOcclusionOn
         vec3 ambient = vec3(0.0);
-      #endif        
+      #endif
       vec3 vertLightDirection;
       for (int i = 0; i < lightNum; i++){
         float ndotL,vdotR;
@@ -855,12 +855,12 @@ float computeLAO(vec3 posIS, float op, vec3 lightDir, vec4 normal){
         #ifdef localAmbientOcclusionOn
             ambient += computeLAO(posIS, tColor.a, vertLightDirection, normal);
         #endif
-      }  
+      }
       #ifdef localAmbientOcclusionOn
         return tColor.rgb * (diffuse * vDiffuse + vAmbient * ambient) + specular*vSpecular;
-      #else 
+      #else
         return tColor.rgb * (diffuse * vDiffuse + vAmbient) + specular*vSpecular;
-      #endif    
+      #endif
     }
   #else
     vec3 applyLightingPositional(vec3 posIS, vec4 tColor, vec4 normal, vec3 posVC)
@@ -870,14 +870,14 @@ float computeLAO(vec3 posIS, float op, vec3 lightDir, vec4 normal){
       vec3 specular = vec3(0.0);
       #ifdef localAmbientOcclusionOn
         vec3 ambient = vec3(0.0);
-      #endif      
+      #endif
       vec3 vertLightDirection;
       for (int i = 0; i < lightNum; i++){
         float distance,attenuation,ndotL,vdotR;
         vec3 lightDir;
         if (lightPositional[i] == 1){
           lightDir = lightDirectionVC[i];
-          vertLightDirection = posVC - lightPositionVC[i]; 
+          vertLightDirection = posVC - lightPositionVC[i];
           distance = length(vertLightDirection);
           vertLightDirection = normalize(vertLightDirection);
           attenuation = 1.0 / (lightAttenuation[i].x
@@ -910,7 +910,7 @@ float computeLAO(vec3 posIS, float op, vec3 lightDir, vec4 normal){
           }
           #ifdef localAmbientOcclusionOn
             ambient += computeLAO(posIS, tColor.a, vertLightDirection, normal);
-          #endif          
+          #endif
         } else {
           vertLightDirection = lightDirectionVC[i];
           ndotL = dot(normal.xyz, vertLightDirection);
@@ -930,16 +930,16 @@ float computeLAO(vec3 posIS, float op, vec3 lightDir, vec4 normal){
           }
           #ifdef localAmbientOcclusionOn
             ambient += computeLAO(posIS, tColor.a, vertLightDirection, normal);
-          #endif          
+          #endif
         }
       }
       #ifdef localAmbientOcclusionOn
         return tColor.rgb * (diffuse * vDiffuse + vAmbient * ambient) + specular*vSpecular;
-      #else 
+      #else
         return tColor.rgb * (diffuse * vDiffuse + vAmbient) + specular*vSpecular;
       #endif
     }
-  #endif 
+  #endif
   #endif
 #endif
 
@@ -1024,26 +1024,26 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
       vec4 normalLight;
       #ifdef vtkComputeNormalFromOpacity
         #ifdef vtkGradientOpacityOn
-          mat3 scalarInterp;  
-          vec3 secondaryGradientMag;  
-          vec4 normal0 = computeNormalForDensity(posIS, tValue.a, tstep, scalarInterp, secondaryGradientMag);  
-          normalLight = computeDensityNormal(tValue.a, normal0.w, scalarInterp,secondaryGradientMag);       
-          if (length(normalLight) == 0.0){  
-            normalLight = normal0;   
-          }                      
+          mat3 scalarInterp;
+          vec3 secondaryGradientMag;
+          vec4 normal0 = computeNormalForDensity(posIS, tValue.a, tstep, scalarInterp, secondaryGradientMag);
+          normalLight = computeDensityNormal(tValue.a, normal0.w, scalarInterp,secondaryGradientMag);
+          if (length(normalLight) == 0.0){
+            normalLight = normal0;
+          }
         #else
-          vec3 scalarInterp;  
-          vec4 normal0 = computeNormalForDensity(posIS, tValue.a, tstep, scalarInterp);  
-          if (length(normal0)>0.0){  
-            normalLight = computeDensityNormal(tValue.a,scalarInterp);  
-            if (length(normalLight)==0.0){  
-              normalLight = normal0;  
-            }  
-          }                
+          vec3 scalarInterp;
+          vec4 normal0 = computeNormalForDensity(posIS, tValue.a, tstep, scalarInterp);
+          if (length(normal0)>0.0){
+            normalLight = computeDensityNormal(tValue.a,scalarInterp);
+            if (length(normalLight)==0.0){
+              normalLight = normal0;
+            }
+          }
         #endif
-      #else 
-        vec4 normal0 = computeNormal(posIS, tValue.a, tstep);  
-        normalLight = normal0;             
+      #else
+        vec4 normal0 = computeNormal(posIS, tValue.a, tstep);
+        normalLight = normal0;
       #endif
     #endif
   #endif
@@ -1080,7 +1080,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
     tColor.a = goFactor.x*texture2D(otexture, vec2(tValue.r * oscale0 + oshift0, 0.5)).r;
     if (tColor.a < EPSILON){
       return vec4(0.0);
-    }    
+    }
   #endif
 
   #if defined(vtkIndependentComponentsOn) && vtkNumComponents >= 2
@@ -1148,9 +1148,8 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
 
   // apply lighting if requested as appropriate
   #if vtkLightComplexity > 0
-    #if !defined(vtkComponent0Proportional) 
+    #if !defined(vtkComponent0Proportional)
       #if vtkNumComponents == 1
-    
         #ifdef SurfaceShadowOn
             #if vtkLightComplexity < 3
                 vec3 tColorS = applyLightingDirectional(posIS, tColor, normalLight);
@@ -1170,7 +1169,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
         #else
             tColor.rgb = tColorS;
         #endif
-        
+
       #else
         applyLighting(tColor.rgb, normal0);
       #endif
@@ -1205,13 +1204,6 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
 #endif
 
 #endif
-
-
-
-
-
-
-
 return tColor;
 }
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
