### PR TITLE
fix(volume): Fix key normal matrix for volume

### DIFF
--- a/Sources/Rendering/OpenGL/Volume/index.js
+++ b/Sources/Rendering/OpenGL/Volume/index.js
@@ -77,6 +77,7 @@ function vtkOpenGLVolume(publicAPI, model) {
       } else {
         mat3.fromMat4(model.normalMatrix, model.MCWCMatrix);
         mat3.invert(model.normalMatrix, model.normalMatrix);
+        mat3.transpose(model.normalMatrix, model.normalMatrix);
       }
       model.keyMatrixTime.modified();
     }


### PR DESCRIPTION
The method `getKeyMatrices` computed inverse instead of inverse+transpose

Close #2922 
Close #2949
