### PR TITLE
docs(vtkpicker): fix and improve typing

### DIFF
--- a/Sources/Rendering/Core/Picker/index.d.ts
+++ b/Sources/Rendering/Core/Picker/index.d.ts
@@ -3,6 +3,7 @@ import vtkAbstractPicker, { IAbstractPickerInitialValues } from "../AbstractPick
 import vtkActor from "../Actor";
 import vtkMapper from '../Mapper';
 import vtkRenderer from '../Renderer';
+import { vtkSubscription } from "../../../interfaces";
 
 
 export interface IPickerInitialValues extends IAbstractPickerInitialValues {
@@ -12,6 +13,8 @@ export interface IPickerInitialValues extends IAbstractPickerInitialValues {
 	pickedPositions?: Array<any>;
 	globalTMin?: number;
 }
+
+type OnPickChangeCallback = (pickedPositions: Vector3[]) => void
 
 export interface vtkPicker extends vtkAbstractPicker {
 
@@ -36,6 +39,11 @@ export interface vtkPicker extends vtkAbstractPicker {
 	getMapperPosition(): Vector3;
 
 	/**
+	 * Get position in mapper (i.e., non-transformed) coordinates of pick point.
+	 */
+	getMapperPositionByReference(): Vector3;
+
+	/**
 	 * Get a list of the points the actors returned by getActors were intersected at.
 	 */
 	getPickedPositions(): Vector3[];
@@ -46,14 +54,18 @@ export interface vtkPicker extends vtkAbstractPicker {
 	getTolerance(): number;
 
 	/**
-	 * Invoke a pick change event.
+	 * Invoke a pick change event with the list of picked points.
+	 * This function is called internally by VTK.js and is not intended for public use.
+	 * @param {Vector3[]} pickedPositions
 	 */
-	invokePickChange(pickedPositions: number[]): unknown;
+	invokePickChange(pickedPositions: Vector3[]): void;
 
 	/**
-	 * FIXME: this needs to be check again
+	 * Execute the given callback when the pickChange event is fired.
+	 * The callback receives an array of picked point positions.
+	 * @param {OnPickChangeCallback}
 	 */
-	//onPickChange(pickedPositions: number[]): any;
+	onPickChange(callback: OnPickChangeCallback): vtkSubscription;
 
 	/**
 	 * Intersect data with specified ray.
@@ -79,6 +91,12 @@ export interface vtkPicker extends vtkAbstractPicker {
 	 * @param {Number} z The z coordinate.
 	 */
 	setMapperPosition(x: number, y: number, z: number): boolean;
+
+	/**
+	 * Set position in mapper coordinates of pick point.
+	 * @param {Vector3} mapperPosition The mapper coordinates of pick point.
+	 */
+	setMapperPositionFrom(mapperPosition: Vector3): boolean;
 
 	/**
 	 * Specify tolerance for performing pick operation. Tolerance is specified


### PR DESCRIPTION
Bring back methods from vtkPicker that were wrongly removed in 1411330c8d3e8abde8fb8c93311407dd Also removes FIXME for invokePickChange and onPickChange after checking and updating their actual signature.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
