### PR TITLE
feat(labelOutline): add per segment label outline thickness

### DIFF
--- a/Examples/Volume/VolumeOutline/index.js
+++ b/Examples/Volume/VolumeOutline/index.js
@@ -154,9 +154,4 @@ reader
     renderer.addVolume(labelMap.actor);
     renderer.getActiveCamera().setViewUp(1, 0, 0);
     renderWindow.render();
-
-    setTimeout(() => {
-      labelMap.actor.getProperty().setLabelOutlineThickness([2, 4]);
-      renderWindow.render();
-    }, 1000);
   });

--- a/Examples/Volume/VolumeOutline/index.js
+++ b/Examples/Volume/VolumeOutline/index.js
@@ -87,7 +87,7 @@ function createLabelPipeline(backgroundImageData) {
   labelMap.actor.getProperty().setScalarOpacity(0, labelMap.ofun);
   labelMap.actor.getProperty().setInterpolationTypeToNearest();
   labelMap.actor.getProperty().setUseLabelOutline(true);
-  labelMap.actor.getProperty().setLabelOutlineThickness([2, 2]);
+  labelMap.actor.getProperty().setLabelOutlineThickness([2, 3]);
   labelMap.actor.getProperty().setLabelOutlineOpacity(1.0);
 
   return labelMap;

--- a/Examples/Volume/VolumeOutline/index.js
+++ b/Examples/Volume/VolumeOutline/index.js
@@ -87,7 +87,7 @@ function createLabelPipeline(backgroundImageData) {
   labelMap.actor.getProperty().setScalarOpacity(0, labelMap.ofun);
   labelMap.actor.getProperty().setInterpolationTypeToNearest();
   labelMap.actor.getProperty().setUseLabelOutline(true);
-  labelMap.actor.getProperty().setLabelOutlineThickness([1, 3]);
+  labelMap.actor.getProperty().setLabelOutlineThickness([2, 2]);
   labelMap.actor.getProperty().setLabelOutlineOpacity(1.0);
 
   return labelMap;
@@ -154,4 +154,9 @@ reader
     renderer.addVolume(labelMap.actor);
     renderer.getActiveCamera().setViewUp(1, 0, 0);
     renderWindow.render();
+
+    setTimeout(() => {
+      labelMap.actor.getProperty().setLabelOutlineThickness([2, 4]);
+      renderWindow.render();
+    }, 1000);
   });

--- a/Examples/Volume/VolumeOutline/index.js
+++ b/Examples/Volume/VolumeOutline/index.js
@@ -87,7 +87,7 @@ function createLabelPipeline(backgroundImageData) {
   labelMap.actor.getProperty().setScalarOpacity(0, labelMap.ofun);
   labelMap.actor.getProperty().setInterpolationTypeToNearest();
   labelMap.actor.getProperty().setUseLabelOutline(true);
-  labelMap.actor.getProperty().setLabelOutlineThickness(3);
+  labelMap.actor.getProperty().setLabelOutlineThickness([1, 3]);
   labelMap.actor.getProperty().setLabelOutlineOpacity(1.0);
 
   return labelMap;

--- a/Sources/Rendering/Core/VolumeProperty/index.d.ts
+++ b/Sources/Rendering/Core/VolumeProperty/index.d.ts
@@ -204,11 +204,20 @@ export interface vtkVolumeProperty extends vtkObject {
 	 */
 	setIndependentComponents(independentComponents: boolean): boolean;
 
-  /**
-   *
-   * @param {Number | Number[]} labelOutlineThickness
-  */
-  setLabelOutlineThickness(labelOutlineThickness: number | number[]): boolean;
+	/**
+	 * It will set the label outline thickness for the labelmaps. It can accept
+	 * a single number or an array of numbers. If a single number is provided,
+	 * it will be used for all the components. If an array is provided, it indicates
+	 * the thickness for each segment index. For instance if you have a labelmap
+	 * with 3 segments (0: background 1: live 2: tumor), you can set the thickness
+	 * to [2,4] to have a thicker outline for the tumor (thickness 4). It should be 
+	 * noted that if the number of segments is greater than the number of thickness
+	 * the first thickness will be used for the remaining segments.
+	 * 
+	 * 
+	 * @param {Number | Number[]} labelOutlineThickness
+	 */
+	setLabelOutlineThickness(labelOutlineThickness: number | number[]): boolean;
 
 
 	/**

--- a/Sources/Rendering/Core/VolumeProperty/index.d.ts
+++ b/Sources/Rendering/Core/VolumeProperty/index.d.ts
@@ -207,13 +207,12 @@ export interface vtkVolumeProperty extends vtkObject {
 	/**
 	 * It will set the label outline thickness for the labelmaps. It can accept
 	 * a single number or an array of numbers. If a single number is provided,
-	 * it will be used for all the components. If an array is provided, it indicates
+	 * it will be used for all the segments. If an array is provided, it indicates
 	 * the thickness for each segment index. For instance if you have a labelmap
-	 * with 3 segments (0: background 1: live 2: tumor), you can set the thickness
+	 * with 3 segments (0: background 1: liver 2: tumor), you can set the thickness
 	 * to [2,4] to have a thicker outline for the tumor (thickness 4). It should be 
-	 * noted that if the number of segments is greater than the number of thickness
-	 * the first thickness will be used for the remaining segments.
-	 * 
+	 * noted that the thickness is in pixel and also the first array value will 
+	 * control the default thickness for all the segments if not specified.
 	 * 
 	 * @param {Number | Number[]} labelOutlineThickness
 	 */

--- a/Sources/Rendering/Core/VolumeProperty/index.d.ts
+++ b/Sources/Rendering/Core/VolumeProperty/index.d.ts
@@ -204,11 +204,12 @@ export interface vtkVolumeProperty extends vtkObject {
 	 */
 	setIndependentComponents(independentComponents: boolean): boolean;
 
-	/**
-	 *
-	 * @param {Number} labelOutlineThickness 
-	 */
-	setLabelOutlineThickness(labelOutlineThickness: number): boolean;
+  /**
+   *
+   * @param {Number | Number[]} labelOutlineThickness
+  */
+  setLabelOutlineThickness(labelOutlineThickness: number | number[]): boolean;
+
 
 	/**
 	 *

--- a/Sources/Rendering/Core/VolumeProperty/index.d.ts
+++ b/Sources/Rendering/Core/VolumeProperty/index.d.ts
@@ -212,7 +212,7 @@ export interface vtkVolumeProperty extends vtkObject {
 	 * with 3 segments (0: background 1: liver 2: tumor), you can set the thickness
 	 * to [2,4] to have a thicker outline for the tumor (thickness 4). It should be 
 	 * noted that the thickness is in pixel and also the first array value will 
-	 * control the default thickness for all the segments if not specified.
+	 * control the default thickness for all labels when 0 or not specified.
 	 * 
 	 * @param {Number | Number[]} labelOutlineThickness
 	 */

--- a/Sources/Rendering/Core/VolumeProperty/index.js
+++ b/Sources/Rendering/Core/VolumeProperty/index.js
@@ -203,6 +203,17 @@ function vtkVolumeProperty(publicAPI, model) {
   publicAPI.getInterpolationTypeAsString = () =>
     macro.enumToString(InterpolationType, model.interpolationType);
 
+  publicAPI.setLabelOutlineThickness = (thickness) => {
+    // handle the old API which was a single number for all segments
+    if (typeof thickness === 'number') {
+      model.labelOutlineThickness = [thickness];
+    } else {
+      model.labelOutlineThickness = thickness;
+    }
+
+    publicAPI.modified();
+  };
+
   const sets = [
     'useGradientOpacity',
     'scalarOpacityUnitDistance',
@@ -252,7 +263,7 @@ const DEFAULT_VALUES = {
   specular: 0.2,
   specularPower: 10.0,
   useLabelOutline: false,
-  labelOutlineThickness: 1,
+  labelOutlineThickness: [1],
   labelOutlineOpacity: 1.0,
 };
 

--- a/Sources/Rendering/Core/VolumeProperty/index.js
+++ b/Sources/Rendering/Core/VolumeProperty/index.js
@@ -203,17 +203,6 @@ function vtkVolumeProperty(publicAPI, model) {
   publicAPI.getInterpolationTypeAsString = () =>
     macro.enumToString(InterpolationType, model.interpolationType);
 
-  publicAPI.setLabelOutlineThickness = (thickness) => {
-    // handle the old API which was a single number for all segments
-    if (typeof thickness === 'number') {
-      model.labelOutlineThickness = [thickness];
-    } else {
-      model.labelOutlineThickness = thickness;
-    }
-
-    publicAPI.modified();
-  };
-
   const sets = [
     'useGradientOpacity',
     'scalarOpacityUnitDistance',
@@ -306,9 +295,10 @@ export function extend(publicAPI, model, initialValues = {}) {
     'specular',
     'specularPower',
     'useLabelOutline',
-    'labelOutlineThickness',
     'labelOutlineOpacity',
   ]);
+
+  macro.setGetArray(publicAPI, model, ['labelOutlineThickness']);
 
   // Object methods
   vtkVolumeProperty(publicAPI, model);

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1621,14 +1621,17 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       const maxThickness = Math.max(...labelOutlineThicknessArray);
 
       for (let i = 0; i < lWidth; ++i) {
-        const thickness = labelOutlineThicknessArray[i];
-        let normalizedThickness;
+        // Retrieve the thickness value for the current segment index.
+        // If the value is undefined, null, or 0, use the first element's value as a default.
+        let thickness = labelOutlineThicknessArray[i];
         if (thickness === undefined || thickness === null || thickness === 0) {
-          normalizedThickness = labelOutlineThicknessArray[0] / maxThickness;
-        } else {
-          normalizedThickness = thickness / maxThickness;
+          thickness = labelOutlineThicknessArray[0];
         }
-        lTable[i] = 255.0 * normalizedThickness;
+
+        // Normalize the thickness value to the range [0, 1].
+        const normalizedThickness = thickness / maxThickness;
+
+        lTable[i] = Math.round(255.0 * normalizedThickness);
       }
 
       model.labelOutlineThicknessTexture.releaseGraphicsResources(
@@ -1638,8 +1641,6 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       model.labelOutlineThicknessTexture.resetFormatAndType();
       model.labelOutlineThicknessTexture.setMinificationFilter(Filter.NEAREST);
       model.labelOutlineThicknessTexture.setMagnificationFilter(Filter.NEAREST);
-      model.labelOutlineThicknessTexture.setWrapS(Wrap.CLAMP_TO_EDGE);
-      model.labelOutlineThicknessTexture.setWrapT(Wrap.CLAMP_TO_EDGE);
 
       // Create a 2D texture (acting as 1D) from the raw data
       model.labelOutlineThicknessTexture.create2DFromRaw(

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1074,7 +1074,11 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       const labelOutlineThickness = actor
         .getProperty()
         .getLabelOutlineThickness();
-      const maxThickness = Math.max(...labelOutlineThickness);
+      const maxThickness = labelOutlineThickness.reduce(
+        (max, thickness) => Math.max(max, thickness),
+        -Infinity
+      );
+
       program.setUniformf('uMaxLabelOutlineThickness', maxThickness);
 
       const labelOutlineOpacity = actor.getProperty().getLabelOutlineOpacity();
@@ -1694,8 +1698,8 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     model.VBOBuildTime.modified();
   };
 
-  publicAPI.updateLabelOutlineThicknessTexture = (actor) => {
-    const labelOutlineThicknessArray = actor
+  publicAPI.updateLabelOutlineThicknessTexture = (volume) => {
+    const labelOutlineThicknessArray = volume
       .getProperty()
       .getLabelOutlineThickness();
     const lTex = model._openGLRenderWindow.getGraphicsResourceForObject(

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1071,7 +1071,9 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       const labelOutlineOpacity = actor.getProperty().getLabelOutlineOpacity();
 
       // Create an array of size 256 and make sure it is padded with zeros
-      const paddedOutlineThicknessArray = new Int32Array(256);
+      // For some reason we can't pass a Uint8Array of size 983 or greater
+      // to the shader, so we just use 900 size
+      const paddedOutlineThicknessArray = new Uint8Array(900);
       paddedOutlineThicknessArray.set(labelOutlineThickness);
 
       program.setUniformiv('outlineThickness', paddedOutlineThicknessArray);

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1693,10 +1693,6 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       .getProperty()
       .getLabelOutlineThickness();
 
-    if (!labelOutlineThicknessArray) {
-      return;
-    }
-
     const lTex = model._openGLRenderWindow.getGraphicsResourceForObject(
       labelOutlineThicknessArray
     );

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1070,7 +1070,11 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
       const labelOutlineOpacity = actor.getProperty().getLabelOutlineOpacity();
 
-      program.setUniformi('outlineThickness', labelOutlineThickness);
+      // Create an array of size 256 and make sure it is padded with zeros
+      const paddedOutlineThicknessArray = new Int32Array(256);
+      paddedOutlineThicknessArray.set(labelOutlineThickness);
+
+      program.setUniformiv('outlineThickness', paddedOutlineThicknessArray);
       program.setUniformf('outlineOpacity', labelOutlineOpacity);
     }
 

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -46,7 +46,6 @@ varying vec3 vertexVCVSOutput;
 
 // For some reason we can't pass a Uint8Array of size 983 or greater
 // to the shader, so we just use 900 size
-uniform int outlineThickness[900];
 uniform float outlineOpacity;
 uniform float vpWidth;
 uniform float vpHeight;
@@ -141,6 +140,10 @@ uniform float cscale0;
 
 // jitter texture
 uniform sampler2D jtexture;
+uniform sampler2D ttexture;
+
+uniform float uMaxLabelOutlineThickness; 
+
 
 // some 3D texture values
 uniform float sampleDistance;
@@ -978,14 +981,10 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
   tColor.a = texture2D(otexture, vec2(centerValue.r * oscale0 + oshift0, 0.5)).r;
 
   int segmentIndex = int(centerValue.r * 255.0);
-  // below we are using [segmentindex - 1] since the first segment is the background it will be index 0
-  int actualThickness = outlineThickness[segmentIndex -1];
-
-  // if there is no thickness defined for this segment, use the first one
-  if (actualThickness == 0) {
-    actualThickness = outlineThickness[0];
-  }
-
+  
+  // // Use texture sampling for outlineThickness
+  float normalizedThickness = texture2D(ttexture, vec2(float(segmentIndex - 1 ) / 1024.0, 0.5)).r;
+  int actualThickness = int(normalizedThickness * uMaxLabelOutlineThickness);
 
   // Only perform outline check on fragments rendering voxels that aren't invisible.
   // Saves a bunch of needless checks on the background.

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -43,7 +43,7 @@ varying vec3 vertexVCVSOutput;
 //VTK::ImageLabelOutlineOn
 
 #ifdef vtkImageLabelOutlineOn
-uniform int outlineThickness;
+uniform int outlineThickness[256];
 uniform float outlineOpacity;
 uniform float vpWidth;
 uniform float vpHeight;
@@ -974,12 +974,22 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
   // Get alpha of segment from opacity function.
   tColor.a = texture2D(otexture, vec2(centerValue.r * oscale0 + oshift0, 0.5)).r;
 
+  int segmentIndex = int(centerValue.r * 255.0);
+  // below we are using [segmentindex - 1] since the first segment is the background it will be index 0
+  int actualThickness = outlineThickness[segmentIndex -1];
+
+  // if there is no thickness defined for this segment, use the first one
+  if (actualThickness == 0) {
+    actualThickness = outlineThickness[0];
+  }
+
+
   // Only perform outline check on fragments rendering voxels that aren't invisible.
   // Saves a bunch of needless checks on the background.
   // TODO define epsilon when building shader?
   if (float(tColor.a) > 0.01) {
-    for (int i = -outlineThickness; i <= outlineThickness; i++) {
-      for (int j = -outlineThickness; j <= outlineThickness; j++) {
+    for (int i = -actualThickness; i <= actualThickness; i++) {
+      for (int j = -actualThickness; j <= actualThickness; j++) {
         if (i == 0 || j == 0) {
           continue;
         }

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -140,8 +140,6 @@ uniform float cscale0;
 uniform sampler2D jtexture;
 uniform sampler2D ttexture;
 
-uniform float uMaxLabelOutlineThickness; 
-
 
 // some 3D texture values
 uniform float sampleDistance;
@@ -981,9 +979,14 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
   int segmentIndex = int(centerValue.r * 255.0);
   
   // Use texture sampling for outlineThickness
-  float normalizedThickness = texture2D(ttexture, vec2(float(segmentIndex - 1 ) / 1024.0, 0.5)).r;
+  float textureCoordinate = float(segmentIndex - 1) / 1024.0;
+  float textureValue = texture2D(ttexture, vec2(textureCoordinate, 0.5)).r;
 
-  int actualThickness = int(round(normalizedThickness * uMaxLabelOutlineThickness));
+  int actualThickness = int(textureValue * 255.0);
+
+  if (actualThickness == 0) {
+    return vec4(0, 0, 1, 1);
+  }
 
   // Only perform outline check on fragments rendering voxels that aren't invisible.
   // Saves a bunch of needless checks on the background.

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -43,7 +43,10 @@ varying vec3 vertexVCVSOutput;
 //VTK::ImageLabelOutlineOn
 
 #ifdef vtkImageLabelOutlineOn
-uniform int outlineThickness[256];
+
+// For some reason we can't pass a Uint8Array of size 983 or greater
+// to the shader, so we just use 900 size
+uniform int outlineThickness[900];
 uniform float outlineOpacity;
 uniform float vpWidth;
 uniform float vpHeight;

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -984,7 +984,8 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
   
   // // Use texture sampling for outlineThickness
   float normalizedThickness = texture2D(ttexture, vec2(float(segmentIndex - 1 ) / 1024.0, 0.5)).r;
-  int actualThickness = int(normalizedThickness * uMaxLabelOutlineThickness);
+
+  int actualThickness = int(round(normalizedThickness * uMaxLabelOutlineThickness));
 
   // Only perform outline check on fragments rendering voxels that aren't invisible.
   // Saves a bunch of needless checks on the background.

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -44,8 +44,6 @@ varying vec3 vertexVCVSOutput;
 
 #ifdef vtkImageLabelOutlineOn
 
-// For some reason we can't pass a Uint8Array of size 983 or greater
-// to the shader, so we just use 900 size
 uniform float outlineOpacity;
 uniform float vpWidth;
 uniform float vpHeight;
@@ -982,7 +980,7 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
 
   int segmentIndex = int(centerValue.r * 255.0);
   
-  // // Use texture sampling for outlineThickness
+  // Use texture sampling for outlineThickness
   float normalizedThickness = texture2D(ttexture, vec2(float(segmentIndex - 1 ) / 1024.0, 0.5)).r;
 
   int actualThickness = int(round(normalizedThickness * uMaxLabelOutlineThickness));


### PR DESCRIPTION
### Context

This pull request will introduce a method to specify individual segment outline thicknesses for the label map outline.


### Results

It will look like this with different outline thickness for each segment.

![CleanShot 2023-11-21 at 16 18 41](https://github.com/Kitware/vtk-js/assets/7490180/3016f09c-0346-444f-ba2a-3120edb10965)

### Changes

The signature of the `setLabelOutlineThickness` has been changed to support both a single number (old API) and a new way of handling it (via an array).

```js
setLabelOutlineThickness(2) => will set 2px for all segments
setLabelOutlineThickness([2]) => will set 2px for all segments
setLabelOutlineThickness([1,3]) => will set 1px for segment index 1  and 3 px for segment index 2 
```




- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: Latest
  - **OS**: MacOS 13.5.2 (22G91)
  - **Browser**:  Chrome Version 119.0.6045.159 (Official Build) (arm64)


