### PR TITLE
fix(ScalarsToColors): direct scalars checked against 1 instead of 255

### DIFF
--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -532,7 +532,7 @@ function vtkScalarsToColors(publicAPI, model) {
       }
       // otherwise look at the range of the alpha channel
       const range = scalars.getRange(numberOfComponents - 1);
-      return range[0] === 255;
+      return range[0] === 1.0;
     }
 
     return true;


### PR DESCRIPTION
### Context
With the upgrade to VTK 27.6.0, I encountered the problem that some polydata meshes where opaque, while other were not. I found that this only occured on the polydata meshes with DIRECT_SCALARS as color mode. 

### Results
Polydata are always shown with its correct opacity

### Changes
For me, changing `range[0] === 255` to `range[0] === 1.0` solved the issue
