### PR TITLE
perf(OpenGL/Texture): reduce lookups in hot loop

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -10,6 +10,7 @@ import { registerOverride } from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactor
 const { Wrap, Filter } = Constants;
 const { VtkDataTypes } = vtkDataArray;
 const { vtkDebugMacro, vtkErrorMacro, vtkWarningMacro } = macro;
+const { toHalf } = HalfFloat;
 
 // ----------------------------------------------------------------------------
 // vtkOpenGLTexture methods
@@ -656,8 +657,9 @@ function vtkOpenGLTexture(publicAPI, model) {
       for (let idx = 0; idx < data.length; idx++) {
         if (data[idx]) {
           const newArray = new Uint16Array(pixCount);
+          const src = data[idx];
           for (let i = 0; i < pixCount; i++) {
-            newArray[i] = HalfFloat.toHalf(data[idx][i]);
+            newArray[i] = toHalf(src[i]);
           }
           pixData.push(newArray);
         } else {


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

For large array inputs, there is a measurable difference in total execution time of the containing loop (observed initially on Chrome).


### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- Faster half float loop
### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Updated OpenGL/Texture.js

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->

Timing results on Chrome provided below. The relevant timing lines are described.
* "toHalf module local fn fewer lookups": this PR
* "toHalf module": original behavior
<img width="592" alt="image" src="https://user-images.githubusercontent.com/1812167/232869742-893a74c1-4146-487a-bb66-69969270f9fe.png">

Timing on Firefox:

<img width="591" alt="image" src="https://user-images.githubusercontent.com/1812167/232870119-d875c120-dda0-4474-9e5d-52177bbff656.png">

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
