### PR TITLE
Fix typed arrays serialization deserialization

### DIFF
--- a/Sources/Testing/testSerialization.js
+++ b/Sources/Testing/testSerialization.js
@@ -3,11 +3,12 @@ import vtk from 'vtk.js/Sources/vtk';
 import macro from 'vtk.js/Sources/macros';
 
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
-import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
+import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
 import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';
+import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkScalarsToColors from 'vtk.js/Sources/Common/Core/ScalarsToColors';
 
-import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import Common from 'vtk.js/Sources/Common';
 import Filters from 'vtk.js/Sources/Filters';
 import Imaging from 'vtk.js/Sources/Imaging';
@@ -21,10 +22,11 @@ const { vtkDebugMacro } = macro;
 
 const classToTest = [
   'vtkDataArray',
-  'vtkPoints',
+  'vtkImageData',
   'vtkLookupTable',
-  'vtkScalarsToColors',
+  'vtkPoints',
   'vtkPolyData',
+  'vtkScalarsToColors',
 ];
 
 const SERIALIZABLE_CLASSES = {
@@ -55,6 +57,7 @@ const SERIALIZABLE_CLASSES = {
       },
     },
   },
+  vtkImageData,
 };
 
 function ignoreMTime(json) {

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -174,6 +174,10 @@ function safeArrays(model) {
   });
 }
 
+function isTypedArray(value) {
+  return Object.values(TYPED_ARRAYS).some((ctor) => value instanceof ctor);
+}
+
 // ----------------------------------------------------------------------------
 // shallow equals
 // ----------------------------------------------------------------------------
@@ -378,6 +382,8 @@ export function obj(publicAPI = {}, model = {}) {
         jsonArchive[keyName] = jsonArchive[keyName].getState();
       } else if (Array.isArray(jsonArchive[keyName])) {
         jsonArchive[keyName] = jsonArchive[keyName].map(getStateArrayMapFunc);
+      } else if (isTypedArray(jsonArchive[keyName])) {
+        jsonArchive[keyName] = Array.from(jsonArchive[keyName]);
       }
     });
 


### PR DESCRIPTION
### Context
The behavior of JSON.stringify for typed arrays is to serialize them as objects with numeric keys. This cause crashes when re-building the object since it would try to fit an object where a typed array is required. This changes makes it so getState replaces typed arrays with plain javascript arrays.

Typical example is `vtkImageData` direction property, which is by default Float64Array
minimal reproduction:
```javascript
import vtk from '@kitware/vtk.js/vtk';
import vtkImageData from '../../Sources/Common/DataModel/ImageData';

const imdt = vtkImageData.newInstance();
const jsonRepr = JSON.stringify(imdt);
const jsonDeserialize = JSON.parse(jsonRepr);

const vtkObj = vtk(jsonDeserialize); // this should crash
```
see also https://github.com/Kitware/glance/issues/480

### Results
makes serialization/deserialization possible and successful


### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

This change makes it so we serialize typed arrays as arrays.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: linux
  - **Browser**: chrome, firefox latest
