### PR TITLE
fix(vtkFollower): fix vtkFollower set vpn param bug when  camera.getParallelProjection() is true

### DIFF
--- a/Sources/Rendering/Core/Follower/index.js
+++ b/Sources/Rendering/Core/Follower/index.js
@@ -45,7 +45,7 @@ function vtkFollower(publicAPI, model) {
         // compute a vpn
         const vpn = new Float64Array(3);
         if (model.camera.getParallelProjection()) {
-          vec3.set(vpn, model.camera.getViewPlaneNormal());
+          vec3.set(vpn, ...model.camera.getViewPlaneNormal());
         } else {
           vec3.set(vpn, ...model.position);
           vec3.subtract(vpn, model.camera.getPosition(), vpn);


### PR DESCRIPTION
### Context
When parallelProjection is true, vtkFollower cannot correct show actor, actor will disappear.
[Reproduce demo.](https://stackblitz.com/edit/dyqwbp-jtgvof?file=src%2Fcellpicker-volume-surface.vue)

### Results

The code mistakes `vec3.set` param, so change the array param to spread operation one.
[glMatrix vec3.set](https://glmatrix.net/docs/module-vec3.html) 



### Changes
- Rectify execution function  param for vec3.set in vtkFollower.
 

### Testing
[ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
[&#10004;] Tested environment:
  - **vtk.js**: <!-- ex: 29.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10 -->
  - **Browser**: <!-- ex: Chrome 120.0.4389.128 -->
