### PR TITLE
fix(MouseCameraAxisRotateManipulator): no sticky

### DIFF
--- a/Sources/Interaction/Manipulators/MouseCameraAxisRotateManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraAxisRotateManipulator/index.js
@@ -3,7 +3,6 @@ import macro from 'vtk.js/Sources/macros';
 import vtkCompositeCameraManipulator from 'vtk.js/Sources/Interaction/Manipulators/CompositeCameraManipulator';
 import vtkCompositeMouseManipulator from 'vtk.js/Sources/Interaction/Manipulators/CompositeMouseManipulator';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
-import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';
 
 // ----------------------------------------------------------------------------
 // vtkMouseCameraAxisRotateManipulator methods
@@ -13,14 +12,15 @@ function vtkMouseCameraAxisRotateManipulator(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkMouseCameraAxisRotateManipulator');
 
+  const negCameraDir = new Float64Array(3);
   const newCamPos = new Float64Array(3);
   const newFp = new Float64Array(3);
-  // const newViewUp = new Float64Array(3);
+  const newViewUp = new Float64Array(3);
   const trans = new Float64Array(16);
+  const rotation = new Float64Array(16);
   const v2 = new Float64Array(3);
   const centerNeg = new Float64Array(3);
-  const direction = new Float64Array(3);
-  const fpDirection = new Float64Array(3);
+  const negRotationAxis = new Float64Array(3);
 
   publicAPI.onButtonDown = (interactor, renderer, position) => {
     model.previousPosition = position;
@@ -36,13 +36,13 @@ function vtkMouseCameraAxisRotateManipulator(publicAPI, model) {
     const cameraFp = camera.getFocalPoint();
     const cameraViewUp = camera.getViewUp();
     const cameraDirection = camera.getDirectionOfProjection();
+    vec3.negate(negCameraDir, cameraDirection);
 
     mat4.identity(trans);
+    mat4.identity(rotation);
 
     const { center, rotationFactor, rotationAxis } = model;
-
-    // Translate to center
-    mat4.translate(trans, trans, center);
+    vec3.negate(negRotationAxis, rotationAxis);
 
     const dx = model.previousPosition.x - position.x;
     const dy = model.previousPosition.y - position.y;
@@ -50,94 +50,55 @@ function vtkMouseCameraAxisRotateManipulator(publicAPI, model) {
     const size = interactor.getView().getViewportSize(renderer);
 
     // Azimuth
-    mat4.rotate(
-      trans,
-      trans,
-      vtkMath.radiansFromDegrees(((360.0 * dx) / size[0]) * rotationFactor),
-      rotationAxis
+    const azimuthDelta = vtkMath.radiansFromDegrees(
+      ((360.0 * dx) / size[0]) * rotationFactor
     );
+    mat4.rotate(rotation, rotation, azimuthDelta, rotationAxis);
 
     // Elevation
     vtkMath.cross(cameraDirection, cameraViewUp, v2);
-    mat4.rotate(
-      trans,
-      trans,
-      vtkMath.radiansFromDegrees(((-360.0 * dy) / size[1]) * rotationFactor),
-      v2
+    let elevationDelta = vtkMath.radiansFromDegrees(
+      ((-360.0 * dy) / size[1]) * rotationFactor
     );
+    // angle of camera to rotation axis on the positive or negative half,
+    // relative to the origin.
+    const angleToPosHalf = Math.acos(vec3.dot(negCameraDir, rotationAxis));
+    const angleToNegHalf = Math.acos(vec3.dot(negCameraDir, negRotationAxis));
 
-    // Translate back
-    centerNeg[0] = -center[0];
-    centerNeg[1] = -center[1];
-    centerNeg[2] = -center[2];
+    // whether camera is in positive half of the rotation axis or neg half
+    const inPosHalf = angleToPosHalf <= angleToNegHalf;
+    const elevationToAxis = Math.min(angleToPosHalf, angleToNegHalf);
+
+    if (model.useHalfAxis && !inPosHalf) {
+      elevationDelta = Math.PI / 2 - angleToPosHalf;
+    } else if (inPosHalf && elevationToAxis + elevationDelta < 0) {
+      elevationDelta = -elevationToAxis;
+      // } else if (!inPosHalf && elevationToAxis - elevationDelta < 0) {
+    } else if (!inPosHalf && angleToPosHalf + elevationDelta > Math.PI) {
+      elevationDelta = elevationToAxis;
+    }
+
+    mat4.rotate(rotation, rotation, elevationDelta, v2);
+
+    // Translate from origin
+    mat4.translate(trans, trans, center);
+
+    // apply rotation
+    mat4.multiply(trans, trans, rotation);
+
+    // Translate to origin
+    vec3.negate(centerNeg, center);
     mat4.translate(trans, trans, centerNeg);
 
     // Apply transformation to camera position, focal point, and view up
     vec3.transformMat4(newCamPos, cameraPos, trans);
     vec3.transformMat4(newFp, cameraFp, trans);
 
-    // what is the current direction from the fp
-    // to the camera
-    vec3.subtract(fpDirection, newCamPos, newFp);
-    vec3.normalize(fpDirection, fpDirection);
-
-    // make the top sticky to avoid accidental flips
-    if (Math.abs(vec3.dot(fpDirection, rotationAxis)) > 0.95) {
-      // this can be smarter where it still allows Azimuth here
-      // but prevents the elevation part
-      model.previousPosition = position;
-      return;
-    }
-
-    if (model.useHalfAxis) {
-      // what is the current distance from pos to center of rotation
-      const distance = vec3.distance(newCamPos, center);
-
-      // what is the current direction from the center of rotation
-      // to the camera
-      vec3.subtract(direction, newCamPos, center);
-      vec3.normalize(direction, direction);
-
-      // project the rotation axis onto the direction
-      // so we know how much below the half plane we are
-      const dotP = vec3.dot(rotationAxis, direction);
-
-      if (dotP < 0) {
-        // adjust the new camera position to bring it up to the half plane
-        vec3.scaleAndAdd(newCamPos, newCamPos, rotationAxis, -dotP * distance);
-
-        // the above step will change the distance which might feel odd
-        // so the next couple lines restore the distance to the center
-
-        // what is the new direction from the center of rotation
-        // to the camera
-        vec3.subtract(direction, newCamPos, center);
-        vec3.normalize(direction, direction);
-        vec3.scaleAndAdd(newCamPos, center, direction, distance);
-
-        // compute original cam direction to center
-        vec3.subtract(v2, cameraPos, center);
-        vec3.normalize(v2, v2);
-
-        // const rAngle = 0.0;
-        const acosR = Math.min(1.0, Math.max(-1.0, vec3.dot(direction, v2)));
-        const rAngle = Math.acos(acosR); // 0 to pi
-        vec3.cross(v2, v2, direction);
-        vec3.normalize(v2, v2);
-
-        vec3.subtract(newFp, cameraFp, center);
-        const fpDist = vec3.length(newFp);
-
-        // Note it normalizes the vector to be rotated
-        const result = [...newFp];
-        vtkMatrixBuilder.buildFromRadian().rotate(rAngle, v2).apply(result);
-        vec3.scaleAndAdd(newFp, center, result, fpDist);
-      }
-    }
+    vec3.transformMat4(newViewUp, cameraViewUp, rotation);
 
     camera.setPosition(newCamPos[0], newCamPos[1], newCamPos[2]);
     camera.setFocalPoint(newFp[0], newFp[1], newFp[2]);
-    camera.setViewUp(rotationAxis);
+    camera.setViewUp(newViewUp);
 
     renderer.resetCameraClippingRange();
 


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
- Camera's viewUp param is updated incorrectly
- sticky at the axes
### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- Avoids stickiness at the axes.
- camera viewUp is correct

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
