### PR TITLE
fix(DataArray): scalar data implies index 0

### DIFF
--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -231,8 +231,13 @@ function vtkDataArray(publicAPI, model) {
       : model.values.subarray(0, model.size);
 
   publicAPI.getRange = (componentIndex = -1) => {
-    const rangeIdx =
-      componentIndex < 0 ? model.numberOfComponents : componentIndex;
+    let rangeIdx = componentIndex;
+    if (rangeIdx < 0) {
+      // If scalar data, then store in slot 0 (same as componentIndex = 0).
+      // If vector data, then store in last slot.
+      rangeIdx = model.numberOfComponents === 1 ? 0 : model.numberOfComponents;
+    }
+
     let range = null;
 
     if (!model.ranges) {


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Calling `getRange()` and then `getRange(0)` on scalar data computes the range twice, when it should be computed once.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- Avoids recomputing the range of scalar data

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] DataArray.getRange now correctly caches the range

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
