### PR TITLE
fix(ImageMarchingSquares): incorrect edge iterator

### DIFF
--- a/Sources/Filters/General/ImageMarchingSquares/index.js
+++ b/Sources/Filters/General/ImageMarchingSquares/index.js
@@ -89,7 +89,7 @@ function vtkImageMarchingSquares(publicAPI, model) {
     publicAPI.getPixelPoints(i, j, k, dims, origin, spacing);
 
     const z = origin[2] + k * spacing[2];
-    for (let idx = 0; pixelLines[idx] >= 0; idx += 3) {
+    for (let idx = 0; pixelLines[idx] >= 0; idx += 2) {
       lines.push(2);
       for (let eid = 0; eid < 2; eid++) {
         const edgeVerts = vtkCaseTable.getEdge(pixelLines[idx + eid]);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
ImageMarchingSquares failed under certain circumstances due to an incorrect edge iterator skip value. [Here is the VTK implementation for reference](https://github.com/Kitware/VTK/blob/master/Filters/Core/vtkMarchingSquares.cxx#L219).

### Results
ImageMarchingSquares does not break under certain circumstances.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] vtkImageMarchingSquares

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
