### PR TITLE
Fix logic of computeClosestIJKAxis

### DIFF
--- a/Sources/Common/Core/Math/index.d.ts
+++ b/Sources/Common/Core/Math/index.d.ts
@@ -879,6 +879,19 @@ export function createUninitializedBounds(): Bounds;
 export function getMajorAxisIndex(vector: number[]): number;
 
 /**
+ * Return the closest orthogonal matrix of 1, -1 and 0
+ * It works for both column major and row major matrices
+ * This function iteratively associate a column with a row by choosing
+ * the greatest absolute value from the remaining row and columns
+ * For each association, a -1 or a 1 is set in the output, depending on
+ * the sign of the value in the original matrix
+ * 
+ * @param {Number[]} matrix The matrix of size nxn
+ * @param {Number[]} n The size of the square matrix, defaults to 3
+ */
+export function getSparseOrthogonalMatrix(matrix: number[], n: number): number[];
+
+/**
  *
  * @param {Number} value The value to convert.
  */
@@ -1028,6 +1041,7 @@ export declare const vtkMath: {
 	isInf: typeof isInf;
 	createUninitializedBounds: typeof createUninitializedBounds;
 	getMajorAxisIndex: typeof getMajorAxisIndex;
+	getSparseOrthogonalMatrix: typeof getSparseOrthogonalMatrix;
 	floatToHex2: typeof floatToHex2;
 	floatRGB2HexCode: typeof floatRGB2HexCode;
 	float2CssRGBA: typeof float2CssRGBA;

--- a/Sources/Common/Core/Math/test/testMath.js
+++ b/Sources/Common/Core/Math/test/testMath.js
@@ -754,3 +754,47 @@ test('Test singularValueDecomposition', (t) => {
   }
   t.end();
 });
+
+test('Test getSparseOrthogonalMatrix', (t) => {
+  const successMsg = 'Row/column association is correct';
+  const tests = [
+    {
+      matrix: [
+        0.702, 0.7025, -0.1163, -0.2856, 0.1281, -0.9497, -0.6523, 0.7, 0.2906,
+      ],
+      expected: [0, 1, 0, 0, 0, -1, -1, 0, 0],
+    },
+  ];
+
+  // Test all matrices of size 3x3 which are orthogonal and contain only -1, 1 and 0
+  // There are 6 x 8 = 54 matrices to test
+  const permutation = [0, 1, 2];
+  for (let permutationIdx = 0; permutationIdx < 6; ++permutationIdx) {
+    for (let signBitField = 0; signBitField < 8; ++signBitField) {
+      const matrix = new Array(9).fill(0);
+      for (let row = 0; row < permutation.length; ++row) {
+        const col = permutation[row];
+        // eslint-disable-next-line no-bitwise
+        matrix[row + 3 * col] = signBitField & (1 << row) ? -1 : 1;
+      }
+      tests.push({ matrix, expected: matrix });
+    }
+    // Next permutation
+    if (permutationIdx % 2 === 0) {
+      [permutation[0], permutation[1]] = [permutation[1], permutation[0]];
+    } else {
+      [permutation[1], permutation[2]] = [permutation[2], permutation[1]];
+    }
+  }
+
+  tests.forEach(({ matrix, expected }) => {
+    const outputMatrix = vtkMath.getSparseOrthogonalMatrix(matrix);
+    const testResult = vtkMath.areEquals(expected, outputMatrix, 0);
+    const msg = testResult
+      ? successMsg
+      : `Bad row/column association with matrix ${matrix}\nExpected: ${expected}\nGot: ${outputMatrix}`;
+    t.ok(testResult, msg);
+  });
+
+  t.end();
+});


### PR DESCRIPTION
Two mappers with two different slicing modes could have the same ijkMode
For example, two mappers with X and Y slicing mode could both show slice J
Also remove the warning about inaccurate slicing because oblique slicing should be done with the new ImageResliceMapper and the slicing modes XYZ are intentionally used to snap to IJK

Add a function to vtkMath (with tests and docs)
