### PR TITLE
fix(vtkOpenGLRenderWindow): Remove unused `HaveVRDisplay` event and outdated TypeScript definitions

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -378,24 +378,6 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 	getSize(): Vector2;
 
 	/**
-	 *
-	 * @param {Vector2} size
-	 */
-	setVrResolution(size: Vector2): void;
-
-	/**
-	 *
-	 * @param {Number} x
-	 * @param {Number} y
-	 */
-	setVrResolution(x: number, y: number): void;
-
-	/**
-	 *
-	 */
-	getVrResolution(): Vector2;
-
-	/**
 	 * Scales the size of a browser CSS pixel to a rendered canvas pixel.  
 	 * `const renderedPixelWidth = cssPixelWidth * apiRenderWindow.getComputedDevicePixelRatio()`
 	 * Use to scale rendered objects to a consistent perceived size or DOM pixel position.

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -107,11 +107,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     false
   );
 
-  // Cache the value here as calling it on each frame is expensive
-  const isImmersiveVrSupported =
-    navigator.xr !== undefined &&
-    navigator.xr.isSessionSupported('immersive-vr');
-
   // Auto update style
   const previousSize = [0, 0];
   function updateWindow() {
@@ -262,11 +257,6 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     }
   ) => {
     let result = null;
-
-    // Do we have webxr support
-    if (isImmersiveVrSupported) {
-      publicAPI.invokeHaveVRDisplay();
-    }
 
     const webgl2Supported = typeof WebGL2RenderingContext !== 'undefined';
     model.webgl2 = false;
@@ -1367,7 +1357,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.renderPasses[0] = vtkForwardPass.newInstance();
 
   macro.event(publicAPI, model, 'imageReady');
-  macro.event(publicAPI, model, 'haveVRDisplay');
 
   // Build VTK API
   macro.get(publicAPI, model, [


### PR DESCRIPTION
Removes `vtkOpenGLRenderWindow.HaveVRDisplay` event. This event is unused internally and was previously left over from WebVR to WebXR integration to avoid API breakage.

Under previous behavior the `navigator.xr` check was called eagerly at construction, which could result in an unhandled exception. This change removes that eager check so that `navigator.xr` is referenced only if an XR-related method such as `startXR` is called.

Applications should query `navigator.xr` directly to determine whether a given session type may be supported.

Resolves https://github.com/Kitware/vtk-js/issues/2537

Also removes outdated WebVR-related TypeScript definitions from `vtkOpenGLRenderWindow`. Affected method implementations were previously removed in transition from WebVR to WebXR.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

`navigator.xr` is only available where WebXR is supported, and sometimes appears available but is disabled for security. Queries should be limited to instances where XR is explicitly being used, or at least exceptions should be handled otherwise.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) --> `master`
  - **OS**: <!-- ex: Windows 10, iOS 13.6 --> Windows 10
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->Chrome 115.0.0.0

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
