### PR TITLE
fix(TubeFilter): do not drop output arrays

### DIFF
--- a/Sources/Filters/General/TubeFilter/index.js
+++ b/Sources/Filters/General/TubeFilter/index.js
@@ -701,7 +701,6 @@ function vtkTubeFilter(publicAPI, model) {
         numberOfComponents: oldArray.getNumberOfComponents(),
         size: numNewPts * oldArray.getNumberOfComponents(),
       });
-      output.getPointData().removeArrayByIndex(0); // remove oldArray from beginning
       output.getPointData().addArray(newArray); // concat newArray to end
     }
 
@@ -719,7 +718,6 @@ function vtkTubeFilter(publicAPI, model) {
         numberOfComponents: oldArray.getNumberOfComponents(),
         size: numNewCells * oldArray.getNumberOfComponents(),
       });
-      output.getCellData().removeArrayByIndex(0); // remove oldArray from beginning
       output.getCellData().addArray(newArray); // concat newArray to end
     }
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Output cell/point arrays were being dropped when they shouldn't be. Every update invocation creates a new polydata array, so there are no old arrays to be dropped.

Related: https://discourse.vtk.org/t/tubefilter-broken-for-celldata/12863

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

Cell and point data arrays should be properly copied to the output polydata.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Fix TubeFilter not copying cell/pointdata properly

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
