### PR TITLE
fix(webgpu): Fix support of WebGPU render backend

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,6 @@
+## From 28.x to 29
+
+- **getOpenGLRenderWindow**: `getOpenGLRenderWindow` has been renamed to `getApiSpecificRenderWindow` in `vtkFullScreenRenderWindow`, `vtkGenericRenderWindow` and `vtkViewProxy` to support WebGL and WebGPU backend.
 ## From 27.x to 28
 
 - **vtkManipulator.handleEvent**: Change all `handleEvent` signatures of manipulators. Used to be `handleEvent(callData, glRenderWindow): vec3`, it is now `handleEvent(callData, glRenderWindow): { worldCoords: Nullable<vec3>, worldDirection?: mat3 }`.

--- a/Examples/Applications/SkyboxViewer/index.js
+++ b/Examples/Applications/SkyboxViewer/index.js
@@ -270,8 +270,8 @@ function createVisualization(container, mapReader) {
   }
 
   if (grid) {
-    console.log(fullScreenRenderer.getOpenGLRenderWindow().getSize());
-    createGrid(...fullScreenRenderer.getOpenGLRenderWindow().getSize());
+    console.log(fullScreenRenderer.getApiSpecificRenderWindow().getSize());
+    createGrid(...fullScreenRenderer.getApiSpecificRenderWindow().getSize());
   }
 }
 

--- a/Sources/IO/Core/ImageStream/example/index.md
+++ b/Sources/IO/Core/ImageStream/example/index.md
@@ -19,7 +19,7 @@ smartConnect.onConnectionReady((connection) => {
   // Image
   imageStream.connect(session);
   const viewStream = imageStream.createViewStream('-1');
-  fullScreenRenderer.getOpenGLRenderWindow().setViewStream(viewStream);
+  fullScreenRenderer.getApiSpecificRenderWindow().setViewStream(viewStream);
 
   // Configure image quality
   viewStream.setInteractiveQuality(75);

--- a/Sources/Proxy/Core/ProxyManager/example/index.js
+++ b/Sources/Proxy/Core/ProxyManager/example/index.js
@@ -69,7 +69,7 @@ view2DContainer.className = 'viewContainer';
 const view3DProxy = proxyManager.createProxy('Views', 'View3D');
 view3DProxy.setContainer(view3DContainer);
 view3DProxy
-  .getOpenGLRenderWindow()
+  .getApiSpecificRenderWindow()
   .setSize([view3DContainer.clientWidth, view3DContainer.clientHeight]);
 
 // ----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ view3DProxy
 const view2DProxy = proxyManager.createProxy('Views', 'View2D', { axis: 2 });
 view2DProxy.setContainer(view2DContainer);
 view2DProxy
-  .getOpenGLRenderWindow()
+  .getApiSpecificRenderWindow()
   .setSize([view2DContainer.clientWidth, view2DContainer.clientHeight]);
 
 // ----------------------------------------------------------------------------

--- a/Sources/Proxy/Core/View2DProxy/example/index.js
+++ b/Sources/Proxy/Core/View2DProxy/example/index.js
@@ -68,7 +68,7 @@ const view2DProxy = proxyManager.createProxy('Views', 'View2D', {
 });
 view2DProxy.setContainer(mainContainer);
 view2DProxy
-  .getOpenGLRenderWindow()
+  .getApiSpecificRenderWindow()
   .setSize(mainContainer.clientWidth, mainContainer.clientHeight);
 
 fitCameraButton.addEventListener('click', () => {

--- a/Sources/Proxy/Core/ViewProxy/index.d.ts
+++ b/Sources/Proxy/Core/ViewProxy/index.d.ts
@@ -8,6 +8,7 @@ import { vtkSubscription, vtkObject } from '../../../interfaces';
 import vtkRenderer from '../../../Rendering/Core/Renderer';
 import vtkRenderWindow from '../../../Rendering/Core/RenderWindow';
 import vtkOpenGLRenderWindow from '../../../Rendering/OpenGL/RenderWindow';
+import vtkWebGPURenderWindow from '../../../Rendering/WebGPU/RenderWindow';
 import { VtkProxy } from '../../../macros';
 
 export interface vtkViewProxy extends VtkProxy {
@@ -66,7 +67,7 @@ export interface vtkViewProxy extends VtkProxy {
   getInteractor(): vtkRenderWindowInteractor;
   getInteractorStyle2D(): vtkInteractorStyle;
   getInteractorStyle3D(): vtkInteractorStyle;
-  getOpenGLRenderWindow(): vtkOpenGLRenderWindow;
+  getApiSpecificRenderWindow(): vtkOpenGLRenderWindow|vtkWebGPURenderWindow;
   getOrientationAxesType(): string;
   getPresetToOrientationAxes(): any;
   getRenderer(): vtkRenderer;

--- a/Sources/Proxy/Representations/ResliceRepresentationProxy/example/index.js
+++ b/Sources/Proxy/Representations/ResliceRepresentationProxy/example/index.js
@@ -73,7 +73,7 @@ const view2DProxy = proxyManager.createProxy('Views', 'View2D', {
 });
 view2DProxy.setContainer(mainContainer);
 view2DProxy
-  .getOpenGLRenderWindow()
+  .getApiSpecificRenderWindow()
   .setSize(mainContainer.clientWidth, mainContainer.clientHeight);
 
 fitCameraButton.addEventListener('click', () => {

--- a/Sources/Rendering/Core/RenderWindow/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindow/index.d.ts
@@ -148,6 +148,7 @@ export interface vtkRenderWindow extends vtkObject {
 	 * Switch the rendering backend between WebGL and WebGPU.
 	 * By default, the WebGL backend is used. To switch, to WebGPU call
 	 * `renderWindow.setDefaultViewAPI('WebGPU')` before calling `render`.
+	 * Must be called before `newAPISpecificView()` is called.
 	 * @param defaultViewAPI (default: 'WebGL')
 	 */
 	setDefaultViewAPI(defaultViewAPI: DEFAULT_VIEW_API): boolean;

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
@@ -17,6 +17,7 @@ export interface IFullScreenRenderWindowInitialValues {
 	containerStyle?: object;
 	controlPanelStyle?: object;
 	controllerVisibility?: boolean;
+	defaultViewAPI?: boolean;
 	listenWindowResize?: boolean;
 	resizeCallback?: any;
 }
@@ -42,7 +43,9 @@ export interface vtkFullScreenRenderWindow extends vtkObject {
 	delete(): void;
 
 	/**
-	 * 
+	 * Returns vtkWebGPURenderWindow if ?viewAPI='WebGPU' is in URL, or if
+	 * vtkFullScreenRenderWindow has been created with "defaultViewAPI: 'WebGPU",
+	 * otherwise vtkOpenGLRenderWindow is returned.
 	 */
 	getApiSpecificRenderWindow(): any; // vtkOpenGLRenderWindow || vtkWebGPURenderWindow
 

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
@@ -80,7 +80,7 @@ function vtkFullScreenRenderWindow(publicAPI, model) {
 
   // apiSpecificRenderWindow
   model.apiSpecificRenderWindow = model.renderWindow.newAPISpecificView(
-    userParams.viewAPI
+    userParams.viewAPI ?? model.defaultViewAPI
   );
   model.apiSpecificRenderWindow.setContainer(model.container);
   model.renderWindow.addView(model.apiSpecificRenderWindow);
@@ -192,6 +192,7 @@ const DEFAULT_VALUES = {
   background: [0.32, 0.34, 0.43],
   containerStyle: null,
   controlPanelStyle: null,
+  // defaultViewAPI: undefined,
   listenWindowResize: true,
   resizeCallback: null,
   controllerVisibility: true,

--- a/Sources/Rendering/Misc/GenericRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/GenericRenderWindow/index.d.ts
@@ -4,6 +4,7 @@ import vtkRenderer from "../../Core/Renderer";
 import vtkRenderWindow from "../../Core/RenderWindow";
 import vtkRenderWindowInteractor from "../../Core/RenderWindowInteractor";
 import vtkOpenGLRenderWindow from "../../OpenGL/RenderWindow";
+import vtkWebGPURenderWindow from "../../WebGPU/RenderWindow";
 
 
 /**
@@ -33,9 +34,9 @@ export interface vtkGenericRenderWindow extends vtkObject {
 	getInteractor(): vtkRenderWindowInteractor;
 
 	/**
-	 * 
+	 * Get the render back-end specific render window.
 	 */
-	getOpenGLRenderWindow(): vtkOpenGLRenderWindow;
+	getApiSpecificRenderWindow(): vtkOpenGLRenderWindow|vtkWebGPURenderWindow;
 
 	/**
 	 * 

--- a/Sources/Rendering/Misc/GenericRenderWindow/test/testGenericRenderWindowCreateDelete.js
+++ b/Sources/Rendering/Misc/GenericRenderWindow/test/testGenericRenderWindowCreateDelete.js
@@ -39,7 +39,7 @@ test('Test vtkGenericRenderWindow create/delete', (t) => {
     grw.setContainer(rwContainer);
     grw.getRenderer().addActor(actor);
 
-    images.push(grw.getOpenGLRenderWindow().captureNextImage());
+    images.push(grw.getApiSpecificRenderWindow().captureNextImage());
     grw.getRenderWindow().render();
 
     grw.delete();

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1308,15 +1308,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     model.activeFramebuffer = newActiveFramebuffer;
   };
 
-  const superSetSize = publicAPI.setSize;
-  publicAPI.setSize = (width, height) => {
-    const modified = superSetSize(width, height);
-    if (modified) {
-      publicAPI.invokeWindowResizeEvent({ width, height });
-    }
-    return modified;
-  };
-
   publicAPI.getGraphicsResourceForObject = (vtkObj) => {
     if (!vtkObj) {
       return null;
@@ -1369,6 +1360,12 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       glRen?.releaseGraphicsResources();
     });
   };
+
+  model._onSizeChanged = (_publicAPI, _model, newValue) =>
+    publicAPI.invokeWindowResizeEvent({
+      width: newValue[0],
+      height: newValue[1],
+    });
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1308,6 +1308,15 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     model.activeFramebuffer = newActiveFramebuffer;
   };
 
+  const superSetSize = publicAPI.setSize;
+  publicAPI.setSize = (width, height) => {
+    const modified = superSetSize(width, height);
+    if (modified) {
+      publicAPI.invokeWindowResizeEvent({ width, height });
+    }
+    return modified;
+  };
+
   publicAPI.getGraphicsResourceForObject = (vtkObj) => {
     if (!vtkObj) {
       return null;
@@ -1360,12 +1369,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       glRen?.releaseGraphicsResources();
     });
   };
-
-  model._onSizeChanged = (_publicAPI, _model, newValue) =>
-    publicAPI.invokeWindowResizeEvent({
-      width: newValue[0],
-      height: newValue[1],
-    });
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/WebGPU/RenderWindow/index.js
+++ b/Sources/Rendering/WebGPU/RenderWindow/index.js
@@ -543,12 +543,16 @@ function vtkWebGPURenderWindow(publicAPI, model) {
     return ret;
   };
 
+  const superSetSize = publicAPI.setSize;
+  publicAPI.setSize = (width, height) => {
+    const modified = superSetSize(width, height);
+    if (modified) {
+      publicAPI.invokeWindowResizeEvent({ width, height });
+    }
+    return modified;
+  };
+
   publicAPI.delete = macro.chain(publicAPI.delete, publicAPI.setViewStream);
-  model._onSizeChanged = (_publicAPI, _model, newValue) =>
-    publicAPI.invokeWindowResizeEvent({
-      width: newValue[0],
-      height: newValue[1],
-    });
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/WebGPU/RenderWindow/index.js
+++ b/Sources/Rendering/WebGPU/RenderWindow/index.js
@@ -544,6 +544,11 @@ function vtkWebGPURenderWindow(publicAPI, model) {
   };
 
   publicAPI.delete = macro.chain(publicAPI.delete, publicAPI.setViewStream);
+  model._onSizeChanged = (_publicAPI, _model, newValue) =>
+    publicAPI.invokeWindowResizeEvent({
+      width: newValue[0],
+      height: newValue[1],
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -627,6 +632,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
 
   macro.setGetArray(publicAPI, model, ['size'], 2);
+  macro.event(publicAPI, model, 'windowResizeEvent');
 
   // Object methods
   vtkWebGPURenderWindow(publicAPI, model);

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -206,22 +206,23 @@ function vtkWidgetManager(publicAPI, model) {
 
   async function captureBuffers(x1, y1, x2, y2) {
     if (model._captureInProgress) {
+      await model._captureInProgress;
       return;
     }
-    model._captureInProgress = true;
     renderPickingBuffer();
 
     model._capturedBuffers = null;
-    model._capturedBuffers = await model._selector.getSourceDataAsync(
+    model._captureInProgress = model._selector.getSourceDataAsync(
       model._renderer,
       x1,
       y1,
       x2,
       y2
     );
+    model._capturedBuffers = await model._captureInProgress;
+    model._captureInProgress = null;
     model.previousSelectedData = null;
     renderFrontBuffer();
-    model._captureInProgress = false;
   }
 
   publicAPI.enablePicking = () => {

--- a/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
+++ b/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
@@ -72,7 +72,7 @@ test.onlyIfWebGL('Test getPixelWorldHeightAtCoord', (t) => {
       resolve = res;
     });
     grw
-      .getOpenGLRenderWindow()
+      .getApiSpecificRenderWindow()
       .captureNextImage()
       .then((image) => {
         testUtils.compareImages(
@@ -102,7 +102,7 @@ test.onlyIfWebGL('Test getPixelWorldHeightAtCoord', (t) => {
       resolve = res;
     });
     grw
-      .getOpenGLRenderWindow()
+      .getApiSpecificRenderWindow()
       .captureNextImage()
       .then((image) => {
         testUtils.compareImages(
@@ -132,7 +132,7 @@ test.onlyIfWebGL('Test getPixelWorldHeightAtCoord', (t) => {
       resolve = res;
     });
     grw
-      .getOpenGLRenderWindow()
+      .getApiSpecificRenderWindow()
       .captureNextImage()
       .then((image) => {
         testUtils.compareImages(
@@ -159,7 +159,7 @@ test.onlyIfWebGL('Test getPixelWorldHeightAtCoord', (t) => {
       resolve = res;
     });
     grw
-      .getOpenGLRenderWindow()
+      .getApiSpecificRenderWindow()
       .captureNextImage()
       .then((image) => {
         testUtils.compareImages(

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -135,7 +135,7 @@ for (let i = 0; i < 4; i++) {
   const obj = {
     renderWindow: grw.getRenderWindow(),
     renderer: grw.getRenderer(),
-    GLWindow: grw.getOpenGLRenderWindow(),
+    GLWindow: grw.getApiSpecificRenderWindow(),
     interactor: grw.getInteractor(),
     widgetManager: vtkWidgetManager.newInstance(),
     orientationWidget: null,


### PR DESCRIPTION
### Context
Running the LineWidget example with WebGPU backend generated an error because WidgetManager requires onWindowResizeEvent public function.
Moreover in many places `getOpenGLRenderWindow()` was still called (even in a WebGPU context)

### Results
Expose onWindowResizeEvent and trigger it when the size of the window is modified.
Rename `getOpenGLRenderWindow()` into `getApiSpecificRenderWindow()`

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome Canary
