### PR TITLE
Add I and J slicing to vtkImageMarchingSquares filter

### DIFF
--- a/Sources/Filters/General/ImageMarchingSquares/api.md
+++ b/Sources/Filters/General/ImageMarchingSquares/api.md
@@ -12,10 +12,15 @@ algorithm).
 
 Set/Get an array of isocontour values.
 
-### sliceNumber
+### slice
 
-Set/Get the k-slice number of the input volume. By default the
-sliceNumber = 0.
+Set/Get the IJK slice number of the input volume. By default the
+slice = 0.
+
+### slicingMode
+
+Set/Get the slicing mode (IJK) which determines the direction to slice. By
+default the slicingMode = 2.
 
 ### mergePoints
 

--- a/Sources/Filters/General/ImageMarchingSquares/example/controller.html
+++ b/Sources/Filters/General/ImageMarchingSquares/example/controller.html
@@ -1,20 +1,44 @@
 <table>
   <tr>
+    <td>Slicing mode</td>
+    <td>
+      <select class="slicingMode">
+        <option value="0">I</option>
+        <option value="1">J</option>
+        <option value="2" selected>K</option>
+      </select>
+    </td>
+  </tr>
+  <tr>
     <td>Volume resolution</td>
     <td>
-      <input class='volumeResolution' type="range" min="10" max="100" step="1" value="50" />
+      <input
+        class="volumeResolution"
+        type="range"
+        min="10"
+        max="100"
+        step="1"
+        value="50"
+      />
     </td>
   </tr>
   <tr>
     <td>Radius</td>
     <td>
-      <input class='sphereRadius' type="range" min="0.01" max="1.0" step="0.01" value="0.025" />
+      <input
+        class="sphereRadius"
+        type="range"
+        min="0.01"
+        max="1.0"
+        step="0.01"
+        value="0.025"
+      />
     </td>
   </tr>
   <tr>
     <td>Merge Points</td>
     <td>
-      <input class='mergePoints' type="checkbox" unchecked />
+      <input class="mergePoints" type="checkbox" unchecked />
     </td>
   </tr>
 </table>

--- a/Sources/Filters/General/ImageMarchingSquares/example/index.js
+++ b/Sources/Filters/General/ImageMarchingSquares/example/index.js
@@ -50,6 +50,7 @@ const sample = vtkSampleFunction.newInstance({
 
 // Isocontour
 const mSquares = vtkImageMarchingSquares.newInstance({ slice: 1 });
+mSquares.setSlicingMode(2);
 
 // Connect the pipeline proper
 mSquares.setInputConnection(sample.getOutputPort());
@@ -81,6 +82,13 @@ renderer.addActor(outlineActor);
 // UI control handling
 // ----------------------------------------------------------------------------
 fullScreenRenderer.addController(controlPanel);
+
+// Define the slicing mode
+document.querySelector('.slicingMode').addEventListener('input', (e) => {
+  const value = Number(e.target.value);
+  mSquares.setSlicingMode(value);
+  renderWindow.render();
+});
 
 // Define the volume resolution
 document.querySelector('.volumeResolution').addEventListener('input', (e) => {

--- a/Sources/Filters/General/ImageMarchingSquares/index.js
+++ b/Sources/Filters/General/ImageMarchingSquares/index.js
@@ -11,10 +11,37 @@ const { vtkErrorMacro, vtkDebugMacro } = macro;
 // ----------------------------------------------------------------------------
 
 function vtkImageMarchingSquares(publicAPI, model) {
+  /**
+   * Get the X,Y kernels based on the set slicing mode.
+   * @returns {[number, number]}
+   */
+  function getKernels() {
+    let kernelX = 0; // default K slicing mode
+    let kernelY = 1;
+    if (model.slicingMode === 1) {
+      kernelX = 0;
+      kernelY = 2;
+    } else if (model.slicingMode === 0) {
+      kernelX = 1;
+      kernelY = 2;
+    }
+
+    return [kernelX, kernelY];
+  }
+
   // Set our className
   model.classHierarchy.push('vtkImageMarchingSquares');
 
+  /**
+   * Get the list of contour values.
+   * @returns {number[]}
+   */
   publicAPI.getContourValues = () => model.contourValues;
+
+  /**
+   * Set the list contour values.
+   * @param {number[]} cValues
+   */
   publicAPI.setContourValues = (cValues) => {
     model.contourValues = cValues;
     publicAPI.modified();
@@ -25,54 +52,96 @@ function vtkImageMarchingSquares(publicAPI, model) {
   const pixelPts = [];
   const edgeLocator = vtkEdgeLocator.newInstance();
 
-  // Retrieve scalars and pixel coordinates. i-j-k is origin of pixel.
-  publicAPI.getPixelScalars = (i, j, k, slice, dims, origin, spacing, s) => {
+  /**
+   * Retrieve scalars and pixel coordinates.
+   * @param {Vector3} ijk origin of the pixel
+   * @param {Vector3} dims dimensions of the image
+   * @param {TypedArray} scalars list of scalar values
+   * @param {Vector3} increments IJK slice increments
+   * @param {number} kernelX index of the X element
+   * @param {number} kernelY index of the Y element
+   */
+  publicAPI.getPixelScalars = (
+    ijk,
+    dims,
+    scalars,
+    increments,
+    kernelX,
+    kernelY
+  ) => {
+    const [i, j, k] = ijk;
+
     // First get the indices for the pixel
-    ids[0] = k * slice + j * dims[0] + i; // i, j, k
-    ids[1] = ids[0] + 1; // i+1, j, k
-    ids[2] = ids[0] + dims[0]; // i, j+1, k
-    ids[3] = ids[2] + 1; // i+1, j+1, k
+    ids[0] = k * dims[1] * dims[0] + j * dims[0] + i; // i, j, k
+    ids[1] = ids[0] + increments[kernelX]; // i+1, j, k
+    ids[2] = ids[0] + increments[kernelY]; // i, j+1, k
+    ids[3] = ids[2] + increments[kernelX]; // i+1, j+1, k
 
     // Now retrieve the scalars
     for (let ii = 0; ii < 4; ++ii) {
-      pixelScalars[ii] = s[ids[ii]];
+      pixelScalars[ii] = scalars[ids[ii]];
     }
   };
 
-  // Retrieve pixel coordinates. i-j-k is origin of pixel.
-  publicAPI.getPixelPoints = (i, j, k, dims, origin, spacing) => {
-    // (i,i+1),(j,j+1),(k,k+1) - i varies fastest; then j; then k
-    pixelPts[0] = origin[0] + i * spacing[0]; // 0
-    pixelPts[1] = origin[1] + j * spacing[1];
+  /**
+   * Retrieve pixel coordinates.
+   * @param {Vector3} ijk origin of the pixel
+   * @param {Vector3} origin origin of the image
+   * @param {Vector3} spacing spacing of the image
+   * @param {number} kernelX index of the X element
+   * @param {number} kernelY index of the Y element
+   */
+  publicAPI.getPixelPoints = (ijk, origin, spacing, kernelX, kernelY) => {
+    const i = ijk[kernelX];
+    const j = ijk[kernelY];
 
-    pixelPts[2] = pixelPts[0] + spacing[0]; // 1
+    // (i,i+1),(j,j+1),(k,k+1) - i varies fastest; then j; then k
+    pixelPts[0] = origin[kernelX] + i * spacing[kernelX]; // 0
+    pixelPts[1] = origin[kernelY] + j * spacing[kernelY];
+
+    pixelPts[2] = pixelPts[0] + spacing[kernelX]; // 1
     pixelPts[3] = pixelPts[1];
 
     pixelPts[4] = pixelPts[0]; // 2
-    pixelPts[5] = pixelPts[1] + spacing[1];
+    pixelPts[5] = pixelPts[1] + spacing[kernelY];
 
     pixelPts[6] = pixelPts[2]; // 3
     pixelPts[7] = pixelPts[5];
   };
 
+  /**
+   * Produce points and lines for the polydata.
+   * @param {number[]} cVal list of contour values
+   * @param {Vector3} ijk origin of the pixel
+   * @param {Vector3} dims dimensions of the image
+   * @param {Vector3} origin origin of the image
+   * @param {Vector3} spacing sapcing of the image
+   * @param {TypedArray} scalars list of scalar values
+   * @param {number[]} points list of points
+   * @param {number[]} lines list of lines
+   * @param {Vector3} increments IJK slice increments
+   * @param {number} kernelX index of the X element
+   * @param {number} kernelY index of the Y element
+   */
   publicAPI.produceLines = (
     cVal,
-    i,
-    j,
-    k,
-    slice,
+    ijk,
     dims,
     origin,
     spacing,
     scalars,
     points,
-    lines
+    lines,
+    increments,
+    kernelX,
+    kernelY
   ) => {
+    const k = ijk[model.slicingMode];
     const CASE_MASK = [1, 2, 8, 4]; // case table is actually for quad
     const xyz = [];
     let pId;
 
-    publicAPI.getPixelScalars(i, j, k, slice, dims, origin, spacing, scalars);
+    publicAPI.getPixelScalars(ijk, dims, scalars, increments, kernelX, kernelY);
 
     let index = 0;
     for (let idx = 0; idx < 4; idx++) {
@@ -86,9 +155,9 @@ function vtkImageMarchingSquares(publicAPI, model) {
       return; // don't get the pixel coordinates, nothing to do
     }
 
-    publicAPI.getPixelPoints(i, j, k, dims, origin, spacing);
+    publicAPI.getPixelPoints(ijk, origin, spacing, kernelX, kernelY);
 
-    const z = origin[2] + k * spacing[2];
+    const z = origin[model.slicingMode] + k * spacing[model.slicingMode];
     for (let idx = 0; pixelLines[idx] >= 0; idx += 2) {
       lines.push(2);
       for (let eid = 0; eid < 2; eid++) {
@@ -106,10 +175,11 @@ function vtkImageMarchingSquares(publicAPI, model) {
             (pixelScalars[edgeVerts[1]] - pixelScalars[edgeVerts[0]]);
           const x0 = pixelPts.slice(edgeVerts[0] * 2, (edgeVerts[0] + 1) * 2);
           const x1 = pixelPts.slice(edgeVerts[1] * 2, (edgeVerts[1] + 1) * 2);
-          xyz[0] = x0[0] + t * (x1[0] - x0[0]);
-          xyz[1] = x0[1] + t * (x1[1] - x0[1]);
+          xyz[kernelX] = x0[0] + t * (x1[0] - x0[0]);
+          xyz[kernelY] = x0[1] + t * (x1[1] - x0[1]);
+          xyz[model.slicingMode] = z;
           pId = points.length / 3;
-          points.push(xyz[0], xyz[1], z);
+          points.push(xyz[0], xyz[1], xyz[2]);
 
           if (model.mergePoints) {
             edgeLocator.insertEdge(ids[edgeVerts[0]], ids[edgeVerts[1]], pId);
@@ -129,53 +199,70 @@ function vtkImageMarchingSquares(publicAPI, model) {
       return;
     }
 
+    if (
+      model.slicingMode == null ||
+      model.slicingMode < 0 ||
+      model.slicingMode > 2
+    ) {
+      vtkErrorMacro('Invalid or missing slicing mode');
+      return;
+    }
+
     console.time('msquares');
 
     // Retrieve output and volume data
     const origin = input.getOrigin();
     const spacing = input.getSpacing();
     const dims = input.getDimensions();
-    const s = input.getPointData().getScalars().getData();
+    const extent = input.getExtent();
+    const increments = input.computeIncrements(extent);
+    const scalars = input.getPointData().getScalars().getData();
+    const [kernelX, kernelY] = getKernels();
 
     // Points - dynamic array
-    const pBuffer = [];
+    const points = [];
 
     // Cells - dynamic array
-    const lBuffer = [];
+    const lines = [];
 
     // Ensure slice is valid
-    const slice = dims[0] * dims[1];
     let k = Math.round(model.slice);
-    if (k >= dims[2]) {
+    if (k >= dims[model.slicingMode]) {
       k = 0;
     }
 
     // Loop over all contour values, and then pixels, determine case and process
+    const ijk = [0, 0, 0];
+    ijk[model.slicingMode] = k;
     for (let cv = 0; cv < model.contourValues.length; ++cv) {
-      for (let j = 0; j < dims[1] - 1; ++j) {
-        for (let i = 0; i < dims[0] - 1; ++i) {
+      for (let j = 0; j < dims[kernelY] - 1; ++j) {
+        ijk[kernelY] = j;
+        for (let i = 0; i < dims[kernelX] - 1; ++i) {
+          ijk[kernelX] = i;
+
           publicAPI.produceLines(
             model.contourValues[cv],
-            i,
-            j,
-            k,
-            slice,
+            ijk,
             dims,
             origin,
             spacing,
-            s,
-            pBuffer,
-            lBuffer
+            scalars,
+            points,
+            lines,
+            increments,
+            kernelX,
+            kernelY
           );
         }
       }
+
       edgeLocator.initialize();
     }
 
     // Update output
     const polydata = vtkPolyData.newInstance();
-    polydata.getPoints().setData(new Float32Array(pBuffer), 3);
-    polydata.getLines().setData(new Uint32Array(lBuffer));
+    polydata.getPoints().setData(new Float32Array(points), 3);
+    polydata.getLines().setData(new Uint32Array(lines));
     outData[0] = polydata;
 
     vtkDebugMacro('Produced output');
@@ -189,6 +276,7 @@ function vtkImageMarchingSquares(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   contourValues: [],
+  slicingMode: 2,
   slice: 0,
   mergePoints: false,
 };
@@ -204,7 +292,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Also make it an algorithm with one input and one output
   macro.algo(publicAPI, model, 1, 1);
 
-  macro.setGet(publicAPI, model, ['slice', 'mergePoints']);
+  macro.setGet(publicAPI, model, ['slicingMode', 'slice', 'mergePoints']);
 
   // Object specific methods
   macro.algo(publicAPI, model, 1, 1);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

The vtkImageMarchingSquares filter currently only supports K slicing. 

I and J slicing has been discussed before, but has not been implemented yet:
[Apply Marching Squares to ImageSlices](https://discourse.vtk.org/t/apply-marching-squares-to-imageslices/4279)

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

These changes enable using I and J slicing modes so it is now possible to run the vtkImageMarchingSquares filter in all IJK directions.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->

The vtkImageMarchingSquares class has been changed to dynamically select IJK/XYZ indices based on the provided `slicingMode`. This enables slicing in all IJK directions.

Added new method:

`(set/get)SlicingMode` - Set/Get the slicing mode (IJK) which determines the direction to slice. By
default the slicingMode = 2.

Documentation of the vtkImageMarchingSquares class has been updated to include this new method and to correct `sliceNumber` to the actual model name `slice`. The documentation also no longer implies that K-slicing is the only slicing mode available.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: 28.7.0
  - **OS**: macOS 13.1
  - **Browser**:  Chrome 116.0.5845.96



<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
