### PR TITLE
Change style of reslice cursor widget back to as it was in v25

### DIFF
--- a/Sources/Widgets/Representations/GlyphRepresentation/index.js
+++ b/Sources/Widgets/Representations/GlyphRepresentation/index.js
@@ -303,6 +303,9 @@ export function extend(publicAPI, model, initialValues = {}) {
       defaultValues(publicAPI, model, initialValues)
     );
   }
+  if ('lighting' in initialValues) {
+    model._pipeline.actor.getProperty().setLighting(initialValues.lighting);
+  }
 
   macro.setGet(publicAPI, model._pipeline, ['defaultScale']);
   macro.get(publicAPI, model._pipeline, ['glyph', 'mapper', 'actor']);

--- a/Sources/Widgets/Representations/LineHandleRepresentation/index.js
+++ b/Sources/Widgets/Representations/LineHandleRepresentation/index.js
@@ -96,6 +96,7 @@ function defaultValues(initialValues) {
     _pipeline: {
       glyph: vtkCylinderSource.newInstance({
         resolution: initialValues.glyphResolution ?? 4,
+        initAngle: initialValues.glyphAngle ?? Math.PI / 4,
         direction: [0, 0, 1],
       }),
     },

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -294,6 +294,7 @@ function vtkResliceCursorWidget(publicAPI, model) {
             initialValues: {
               useActiveColor: false,
               scaleInPixels: model.scaleInPixels,
+              lighting: false,
             },
           },
           {
@@ -302,6 +303,7 @@ function vtkResliceCursorWidget(publicAPI, model) {
             initialValues: {
               useActiveColor: false,
               scaleInPixels: model.scaleInPixels,
+              lighting: false,
             },
           },
         ];


### PR DESCRIPTION
Remove lighting
Spin cyclinder representations to avoid cropping of the cylinder by the imageReslice
