### PR TITLE
docs(webxr): prefer VR over AR session in XR documentation

### DIFF
--- a/Documentation/content/docs/develop_webxr.md
+++ b/Documentation/content/docs/develop_webxr.md
@@ -72,7 +72,7 @@ The following examples target a head-mounted virtual reality device, such as the
 [![VR Cone Example][VrCone]](../examples/VR.html)
 [![SkyboxViewer Example][SkyboxViewerVR]](../examples/SkyboxViewer.html?fileURL=https://data.kitware.com/api/v1/file/5ae8a89c8d777f0685796bae/download)
 [![GeometryViewer Brain Blood Vessels][GeometryViewerBrainBloodVessels]](../examples/GeometryViewer/GeometryViewer.html?xrSessionType=0&fileURL=[https://kitware.github.io/vtk-js/examples/GeometryViewer/GeometryViewer.html?xrSessionType=0&fileURL=%5Bhttps://data.kitware.com/api/v1/file/61f041f14acac99f42c2ff9a/download,https://data.kitware.com/api/v1/file/61f042024acac99f42c2ffa6/download,https://data.kitware.com/api/v1/file/61f042b74acac99f42c30079/download%5D])
-[![XR Volume Example][WebXRVolume]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=0&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
+[![XR Volume Example][WebXRVolumeHeadAndNeck]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=0&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
 
 </div>
 
@@ -84,7 +84,7 @@ The following examples target a handheld or head-mounted mobile augmented realit
 
 [![AR Cone Example][ArCone]](../examples/AR.html)
 [![GeometryViewer Brain Blood Vessels][GeometryViewerBrainBloodVessels]](../examples/GeometryViewer/GeometryViewer.html?xrSessionType=1&fileURL=[https://kitware.github.io/vtk-js/examples/GeometryViewer/GeometryViewer.html?xrSessionType=0&fileURL=%5Bhttps://data.kitware.com/api/v1/file/61f041f14acac99f42c2ff9a/download,https://data.kitware.com/api/v1/file/61f042024acac99f42c2ffa6/download,https://data.kitware.com/api/v1/file/61f042b74acac99f42c30079/download%5D])
-[![XR Volume Example][WebXRVolume]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=1&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
+[![XR Volume Example][WebXRVolumeHeadAndNeck]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=1&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
 
 </div>
 
@@ -98,7 +98,7 @@ Microsoft HoloLens 2 users should run the [virtual reality examples](#Virtual-Re
 
 [![AR Cone Example][ArCone]](../examples/AR/index.html?xrSessionType=3)
 [![GeometryViewer Brain Blood Vessels][GeometryViewerBrainBloodVessels]](../examples/GeometryViewer/GeometryViewer.html?xrSessionType=3&fileURL=[https://kitware.github.io/vtk-js/examples/GeometryViewer/GeometryViewer.html?xrSessionType=0&fileURL=%5Bhttps://data.kitware.com/api/v1/file/61f041f14acac99f42c2ff9a/download,https://data.kitware.com/api/v1/file/61f042024acac99f42c2ffa6/download,https://data.kitware.com/api/v1/file/61f042b74acac99f42c30079/download%5D])
-[![XR Volume Example][WebXRVolume]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=3&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
+[![XR Volume Example][WebXRVolumeHeadAndNeck]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=3&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
 
 </div>
 
@@ -110,7 +110,7 @@ The following examples target holographic displays from Looking Glass Factory. M
 
 [![Looking Glass Cone Example][LookingGlassCone]](../examples/LookingGlass.html)
 [![GeometryViewer Brain Blood Vessels][GeometryViewerBrainBloodVessels]](../examples/GeometryViewer/GeometryViewer.html?xrSessionType=2&fileURL=[https://kitware.github.io/vtk-js/examples/GeometryViewer/GeometryViewer.html?xrSessionType=0&fileURL=%5Bhttps://data.kitware.com/api/v1/file/61f041f14acac99f42c2ff9a/download,https://data.kitware.com/api/v1/file/61f042024acac99f42c2ffa6/download,https://data.kitware.com/api/v1/file/61f042b74acac99f42c30079/download%5D])
-[![XR Volume Example][WebXRVolume]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=2&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
+[![XR Volume Example][WebXRVolumeHeadAndNeck]](../examples/WebXRVolume/WebXRVolume.html?xrSessionType=2&fileURL=https://data.kitware.com/api/v1/file/63fe3f237b0dfcc98f66a857/download&colorPreset=CT-AAA&rotateX=90&rotateY=180)
 
 </div>
 

--- a/Examples/Applications/GeometryViewer/index.js
+++ b/Examples/Applications/GeometryViewer/index.js
@@ -101,14 +101,14 @@ if (requestedXrSessionType === XrSessionTypes.LookingGlassVR) {
     // eslint-disable-next-line no-new
     new obj.LookingGlassWebXRPolyfill();
   });
-} else if (requestedXrSessionType === null && navigator.xr !== undefined) {
-  // Determine supported session type
-  navigator.xr.isSessionSupported('immersive-ar').then((arSupported) => {
-    if (arSupported) {
-      requestedXrSessionType = XrSessionTypes.MobileAR;
+} else if (requestedXrSessionType === null) {
+  // Guess the session type based on what XR session(s) the device supports
+  navigator.xr.isSessionSupported('immersive-vr').then((vrSupported) => {
+    if (vrSupported) {
+      requestedXrSessionType = XrSessionTypes.HmdVr;
     } else {
-      navigator.xr.isSessionSupported('immersive-vr').then((vrSupported) => {
-        requestedXrSessionType = vrSupported ? XrSessionTypes.HmdVR : null;
+      navigator.xr.isSessionSupported('immersive-ar').then((arSupported) => {
+        requestedXrSessionType = arSupported ? XrSessionTypes.MobileAR : null;
       });
     }
   });

--- a/Examples/Volume/WebXRVolume/index.js
+++ b/Examples/Volume/WebXRVolume/index.js
@@ -85,13 +85,13 @@ if (requestedXrSessionType === XrSessionTypes.LookingGlassVR) {
     new obj.LookingGlassWebXRPolyfill();
   });
 } else if (requestedXrSessionType === null) {
-  // Determine supported session type
-  navigator.xr.isSessionSupported('immersive-ar').then((arSupported) => {
-    if (arSupported) {
-      requestedXrSessionType = XrSessionTypes.MobileAR;
+  // Guess the session type based on what XR session(s) the device supports.
+  navigator.xr.isSessionSupported('immersive-vr').then((vrSupported) => {
+    if (vrSupported) {
+      requestedXrSessionType = XrSessionTypes.HmdVr;
     } else {
-      navigator.xr.isSessionSupported('immersive-vr').then((vrSupported) => {
-        requestedXrSessionType = vrSupported ? XrSessionTypes.HmdVR : null;
+      navigator.xr.isSessionSupported('immersive-ar').then((arSupported) => {
+        requestedXrSessionType = arSupported ? XrSessionTypes.MobileAR : null;
       });
     }
   });


### PR DESCRIPTION
Updates the default XR session type preference in WebXRVolume and GeometryViewer examples to better reflect our current XR supported devices list. 


re #2862

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Previously single-screen mobile devices were the only devices supporting both VR (Cardboard) and AR sessions with AR generally favored, so AR mode was made the default. Recently vtk.js added support for HMDs compatible with both VR and AR (passthrough) mode, which require stereoscopic AR rendering different from the mobile AR approach. 

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
Under the status quo the default behavior on such an HMD was to attempt to render in AR mobile as if it were a mobile device, which would produce incorrect renderings. This change prefers rendering in VR mode such that default HMD behavior will be rendering in full virtual reality and some mobile devices may render in Cardboard VR mode by default. AR HMD and AR mobile experiences may still be accessed through explicit, non-default links in the WebXR documentation landing page.

Also updates the default image for WebXRVolume "Head and Neck" rendering examples.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->`master`
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->Windows 10
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->Chrome 114.0.0.0

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
