### PR TITLE
fix: directly assign the value from getDirection to mat3

### DIFF
--- a/Sources/Rendering/Core/ImageMapper/index.js
+++ b/Sources/Rendering/Core/ImageMapper/index.js
@@ -120,12 +120,7 @@ function vtkImageMapper(publicAPI, model) {
 
   publicAPI.getSlicingModeNormal = () => {
     const out = [0, 0, 0];
-    const a = publicAPI.getCurrentImage().getDirection();
-    const mat3 = [
-      [a[0], a[1], a[2]],
-      [a[3], a[4], a[5]],
-      [a[6], a[7], a[8]],
-    ];
+    const mat3 = publicAPI.getCurrentImage().getDirection();
 
     switch (model.slicingMode) {
       case SlicingMode.X:


### PR DESCRIPTION
According to the implementation of the multiply3x3_vect3 function, mat_3x3 should be a one-dimensional array

```javascript
export function multiply3x3_vect3(mat_3x3, in_3, out_3) {
  const x = mat_3x3[0] * in_3[0] + mat_3x3[1] * in_3[1] + mat_3x3[2] * in_3[2];
  const y = mat_3x3[3] * in_3[0] + mat_3x3[4] * in_3[1] + mat_3x3[5] * in_3[2];
  const z = mat_3x3[6] * in_3[0] + mat_3x3[7] * in_3[1] + mat_3x3[8] * in_3[2];

  out_3[0] = x;
  out_3[1] = y;
  out_3[2] = z;
}
```

i am not saying  it is not my image "direction", i mean multiplying an array by a number may be a NaN or 0