### PR TITLE
fix(synchronizablerenderwindow/objectmanager): fix ObjectManager array processing

### DIFF
--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
@@ -466,6 +466,16 @@ function removeUnavailableArrays(fields, availableNames) {
     fields.removeArray(namesToDelete[i]);
   }
 }
+/**
+ * Get a unique string suitable for use as state.arrays key.
+ * @param {object} arrayMeta
+ * @returns {string} array key
+ */
+function getArrayKey(arrayMeta) {
+  // Two arrays can have exactly the same hash so try to distinquish with name.
+  const namePart = arrayMeta.name ? `_${arrayMeta.name}` : '';
+  return `${arrayMeta.hash}_${arrayMeta.dataType}${namePart}`;
+}
 
 function createDataSetUpdate(piecesToFetch = []) {
   return (instance, state, context) => {
@@ -484,7 +494,7 @@ function createDataSetUpdate(piecesToFetch = []) {
       if (state.properties[key]) {
         const arrayMeta = state.properties[key];
         arrayMeta.registration = `set${macro.capitalize(key)}`;
-        const arrayKey = `${arrayMeta.hash}_${arrayMeta.dataType}`;
+        const arrayKey = getArrayKey(arrayMeta);
         state.arrays[arrayKey] = arrayMeta;
         delete localProperties[key];
       }
@@ -494,7 +504,7 @@ function createDataSetUpdate(piecesToFetch = []) {
     const fieldsArrays = state.properties.fields || [];
     for (let i = 0; i < fieldsArrays.length; i++) {
       const arrayMeta = fieldsArrays[i];
-      const arrayKey = `${arrayMeta.hash}_${arrayMeta.dataType}`;
+      const arrayKey = getArrayKey(arrayMeta);
       state.arrays[arrayKey] = arrayMeta;
     }
     delete localProperties.fields;


### PR DESCRIPTION
Prevent overriding of two distinct arrays that have same exact data and thus hash but have different meaning as defined by their name.

fix #2815

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Described in the Issue #2815
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Our application was crashing on not finding one of the arrays, with this fix it's working again.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
The code was internal to the module so no TS or documentation changes were necessary.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**:  latest master<!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: OSX 12.6.5 <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: Chrome 112.0.5615.137 (Official Build) (arm64)  <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->

Ping @psavery for the latest change that caused the issue.