### PR TITLE
feat(XMLReader): read in string arrays

### DIFF
--- a/Sources/Common/Core/StringArray/index.js
+++ b/Sources/Common/Core/StringArray/index.js
@@ -57,8 +57,7 @@ function vtkStringArray(publicAPI, model) {
 
   publicAPI.getName = () => {
     if (!model.name) {
-      publicAPI.modified();
-      model.name = `vtkStringArray${publicAPI.getMTime()}`;
+      publicAPI.setName(`vtkStringArray${publicAPI.getMTime()}`);
     }
     return model.name;
   };


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
XMLReader doesn't process field data and doesn't support reading in string arrays.

### Results
XMLReader now supports field data and handling of string arrays.

### Changes
- Fix zlib data parsing by finding the first zlib magic byte.
- Refactor out common logic between processDataArray and
  processStringArray.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
