### PR TITLE
Several fixes for WebGPU

### DIFF
--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -97,7 +97,8 @@ function vtkRenderWindow(publicAPI, model) {
   publicAPI.getStatistics = () => {
     const results = { propCount: 0, invisiblePropCount: 0, gpuMemoryMB: 0 };
     model._views.forEach((v) => {
-      results.gpuMemoryMB += v.getGraphicsMemoryInfo() / 1e6;
+      if (v.getGraphicsMemoryInfo)
+        results.gpuMemoryMB += v.getGraphicsMemoryInfo() / 1e6;
     });
     model.renderers.forEach((ren) => {
       const props = ren.getViewProps();
@@ -109,7 +110,10 @@ function vtkRenderWindow(publicAPI, model) {
           if (mpr && mpr.getPrimitiveCount) {
             const gmpr = gren.getViewNodeFor(mpr);
             if (gmpr) {
-              results.gpuMemoryMB += gmpr.getAllocatedGPUMemoryInBytes() / 1e6;
+              if (gmpr.getAllocatedGPUMemoryInBytes) {
+                results.gpuMemoryMB +=
+                  gmpr.getAllocatedGPUMemoryInBytes() / 1e6;
+              }
               const pcount = mpr.getPrimitiveCount();
               Object.keys(pcount).forEach((keyName) => {
                 if (!results[keyName]) {

--- a/Sources/Rendering/WebGPU/ForwardPass/index.js
+++ b/Sources/Rendering/WebGPU/ForwardPass/index.js
@@ -25,7 +25,7 @@ fn main(
 {
   var output: fragmentOutput;
 
-  var computedColor: vec4<f32> = clamp(textureSampleLevel(opaquePassColorTexture, finalPassSampler, input.tcoordVS, 0),vec4<f32>(0.0),vec4<f32>(1.0));
+  var computedColor: vec4<f32> = clamp(textureSampleLevel(opaquePassColorTexture, finalPassSampler, input.tcoordVS, 0.0),vec4<f32>(0.0),vec4<f32>(1.0));
 
   //VTK::RenderEncoder::Impl
   return output;

--- a/Sources/Rendering/WebGPU/Renderer/index.js
+++ b/Sources/Rendering/WebGPU/Renderer/index.js
@@ -73,7 +73,7 @@ fn main(
   var tcoord: vec4<f32> = vec4<f32>(input.vertexVC.xy, -1, 1);
   var V: vec4<f32> = normalize(mapperUBO.FSQMatrix * tcoord); // vec2<f32>((input.tcoordVS.x - 0.5) * 2, -(input.tcoordVS.y - 0.5) * 2);
   // textureSampleLevel gets rid of some ugly artifacts
-  var background = textureSampleLevel(EnvironmentTexture, EnvironmentTextureSampler, vecToRectCoord(V.xyz), 0);
+  var background = textureSampleLevel(EnvironmentTexture, EnvironmentTextureSampler, vecToRectCoord(V.xyz), 0.0);
   var computedColor: vec4<f32> = vec4<f32>(background.rgb, 1);
 
   //VTK::RenderEncoder::Impl


### PR DESCRIPTION
### Context

WebGPU rendering pipeline was not behaving correctly:
-  With firefox nightly (and chrome canary), several WGSL shaders  were not compiling due to type errors.
-  RenderWindow.getStatistics() was calling undefined functions when manipulation WebGPU specialized classes like vtkWebGPURenderWindow or vtkWebGPUPolyDataMapper #2942.

### Results

Now the PBR example run when choosing the webGPU Api.  

### Changes

- Fix various type errors inside WGSL shaders (most of the time, missing floating point for floats)
- Added guards inside RenderWindow.getStatistics() to prevent the call of undefined methods for webGPU specifics objects 


### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] Tested environment:
  - **vtk.js**: 29.4.1
  - **OS**: Linux
  - **Browser**: Firefox nightly 123.0a1
