### PR TITLE
fix(interactor): mouseEvent is not available in the worker

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -11,7 +11,17 @@ const { vtkWarningMacro, vtkErrorMacro, normalizeWheel, vtkOnceErrorMacro } =
 // Global methods
 // ----------------------------------------------------------------------------
 
-const EMPTY_MOUSE_EVENT = new MouseEvent('');
+let EMPTY_MOUSE_EVENT;
+if (typeof MouseEvent !== 'undefined') {
+  EMPTY_MOUSE_EVENT = new MouseEvent('');
+} else {
+  // Provide a fallback or handle differently for web worker context
+  EMPTY_MOUSE_EVENT = {
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+  };
+}
 
 const deviceInputMap = {
   'xr-standard': [

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -11,17 +11,11 @@ const { vtkWarningMacro, vtkErrorMacro, normalizeWheel, vtkOnceErrorMacro } =
 // Global methods
 // ----------------------------------------------------------------------------
 
-let EMPTY_MOUSE_EVENT;
-if (typeof MouseEvent !== 'undefined') {
-  EMPTY_MOUSE_EVENT = new MouseEvent('');
-} else {
-  // Provide a fallback or handle differently for web worker context
-  EMPTY_MOUSE_EVENT = {
-    ctrlKey: false,
-    altKey: false,
-    shiftKey: false,
-  };
-}
+const EMPTY_MOUSE_EVENT = {
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+};
 
 const deviceInputMap = {
   'xr-standard': [


### PR DESCRIPTION


### Context

I was trying to consume @kitware/vtk.js inside a webworker which I encountered an error regarding MouseEvent not being available (since it is worker context). This PR will check if the MouseEvent is available then use it

### Results

Added conditional check for mouseEvent

### Changes

replaces 

```js
EMPTY_MOUSE_EVENT = new MouseEvent('');
``` 

with

```js
let EMPTY_MOUSE_EVENT;
if (typeof MouseEvent !== 'undefined') {
  EMPTY_MOUSE_EVENT = new MouseEvent('');
} else {
  // Provide a fallback or handle differently for web worker context
  EMPTY_MOUSE_EVENT = {
    ctrlKey: false,
    altKey: false,
    shiftKey: false,
  };
}

```

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
