### PR TITLE
2775 fix contour triangulator

### DIFF
--- a/Sources/Filters/General/ContourTriangulator/example/index.js
+++ b/Sources/Filters/General/ContourTriangulator/example/index.js
@@ -63,10 +63,8 @@ for (let i = 0; i < nbPoints; i++) {
 // Build pipeline
 const filter = vtkContourTriangulator.newInstance();
 filter.setInputData(source);
-filter.update();
-const filterData = filter.getOutputData();
 
-mapper.setInputData(filterData);
+mapper.setInputConnection(filter.getOutputPort());
 
 // -----------------------------------------------------------
 
@@ -80,6 +78,6 @@ renderWindow.render();
 
 global.source = source;
 global.filter = filter;
-global.filterData = filterData;
+global.filterData = filter.getOutputData();
 global.mapper = mapper;
 global.actor = actor;

--- a/Sources/Filters/General/ContourTriangulator/index.d.ts
+++ b/Sources/Filters/General/ContourTriangulator/index.d.ts
@@ -20,6 +20,20 @@ export interface vtkContourTriangulator extends vtkContourTriangulatorBase {
 	 * @param {any} outData
 	 */
 	requestData(inData: any, outData: any): void;
+
+	/**
+	 * Sets the behavior of the filter regarding polys.
+	 * @param {boolean} triangulate whether the filter should triangulate polys
+	 * or leave them untouched. True by default
+	 * @return {boolean} true if it changes
+	 */
+	setTriangulatePolys(triangulate: boolean): boolean;
+
+	/**
+	 * Returns the behavior of the filter regarding polys.
+	 * @return {boolean} True if the filter triangulates polys, false otherwise.
+	 */
+	getTriangulatePolys(): boolean;
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/General/ContourTriangulator/index.js
+++ b/Sources/Filters/General/ContourTriangulator/index.js
@@ -92,7 +92,7 @@ function triangulateContours(
 
   // Initialize each group to hold just one polygon.
   const numNewPolys = newPolys.length;
-  const polyGroups = [];
+  const polyGroups = new Array(numNewPolys);
   for (let i = 0; i < numNewPolys; i++) {
     polyGroups[i] = [i];
   }
@@ -210,6 +210,7 @@ function vtkContourTriangulator(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     // implement requestData
     const input = inData[0];
+    // FIXME: do not instantiate a new polydata each time the filter is executed.
     const output = vtkPolyData.newInstance();
     outData[0] = output;
 
@@ -271,7 +272,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Also make it an algorithm with one input and one output
   macro.algo(publicAPI, model, 1, 1);
 
-  macro.setGet(publicAPI, model, ['triangulate']);
+  macro.setGet(publicAPI, model, ['triangulatePolys']);
 
   // Object specific methods
   vtkContourTriangulator(publicAPI, model);

--- a/Sources/Filters/General/ContourTriangulator/index.js
+++ b/Sources/Filters/General/ContourTriangulator/index.js
@@ -44,7 +44,7 @@ function triangulateContours(
   const newPolys = [];
   const incompletePolys = [];
 
-  const oriented = normal != null;
+  const oriented = normal?.length < 3;
   vtkCCSMakePolysFromLines(
     polyData,
     firstLine,
@@ -55,8 +55,9 @@ function triangulateContours(
   );
 
   // if no normal specified, then compute one from largest contour
-  const computedNormal = normal;
-  if (normal == null) {
+  let computedNormal = normal;
+  if (!oriented) {
+    computedNormal = [0, 0, 1];
     let maxnorm = 0;
     const n = [];
     for (let i = 0; i < newPolys.length; i++) {
@@ -239,7 +240,7 @@ function vtkContourTriangulator(publicAPI, model) {
       input.getNumberOfVerts(),
       lines.getNumberOfCells(),
       polysArray,
-      [],
+      null,
       model.triangulatePolys
     );
 

--- a/Sources/Rendering/Core/Renderer/index.d.ts
+++ b/Sources/Rendering/Core/Renderer/index.d.ts
@@ -649,7 +649,7 @@ export interface vtkRenderer extends vtkViewport {
      * @param {Number} r Defines the red component (between 0 and 1).
      * @param {Number} g Defines the green component (between 0 and 1).
      * @param {Number} b Defines the blue component (between 0 and 1).
-     * @param {Number} b Defines the alpha component (between 0 and 1).
+     * @param {Number} a Defines the alpha component (between 0 and 1).
      */
 	setBackground(r: number, g: number, b: number, a: number): boolean;
 

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
@@ -1,5 +1,5 @@
 import { vtkObject } from "../../../interfaces";
-import { RGBColor } from "../../../types";
+import { RGBAColor, RGBColor } from "../../../types";
 import vtkRenderer from "../../Core/Renderer";
 import vtkRenderWindow from "../../Core/RenderWindow";
 import vtkRenderWindowInteractor from "../../Core/RenderWindowInteractor";
@@ -12,7 +12,7 @@ import vtkRenderWindowInteractor from "../../Core/RenderWindowInteractor";
  *
  */
 export interface IFullScreenRenderWindowInitialValues {
-	background?: RGBColor;
+	background?: RGBColor | RGBAColor;
 	container?: HTMLElement
 	containerStyle?: object;
 	controlPanelStyle?: object;
@@ -94,9 +94,9 @@ export interface vtkFullScreenRenderWindow extends vtkObject {
 
 	/**
 	 * Set background color
-	 * @param {Number[]} background The background color.
+	 * @param {RGBColor | RGBAColor} background The background color.
 	 */
-	setBackground(background: number[]): boolean;
+	setBackground(background: RGBColor | RGBAColor): boolean;
 
 	/**
 	 * Hide or show controller

--- a/Sources/Rendering/Misc/GenericRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/GenericRenderWindow/index.d.ts
@@ -1,5 +1,5 @@
 import { vtkObject, vtkSubscription } from "../../../interfaces";
-import { RGBColor } from "../../../types";
+import { RGBAColor, RGBColor } from "../../../types";
 import vtkRenderer from "../../Core/Renderer";
 import vtkRenderWindow from "../../Core/RenderWindow";
 import vtkRenderWindowInteractor from "../../Core/RenderWindowInteractor";
@@ -10,7 +10,7 @@ import vtkOpenGLRenderWindow from "../../OpenGL/RenderWindow";
  *
  */
 export interface IGenericRenderWindowInitialValues {
-	background?: RGBColor;
+	background?: RGBColor|RGBAColor;
 	listenWindowResize?: boolean;
 	container?: HTMLElement,
 }
@@ -62,9 +62,10 @@ export interface vtkGenericRenderWindow extends vtkObject {
 
 	/**
 	 * Set background color
-	 * @param {RGBColor} background The background color.
+	 * @param {RGBColor|RGBAColor} background The background color.
+	 * @returns true if the background color actually changed, false otherwise
 	 */
-	setBackground(background: RGBColor): boolean;
+	setBackground(background: RGBColor|RGBAColor): boolean;
 
 	/**
 	 * Set thecontainer element


### PR DESCRIPTION

### Context
vtkContourTriangulator was broken, filter output polydata had no lines/polys.

### Results
vtkContourTriangulator example now show a triangulated contour.

### Changes
Input normal was empty and not computed. This fix makes sure the normal is computed.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Latest Chrome

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
