### PR TITLE
fix(DataArray): fix range for data arrays with NaN values

### DIFF
--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -13,16 +13,11 @@ const { DefaultDataType } = Constants;
 // Modified to accept type arrays
 function fastComputeRange(arr, offset, numberOfComponents) {
   const len = arr.length;
-  let min;
-  let max;
+  let min = Number.MAX_VALUE;
+  let max = -Number.MAX_VALUE;
   let x;
   let i;
-
-  if (len === 0) {
-    return { min: Number.MAX_VALUE, max: -Number.MAX_VALUE };
-  }
-  min = arr[offset];
-  max = min;
+  
   for (i = offset; i < len; i += numberOfComponents) {
     x = arr[i];
     if (x < min) {

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -17,7 +17,7 @@ function fastComputeRange(arr, offset, numberOfComponents) {
   let max = -Number.MAX_VALUE;
   let x;
   let i;
-  
+
   for (i = offset; i < len; i += numberOfComponents) {
     x = arr[i];
     if (x < min) {

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -18,7 +18,16 @@ function fastComputeRange(arr, offset, numberOfComponents) {
   let x;
   let i;
 
+  // find first non-NaN value
   for (i = offset; i < len; i += numberOfComponents) {
+    if (!Number.isNaN(arr[i])) {
+      min = arr[i];
+      max = min;
+      break;
+    }
+  }
+
+  for (; i < len; i += numberOfComponents) {
     x = arr[i];
     if (x < min) {
       min = x;

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -30,7 +30,7 @@ test('Test vtkDataArray getRange function with single-channel data.', (t) => {
   t.end();
 });
 
-test.only('Test vtkDataArray getRange function with NaN values.', (t) => {
+test('Test vtkDataArray getRange function with NaN values.', (t) => {
   // a data array with a NaN value
   const da = vtkDataArray.newInstance({
     numberOfComponents: 1,

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -31,7 +31,6 @@ test('Test vtkDataArray getRange function with single-channel data.', (t) => {
 });
 
 test.only('Test vtkDataArray getRange function with NaN values.', (t) => {
-
   // a data array with a NaN value
   const da = vtkDataArray.newInstance({
     numberOfComponents: 1,
@@ -56,8 +55,16 @@ test.only('Test vtkDataArray getRange function with NaN values.', (t) => {
     values: new Float64Array([]),
   });
 
-  t.equal(da3.getRange(0)[0], Number.MAX_VALUE, 'getRange minimum value should be MAX_VALUE');
-  t.equal(da3.getRange(0)[1], -Number.MAX_VALUE, 'getRange maximum value should be -MAX_VALUE');
+  t.equal(
+    da3.getRange(0)[0],
+    Number.MAX_VALUE,
+    'getRange minimum value should be MAX_VALUE'
+  );
+  t.equal(
+    da3.getRange(0)[1],
+    -Number.MAX_VALUE,
+    'getRange maximum value should be -MAX_VALUE'
+  );
 
   // a data array with multiple components
   const da4 = vtkDataArray.newInstance({
@@ -65,10 +72,26 @@ test.only('Test vtkDataArray getRange function with NaN values.', (t) => {
     values: new Float64Array([NaN, 1.0, 2.0, 3.0, 5.0, NaN]),
   });
 
-  t.equal(da4.getRange(0)[0], 2.0, 'component:0 getRange minimum value should be 2');
-  t.equal(da4.getRange(0)[1], 5.0, 'component:0 getRange maximum value should be 5');
-  t.equal(da4.getRange(1)[0], 1.0, 'component:1 getRange minimum value should be 1');
-  t.equal(da4.getRange(1)[1], 3.0, 'component:1 getRange maximum value should be 3');
+  t.equal(
+    da4.getRange(0)[0],
+    2.0,
+    'component:0 getRange minimum value should be 2'
+  );
+  t.equal(
+    da4.getRange(0)[1],
+    5.0,
+    'component:0 getRange maximum value should be 5'
+  );
+  t.equal(
+    da4.getRange(1)[0],
+    1.0,
+    'component:1 getRange minimum value should be 1'
+  );
+  t.equal(
+    da4.getRange(1)[1],
+    3.0,
+    'component:1 getRange maximum value should be 3'
+  );
 
   t.end();
 });

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -30,6 +30,49 @@ test('Test vtkDataArray getRange function with single-channel data.', (t) => {
   t.end();
 });
 
+test.only('Test vtkDataArray getRange function with NaN values.', (t) => {
+
+  // a data array with a NaN value
+  const da = vtkDataArray.newInstance({
+    numberOfComponents: 1,
+    values: new Float64Array([2.0, 0, NaN, 3.0, 4.0, 1.0]),
+  });
+
+  t.equal(da.getRange(0)[0], 0.0, 'getRange minimum value should be 0');
+  t.equal(da.getRange(0)[1], 4.0, 'getRange maximum value should be 4');
+
+  // a data array with NaN as first value
+  const da2 = vtkDataArray.newInstance({
+    numberOfComponents: 1,
+    values: new Float64Array([NaN, 0.0, 2.0, 3.0, 4.0, 1.0]),
+  });
+
+  t.equal(da2.getRange(0)[0], 0.0, 'getRange minimum value should be 0');
+  t.equal(da2.getRange(0)[1], 4.0, 'getRange maximum value should be 4');
+
+  // an empty data array
+  const da3 = vtkDataArray.newInstance({
+    numberOfComponents: 1,
+    values: new Float64Array([]),
+  });
+
+  t.equal(da3.getRange(0)[0], Number.MAX_VALUE, 'getRange minimum value should be MAX_VALUE');
+  t.equal(da3.getRange(0)[1], -Number.MAX_VALUE, 'getRange maximum value should be -MAX_VALUE');
+
+  // a data array with multiple components
+  const da4 = vtkDataArray.newInstance({
+    numberOfComponents: 2,
+    values: new Float64Array([NaN, 1.0, 2.0, 3.0, 5.0, NaN]),
+  });
+
+  t.equal(da4.getRange(0)[0], 2.0, 'component:0 getRange minimum value should be 2');
+  t.equal(da4.getRange(0)[1], 5.0, 'component:0 getRange maximum value should be 5');
+  t.equal(da4.getRange(1)[0], 1.0, 'component:1 getRange minimum value should be 1');
+  t.equal(da4.getRange(1)[1], 3.0, 'component:1 getRange maximum value should be 3');
+
+  t.end();
+});
+
 test('Test vtkDataArray getTuple', (t) => {
   const da = vtkDataArray.newInstance({
     numberOfComponents: 3,

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -31,10 +31,10 @@ test('Test vtkDataArray getRange function with single-channel data.', (t) => {
 });
 
 test('Test vtkDataArray getRange function with NaN values.', (t) => {
-  // a data array with a NaN value
+  // a data array with a NaN value and max as first value
   const da = vtkDataArray.newInstance({
     numberOfComponents: 1,
-    values: new Float64Array([2.0, 0, NaN, 3.0, 4.0, 1.0]),
+    values: new Float64Array([4.0, 0, NaN, 3.0, 2.0, 1.0]),
   });
 
   t.equal(da.getRange(0)[0], 0.0, 'getRange minimum value should be 0');
@@ -66,29 +66,64 @@ test('Test vtkDataArray getRange function with NaN values.', (t) => {
     'getRange maximum value should be -MAX_VALUE'
   );
 
-  // a data array with multiple components
+  // a data array with all NaN values except one in the middle
   const da4 = vtkDataArray.newInstance({
+    numberOfComponents: 1,
+    values: new Float64Array([NaN, NaN, 2.0, NaN]),
+  });
+
+  t.equal(da4.getRange(0)[0], 2.0, 'getRange minimum value should be 2');
+  t.equal(da4.getRange(0)[1], 2.0, 'getRange maximum value should be 2');
+
+  // a data array with all NaN values except one at the end
+  const da5 = vtkDataArray.newInstance({
+    numberOfComponents: 1,
+    values: new Float64Array([NaN, NaN, 2.0]),
+  });
+
+  t.equal(da5.getRange(0)[0], 2.0, 'getRange minimum value should be 2');
+  t.equal(da5.getRange(0)[1], 2.0, 'getRange maximum value should be 2');
+
+  // a data array with all NaN values
+  const da6 = vtkDataArray.newInstance({
+    numberOfComponents: 1,
+    values: new Float64Array([NaN, NaN, NaN]),
+  });
+
+  t.equal(
+    da6.getRange(0)[0],
+    Number.MAX_VALUE,
+    'getRange minimum value should be MAX_VALUE'
+  );
+  t.equal(
+    da6.getRange(0)[1],
+    -Number.MAX_VALUE,
+    'getRange maximum value should be -MAX_VALUE'
+  );
+
+  // a data array with multiple components
+  const da7 = vtkDataArray.newInstance({
     numberOfComponents: 2,
     values: new Float64Array([NaN, 1.0, 2.0, 3.0, 5.0, NaN]),
   });
 
   t.equal(
-    da4.getRange(0)[0],
+    da7.getRange(0)[0],
     2.0,
     'component:0 getRange minimum value should be 2'
   );
   t.equal(
-    da4.getRange(0)[1],
+    da7.getRange(0)[1],
     5.0,
     'component:0 getRange maximum value should be 5'
   );
   t.equal(
-    da4.getRange(1)[0],
+    da7.getRange(1)[0],
     1.0,
     'component:1 getRange minimum value should be 1'
   );
   t.equal(
-    da4.getRange(1)[1],
+    da7.getRange(1)[1],
     3.0,
     'component:1 getRange maximum value should be 3'
   );


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Fix #2920: the range of data arrays with NaN as first value was wrongly computed (always returned NaN). Fixed by properly initializing the min/max values in the `fastComputeRange` function.

### Results
Changes are captured by the newly added tests.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: 28.11.0
  - **OS**:  Windows
  - **Browser**: Edge
