### PR TITLE
Add typescript definitions and expose lineWidth in vtkGeometryRepresentationProxy

### DIFF
--- a/Sources/Proxy/Representations/GeometryRepresentationProxy/index.d.ts
+++ b/Sources/Proxy/Representations/GeometryRepresentationProxy/index.d.ts
@@ -1,0 +1,35 @@
+import { RGBColor } from "../../../types";
+import vtkAbstractRepresentationProxy from '../../Core/AbstractRepresentationProxy';
+
+export interface vtkGeometryRepresentationProxy
+  extends vtkAbstractRepresentationProxy {
+
+  /**
+   * 
+   * @param representation a string that describes what representation to use for the explicit geometry.
+   *                       possible values are 'Surface with edges', 'Surface' (default), 'Wireframe',
+   *                       and 'Points'. 
+   */
+  setRepresentation(representation: string): boolean;
+  getRepresentation(): string;
+
+  // proxy property mappings
+  getColor(): RGBColor;
+  setColor(color: RGBColor): boolean;
+	getInterpolateScalarsBeforeMapping(): boolean;
+	setInterpolateScalarsBeforeMapping(interpolateScalarsBeforeMapping: boolean): boolean;
+  setOpacity(opacity: boolean): boolean;
+  getOpacity(): boolean;
+  setVisibility(visible: boolean): boolean;
+  getVisibility(): boolean;
+	getPointSize(): number;
+	setPointSize(pointSize: number): boolean;
+  getUseShadow(): boolean;
+  setUseShadow(lighting: boolean): boolean;
+  getUseBounds(): boolean;
+  setUseBounds(useBounds: boolean): boolean;
+  getLineWidth(): number;
+  setLineWidth(width: number): boolean;
+}
+
+export default vtkGeometryRepresentationProxy;

--- a/Sources/Proxy/Representations/GeometryRepresentationProxy/index.js
+++ b/Sources/Proxy/Representations/GeometryRepresentationProxy/index.js
@@ -79,6 +79,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     },
     pointSize: { modelKey: 'property', property: 'pointSize' },
     useShadow: { modelKey: 'property', property: 'lighting' },
+    lineWidth: { modelKey: 'property', property: 'lineWidth' },
     useBounds: { modelKey: 'actor', property: 'useBounds' },
   });
 }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Required for VolView development: https://github.com/Kitware/VolView/pull/359

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] ~This change adds or fixes unit tests~ <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) --> latest master
  - **OS**: <!-- ex: Windows 10, iOS 13.6 --> Windows 11, Pro
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 --> Chrome Version 116.0.5845.140 (Official Build) (64-bit)

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
