### PR TITLE
fix(OBJReader): race condition on loadData

### DIFF
--- a/Sources/IO/Misc/OBJReader/index.js
+++ b/Sources/IO/Misc/OBJReader/index.js
@@ -308,7 +308,9 @@ function vtkOBJReader(publicAPI, model) {
 
   // Fetch the actual data arrays
   publicAPI.loadData = (option = {}) =>
-    fetchData(model.url, option).then(publicAPI.parseAsText);
+    fetchData(model.url, option).then((content) =>
+      publicAPI.isDeleted() ? false : publicAPI.parseAsText(content)
+    );
 
   publicAPI.parseAsText = (content) => {
     if (!content) {


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
It's possible for OBJReader to become deleted while fetchData is loading.
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- loadData resolves to false instead of throwing an error about being deleted

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Fixed OBJReader

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
