### PR TITLE
fix(fielddata): fix removeArray

### DIFF
--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.js
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.js
@@ -53,7 +53,7 @@ function vtkFieldData(publicAPI, model) {
   };
   publicAPI.removeArray = (arrayName) => {
     const index = model.arrays.findIndex(
-      (array) => array.getName() === arrayName
+      (array) => array.data.getName() === arrayName
     );
     return publicAPI.removeArrayByIndex(index);
   };

--- a/Sources/Common/DataModel/DataSetAttributes/test/testDataSetAttributes.js
+++ b/Sources/Common/DataModel/DataSetAttributes/test/testDataSetAttributes.js
@@ -65,5 +65,9 @@ test('Test vtkDataSetAttributes instance', (t) => {
   // t.equal(instance.setScalars('Foo'), 0, 'Setting scalars should return index of array');
   // instance.addArray(vtkDataArray.newInstance({ name: 'Bar', numberOfComponents: 3, values: new Float32Array(3 * ntuples) }));
 
+  t.equal(instance.getNumberOfArrays(), numArrs);
+  instance.removeArray('FooScalars');
+  t.equal(instance.getNumberOfArrays(), numArrs - 1);
+
   t.end();
 });


### PR DESCRIPTION
Arrays are stored in a 'data' sub object

fix #2813


### Context
Crash when `removeArray` was called.
### Results
No more crash
### Changes
Crash was due to a regression.

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome 112
