### PR TITLE
perf(ImageMapper): do not use subarray

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -983,10 +983,13 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         let id = 0;
         for (let k = 0; k < dims[2]; k++) {
           for (let j = 0; j < dims[1]; j++) {
-            const bsIdx =
+            let bsIdx =
               (sliceOffset + j * dims[0] + k * dims[0] * dims[1]) * numComp;
             id = (k * dims[1] + j) * numComp;
-            scalars.set(basicScalars.subarray(bsIdx, bsIdx + numComp), id);
+            const end = bsIdx + numComp;
+            while (bsIdx < end) {
+              scalars[id++] = basicScalars[bsIdx++];
+            }
           }
         }
         dims[0] = dims[1];
@@ -1008,10 +1011,13 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         let id = 0;
         for (let k = 0; k < dims[2]; k++) {
           for (let i = 0; i < dims[0]; i++) {
-            const bsIdx =
+            let bsIdx =
               (i + sliceOffset * dims[0] + k * dims[0] * dims[1]) * numComp;
             id = (k * dims[0] + i) * numComp;
-            scalars.set(basicScalars.subarray(bsIdx, bsIdx + numComp), id);
+            const end = bsIdx + numComp;
+            while (bsIdx < end) {
+              scalars[id++] = basicScalars[bsIdx++];
+            }
           }
         }
         dims[1] = dims[2];


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
TypedArray.subarray is slower than just looping through values and copying them.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- ImageMapper.buildBufferObjects is faster for large arrays.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] ImageMapper updated

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
