### PR TITLE
Support widget behavior on decorated rw

### DIFF
--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/BehaviorManager/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/BehaviorManager/index.js
@@ -49,11 +49,11 @@ const BEHAVIORS_TYPES = {
 };
 
 export function applyBehaviors(renderWindow, state, context) {
-  if (!state.behaviors || !renderWindow.getSynchronizedViewId) {
+  const rwId = renderWindow.get('synchronizedViewId').synchronizedViewId;
+  if (!state.behaviors || !rwId) {
     return;
   }
   // Apply auto behavior
-  const rwId = renderWindow.getSynchronizedViewId();
   if (!BEHAVIORS[rwId]) {
     BEHAVIORS[rwId] = {};
   }


### PR DESCRIPTION
Allow widget behavior for local view to work with decorated RenderWindow rather than only supporting only SynchronizableRenderWindow class instance.