### PR TITLE
Ensure that API docs can be generated

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,3 +23,5 @@ jobs:
         run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
       - name: Tests must not use test.only
         run: bash .github/workflows/test-only-check.sh
+      - name: API docs should generate without error
+        run: npm run doc:generate-api

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.d.ts
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.d.ts
@@ -75,7 +75,7 @@ export interface vtkResliceCursorWidget extends vtkAbstractWidgetFactory {
    * Return an array of the first and the last possible points of the plane
    * along its normal.
    * @param {ViewTypes} viewType
-   * @returns {[Vector3, Vector3]} first and last points
+   * @returns {Array<Vector3>} two Vector3 arrays (first and last points)
    */
   getPlaneExtremities(viewType: ViewTypes): Array<Vector3>;
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our CONTRIBUTING.md guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The release is being blocked by API doc generation. This should be caught during PR checks, and not during release.

### Results
API doc generation does not block a release.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] github actions updated

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
This will be considered tested once release is unblocked.

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
