### PR TITLE
docs(vtkpicker): update doc and typing

### DIFF
--- a/Sources/Rendering/Core/Picker/index.d.ts
+++ b/Sources/Rendering/Core/Picker/index.d.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from "../../../types";
+import { Vector3, Nullable } from "../../../types";
 import vtkAbstractPicker, { IAbstractPickerInitialValues } from "../AbstractPicker";
 import vtkActor from "../Actor";
 import vtkMapper from '../Mapper';
@@ -21,29 +21,24 @@ export interface vtkPicker extends vtkAbstractPicker {
 	getActors(): vtkActor[];
 
 	/**
-	 * Get a pointer to the dataset that was picked (if any).
+	 * Get the dataset that was picked (if any).
 	 */
 	getDataSet(): any;
 
 	/**
 	 * Get mapper that was picked (if any)
 	 */
-	getMapper(): null | vtkMapper;
+	getMapper(): Nullable<vtkMapper>;
 
 	/**
 	 * Get position in mapper (i.e., non-transformed) coordinates of pick point.
 	 */
-	getMapperPosition(): number[];
+	getMapperPosition(): Vector3;
 
 	/**
-	 * 
+	 * Get a list of the points the actors returned by getActors were intersected at.
 	 */
-	getMapperPositionByReference(): number[];
-
-	/**
-	 * Get a list of the points the actors returned by GetProp3Ds were intersected at.
-	 */
-	getPickedPositions(): number[];
+	getPickedPositions(): Vector3[];
 
 	/**
 	 * Get tolerance for performing pick operation.
@@ -51,9 +46,9 @@ export interface vtkPicker extends vtkAbstractPicker {
 	getTolerance(): number;
 
 	/**
-	 * FIXME: this needs to be check again
+	 * Invoke a pick change event.
 	 */
-	//invokePickChange(pickedPositions: number[]): any;
+	invokePickChange(pickedPositions: number[]): unknown;
 
 	/**
 	 * FIXME: this needs to be check again
@@ -72,10 +67,10 @@ export interface vtkPicker extends vtkAbstractPicker {
 
 	/**
 	 * Perform pick operation with selection point provided.
-	 * @param selection 
-	 * @param {vtkRenderer} renderer The vtkRenderer instance.
+	 * @param {Vector3} selection First two values should be x-y pixel coordinate, the third is usually zero.
+	 * @param {vtkRenderer} renderer The renderer on which you want to do picking.
 	 */
-	pick(selection: any, renderer: vtkRenderer): any;
+	pick(selection: Vector3, renderer: vtkRenderer): void;
 
 	/**
 	 * Set position in mapper coordinates of pick point.
@@ -86,13 +81,9 @@ export interface vtkPicker extends vtkAbstractPicker {
 	setMapperPosition(x: number, y: number, z: number): boolean;
 
 	/**
-	 * Set position in mapper coordinates of pick point.
-	 * @param {Vector3} mapperPosition The mapper coordinates of pick point.
-	 */
-	setMapperPositionFrom(mapperPosition: Vector3): boolean;
-
-	/**
-	 * Specify tolerance for performing pick operation.
+	 * Specify tolerance for performing pick operation. Tolerance is specified
+	 * as fraction of rendering window size. (Rendering window size is measured
+	 * across diagonal.)
 	 * @param {Number} tolerance The tolerance value.
 	 */
 	setTolerance(tolerance: number): boolean;
@@ -127,6 +118,11 @@ export function newInstance(initialValues?: IPickerInitialValues): vtkPicker;
  * the prop itself, the data set, and the mapper. 
  * For vtkPicker the closest prop is the one whose center point (i.e., center of bounding box) projected on the view ray is closest
  * to the camera. Subclasses of vtkPicker use other methods for computing the pick point.
+ * 
+ * vtkPicker is used for quick geometric picking. If you desire more precise
+ * picking of points or cells based on the geometry of any vtkProp3D, use the
+ * subclasses vtkPointPicker or vtkCellPicker.  For hardware-accelerated
+ * picking of any type of vtkProp, use vtkPropPicker or vtkWorldPointPicker.
  */
 export declare const vtkPicker: {
 	newInstance: typeof newInstance,


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
