### PR TITLE
fix(imageOutline): fix the bug where outline was not showing without filling

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -346,36 +346,40 @@ function vtkOpenGLImageMapper(publicAPI, model) {
                   float textureValue = texture2D(labelOutlineTexture1, vec2(textureCoordinate, 0.5)).r;
                   int actualThickness = int(textureValue * 255.0);
 
+                  if (segmentIndex == 0){
+                    gl_FragData[0] = vec4(0.0, 1.0, 1.0, 0.0);
+                    return;
+                  }
+
                   if (actualThickness == 0) {
                     gl_FragData[0] = vec4(0.0, 0.0, 1.0, 1.0);
                     return;
                   }
-                  if (opacityToUse > 0.01) {
-                    for (int i = -actualThickness; i <= actualThickness; i++) {
-                      for (int j = -actualThickness; j <= actualThickness; j++) {
-                        if (i == 0 || j == 0) {
-                          continue;
-                        }
-                        vec4 neighborPixelCoord = vec4(gl_FragCoord.x + float(i),
-                          gl_FragCoord.y + float(j),
-                          gl_FragCoord.z, gl_FragCoord.w);
-                        vec3 neighborPosIS = fragCoordToIndexSpace(neighborPixelCoord);
-                        float value = texture2D(texture1, neighborPosIS.xy).r;
-                        if (value != centerValue) {
-                          pixelOnBorder = true;
-                          break;
-                        }
+
+                  for (int i = -actualThickness; i <= actualThickness; i++) {
+                    for (int j = -actualThickness; j <= actualThickness; j++) {
+                      if (i == 0 || j == 0) {
+                        continue;
                       }
-                      if (pixelOnBorder == true) {
+                      vec4 neighborPixelCoord = vec4(gl_FragCoord.x + float(i),
+                        gl_FragCoord.y + float(j),
+                        gl_FragCoord.z, gl_FragCoord.w);
+                      vec3 neighborPosIS = fragCoordToIndexSpace(neighborPixelCoord);
+                      float value = texture2D(texture1, neighborPosIS.xy).r;
+                      if (value != centerValue) {
+                        pixelOnBorder = true;
                         break;
                       }
                     }
                     if (pixelOnBorder == true) {
-                      gl_FragData[0] = vec4(tColor, outlineOpacity);
+                      break;
                     }
-                    else {
-                      gl_FragData[0] = vec4(tColor, opacityToUse);
-                    }
+                  }
+                  if (pixelOnBorder == true) {
+                    gl_FragData[0] = vec4(tColor, outlineOpacity);
+                  }
+                  else {
+                    gl_FragData[0] = vec4(tColor, opacityToUse);
                   }
                 #else
                   float intensity = texture2D(texture1, tcoordVCVSOutput).r;


### PR DESCRIPTION


### Context
The labelmap outline in the volume/image mapper used the condition `tColor.a > 0.01` to improve performance by skipping the background. However, this meant that we couldn't render the outline when the fill is 0 (or a small number).You can see [the bug here in this code sand box](https://codesandbox.io/p/sandbox/volume-outline-bug-when-not-filled-sdgpxm?file=%2Fsrc%2Findex.js%3A100%2C1-101%2C1&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clpwuy96300063b6hk56qsdma%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clpwuy96300023b6hlfs7xpbr%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clpwuy96300033b6haoq2uh4f%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clpwuy96300053b6h1qgctgii%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B51.22612410674943%252C48.77387589325057%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clpwuy96300023b6hlfs7xpbr%2522%253A%257B%2522id%2522%253A%2522clpwuy96300023b6hlfs7xpbr%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cls0jfxd800023b6glt5i9yun%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A12%252C%2522startColumn%2522%253A25%252C%2522endLineNumber%2522%253A12%252C%2522endColumn%2522%253A31%257D%255D%252C%2522filepath%2522%253A%2522%252Fpackage.json%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clsaufu4u00023b6oqlmnxtd1%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A100%252C%2522startColumn%2522%253A1%252C%2522endLineNumber%2522%253A101%252C%2522endColumn%2522%253A1%257D%255D%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clsauhdhb00023b6or0mn1u5l%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A4%252C%2522startColumn%2522%253A1%252C%2522endLineNumber%2522%253A4%252C%2522endColumn%2522%253A1%257D%255D%252C%2522filepath%2522%253A%2522%252Fsandbox.config.json%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clsaufu4u00023b6oqlmnxtd1%2522%257D%252C%2522clpwuy96300053b6h1qgctgii%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clpwuy96300043b6hsru7jjhp%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clpwuy96300053b6h1qgctgii%2522%252C%2522activeTabId%2522%253A%2522clpwuy96300043b6hsru7jjhp%2522%257D%252C%2522clpwuy96300033b6haoq2uh4f%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clpwuy96300033b6haoq2uh4f%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

I changed the logic to not rely on that and only work on segment Index. 


### Results

Now we can render them fine if the opacity is set to 0

### Changes
Changed the logic of outline detection to not rely on the color opacity but rather the segment index itself.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: Latest
  - **OS**: macOS
  - **Browser**: Latest Chrome Stable

