### PR TITLE
fix(scalarbaractor): support ScalarBarActor resize

### DIFF
--- a/Sources/Rendering/Core/Texture/index.js
+++ b/Sources/Rendering/Core/Texture/index.js
@@ -266,6 +266,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'image',
     'jsImageData',
     'imageLoaded',
+    'resizable',
   ]);
 
   macro.setGet(publicAPI, model, [

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -781,7 +781,7 @@ function vtkOpenGLTexture(publicAPI, model) {
   //----------------------------------------------------------------------------
   function useTexStorage(dataType) {
     if (model._openGLRenderWindow) {
-      if (model.resizable) {
+      if (model.resizable || model.renderable?.getResizable()) {
         // Cannot use texStorage if the texture is supposed to be resizable.
         return false;
       }
@@ -969,7 +969,7 @@ function vtkOpenGLTexture(publicAPI, model) {
         if (j <= model.maxLevel) {
           tempData = invertedData[6 * j + i];
         }
-        if (model._openGLRenderWindow.getWebgl2() && !model.resizable) {
+        if (useTexStorage(dataType)) {
           if (tempData != null) {
             model.context.texSubImage2D(
               model.context.TEXTURE_CUBE_MAP_POSITIVE_X + i,


### PR DESCRIPTION
The texture size may change over time. WebGL2 functions texSubImage2D can't therefore be used. The 'resizable' member variable should be considered. It was considered for von vtkOpenGLTexture but ignored on vtkTexture.

### Context
ScalarBarActor example was having resize issues when in full screen

### Results
No more resize issue with the ScalarBarActor.

### Changes
Do not use WebGL2 functions `texSubImage2D` when texture is resizable.

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: latest Chrome
