### PR TITLE
fix(reslicecursor): fix camera update when mouse wheel on rotation ha…

### DIFF
--- a/Sources/Widgets/Core/AbstractWidget/index.js
+++ b/Sources/Widgets/Core/AbstractWidget/index.js
@@ -112,7 +112,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.get(publicAPI, model, [
     'representations',
     'widgetState',
-    'activeState',
+    'activeState', // stores the last activated sub state(handle)
   ]);
   macro.moveToProtected(publicAPI, model, ['widgetManager']);
   macro.event(publicAPI, model, 'ActivateHandle');

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.js
@@ -226,7 +226,10 @@ export default function widgetBehavior(publicAPI, model) {
     isScrolling = true;
     publicAPI.translateCenterOnPlaneDirection(step);
 
-    publicAPI.invokeInternalInteractionEvent();
+    publicAPI.invokeInternalInteractionEvent(
+      // Force interaction mode because mouse cursor could be above rotation handle
+      InteractionMethodsName.TranslateCenter
+    );
     isScrolling = false;
 
     return macro.EVENT_ABORT;
@@ -256,15 +259,17 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.handleEvent = (callData) => {
     if (model.activeState.getActive()) {
-      publicAPI[publicAPI.getActiveInteraction()](callData);
-      publicAPI.invokeInternalInteractionEvent();
+      const methodName = publicAPI.getActiveInteraction();
+      publicAPI[methodName](callData);
+      publicAPI.invokeInternalInteractionEvent(methodName);
       return macro.EVENT_ABORT;
     }
     return macro.VOID;
   };
 
-  publicAPI.invokeInternalInteractionEvent = () => {
-    const methodName = publicAPI.getActiveInteraction();
+  publicAPI.invokeInternalInteractionEvent = (
+    methodName = publicAPI.getActiveInteraction()
+  ) => {
     const computeFocalPointOffset =
       methodName !== InteractionMethodsName.RotateLine;
     const canUpdateFocalPoint =


### PR DESCRIPTION
…ndle



### Context
When the cursor is hover the rotation handle, a mouse wheel event wrongly assumes that the rotation line action was active.

### Results
The mouse wheel event now forces the behavior to consider a "center translation" event even when hovering the rotation handle.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 10
  - **Browser**: Chrome
