### PR TITLE
Fix Paint Widget Rotation Interaction

### DIFF
--- a/Sources/Widgets/Manipulators/PickerManipulator/index.js
+++ b/Sources/Widgets/Manipulators/PickerManipulator/index.js
@@ -14,11 +14,13 @@ function vtkPickerManipulator(publicAPI, model) {
     const { position, pokedRenderer } = callData;
 
     model.picker.pick([position.x, position.y, 0.0], pokedRenderer);
-    if (model.picker.getActors().length > 0) {
+    if (model.picker.getPickedPositions().length > 0) {
       model.position = model.picker.getPickedPositions()[0];
+    } else {
+      model.position = null;
     }
     return {
-      worldCoords: model.position || null,
+      worldCoords: model.position,
     };
   };
 }

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -8,6 +8,7 @@ export default function widgetBehavior(publicAPI, model) {
     const manipulator =
       model.activeState?.getManipulator?.() ?? model.manipulator;
     if (!(manipulator && model.activeState && model.activeState.getActive())) {
+      model.painting = false;
       return macro.VOID;
     }
 
@@ -45,6 +46,7 @@ export default function widgetBehavior(publicAPI, model) {
     const manipulator =
       model.activeState?.getManipulator?.() ?? model.manipulator;
     if (!(manipulator && model.activeState && model.activeState.getActive())) {
+      model.painting = false;
       return macro.VOID;
     }
 

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -4,8 +4,20 @@ import { vec3 } from 'gl-matrix';
 export default function widgetBehavior(publicAPI, model) {
   model.painting = model._factory.getPainting();
 
-  publicAPI.handleLeftButtonPress = () => {
-    if (!model.activeState || !model.activeState.getActive()) {
+  publicAPI.handleLeftButtonPress = (callData) => {
+    const manipulator =
+      model.activeState?.getManipulator?.() ?? model.manipulator;
+    if (!(manipulator && model.activeState && model.activeState.getActive())) {
+      return macro.VOID;
+    }
+
+    const { worldCoords } = manipulator.handleEvent(
+      callData,
+      model._apiSpecificRenderWindow
+    );
+
+    if (!worldCoords?.length) {
+      model.painting = false;
       return macro.VOID;
     }
 
@@ -26,7 +38,7 @@ export default function widgetBehavior(publicAPI, model) {
       model.widgetState.clearTrailList();
     }
     model.painting = false;
-    return model.hasFocus ? macro.EVENT_ABORT : macro.VOID;
+    return macro.VOID;
   };
 
   publicAPI.handleEvent = (callData) => {
@@ -61,6 +73,8 @@ export default function widgetBehavior(publicAPI, model) {
       trailCircle.set(
         model.activeState.get('origin', 'up', 'right', 'direction', 'scale1')
       );
+    } else {
+      return macro.VOID;
     }
 
     publicAPI.invokeInteractionEvent();

--- a/Sources/Widgets/Widgets3D/SeedWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SeedWidget/behavior.js
@@ -38,13 +38,13 @@ export default function widgetBehavior(publicAPI, model) {
     const worldCoords = currentWorldCoords(e);
 
     if (model.activeState === moveHandle) {
-      if (!moveHandle.getOrigin()) {
+      if (!moveHandle.getOrigin() && worldCoords) {
         moveHandle.setOrigin(worldCoords);
+        model.previousPosition = [...worldCoords];
       }
     }
     model._isDragging = true;
     model._apiSpecificRenderWindow.setCursor('grabbing');
-    model.previousPosition = [...currentWorldCoords(e)];
     publicAPI.invokeStartInteractionEvent();
     return macro.EVENT_ABORT;
   };
@@ -73,8 +73,10 @@ export default function widgetBehavior(publicAPI, model) {
     }
     if (!model.activeState) throw Error('no activestate');
     const worldCoords = currentWorldCoords(e);
-    model.activeState.setOrigin(worldCoords);
-    model.previousPosition = worldCoords;
+    if (worldCoords) {
+      model.activeState.setOrigin(worldCoords);
+      model.previousPosition = worldCoords;
+    }
     return macro.VOID;
   };
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
While using a PaintWidget on a 3D object with a PickerManipulator, the user cannot rotate the object while painting is active.

https://github.com/Kitware/vtk-js/assets/44912689/638e8c3f-1e30-4c25-9a83-9d99bb29722a

Behavior was tested using the following code (for both before and after videos):
[index.txt](https://github.com/Kitware/vtk-js/files/14085010/index.txt)
(This was converted from `.js` to `.txt` for GH upload)

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
A user can rotate an object while using an active PaintWidget. Drag motions that start with the mouse over the object result in a paint event. Drag motions that start with the mouse not over the object result in a default interaction event. 

https://github.com/Kitware/vtk-js/assets/44912689/3c724351-6eaf-4040-8c77-7b60bd379212


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] PickerManipulator: When no picked position is found, return null `worldCoordinates` instead of last valid value.
- [x] PaintWidget: If `worldCoordinates` are null on mouse down, don't paint and don't block events.
- [x] SeedWidget: protect against null `worldCoordinates`
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: 29.4.5
  - **OS**: Ubuntu 20.04.6 LTS
  - **Browser**: Chrome 120.0.6099.224 and Firefox 121.0.1

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
