### PR TITLE
fix(contourtriangulator): fix vtkContourTriangulator when points are …

### DIFF
--- a/Sources/Filters/General/ContourTriangulator/helper.js
+++ b/Sources/Filters/General/ContourTriangulator/helper.js
@@ -523,8 +523,8 @@ export function vtkCCSMakePolysFromLines(
             let ptsEnd = npts - 1;
             if (endIdx === 1) {
               pit = npts - 1 - (completePoly ? 1 : 0);
-              ptsIt = pts + 1;
-              ptsEnd = pts + npts - (completePoly ? 1 : 0);
+              ptsIt = 1;
+              ptsEnd = npts - (completePoly ? 1 : 0);
             }
             while (ptsIt !== ptsEnd) {
               poly[--pit] = poly[ptsIt++];


### PR DESCRIPTION
…ordered in odd way

An integer number was additioned to an array.

fix #2990

### Context
Read #2990 

### Results
No more hanging when running vtkContourTriangulator.
It was running for infinity in a while loop of `vtkCCSMakePolysFromLines` due to variables being NaN.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
