### PR TITLE
feat(labelwidget): expose vtkLabelWidget and vtkSphereWidget to UMD module

### DIFF
--- a/Sources/Widgets/Widgets3D/index.js
+++ b/Sources/Widgets/Widgets3D/index.js
@@ -4,12 +4,14 @@ import vtkEllipseWidget from './EllipseWidget';
 import vtkImageCroppingWidget from './ImageCroppingWidget';
 import vtkImplicitPlaneWidget from './ImplicitPlaneWidget';
 import vtkInteractiveOrientationWidget from './InteractiveOrientationWidget';
+import vtkLabelWidget from './LabelWidget';
 import vtkLineWidget from './LineWidget';
 import vtkPaintWidget from './PaintWidget';
 import vtkPolyLineWidget from './PolyLineWidget';
 import vtkRectangleWidget from './RectangleWidget';
 import vtkResliceCursorWidget from './ResliceCursorWidget';
 import vtkShapeWidget from './ShapeWidget';
+import vtkSphereWidget from './SphereWidget';
 import vtkSplineWidget from './SplineWidget';
 
 export default {
@@ -19,11 +21,13 @@ export default {
   vtkImageCroppingWidget,
   vtkImplicitPlaneWidget,
   vtkInteractiveOrientationWidget,
+  vtkLabelWidget,
   vtkLineWidget,
   vtkPaintWidget,
   vtkPolyLineWidget,
   vtkRectangleWidget,
   vtkResliceCursorWidget,
   vtkShapeWidget,
+  vtkSphereWidget,
   vtkSplineWidget,
 };


### PR DESCRIPTION

### Context
LabelWidget and SphereWidget are missing from UMD module.

### Results
The widgets are now available in UMD module

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome 113
