### PR TITLE
docs(OfflineLocalView): defer data loading when not visible

### DIFF
--- a/Examples/Applications/OfflineLocalView/index.js
+++ b/Examples/Applications/OfflineLocalView/index.js
@@ -33,6 +33,31 @@ function preventDefaults(e) {
   e.stopPropagation();
 }
 
+function onVisible(element, callback) {
+  new window.parent.IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.intersectionRatio > 0) {
+        callback();
+        observer.disconnect();
+      }
+    });
+  }).observe(element);
+}
+
+function runOnVisible(callback) {
+  if (!window.frameElement) {
+    callback();
+    return true;
+  }
+  const visible = window.frameElement.getClientRects().length > 0;
+  if (!visible) {
+    onVisible(window.frameElement, callback);
+  } else {
+    callback();
+  }
+  return visible;
+}
+
 export function load(container, options) {
   autoInit = false;
   emptyContainer(container);
@@ -161,7 +186,9 @@ if (userParams.url || userParams.fileURL) {
     rootBody.style.margin = '0';
     rootBody.style.padding = '0';
   }
-  load(myContainer, userParams);
+
+  autoInit = false;
+  runOnVisible(() => load(myContainer, userParams));
 }
 
 // Auto setup if no method get called within 100ms


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
