### PR TITLE
fix(PaintWidget): blocked event w/o intersection

### DIFF
--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -32,42 +32,39 @@ export default function widgetBehavior(publicAPI, model) {
   publicAPI.handleEvent = (callData) => {
     const manipulator =
       model.activeState?.getManipulator?.() ?? model.manipulator;
-    if (manipulator && model.activeState && model.activeState.getActive()) {
-      const normal = model._camera.getDirectionOfProjection();
-      const up = model._camera.getViewUp();
-      const right = [];
-      vec3.cross(right, up, normal);
-      model.activeState.setUp(...up);
-      model.activeState.setRight(...right);
-      model.activeState.setDirection(...normal);
-
-      const { worldCoords } = manipulator.handleEvent(
-        callData,
-        model._apiSpecificRenderWindow
-      );
-
-      if (worldCoords.length) {
-        model.widgetState.setTrueOrigin(...worldCoords);
-        model.activeState.setOrigin(...worldCoords);
-
-        if (model.painting) {
-          const trailCircle = model.widgetState.addTrail();
-          trailCircle.set(
-            model.activeState.get(
-              'origin',
-              'up',
-              'right',
-              'direction',
-              'scale1'
-            )
-          );
-        }
-      }
-
-      publicAPI.invokeInteractionEvent();
-      return macro.EVENT_ABORT;
+    if (!(manipulator && model.activeState && model.activeState.getActive())) {
+      return macro.VOID;
     }
-    return macro.VOID;
+
+    const normal = model._camera.getDirectionOfProjection();
+    const up = model._camera.getViewUp();
+    const right = [];
+    vec3.cross(right, up, normal);
+    model.activeState.setUp(...up);
+    model.activeState.setRight(...right);
+    model.activeState.setDirection(...normal);
+
+    const { worldCoords } = manipulator.handleEvent(
+      callData,
+      model._apiSpecificRenderWindow
+    );
+
+    if (!worldCoords.length) {
+      return macro.VOID;
+    }
+
+    model.widgetState.setTrueOrigin(...worldCoords);
+    model.activeState.setOrigin(...worldCoords);
+
+    if (model.painting) {
+      const trailCircle = model.widgetState.addTrail();
+      trailCircle.set(
+        model.activeState.get('origin', 'up', 'right', 'direction', 'scale1')
+      );
+    }
+
+    publicAPI.invokeInteractionEvent();
+    return macro.EVENT_ABORT;
   };
 
   publicAPI.grabFocus = () => {


### PR DESCRIPTION

### Context
Events were being aborted even when the manipulator returns no world coordinates.

### Results
The paint widget does not abort events during non-intersecting actions.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment: not tested

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
