### PR TITLE
Drop tape catch

### DIFF
--- a/Documentation/content/docs/develop_test.md
+++ b/Documentation/content/docs/develop_test.md
@@ -5,6 +5,8 @@ This guide illustrates how to add tests to the vtk.js repository and how to run 
 
 First each VTK class can have several tests spread among several files but we also have infrastructure for global tests which live inside __Sources/Testing/test*.js__.
 
+vtk.js uses [tape](https://github.com/ljharb/tape) for running tests. Please refer to tape's documentation for more information about the test harness API.
+
 ## Class tests
 
 In order to add test to vtk.js you will need to create a __test__ directory underneath your class directory.
@@ -16,7 +18,7 @@ That __test__ directory should contain as many test file as you like with their 
 Some vtkClass'es don't necessarily involve rendering and can be tested without a WebGL environment. In which case a plain JavaScript test could be written as follows and an additional test() function could be added within the same file:
 
 ```js ClassName/test/testExample.js
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkMyClass from '..';
 
@@ -41,7 +43,7 @@ test('Validate vtkMyClass properties', (t) => {
 ## Testing rendering with image comparison
 
 ```js ClassName/test/testRendering.js
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkOpenGLRenderWindow from '../../../../Rendering/OpenGL/RenderWindow';
 import vtkRenderWindow from '../../../../Rendering/Core/RenderWindow';

--- a/Sources/Common/Core/CellArray/test/testCellArray.js
+++ b/Sources/Common/Core/CellArray/test/testCellArray.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkCellArray from 'vtk.js/Sources/Common/Core/CellArray';
 import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';

--- a/Sources/Common/Core/LookupTable/test/testCategoricalColors.js
+++ b/Sources/Common/Core/LookupTable/test/testCategoricalColors.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Common/Core/LookupTable/test/testScalarBar.js
+++ b/Sources/Common/Core/LookupTable/test/testScalarBar.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Common/Core/LookupTable/test/testSetTable.js
+++ b/Sources/Common/Core/LookupTable/test/testSetTable.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Common/Core/Math/test/testMath.js
+++ b/Sources/Common/Core/Math/test/testMath.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
 test('Test angleBetweenVector', (t) => {

--- a/Sources/Common/Core/MatrixBuilder/test/testMatrixBuilder.js
+++ b/Sources/Common/Core/MatrixBuilder/test/testMatrixBuilder.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
 import vtkMatrixBuilder from 'vtk.js/Sources/Common/Core/MatrixBuilder';

--- a/Sources/Common/Core/Points/test/testPoints.js
+++ b/Sources/Common/Core/Points/test/testPoints.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 
 test('Test vtkPoints instance', (t) => {

--- a/Sources/Common/DataModel/AbstractPointLocator/test/testLocator.js
+++ b/Sources/Common/DataModel/AbstractPointLocator/test/testLocator.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkAbstractPointLocator from 'vtk.js/Sources/Common/DataModel/AbstractPointLocator';
 
 test('Test vtkAbstractPointLocator instance', (t) => {

--- a/Sources/Common/DataModel/BoundingBox/test/testBoundingBox.js
+++ b/Sources/Common/DataModel/BoundingBox/test/testBoundingBox.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 

--- a/Sources/Common/DataModel/Box/test/testBox.js
+++ b/Sources/Common/DataModel/Box/test/testBox.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkBox from 'vtk.js/Sources/Common/DataModel/Box';
 
 test('Test vtkBox instance', (t) => {

--- a/Sources/Common/DataModel/Cell/test/testCell.js
+++ b/Sources/Common/DataModel/Cell/test/testCell.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 import vtkCell from 'vtk.js/Sources/Common/DataModel/Cell';
 

--- a/Sources/Common/DataModel/Collection/test/testCollection.js
+++ b/Sources/Common/DataModel/Collection/test/testCollection.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import vtkCollection from 'vtk.js/Sources/Common/DataModel/Collection';
 

--- a/Sources/Common/DataModel/Cone/test/testConeImplicitFunction.js
+++ b/Sources/Common/DataModel/Cone/test/testConeImplicitFunction.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Common/DataModel/DataSetAttributes/test/testDataSetAttributes.js
+++ b/Sources/Common/DataModel/DataSetAttributes/test/testDataSetAttributes.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkDataSetAttributes from 'vtk.js/Sources/Common/DataModel/DataSetAttributes';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';

--- a/Sources/Common/DataModel/EdgeLocator/test/testEdgeLocator.js
+++ b/Sources/Common/DataModel/EdgeLocator/test/testEdgeLocator.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkEdgeLocator from 'vtk.js/Sources/Common/DataModel/EdgeLocator';
 

--- a/Sources/Common/DataModel/ImageData/test/testImageData.js
+++ b/Sources/Common/DataModel/ImageData/test/testImageData.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
 import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
 

--- a/Sources/Common/DataModel/IncrementalOctreeNode/test/testIncrementalOctreeNode.js
+++ b/Sources/Common/DataModel/IncrementalOctreeNode/test/testIncrementalOctreeNode.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkIncrementalOctreeNode from 'vtk.js/Sources/Common/DataModel/IncrementalOctreeNode';
 
 test('Test vtkIncrementalOctreeNode instance', (t) => {

--- a/Sources/Common/DataModel/IncrementalOctreePointLocator/test/testIncrementalOctreePointLocator.js
+++ b/Sources/Common/DataModel/IncrementalOctreePointLocator/test/testIncrementalOctreePointLocator.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkIncrementalOctreePointLocator from 'vtk.js/Sources/Common/DataModel/IncrementalOctreePointLocator';
 
 test('Test vtkIncrementalOctreePointLocator instance', (t) => {

--- a/Sources/Common/DataModel/Line/test/testLine.js
+++ b/Sources/Common/DataModel/Line/test/testLine.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkLine from 'vtk.js/Sources/Common/DataModel/Line';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 

--- a/Sources/Common/DataModel/Locator/test/testLocator.js
+++ b/Sources/Common/DataModel/Locator/test/testLocator.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkLocator from 'vtk.js/Sources/Common/DataModel/Locator';
 
 test('Test vtkLocator instance', (t) => {

--- a/Sources/Common/DataModel/Plane/test/testPlane.js
+++ b/Sources/Common/DataModel/Plane/test/testPlane.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';
 
 test('Test vtkPlane instance', (t) => {

--- a/Sources/Common/DataModel/PolyData/test/testPolyData.js
+++ b/Sources/Common/DataModel/PolyData/test/testPolyData.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkLine from 'vtk.js/Sources/Common/DataModel/Line';
 import vtkTriangle from 'vtk.js/Sources/Common/DataModel/Triangle';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';

--- a/Sources/Common/DataModel/Quad/test/testQuad.js
+++ b/Sources/Common/DataModel/Quad/test/testQuad.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkQuad from 'vtk.js/Sources/Common/DataModel/Quad';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 import { QuadWithLineIntersectionState } from 'vtk.js/Sources/Common/DataModel/Quad/Constants';

--- a/Sources/Common/DataModel/Triangle/test/testTriangle.js
+++ b/Sources/Common/DataModel/Triangle/test/testTriangle.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 import vtkTriangle from 'vtk.js/Sources/Common/DataModel/Triangle';

--- a/Sources/Common/Transform/LandmarkTransform/test/testLandmarkTransform.js
+++ b/Sources/Common/Transform/LandmarkTransform/test/testLandmarkTransform.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import Constants from 'vtk.js/Sources/Common/Transform/LandmarkTransform/Constants';
 import LandmarkTransform from 'vtk.js/Sources/Common/Transform/LandmarkTransform';

--- a/Sources/Filters/Core/Cutter/test/testCutter.js
+++ b/Sources/Filters/Core/Cutter/test/testCutter.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
 import vtkCutter from 'vtk.js/Sources/Filters/Core/Cutter';

--- a/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
+++ b/Sources/Filters/Core/PolyDataNormals/test/testPolyDataNormals.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math';

--- a/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
+++ b/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkAppendPolyData from 'vtk.js/Sources/Filters/General/AppendPolyData';

--- a/Sources/Filters/General/Calculator/test/testCalculator.js
+++ b/Sources/Filters/General/Calculator/test/testCalculator.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';
 import vtkImageGridSource from 'vtk.js/Sources/Filters/Sources/ImageGridSource';

--- a/Sources/Filters/General/ClipClosedSurface/test/testClipClosedSurface.js
+++ b/Sources/Filters/General/ClipClosedSurface/test/testClipClosedSurface.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkClipClosedSurface from 'vtk.js/Sources/Filters/General/ClipClosedSurface';
 import vtkLineSource from 'vtk.js/Sources/Filters/Sources/LineSource';
 import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';

--- a/Sources/Filters/General/ClosedPolyLineToSurfaceFilter/test/testClosedPolyLineToSurfaceFilter.js
+++ b/Sources/Filters/General/ClosedPolyLineToSurfaceFilter/test/testClosedPolyLineToSurfaceFilter.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtk from 'vtk.js/Sources/vtk';
 import vtkClosedPolyLineToSurfaceFilter from 'vtk.js/Sources/Filters/General/ClosedPolyLineToSurfaceFilter';

--- a/Sources/Filters/General/ContourTriangulator/test/testContourTriangulator.js
+++ b/Sources/Filters/General/ContourTriangulator/test/testContourTriangulator.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkContourTriangulator from 'vtk.js/Sources/Filters/General/ContourTriangulator';
 import { reverseElements } from '../helper';
 

--- a/Sources/Filters/General/ImageDataOutlineFilter/test/testImageDataOutlineFilter.js
+++ b/Sources/Filters/General/ImageDataOutlineFilter/test/testImageDataOutlineFilter.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/General/ImageStreamline/test/testStreamline.js
+++ b/Sources/Filters/General/ImageStreamline/test/testStreamline.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import macro from 'vtk.js/Sources/macros';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';

--- a/Sources/Filters/General/MoleculeToRepresentation/test/testMultipleBonds.js
+++ b/Sources/Filters/General/MoleculeToRepresentation/test/testMultipleBonds.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Filters/General/OBBTree/test/testHelpers.js
+++ b/Sources/Filters/General/OBBTree/test/testHelpers.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import { CellType } from 'vtk.js/Sources/Common/DataModel/CellTypes/Constants';
 import { getCellTriangles } from 'vtk.js/Sources/Filters/General/OBBTree/helper';

--- a/Sources/Filters/General/OBBTree/test/testOBBTree.js
+++ b/Sources/Filters/General/OBBTree/test/testOBBTree.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math';

--- a/Sources/Filters/General/PaintFilter/test/testPaintEllipse.js
+++ b/Sources/Filters/General/PaintFilter/test/testPaintEllipse.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/General/TubeFilter/test/testTubeColors.js
+++ b/Sources/Filters/General/TubeFilter/test/testTubeColors.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';

--- a/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
+++ b/Sources/Filters/General/TubeFilter/test/testTubeFilter.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtk from 'vtk.js/Sources/vtk';

--- a/Sources/Filters/General/WarpScalar/test/testWarp.js
+++ b/Sources/Filters/General/WarpScalar/test/testWarp.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkWarpScalar from 'vtk.js/Sources/Filters/General/WarpScalar';
 import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';

--- a/Sources/Filters/Sources/ConcentricCylinderSource/test/testConcentricCylinder.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/test/testConcentricCylinder.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/Sources/ConeSource/test/testCone.js
+++ b/Sources/Filters/Sources/ConeSource/test/testCone.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/Sources/CubeSource/test/testCube.js
+++ b/Sources/Filters/Sources/CubeSource/test/testCube.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Filters/Sources/CylinderSource/test/testCylinder.js
+++ b/Sources/Filters/Sources/CylinderSource/test/testCylinder.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/Sources/LineSource/test/testLine.js
+++ b/Sources/Filters/Sources/LineSource/test/testLine.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/Sources/PlaneSource/test/testPlane.js
+++ b/Sources/Filters/Sources/PlaneSource/test/testPlane.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/Sources/PointSource/test/testPointSource.js
+++ b/Sources/Filters/Sources/PointSource/test/testPointSource.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Filters/Texture/TextureMapToPlane/test/testTextureMapToPlane.js
+++ b/Sources/Filters/Texture/TextureMapToPlane/test/testTextureMapToPlane.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
 import vtkTextureMapToPlane from 'vtk.js/Sources/Filters/Texture/TextureMapToPlane';
 

--- a/Sources/Filters/Texture/TextureMapToSphere/test/testTextureMapToSphere.js
+++ b/Sources/Filters/Texture/TextureMapToSphere/test/testTextureMapToSphere.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkCubeSource from 'vtk.js/Sources/Filters/Sources/CubeSource';
 import vtkTextureMapToSphere from 'vtk.js/Sources/Filters/Texture/TextureMapToSphere';
 

--- a/Sources/IO/Core/DataAccessHelper/test/testHttpDataAccessHelperFetchArray.js
+++ b/Sources/IO/Core/DataAccessHelper/test/testHttpDataAccessHelperFetchArray.js
@@ -1,7 +1,7 @@
 import test from 'tape';
 import HttpDataAccessHelper from '../HttpDataAccessHelper';
 
-test('Test array.ref.url is used', (t) => {
+test('Test array.ref.url is used', async (t) => {
   const expectedUrl = 'https://test.io/load_dataset?param1=testing';
 
   const array = {
@@ -12,16 +12,25 @@ test('Test array.ref.url is used', (t) => {
 
   const oldXmlHttpRequest = window.XMLHttpRequest;
 
-  // Mock XmlHttpRequest
-  window.XMLHttpRequest = function MockedXmlHttpRequestConstructor() {
-    this.open = (method, url, async = true) => {
-      t.equals(url, expectedUrl, 'xhr.open gets the same URL as array.ref.url');
-      t.end();
+  await new Promise((resolve) => {
+    // Mock XmlHttpRequest
+    window.XMLHttpRequest = function MockedXmlHttpRequestConstructor() {
+      this.open = (method, url, async = true) => {
+        t.equals(
+          url,
+          expectedUrl,
+          'xhr.open gets the same URL as array.ref.url'
+        );
 
-      // Clear mock
-      window.XMLHttpRequest = oldXmlHttpRequest;
+        // Clear mock
+        window.XMLHttpRequest = oldXmlHttpRequest;
+
+        resolve();
+      };
     };
-  };
 
-  HttpDataAccessHelper.fetchArray({}, '', array);
+    HttpDataAccessHelper.fetchArray({}, '', array);
+  });
+
+  t.end();
 });

--- a/Sources/IO/Core/DataAccessHelper/test/testHttpDataAccessHelperFetchArray.js
+++ b/Sources/IO/Core/DataAccessHelper/test/testHttpDataAccessHelperFetchArray.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import HttpDataAccessHelper from '../HttpDataAccessHelper';
 
 test('Test array.ref.url is used', (t) => {

--- a/Sources/IO/Misc/OBJReader/test/testOBJReader.js
+++ b/Sources/IO/Misc/OBJReader/test/testOBJReader.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkCellArray from 'vtk.js/Sources/Common/Core/CellArray';
 import vtkOBJReader from 'vtk.js/Sources/IO/Misc/OBJReader';
 import vtkPolyDataNormals from 'vtk.js/Sources/Filters/Core/PolyDataNormals';

--- a/Sources/IO/Misc/PDBReader/test/testMolecule.js
+++ b/Sources/IO/Misc/PDBReader/test/testMolecule.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/IO/XML/XMLImageDataReader/test/testXMLImageDataReader.js
+++ b/Sources/IO/XML/XMLImageDataReader/test/testXMLImageDataReader.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkXMLImageDataReader from '../index';
 import vtkMath from '../../../../Common/Core/Math';
 

--- a/Sources/IO/XML/XMLImageDataWriter/test/testXMLImageDataWriter.js
+++ b/Sources/IO/XML/XMLImageDataWriter/test/testXMLImageDataWriter.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtkImageDataWriter from '../index';
 import vtkImageData from '../../../../Common/DataModel/ImageData';
 

--- a/Sources/Imaging/Core/ImageReslice/test/testImageReslice.js
+++ b/Sources/Imaging/Core/ImageReslice/test/testImageReslice.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import { mat4 } from 'gl-matrix';

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/test/testMouseRangeManipulator.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/test/testMouseRangeManipulator.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkMouseRangeManipulator from 'vtk.js/Sources/Interaction/Manipulators/MouseRangeManipulator';
 

--- a/Sources/Interaction/Style/InteractorStyleImage/test/testInteractorStyleImage.js
+++ b/Sources/Interaction/Style/InteractorStyleImage/test/testInteractorStyleImage.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Interaction/Style/InteractorStyleManipulator/test/testDollyToPosition.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/test/testDollyToPosition.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import { vec3 } from 'gl-matrix';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 

--- a/Sources/Proxy/Core/PiecewiseFunctionProxy/test/testPiecewiseFunctionProxy.js
+++ b/Sources/Proxy/Core/PiecewiseFunctionProxy/test/testPiecewiseFunctionProxy.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkPiecewiseFunctionProxy from 'vtk.js/Sources/Proxy/Core/PiecewiseFunctionProxy';
 import Constants from 'vtk.js/Sources/Proxy/Core/PiecewiseFunctionProxy/Constants';

--- a/Sources/Proxy/Core/View2DProxy/test/testView2DProxy.js
+++ b/Sources/Proxy/Core/View2DProxy/test/testView2DProxy.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 // Load the rendering pieces we want to use (for both WebGL and WebGPU)

--- a/Sources/Rendering/Core/AbstractImageMapper/test/testAbstractImageMapper.js
+++ b/Sources/Rendering/Core/AbstractImageMapper/test/testAbstractImageMapper.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkImageArrayMapper from 'vtk.js/Sources/Rendering/Core/ImageArrayMapper';
 

--- a/Sources/Rendering/Core/AbstractMapper/test/testAbstractMapper.js
+++ b/Sources/Rendering/Core/AbstractMapper/test/testAbstractMapper.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkPlane from 'vtk.js/Sources/Common/DataModel/Plane';

--- a/Sources/Rendering/Core/Actor/test/testRotate.js
+++ b/Sources/Rendering/Core/Actor/test/testRotate.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Rendering/Core/Actor2D/test/testActor2D.js
+++ b/Sources/Rendering/Core/Actor2D/test/testActor2D.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/Actor2D/test/testActor2DMultiViewports.js
+++ b/Sources/Rendering/Core/Actor2D/test/testActor2DMultiViewports.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
+++ b/Sources/Rendering/Core/CellPicker/test/testCellPicker.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunction.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionInterpolation.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionInterpolation.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionPresets.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/test/testColorTransferFunctionPresets.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
+++ b/Sources/Rendering/Core/Coordinate/test/testCoordinate.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';

--- a/Sources/Rendering/Core/Follower/test/testFollower.js
+++ b/Sources/Rendering/Core/Follower/test/testFollower.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkFollower from 'vtk.js/Sources/Rendering/Core/Follower';

--- a/Sources/Rendering/Core/Glyph3DMapper/test/testGlyph3DMapper.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/test/testGlyph3DMapper.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelector.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelector.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorGlyph.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorGlyph.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorPoints.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorPoints.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorSpeed.js
+++ b/Sources/Rendering/Core/HardwareSelector/test/testHardwareSelectorSpeed.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapper.js
+++ b/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapper.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCollection from 'vtk.js/Sources/Common/DataModel/Collection';

--- a/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapperColorTF.js
+++ b/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapperColorTF.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCollection from 'vtk.js/Sources/Common/DataModel/Collection';

--- a/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapperFunctions.js
+++ b/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapperFunctions.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCollection from 'vtk.js/Sources/Common/DataModel/Collection';

--- a/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapperNN.js
+++ b/Sources/Rendering/Core/ImageArrayMapper/test/testImageArrayMapperNN.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCollection from 'vtk.js/Sources/Common/DataModel/Collection';

--- a/Sources/Rendering/Core/ImageMapper/test/testImage.js
+++ b/Sources/Rendering/Core/ImageMapper/test/testImage.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkImageGridSource from 'vtk.js/Sources/Filters/Sources/ImageGridSource';

--- a/Sources/Rendering/Core/ImageMapper/test/testImageColorTransferFunction.js
+++ b/Sources/Rendering/Core/ImageMapper/test/testImageColorTransferFunction.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkImageGridSource from 'vtk.js/Sources/Filters/Sources/ImageGridSource';

--- a/Sources/Rendering/Core/ImageMapper/test/testImageLabelOutline.js
+++ b/Sources/Rendering/Core/ImageMapper/test/testImageLabelOutline.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 

--- a/Sources/Rendering/Core/ImageMapper/test/testImageNearestNeighbor.js
+++ b/Sources/Rendering/Core/ImageMapper/test/testImageNearestNeighbor.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkImageGridSource from 'vtk.js/Sources/Filters/Sources/ImageGridSource';

--- a/Sources/Rendering/Core/ImageMapper/test/testSlicingModePosition.js
+++ b/Sources/Rendering/Core/ImageMapper/test/testSlicingModePosition.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
 import { SlicingMode } from 'vtk.js/Sources/Rendering/Core/ImageMapper/Constants';

--- a/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapper.js
+++ b/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapper.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperPolyData.js
+++ b/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperPolyData.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperShareOpenGLTexture.js
+++ b/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperShareOpenGLTexture.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperSlabTypes.js
+++ b/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperSlabTypes.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/Mapper/test/testEdgeVisibility.js
+++ b/Sources/Rendering/Core/Mapper/test/testEdgeVisibility.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/Mapper/test/testInterpolateScalarsBeforeMapping.js
+++ b/Sources/Rendering/Core/Mapper/test/testInterpolateScalarsBeforeMapping.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/Mapper/test/testVectorComponent.js
+++ b/Sources/Rendering/Core/Mapper/test/testVectorComponent.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';

--- a/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
+++ b/Sources/Rendering/Core/PointPicker/test/testPointPicker.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/Prop3D/test/testUserMatrix.js
+++ b/Sources/Rendering/Core/Prop3D/test/testUserMatrix.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Rendering/Core/RenderWindow/test/testMultipleRenderers.js
+++ b/Sources/Rendering/Core/RenderWindow/test/testMultipleRenderers.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Rendering/Core/ScalarBarActor/test/testScalarBar.js
+++ b/Sources/Rendering/Core/ScalarBarActor/test/testScalarBar.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ScalarBarActor/test/testScalarBarNoExtras.js
+++ b/Sources/Rendering/Core/ScalarBarActor/test/testScalarBarNoExtras.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/ScalarBarActor/test/testScalarBarSetGenerateTicks.js
+++ b/Sources/Rendering/Core/ScalarBarActor/test/testScalarBarSetGenerateTicks.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/SphereMapper/test/testDisableScalarColoring.js
+++ b/Sources/Rendering/Core/SphereMapper/test/testDisableScalarColoring.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCalculator from 'vtk.js/Sources/Filters/General/Calculator';

--- a/Sources/Rendering/Core/SphereMapper/test/testSphere.js
+++ b/Sources/Rendering/Core/SphereMapper/test/testSphere.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Rendering/Core/StickMapper/test/testStick.js
+++ b/Sources/Rendering/Core/StickMapper/test/testStick.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Rendering/Core/VolumeMapper/test/testAverageIntensityProjection.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testAverageIntensityProjection.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';

--- a/Sources/Rendering/Core/VolumeMapper/test/testComposite.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testComposite.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/VolumeMapper/test/testComposite16Bit.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testComposite16Bit.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/VolumeMapper/test/testCompositeParallelProjection.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testCompositeParallelProjection.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/VolumeMapper/test/testIntermixed.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testIntermixed.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/VolumeMapper/test/testIntermixedImage.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testIntermixedImage.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/VolumeMapper/test/testMaximumIntensityProjection.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testMaximumIntensityProjection.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Core/VolumeMapper/test/testMinimumIntensityProjection.js
+++ b/Sources/Rendering/Core/VolumeMapper/test/testMinimumIntensityProjection.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/Misc/GenericRenderWindow/test/testGenericRenderWindowCreateDelete.js
+++ b/Sources/Rendering/Misc/GenericRenderWindow/test/testGenericRenderWindowCreateDelete.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Rendering/OpenGL/ImageMapper/test/testImageCroppingPlanes.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/test/testImageCroppingPlanes.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkImageGridSource from 'vtk.js/Sources/Filters/Sources/ImageGridSource';

--- a/Sources/Rendering/OpenGL/ImageMapper/test/testImageIntermediateZSlice.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/test/testImageIntermediateZSlice.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkImageGridSource from 'vtk.js/Sources/Filters/Sources/ImageGridSource';

--- a/Sources/Rendering/OpenGL/ImageMapper/test/testImageWindowLevel.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/test/testImageWindowLevel.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';

--- a/Sources/Rendering/OpenGL/PolyDataMapper/test/testAddShaderReplacements.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/test/testAddShaderReplacements.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';

--- a/Sources/Rendering/OpenGL/PolyDataMapper/test/testClearShaderReplacements.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/test/testClearShaderReplacements.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';

--- a/Sources/Rendering/OpenGL/PolyDataMapper/test/testClippingPlanes.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/test/testClippingPlanes.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';

--- a/Sources/Rendering/OpenGL/PolyDataMapper/test/testMoreClippingPlanes.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/test/testMoreClippingPlanes.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';

--- a/Sources/Rendering/OpenGL/ShaderProgram/test/testSubstitute.js
+++ b/Sources/Rendering/OpenGL/ShaderProgram/test/testSubstitute.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import { substitute } from '../index';
 

--- a/Sources/Rendering/OpenGL/Skybox/test/testSkybox.js
+++ b/Sources/Rendering/OpenGL/Skybox/test/testSkybox.js
@@ -5,7 +5,7 @@ import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import baseline from './testSkybox.png';

--- a/Sources/Rendering/OpenGL/Skybox/test/testSkyboxBackground.js
+++ b/Sources/Rendering/OpenGL/Skybox/test/testSkyboxBackground.js
@@ -5,7 +5,7 @@ import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import baseline from './testSkyboxBackground.png';

--- a/Sources/Rendering/OpenGL/Texture/test/testCreateCubeFromRawTexture.js
+++ b/Sources/Rendering/OpenGL/Texture/test/testCreateCubeFromRawTexture.js
@@ -7,7 +7,7 @@ import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
 import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
 
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import baseline from './testCreateCubeFromRawTexture.png';

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testLabelmapOutlineManyRenderer.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testLabelmapOutlineManyRenderer.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 // Load the rendering pieces we want to use (for both WebGL and WebGPU)

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testLighting.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testLighting.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testProportionalComponents.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testProportionalComponents.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkColorTransferFunction from 'vtk.js/Sources/Rendering/Core/ColorTransferFunction';

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testVolumeMapperBounds.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testVolumeMapperBounds.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testVolumeMapperClip.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testVolumeMapperClip.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Rendering/OpenGL/VolumeMapper/test/testVolumeMapperShadowClip.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/test/testVolumeMapperShadowClip.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';

--- a/Sources/Testing/setupTestEnv.js
+++ b/Sources/Testing/setupTestEnv.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 // Load default classes for tests
 import '../IO/Core/DataAccessHelper/HtmlDataAccessHelper';

--- a/Sources/Testing/testAlgorithm.js
+++ b/Sources/Testing/testAlgorithm.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import macro from 'vtk.js/Sources/macros';
 
 const model = {};

--- a/Sources/Testing/testIf.js
+++ b/Sources/Testing/testIf.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 test.onlyIfWebGL('onlyIfWebGL', (t) => {
   t.ok(1, 'onlyIfWebGL enabled');

--- a/Sources/Testing/testMacro.js
+++ b/Sources/Testing/testMacro.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import macro from 'vtk.js/Sources/macros';
 
 const MY_ENUM = {
@@ -140,7 +140,7 @@ test('Macro methods array tests', (t) => {
     DEFAULT_VALUES.myProp1,
     'Initial gets should match defaults'
   );
-  // we must wrap the non-existent call inside another function to avoid test program exiting, and tape-catch generating error.
+  // we must wrap the non-existent call inside another function to avoid test program exiting, and tape generating error.
   t.throws(
     () => myTestClass.setMyProp1(1, 1, 1),
     /TypeError/,

--- a/Sources/Testing/testProxy.js
+++ b/Sources/Testing/testProxy.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import macro from 'vtk.js/Sources/macros';
 import vtkProxyManager from 'vtk.js/Sources/Proxy/Core/ProxyManager';
 

--- a/Sources/Testing/testSerialization.js
+++ b/Sources/Testing/testSerialization.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import vtk from 'vtk.js/Sources/vtk';
 import macro from 'vtk.js/Sources/macros';
 

--- a/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
+++ b/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkGenericRenderWindow from 'vtk.js/Sources/Rendering/Misc/GenericRenderWindow';

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testBoundPlane.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testBoundPlane.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
 import { boundPlane } from 'vtk.js/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers';

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testHelper.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testHelper.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import {
   getOtherLineName,

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testMultipleRotationPlanes.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testMultipleRotationPlanes.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 
 import vtkHttpDataSetReader from 'vtk.js/Sources/IO/Core/HttpDataSetReader';

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testRotateVector.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/test/testRotateVector.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 
 import { radiansFromDegrees, areEquals } from 'vtk.js/Sources/Common/Core/Math';
 

--- a/Sources/Widgets/Widgets3D/SplineWidget/test/testSplineWidget.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/test/testSplineWidget.js
@@ -1,4 +1,4 @@
-import test from 'tape-catch';
+import test from 'tape';
 import testUtils from 'vtk.js/Sources/Testing/testUtils';
 import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
 import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
         "string-replace-loader": "3.1.0",
         "style-loader": "3.3.1",
         "tape": "5.5.3",
-        "tape-catch": "1.0.6",
         "webpack": "5.76.0",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-cli": "4.9.2",
@@ -6855,12 +6854,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
-    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -9097,16 +9090,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      }
-    },
     "node_modules/global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -9147,15 +9130,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global/node_modules/process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/globals": {
@@ -11950,15 +11924,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "dependencies": {
-        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/min-indent": {
@@ -18636,18 +18601,6 @@
       },
       "bin": {
         "tape": "bin/tape"
-      }
-    },
-    "node_modules/tape-catch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tape-catch/-/tape-catch-1.0.6.tgz",
-      "integrity": "sha1-EpMdXqYKA6l9m9GdDX2M/D9s7PE=",
-      "dev": true,
-      "dependencies": {
-        "global": "~4.3.0"
-      },
-      "peerDependencies": {
-        "tape": "*"
       }
     },
     "node_modules/tape/node_modules/glob": {
@@ -25452,12 +25405,6 @@
         "entities": "^2.0.0"
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
-    },
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -27200,24 +27147,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-    },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-          "dev": true
-        }
-      }
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -29353,15 +29282,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
     },
     "min-indent": {
       "version": "1.0.1",
@@ -34285,15 +34205,6 @@
             "path-parse": "^1.0.6"
           }
         }
-      }
-    },
-    "tape-catch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tape-catch/-/tape-catch-1.0.6.tgz",
-      "integrity": "sha1-EpMdXqYKA6l9m9GdDX2M/D9s7PE=",
-      "dev": true,
-      "requires": {
-        "global": "~4.3.0"
       }
     },
     "tar": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "string-replace-loader": "3.1.0",
     "style-loader": "3.3.1",
     "tape": "5.5.3",
-    "tape-catch": "1.0.6",
     "webpack": "5.76.0",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.2",


### PR DESCRIPTION
### Context
Drops tape-catch in favor of just using tape.

Probably related to failing tests in https://github.com/Kitware/vtk-js/pull/2979.

This change means unhandled exceptions will terminate the test runner rather than resulting in a failed test. Since there are no tests that rely on unhandled exceptions to fail the test, this change doesn't affect anything.

In exchange, we get better handling of unhandled rejected promises. Tests can now be written with async/await and tape will fail a test if a test rejects with an error.

### Results
- tape-catch dropped in favor of tape
### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] updated docs

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: tip (at the time of writing)
  - **OS**: macOS
  - **Browser**: Chrome + Firefox

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
