### PR TITLE
2758 fix get bounds for slice doc

### DIFF
--- a/Sources/Common/DataModel/BoundingBox/index.js
+++ b/Sources/Common/DataModel/BoundingBox/index.js
@@ -28,7 +28,10 @@ export function equals(a, b) {
 
 export function isValid(bounds) {
   return (
-    bounds[0] <= bounds[1] && bounds[2] <= bounds[3] && bounds[4] <= bounds[5]
+    bounds?.length >= 6 &&
+    bounds[0] <= bounds[1] &&
+    bounds[2] <= bounds[3] &&
+    bounds[4] <= bounds[5]
   );
 }
 
@@ -248,8 +251,7 @@ export function getCorners(bounds, corners) {
   for (let ix = 0; ix < 2; ix++) {
     for (let iy = 2; iy < 4; iy++) {
       for (let iz = 4; iz < 6; iz++) {
-        corners[count] = [bounds[ix], bounds[iy], bounds[iz]];
-        count++;
+        corners[count++] = [bounds[ix], bounds[iy], bounds[iz]];
       }
     }
   }
@@ -269,13 +271,11 @@ export function computeCornerPoints(bounds, point1, point2) {
 }
 
 export function transformBounds(bounds, transform, out = []) {
-  if (out.length < 6) {
-    reset(out);
-  }
   const corners = getCorners(bounds, []);
   for (let i = 0; i < corners.length; ++i) {
     vec3.transformMat4(corners[i], corners[i], transform);
   }
+  reset(out);
   return addPoints(out, corners);
 }
 

--- a/Sources/Proxy/Core/View2DProxy/index.js
+++ b/Sources/Proxy/Core/View2DProxy/index.js
@@ -41,7 +41,7 @@ function getPropCoarseHull(prop) {
   // Better bounds using mapper bounds and prop matrix
   const mapper = prop?.getMapper?.();
   const mapperBounds = mapper?.getBounds?.();
-  if (mapperBounds && vtkBoundingBox.isValid(mapperBounds) && prop.getMatrix) {
+  if (vtkBoundingBox.isValid(mapperBounds) && prop.getMatrix) {
     finestBounds = mapperBounds;
     finestMatrix = prop.getMatrix().slice();
     mat4.transpose(finestMatrix, finestMatrix);

--- a/Sources/Rendering/Core/ImageArrayMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageArrayMapper/index.d.ts
@@ -49,8 +49,9 @@ export interface vtkImageArrayMapper extends vtkAbstractImageMapper {
 
 	/**
 	 * Get the bounds for a given slice as [xmin, xmax, ymin, ymax,zmin, zmax].
-	 * @param {Number} [slice] The slice index.
-	 * @param {Number} [halfThickness] Half the slice thickness in index space (unit voxel spacing).
+	 * @param {Number} [slice] The slice index. If undefined, the current slice is considered.
+	 * @param {Number} [halfThickness] Half the slice thickness in index space (unit voxel
+	 * spacing). If undefined, 0 is considered.
 	 * @return {Number[]} The bounds for a given slice.
 	 */
 	getBoundsForSlice(slice?: number, halfThickness?: number): number[];

--- a/Sources/Rendering/Core/ImageMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageMapper/index.d.ts
@@ -43,8 +43,9 @@ export interface vtkImageMapper extends vtkAbstractImageMapper {
 
 	/**
 	 * Get the bounds for a given slice as [xmin, xmax, ymin, ymax,zmin, zmax].
-	 * @param {Number} [slice] The slice index.
-	 * @param {Number} [halfThickness] Half the slice thickness in index space (unit voxel spacing).
+	 * @param {Number} [slice] The slice index. If undefined, the current slice is considered.
+	 * @param {Number} [halfThickness] Half the slice thickness in index space (unit voxel
+	 * spacing). If undefined, 0 is considered.
 	 * @return {Number[]} The bounds for a given slice.
 	 */
 	getBoundsForSlice(slice?: number, halfThickness?: number): number[];

--- a/Sources/Rendering/Core/ImageSlice/index.d.ts
+++ b/Sources/Rendering/Core/ImageSlice/index.d.ts
@@ -31,11 +31,11 @@ export interface vtkImageSlice extends vtkProp3D {
 
 	/**
 	 * Get the bounds for a given slice as [xmin, xmax, ymin, ymax,zmin, zmax].
-	 * @param {Number} slice The slice index.
-	 * @param {Number} [thickness] The slice thickness.
+	 * @param {Number} slice The slice index. If undefined, the current slice is considered.
+	 * @param {Number} [thickness] The slice thickness. If undefined, 0 is considered.
 	 * @return {Bounds} The bounds for a given slice.
 	 */
-	getBoundsForSlice(slice: number, thickness?: number): Bounds;
+	getBoundsForSlice(slice?: number, thickness?: number): Bounds;
 
 	/**
 	 * 


### PR DESCRIPTION

### Context
Documentation was wrongly making mandatory the first parameter of the getBoundsForSlice() function.

### Results
Documentation now correctly informs that the first parameter of the getBoudnsForSlice() function is optional

### Changes
Update documentation and cleanup code
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->
