### PR TITLE
chore(github): no commitlint on merge queue

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Enforce code style
         run: npm run validate
       - name: Lint commits
+        if: github.event_name != 'merge_group'
         run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
       - name: Tests must not use test.only
         run: bash .github/workflows/test-only-check.sh


### PR DESCRIPTION
Well, turns out I do need to mask commitlint on merge_group events. Unsure if merge_group contains a sha to work off of, but PR checks should run just fine for gating PRs prior to merging.