### PR TITLE
feat(WidgetManager): add getActiveWidget()

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.d.ts
+++ b/Sources/Widgets/Core/WidgetManager/index.d.ts
@@ -83,6 +83,13 @@ export interface vtkWidgetManager extends vtkObject {
   getWidgets(): vtkAbstractWidget[];
 
   /**
+   * Get the active widget.
+   *
+   * If no widget is active, returns null.
+   */
+  getActiveWidget(): Nullable<vtkAbstractWidget>;
+
+  /**
    * Get the view id.
    */
   getViewId(): string;

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -153,9 +153,11 @@ function vtkWidgetManager(publicAPI, model) {
     // Default cursor behavior
     model._apiSpecificRenderWindow.setCursor(widget ? 'pointer' : 'default');
 
+    model.activeWidget = null;
     let wantRender = false;
     if (model.widgetInFocus === widget && widget.hasFocus()) {
       activateHandle(widget);
+      model.activeWidget = widget;
       wantRender = true;
     } else {
       for (let i = 0; i < model.widgets.length; i++) {
@@ -485,6 +487,7 @@ const DEFAULT_VALUES = {
   // _currentUpdateSelectionCallID: null,
   viewId: null,
   widgets: [],
+  activeWidget: null,
   renderer: null,
   viewType: ViewTypes.DEFAULT,
   isAnimating: false,
@@ -510,6 +513,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'widgets',
     'viewId',
     'pickingEnabled',
+    'activeWidget',
   ]);
 
   // Object specific methods


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Adds `widgetManager.getActiveWidget()`, which allows users to query the currently active widget, if any. This is most useful if you want to perform operations that depend on whether a widget is currently selected.

### Results
`widgetManager.getActiveWidget()` returns the currently active widget, or null.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

No testing is needed. This further develops and exposes an already-used property.
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
