### PR TITLE
feat(ResliceRepresentationProxy): add outline to slice geometry

### DIFF
--- a/Sources/Proxy/Representations/ResliceRepresentationProxy/example/index.js
+++ b/Sources/Proxy/Representations/ResliceRepresentationProxy/example/index.js
@@ -174,6 +174,9 @@ imageDataPromise.then((imageData) => {
   representation2DProxy.setSlabThickness(30);
   representation2DProxy.setSlabTrapezoidIntegration(1.5);
   representation2DProxy.setSlabType(SlabTypes.MAX);
+  representation2DProxy.setOutlineVisibility(true);
+  representation2DProxy.setOutlineColor([1, 0, 0]);
+  representation2DProxy.setOutlineLineWidth(4.0);
 
   view2DProxy.setFitProps(false);
   view2DProxy.resetCamera();

--- a/Sources/Proxy/Representations/ResliceRepresentationProxy/index.d.ts
+++ b/Sources/Proxy/Representations/ResliceRepresentationProxy/index.d.ts
@@ -1,6 +1,7 @@
 import type vtkPolyData from '../../../Common/DataModel/PolyData';
 import type vtkPlane from '../../../Common/DataModel/Plane';
 import vtkAbstractRepresentationProxy from '../../Core/AbstractRepresentationProxy';
+import { RGBColor } from '../../../types';
 
 export interface vtkResliceRepresentationProxy
   extends vtkAbstractRepresentationProxy {
@@ -15,6 +16,12 @@ export interface vtkResliceRepresentationProxy
   getWindowLevel(): number;
   setInterpolationType(type: number): boolean;
   getInterpolationType(): number;
+  setOutlineLineWidth(lineWidth: number): boolean;
+  getOutlineLineWidth(): number;
+  setOutlineColor(color: RGBColor): boolean;
+  getOutlineColor(): RGBColor;
+  setOutlineVisibility(visibility: boolean): boolean;
+  getOutlineVisibility(): boolean;
   setSlabType(type: number): boolean;
   getSlabtype(): number;
   setSlicePlane(plane: vtkPlane): boolean;


### PR DESCRIPTION
Some applications may want to highlight a the slicing polygon geometry with a colored outline (specially to identify a slice across multiple views). Upgrade the representation proxy to allow for optional rendering of such an outline. Default visibility is off. Exposed properties include `outlineColor`, `outlineVisibility`, and `outlineLineWidth`.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
These changes are added during the following VolView development:
https://github.com/Kitware/VolView/pull/359

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
#### See red outline in below image:
<img width="584" alt="image" src="https://github.com/Kitware/vtk-js/assets/22624785/c8c277d1-ca5f-4724-9474-e97ae426e958">


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) --> master
  - **OS**: <!-- ex: Windows 10, iOS 13.6 --> Windows 11, Pro
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 --> Chrome Version 116.0.5845.141 (Official Build) (64-bit)

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
