### PR TITLE
fix(LookupTable): Add support for Big Int

### DIFF
--- a/Sources/Common/Core/LookupTable/index.js
+++ b/Sources/Common/Core/LookupTable/index.js
@@ -67,13 +67,14 @@ function vtkLookupTable(publicAPI, model) {
   // Apply shift/scale to the scalar value v and return the index.
   publicAPI.linearIndexLookup = (v, p) => {
     let dIndex = 0;
+    const nv = Number(v);
 
-    if (v < p.range[0]) {
+    if (nv < p.range[0]) {
       dIndex = p.maxIndex + BELOW_RANGE_COLOR_INDEX + 1.5;
-    } else if (v > p.range[1]) {
+    } else if (nv > p.range[1]) {
       dIndex = p.maxIndex + ABOVE_RANGE_COLOR_INDEX + 1.5;
     } else {
-      dIndex = (v + p.shift) * p.scale;
+      dIndex = (nv + p.shift) * p.scale;
 
       // This conditional is needed because when v is very close to
       // p.Range[1], it may map above p.MaxIndex in the linear mapping


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
