### PR TITLE
fix(LookupTable): Allow JS 2D arrays to setTable

### DIFF
--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
@@ -429,23 +429,38 @@ function vtkRenderWindowUpdater(instance, state, context) {
 
 function colorTransferFunctionUpdater(instance, state, context) {
   context.start(); // -> start(colorTransferFunctionUpdater)
-  const nodes = state.properties.nodes.map(
-    ([x, r, g, b, midpoint, sharpness]) => ({ x, r, g, b, midpoint, sharpness })
-  );
-  instance.set({ ...state.properties, nodes }, true);
+  if (!state.properties.nodes) {
+    instance.set(state.properties);
+  } else {
+    const nodes = state.properties.nodes.map(
+      ([x, r, g, b, midpoint, sharpness]) => ({
+        x,
+        r,
+        g,
+        b,
+        midpoint,
+        sharpness,
+      })
+    );
+    instance.set({ ...state.properties, nodes }, true);
+  }
   context.end(); // -> end(colorTransferFunctionUpdater)
 }
 
 function piecewiseFunctionUpdater(instance, state, context) {
   context.start(); // -> start(piecewiseFunctionUpdater)
-  const nodes = state.properties.nodes.map(([x, y, midpoint, sharpness]) => ({
-    x,
-    y,
-    midpoint,
-    sharpness,
-  }));
-  instance.set({ ...state.properties, nodes }, true);
-  instance.sortAndUpdateRange();
+  if (!state.properties.nodes) {
+    instance.set(state.properties);
+  } else {
+    const nodes = state.properties.nodes.map(([x, y, midpoint, sharpness]) => ({
+      x,
+      y,
+      midpoint,
+      sharpness,
+    }));
+    instance.set({ ...state.properties, nodes }, true);
+    instance.sortAndUpdateRange();
+  }
   // instance.modified();
   context.end(); // -> end(piecewiseFunctionUpdater)
 }


### PR DESCRIPTION
### Context

- Allow regular vtkLookupTable to be used for local rendering with custom color Table.

### Results

- Not supported before and needed to use the ColorTransferFunction class by converting the server data

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

Tested with PyVista [Color subset](https://github.com/Kitware/trame-vtk/blob/master/examples/validation/PyVistaLookupTable.py) + Preset selector in same dir (not yet there)