### PR TITLE
perf(vtkcutter): improve vtkCutter performances

### DIFF
--- a/Sources/Common/Core/DataArray/index.d.ts
+++ b/Sources/Common/Core/DataArray/index.d.ts
@@ -202,6 +202,15 @@ export interface vtkDataArray extends vtkObject {
 	getNumberOfTuples(): number;
 
 	/**
+	 * Convenient method to search the index of the first matching tuple in the array.
+	 * This is a naïve search, consider using a "locator" instead.
+	 * @param {Array<Number>|TypedArray} tupleToSearch
+	 * @param {Number} precision (1e-6 by default)
+	 * @returns {Number} the index of the tuple if found, -1 otherwise.
+	 */
+	findTuple(tupleToSearch: Array<number>|TypedArray, precision?: number): number;
+
+	/**
 	 * Get the data type of this array as a string.
 	 * @returns {String}
 	 */

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -8,6 +8,7 @@ const { DefaultDataType } = Constants;
 // ----------------------------------------------------------------------------
 // Global methods
 // ----------------------------------------------------------------------------
+const EPSILON = 1e-6;
 
 // Original source from https://www.npmjs.com/package/compute-range
 // Modified to accept type arrays
@@ -318,6 +319,24 @@ function vtkDataArray(publicAPI, model) {
   publicAPI.insertNextTuples = (tuples) => {
     const idx = model.size / model.numberOfComponents;
     return publicAPI.insertTuples(idx, tuples);
+  };
+
+  publicAPI.findTuple = (tuple, precision = EPSILON) => {
+    for (let i = 0; i < model.size; i += model.numberOfComponents) {
+      if (Math.abs(tuple[0] - model.values[i]) <= precision) {
+        let match = true;
+        for (let j = 1; j < model.numberOfComponents; ++j) {
+          if (Math.abs(tuple[j] - model.values[i + j]) > precision) {
+            match = false;
+            break;
+          }
+        }
+        if (match) {
+          return i / model.numberOfComponents;
+        }
+      }
+    }
+    return -1;
   };
 
   publicAPI.getTuple = (idx, tupleToFill = []) => {

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -188,3 +188,20 @@ test('Test vtkDataArray getTuples and insertTuples', (t) => {
 
   t.end();
 });
+
+test('Test vtkDataArray findTuple', (t) => {
+  const values = Uint8Array.from([
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+  ]);
+
+  const dataArray = vtkDataArray.newInstance({
+    dataType: VtkDataTypes.UNSIGNED_CHAR,
+    values,
+    numberOfComponents: 3,
+  });
+
+  t.equal(dataArray.findTuple([9, 10, 11]), 3);
+  t.equal(dataArray.findTuple([3, 4, 4], 1), 1);
+  t.equal(dataArray.findTuple(Float32Array.from([12, 13, 14])), 4);
+  t.end();
+});

--- a/Sources/Common/Core/Points/index.d.ts
+++ b/Sources/Common/Core/Points/index.d.ts
@@ -32,6 +32,15 @@ export interface vtkPoints extends vtkDataArray {
 	getPoint(idx: number, tupleToFill?: number[]|TypedArray): number[]|TypedArray;
 
 	/**
+	 * Convenient method to search a point in the array.
+	 * This is a naïve search. Consider using a "locator" instead.
+	 * @param {Array<Number>|TypedArray} pointToSearch
+	 * @param {Number} precision (1e-6 by default)
+	 * @returns {Number} the index of the point if found, -1 otherwise.
+	 */
+	findPoint(pointToSearch: Array<number>|TypedArray, precision?: number): number;
+
+	/**
 	 * Get the number of points for this object can hold.
 	 */
 	getNumberOfPoints(): number;

--- a/Sources/Common/Core/Points/index.js
+++ b/Sources/Common/Core/Points/index.js
@@ -31,6 +31,7 @@ function vtkPoints(publicAPI, model) {
   };
 
   publicAPI.getPoint = publicAPI.getTuple;
+  publicAPI.findPoint = publicAPI.findTuple;
 
   publicAPI.insertNextPoint = (x, y, z) => publicAPI.insertNextTuple([x, y, z]);
 

--- a/Sources/Filters/Core/Cutter/example/controlPanel.html
+++ b/Sources/Filters/Core/Cutter/example/controlPanel.html
@@ -7,7 +7,7 @@
     <td>
       <form name='originXForm'>
         <input class='originX' id="originXInputId" type="range"
-          min="-0.5" max="0.5" step="0.01" value="0"
+          min="-6" max="6" step="0.01" value="0"
           oninput="originXOutputId.value = originXInputId.value"/>
         <output id="originXOutputId">0</output>
       </form>

--- a/Sources/Filters/Core/Cutter/test/testCutter.js
+++ b/Sources/Filters/Core/Cutter/test/testCutter.js
@@ -29,18 +29,8 @@ test('Test vtkCutter cutCube', (t) => {
     [0, 0.5, 0.5],
   ];
   correctPoints.forEach((correctPoint) => {
-    let isContaining = false;
-    for (let i = 0; i < points.getNumberOfPoints(); i++) {
-      const p = points.getPoint(i);
-      isContaining =
-        p[0] === correctPoint[0] &&
-        p[1] === correctPoint[1] &&
-        p[2] === correctPoint[2];
-      if (isContaining) {
-        break;
-      }
-    }
-    t.equal(isContaining, true);
+    const pointId = points.findPoint(correctPoint);
+    t.ok(pointId > -1);
   });
   t.end();
 });


### PR DESCRIPTION
Avoid using subarray that is costly

### Context
https://discourse.vtk.org/t/cutter-performance/12282/5

### Results
Went from roughly 30ms to 20ms on DragonFly.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master -->
  - **OS**: Windows 11
  - **Browser**: Latest Chrome
