### PR TITLE
Fix calculator for image data

### DIFF
--- a/Sources/Filters/General/Calculator/index.js
+++ b/Sources/Filters/General/Calculator/index.js
@@ -45,11 +45,14 @@ function vtkCalculator(publicAPI, model) {
     singleValueFormula,
     options = {}
   ) => ({
-    getArrays: () => ({
-      input: publicAPI.augmentInputArrays(
-        locn,
-        arrNames.map((x) => ({ location: locn, name: x }))
-      ),
+    getArrays: (inData) => ({
+      // don't augment input data array in case of structured input dataset
+      input: inData[0].isA('vtkImageData')
+        ? arrNames.map((x) => ({ location: locn, name: x }))
+        : publicAPI.augmentInputArrays(
+            locn,
+            arrNames.map((x) => ({ location: locn, name: x }))
+          ),
       output: [
         {
           location: locn,
@@ -191,7 +194,7 @@ function vtkCalculator(publicAPI, model) {
           [
             FieldDataTypes.POINT,
             (x) => x.getPointData(),
-            (x) => x.getPoints().getNumberOfPoints(),
+            (x) => x.getNumberOfPoints(),
           ],
           [
             FieldDataTypes.CELL,


### PR DESCRIPTION
### Context
fix #2257

### Results
we can now use `vtkCalculator` with a `vtkImageData`

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes  

Do not pass point coordinates to formula function in case of `vtkImageData` input since it relies on the `getPoints` function which does not exist on `vtkImageData`.
Also avoid to call `getPoints` to get number of points, directly use `getNumberOfPoints` on the input dataset.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: linux
  - **Browser**: firefox 118.0.1, chrome Version 117.0.5938.132 (Official Build) (64-bit)
