### PR TITLE
2434 vtk poly data normals add compute cell normals

### DIFF
--- a/Sources/Filters/Core/PolyDataNormals/example/controlPanel.html
+++ b/Sources/Filters/Core/PolyDataNormals/example/controlPanel.html
@@ -1,0 +1,14 @@
+<table>
+  <tr>
+    <td>Compute point normals</td>
+    <td>
+      <input class="computePointNormals"  type="checkbox" checked />
+    </td>
+  </tr>
+  <tr>
+    <td>Compute cell normals</td>
+    <td>
+      <input class="computeCellNormals"  type="checkbox" />
+    </td>
+  </tr>
+</table>

--- a/Sources/Filters/Core/PolyDataNormals/example/index.js
+++ b/Sources/Filters/Core/PolyDataNormals/example/index.js
@@ -1,0 +1,112 @@
+import '@kitware/vtk.js/favicon';
+
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import '@kitware/vtk.js/Rendering/Profiles/Geometry';
+import '@kitware/vtk.js/Rendering/Profiles/Glyph';
+
+import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
+
+import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
+import vtkArrowSource from '@kitware/vtk.js/Filters/Sources/ArrowSource';
+import vtkCubeSource from '@kitware/vtk.js/Filters/Sources/CubeSource';
+import vtkLookupTable from '@kitware/vtk.js/Common/Core/LookupTable';
+import vtkGlyph3DMapper from '@kitware/vtk.js/Rendering/Core/Glyph3DMapper';
+import vtkMapper from '@kitware/vtk.js/Rendering/Core/Mapper';
+import vtkPolyDataNormals from '@kitware/vtk.js/Filters/Core/PolyDataNormals';
+
+import controlPanel from './controlPanel.html';
+
+const { ColorMode, ScalarMode } = vtkMapper;
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
+  background: [0.9, 0.9, 0.9],
+});
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+
+// ----------------------------------------------------------------------------
+// Example code
+// ----------------------------------------------------------------------------
+
+const lookupTable = vtkLookupTable.newInstance({ hueRange: [0.666, 0] });
+
+const source = vtkCubeSource.newInstance();
+const inputPolyData = source.getOutputData();
+inputPolyData.getPointData().setNormals(null);
+
+const mapper = vtkMapper.newInstance({
+  interpolateScalarsBeforeMapping: true,
+  colorMode: ColorMode.DEFAULT,
+  scalarMode: ScalarMode.DEFAULT,
+  useLookupTableScalarRange: true,
+  lookupTable,
+});
+const actor = vtkActor.newInstance();
+actor.getProperty().setEdgeVisibility(true);
+
+const polyDataNormals = vtkPolyDataNormals.newInstance();
+
+// The generated 'z' array will become the default scalars, so the plane mapper will color by 'z':
+polyDataNormals.setInputData(inputPolyData);
+
+mapper.setInputConnection(polyDataNormals.getOutputPort());
+actor.setMapper(mapper);
+
+renderer.addActor(actor);
+
+const arrowSource = vtkArrowSource.newInstance();
+
+const glyphMapper = vtkGlyph3DMapper.newInstance();
+glyphMapper.setInputConnection(polyDataNormals.getOutputPort());
+glyphMapper.setSourceConnection(arrowSource.getOutputPort());
+glyphMapper.setOrientationModeToDirection();
+glyphMapper.setOrientationArray('Normals');
+glyphMapper.setScaleModeToScaleByMagnitude();
+glyphMapper.setScaleArray('Normals');
+glyphMapper.setScaleFactor(0.1);
+
+const glyphActor = vtkActor.newInstance();
+glyphActor.setMapper(glyphMapper);
+renderer.addActor(glyphActor);
+
+renderer.resetCamera();
+renderWindow.render();
+
+// ----------------------------------------------------------------------------
+// UI control handling
+// ----------------------------------------------------------------------------
+
+fullScreenRenderer.addController(controlPanel);
+
+// Checkbox
+document
+  .querySelector('.computePointNormals')
+  .addEventListener('change', (e) => {
+    polyDataNormals.setComputePointNormals(!!e.target.checked);
+    renderWindow.render();
+  });
+
+document
+  .querySelector('.computeCellNormals')
+  .addEventListener('change', (e) => {
+    polyDataNormals.setComputeCellNormals(!!e.target.checked);
+    renderWindow.render();
+  });
+
+// -----------------------------------------------------------
+// Make some variables global so that you can inspect and
+// modify objects in your browser's developer console:
+// -----------------------------------------------------------
+
+global.mapper = mapper;
+global.actor = actor;
+global.source = source;
+global.renderer = renderer;
+global.renderWindow = renderWindow;
+global.lookupTable = lookupTable;
+global.polyDataNormals = polyDataNormals;
+global.glyphMapper = glyphMapper;

--- a/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
+++ b/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
@@ -1,7 +1,11 @@
 import test from 'tape-catch';
 
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkPolyDataNormals from 'vtk.js/Sources/Filters/Core/PolyDataNormals';
+import vtkTriangle from 'vtk.js/Sources/Common/DataModel/Triangle';
+
+const PRECISION = 4;
 
 test('Test vtkPolyDataNormals passData', (t) => {
   const cube = vtkCubeSource.newInstance();
@@ -21,6 +25,73 @@ test('Test vtkPolyDataNormals passData', (t) => {
     output.getPointData().getTCoords(),
     input.getPointData().getTCoords()
   );
+
+  t.end();
+});
+
+test.only('Test vtkPolyDataNormals normals', (t) => {
+  const cube = vtkCubeSource.newInstance();
+  const input = cube.getOutputData();
+  const pointNormalsData = input.getPointData().getNormals().getData();
+  // const cellNormalsData = input.getCellData().getNormals().getData();
+  input.getPointData().setNormals(null);
+  input.getCellData().setNormals(null);
+
+  const normals = vtkPolyDataNormals.newInstance();
+  normals.setInputData(input);
+  normals.setComputeCellNormals(true);
+  normals.update();
+  const output = normals.getOutputData();
+
+  console.log(pointNormalsData);
+  console.log(output.getPointData().getNormals().getData());
+  t.deepEqual(
+    vtkMath.roundVector(pointNormalsData, [], PRECISION),
+    vtkMath.roundVector(
+      output.getPointData().getNormals().getData(),
+      [],
+      PRECISION
+    ),
+    'Same point normals'
+  );
+
+  const pointsData = output.getPoints().getData();
+  const polysData = output.getPolys().getData();
+  const polysDataLength = polysData.length;
+  const cellPointIds = [0, 0, 0];
+  let numberOfPoints = 0;
+  let polysId = 0;
+  for (let c = 0; c < polysDataLength; c += numberOfPoints + 1) {
+    numberOfPoints = polysData[c];
+
+    for (let i = 1; i <= 3; ++i) {
+      cellPointIds[i - 1] = 3 * polysData[c + i];
+    }
+
+    const cellNormal = [];
+
+    vtkTriangle.computeNormal(
+      pointsData.slice(cellPointIds[0], cellPointIds[0] + 3),
+      pointsData.slice(cellPointIds[1], cellPointIds[1] + 3),
+      pointsData.slice(cellPointIds[2], cellPointIds[2] + 3),
+      cellNormal
+    );
+
+    t.deepEqual(
+      vtkMath.roundVector(cellNormal, [], PRECISION),
+      vtkMath.roundVector(
+        output
+          .getCellData()
+          .getNormals()
+          .getData()
+          .slice(3 * polysId, 3 * polysId + 3),
+        [],
+        PRECISION
+      ),
+      `Same cell normal #${polysId}`
+    );
+    ++polysId;
+  }
 
   t.end();
 });

--- a/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
+++ b/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
@@ -29,7 +29,7 @@ test('Test vtkPolyDataNormals passData', (t) => {
   t.end();
 });
 
-test.only('Test vtkPolyDataNormals normals', (t) => {
+test('Test vtkPolyDataNormals normals', (t) => {
   const cube = vtkCubeSource.newInstance();
   const input = cube.getOutputData();
   const pointNormalsData = input.getPointData().getNormals().getData();

--- a/Sources/Rendering/Core/Glyph3DMapper/index.d.ts
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.d.ts
@@ -1,4 +1,4 @@
-import { Bounds } from "../../../types";
+import { Bounds, Nullable, vtkPipelineConnection } from "../../../types";
 import vtkMapper, { IMapperInitialValues } from "../Mapper";
 import { OrientationModes, ScaleModes } from "./Constants";
 
@@ -88,6 +88,12 @@ export interface vtkGlyph3DMapper extends vtkMapper {
 	getPrimitiveCount(): IPrimitiveCount;
 
 	/**
+	 * Sets the name of the array to use as orientation.
+	 * @param {String} arrayName Name of the array
+	 */
+	setOrientationArray(arrayName: Nullable<string>): boolean;
+
+	/**
 	 * Orientation mode indicates if the OrientationArray provides the direction 
 	 * vector for the orientation or the rotations around each axes.
 	 * @param {OrientationModes} orientationMode The orientation mode.
@@ -138,6 +144,13 @@ export interface vtkGlyph3DMapper extends vtkMapper {
 	 * Set scale to `SCALE_BY_CONSTANT`
 	 */
 	setScaleModeToScaleByConstant(): boolean;
+
+	/**
+	 * Convenient method to set the source glyph connection
+	 * @param {vtkPipelineConnection} outputPort The output port of the glyph source.
+	 */
+	setSourceConnection(outputPort: vtkPipelineConnection): void;
+
 }
 
 /**

--- a/Sources/Rendering/Core/Glyph3DMapper/index.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.js
@@ -134,6 +134,7 @@ function vtkGlyph3DMapper(publicAPI, model) {
       model.normalArray = new Float32Array(9 * numPts);
       const nbuff = model.normalArray.buffer;
       const tuple = [];
+      const orientation = [];
       for (let i = 0; i < numPts; ++i) {
         const z = new Float32Array(mbuff, i * 64, 16);
         trans[0] = pts[i * 3];
@@ -142,7 +143,6 @@ function vtkGlyph3DMapper(publicAPI, model) {
         mat4.translate(z, identity, trans);
 
         if (oArray) {
-          const orientation = [];
           oArray.getTuple(i, orientation);
           switch (model.orientationMode) {
             case OrientationModes.MATRIX: {
@@ -299,6 +299,9 @@ function vtkGlyph3DMapper(publicAPI, model) {
     };
     return pcount;
   };
+
+  publicAPI.setSourceConnection = (outputPort) =>
+    publicAPI.setInputConnection(outputPort, 1);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
### Context
fix #2434 

### Results
Add `setComputePointNormals` and `setComputeCellNormals`

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome