### PR TITLE
fix(ColorTransferFunction): misuse of return value

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -389,13 +389,17 @@ function vtkColorTransferFunction(publicAPI, model) {
       // todo
       const idx = publicAPI.getAnnotatedValueIndexInternal(x);
       if (idx < 0 || numNodes === 0) {
-        publicAPI.getNanColor(rgb);
+        const nanColor = publicAPI.getNanColorByReference();
+        rgb[0] = nanColor[0];
+        rgb[1] = nanColor[1];
+        rgb[2] = nanColor[2];
       } else {
         const nodeVal = [];
         publicAPI.getNodeValue(idx % numNodes, nodeVal);
-        rgb[0] = nodeVal.r;
-        rgb[1] = nodeVal.g;
-        rgb[2] = nodeVal.b;
+        // nodeVal[0] is the x value. nodeVal[1...3] is rgb.
+        rgb[0] = nodeVal[1];
+        rgb[1] = nodeVal[2];
+        rgb[2] = nodeVal[3];
       }
       return;
     }
@@ -1030,7 +1034,10 @@ function vtkColorTransferFunction(publicAPI, model) {
       rgba[3] = 1.0; // NodeColor is RGB-only.
       return;
     }
-    publicAPI.getNanColor(rgba);
+    const nanColor = publicAPI.getNanColorByReference();
+    rgba[0] = nanColor[0];
+    rgba[1] = nanColor[1];
+    rgba[2] = nanColor[2];
     rgba[3] = 1.0; // NanColor is RGB-only.
   };
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Fixes #2881 
- getNanColor returns an array and accepts no parameters.
- getNodeValue sets nodeVal to an array, not object.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- Correct usage of getNanColor and getNodeValue

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Updates to vtkColorTransferFunction

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
