### PR TITLE
fix(imagemapper): adding types for slicingMode and preferSizeOverAccu…

### DIFF
--- a/Sources/Rendering/Core/ImageMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageMapper/index.d.ts
@@ -260,14 +260,13 @@ export interface vtkImageMapper extends vtkAbstractImageMapper {
 	/**
 	 * Get the slicing mode. 
 	 */
-	getSlicingMode(): number;
-
+	getSlicingMode(): SlicingMode;
 
 	/**
 	 * Set the slicing mode. 
-	 * @param {Number} mode The slicing mode.
+	 * @param {SlicingMode} mode The slicing mode.
 	 */
-	setSlicingMode(mode: number): boolean;
+	setSlicingMode(mode: SlicingMode): boolean;
 
 	/**
 	 * Get the preference to use halfFloat representation of float
@@ -276,9 +275,9 @@ export interface vtkImageMapper extends vtkAbstractImageMapper {
 
 	/**
 	 * Set the preference to use halfFloat representation of float
-	 * @param {Boolean} sizeOverAccuracy
+	 * @param {Boolean} preferSizeOverAccuracy
 	 */
-	setPreferSizeOverAccuracy(sizeOverAccuracy: boolean): boolean;
+	setPreferSizeOverAccuracy(preferSizeOverAccuracy: boolean): boolean;
 }
 
 /**

--- a/Sources/Rendering/Core/ImageMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageMapper/index.d.ts
@@ -258,10 +258,27 @@ export interface vtkImageMapper extends vtkAbstractImageMapper {
 	getSlicingModeNormal(): number[];
 
 	/**
+	 * Get the slicing mode. 
+	 */
+	getSlicingMode(): number;
+
+
+	/**
 	 * Set the slicing mode. 
 	 * @param {Number} mode The slicing mode.
 	 */
 	setSlicingMode(mode: number): boolean;
+
+	/**
+	 * Get the preference to use halfFloat representation of float
+	 */
+	getPreferSizeOverAccuracy(): boolean;
+
+	/**
+	 * Set the preference to use halfFloat representation of float
+	 * @param {Boolean} sizeOverAccuracy
+	 */
+	setPreferSizeOverAccuracy(sizeOverAccuracy: boolean): boolean;
 }
 
 /**


### PR DESCRIPTION
### Context
This adds extra typing for missing setters and getters for slicingMode and preferSizeOverAccuracy in ImageMapper. 

### Results and Changes
- added types for setSlicingMode(number), getPreferSizeOverAccuracy(bool), setPreferSizeOverAccuracy(bool)
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: 28.11.0
  - **OS**: Ubuntu 22.04 (WSL)
  - **Browser**: Firefox 117.9.1
 