### PR TITLE
fix(PolyLineRepresentation): when closePolyLine is true

### DIFF
--- a/Sources/Widgets/Representations/PolyLineRepresentation/index.js
+++ b/Sources/Widgets/Representations/PolyLineRepresentation/index.js
@@ -49,7 +49,7 @@ function vtkPolyLineRepresentation(publicAPI, model) {
           cellData[i] = i - 1;
         }
         if (closePolyLine) {
-          cellData[cellSize - 1] = 0;
+          cellData[cellSize] = 0;
         }
         lines.setData(cellData);
       }


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Inserting this code into PolyLineWidget/example
```
const widget = vtkPolyLineWidget.newInstance();
widget.placeWidget(cone.getOutputData().getBounds());

const widgetInstance = widgetManager.addWidget(widget);
widgetInstance.setClosePolyLine(true);
```
Broke line rendering
![image](https://github.com/Kitware/vtk-js/assets/16823231/aa625e07-6e84-4a65-850c-01b8591ec553)


### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Fixed
![image](https://github.com/Kitware/vtk-js/assets/16823231/7d55a15f-8e32-4c77-83eb-7a835e4cf4d7)


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
Last CellData element was incorrect for closePolyLine true case.


### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

