### PR TITLE
Fix multiple configuration error

### DIFF
--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -261,11 +261,11 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     if (model.zBufferTexture !== null) {
       FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::ZBuffer::Dec', [
         'uniform sampler2D zBufferTexture;',
-        'uniform float vpWidth;',
-        'uniform float vpHeight;',
+        'uniform float vpZWidth;',
+        'uniform float vpZHeight;',
       ]).result;
       FSSource = vtkShaderProgram.substitute(FSSource, '//VTK::ZBuffer::Impl', [
-        'vec4 depthVec = texture2D(zBufferTexture, vec2(gl_FragCoord.x / vpWidth, gl_FragCoord.y/vpHeight));',
+        'vec4 depthVec = texture2D(zBufferTexture, vec2(gl_FragCoord.x / vpZWidth, gl_FragCoord.y/vpZHeight));',
         'float zdepth = (depthVec.r*256.0 + depthVec.g)/257.0;',
         'zdepth = zdepth * 2.0 - 1.0;',
         'if (cameraParallel == 0) {',
@@ -650,8 +650,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       const size = model._useSmallViewport
         ? [model._smallViewportWidth, model._smallViewportHeight]
         : model._openGLRenderWindow.getFramebufferSize();
-      program.setUniformf('vpWidth', size[0]);
-      program.setUniformf('vpHeight', size[1]);
+      program.setUniformf('vpZWidth', size[0]);
+      program.setUniformf('vpZHeight', size[1]);
     }
   };
 
@@ -853,8 +853,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
       const size = publicAPI.getRenderTargetSize();
 
-      program.setUniformf('vpWidth', size[0]);
-      program.setUniformf('vpHeight', size[1]);
+      program.setUniformf('vpZWidth', size[0]);
+      program.setUniformf('vpZHeight', size[1]);
 
       const offset = publicAPI.getRenderTargetOffset();
       program.setUniformf('vpOffsetX', offset[0] / size[0]);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
This PR aims to fix the problem occuring when both options z-Buffer and Image Outline are configured. As this two options declare the same variable names when activated, it gives error in shader compilation

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**:  27.3.1
  - **OS**: Windows 10
  - Browser:  Chrome 117.0.5938.152 
<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
