### PR TITLE
fix(imageMapper): not exact half float should be under a flag

### DIFF
--- a/Sources/Rendering/Core/ImageMapper/index.js
+++ b/Sources/Rendering/Core/ImageMapper/index.js
@@ -320,6 +320,7 @@ const DEFAULT_VALUES = {
   closestIJKAxis: { ijkMode: SlicingMode.NONE, flip: false },
   renderToRectangle: false,
   sliceAtFocalPoint: false,
+  preferSizeOverAccuracy: false, // Whether to use halfFloat representation of float, when it is inaccurate
 };
 
 // ----------------------------------------------------------------------------
@@ -335,6 +336,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'closestIJKAxis',
     'renderToRectangle',
     'sliceAtFocalPoint',
+    'preferSizeOverAccuracy',
   ]);
 
   CoincidentTopologyHelper.implementCoincidentTopologyMethods(publicAPI, model);

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -1062,17 +1062,21 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         vtkErrorMacro('Reformat slicing not yet supported.');
       }
 
-      const { offset, scale } = model.openGLTexture.computeScaleOffsets(
-        numComp,
-        scalars
-      );
+      // For now, fix the image mapper, but we should probably fix the
+      // vtkImageArrayMapper as well
+      if (!model.renderable.isA('vtkImageArrayMapper')) {
+        const { offset, scale } = model.openGLTexture.computeScaleOffsets(
+          numComp,
+          scalars
+        );
 
-      model.openGLTexture.setUseHalfFloat(
-        dataType,
-        offset,
-        scale,
-        model.renderable.getPreferSizeOverAccuracy()
-      );
+        model.openGLTexture.setUseHalfFloat(
+          dataType,
+          offset,
+          scale,
+          model.renderable.getPreferSizeOverAccuracy()
+        );
+      }
 
       model.openGLTexture.create2DFromRaw(
         dims[0],

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -1062,6 +1062,18 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         vtkErrorMacro('Reformat slicing not yet supported.');
       }
 
+      const { offset, scale } = model.openGLTexture.computeScaleOffsets(
+        numComp,
+        scalars
+      );
+
+      model.openGLTexture.setUseHalfFloat(
+        dataType,
+        offset,
+        scale,
+        model.renderable.getPreferSizeOverAccuracy()
+      );
+
       model.openGLTexture.create2DFromRaw(
         dims[0],
         dims[1],


### PR DESCRIPTION


### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Half float in ImageMapper was always used even if there was potential inaccurate representation. Since half float uses 11 bits compared to short which has 15 bits, there is a potential that the values are above 2048 which makes the rendering inaccurate. See https://github.com/Kitware/vtk-js/pull/2046#discussion_r699478690 for more information



### Results and Changes
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

Add `preferSizeOverAccuracy` for imageMapper similar to Volume mapper PR for half float under a flag which was previously done in https://github.com/Kitware/vtk-js/pull/2046 


- [x] Documentation and TypeScript definitions were updated to match those changes

Although not sure where to put the new publicAPI docs, since there is no index.d.ts for the openGL texture 

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: Latest
  - **OS**: macOS
  - **Browser**: Chrome