### PR TITLE
fix(macro): fix shift + mousewheel on mac by using spinX values when …

### DIFF
--- a/Sources/Testing/testMacro.js
+++ b/Sources/Testing/testMacro.js
@@ -650,11 +650,51 @@ test('Macro methods keystore tests', (t) => {
   t.end();
 });
 
+test('Macro methods normalizeWheel tests', (t) => {
+  const wheelEvent = { wheelDeltaX: 120 };
+
+  let normalizeWheelReturn = macro.normalizeWheel(wheelEvent);
+  t.equal(
+    normalizeWheelReturn.spinY,
+    -1,
+    'spinY should be set when only wheelDeltaX is defined'
+  );
+  t.equal(
+    normalizeWheelReturn.spinY,
+    normalizeWheelReturn.spinX,
+    'spinY should equal spinX when only wheelDeltaX is defined'
+  );
+  t.equal(
+    normalizeWheelReturn.pixelY,
+    -10,
+    'pixelY should be set when only wheelDeltaX is defined'
+  );
+  t.equal(
+    normalizeWheelReturn.pixelY,
+    normalizeWheelReturn.pixelX,
+    'pixelY should equal pixelX when only wheelDeltaX is defined'
+  );
+
+  wheelEvent.wheelDeltaY = 240;
+  normalizeWheelReturn = macro.normalizeWheel(wheelEvent);
+  t.equal(
+    normalizeWheelReturn.spinY,
+    -2,
+    'spinY should be set using wheelDeltaY when defined'
+  );
+  t.equal(
+    normalizeWheelReturn.pixelY,
+    -20,
+    'pixelY should be set using wheelDeltaY when defined'
+  );
+
+  t.end();
+});
+
 test('Macro debounce can be cancelled', (t) => {
   const func = () => {
     t.fail('Should not call cancelled debounce function');
   };
-
   const debFunc = macro.debounce(func, 5);
   debFunc();
   debFunc.cancel();

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -1746,9 +1746,9 @@ export function normalizeWheel(wheelEvent) {
 
   return {
     spinX: sX,
-    spinY: sY,
+    spinY: sY || sX,
     pixelX: pX,
-    pixelY: pY,
+    pixelY: pY || pX,
   };
 }
 


### PR DESCRIPTION
…spinY is 0

Shift + mousewheel on mac is used for "horizontal scrolling". Per comment in #2834, set spinY and pixelY in normalizeWheel to spinX/pixelX when y values are 0

re #2834

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Fix #2834 . Shift + mousewheel on mac doesn't work.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Shift + mousewheel on mac now works because spinX and pixelX are set to the spinY and pixelY values when spinX/pixelX are 0 or undefined. Before change Shift + mousewheel on mac does not scroll. After fix, scrolling works correctly.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

1. Updated macros.js `normalizeWheel` function per this [comment](https://github.com/Kitware/vtk-js/issues/2834#issuecomment-1584661716) in #2834.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [X] Tested environment:
  - **vtk.js**: master (28.10.0)<!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: macOS 14 Sonoma<!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: Chrome 120.0.6099.109<!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
