### PR TITLE
fix(types): improve vtkrenderer type definitions

### DIFF
--- a/Sources/Rendering/Core/Renderer/index.d.ts
+++ b/Sources/Rendering/Core/Renderer/index.d.ts
@@ -487,13 +487,13 @@ export interface vtkRenderer extends vtkViewport {
 	 * 
 	 * @param {Boolean} preserveColorBuffer 
 	 */
-	setPreserveColorbuffer(preserveColorBuffer: boolean): boolean;
+	setPreserveColorBuffer(preserveColorBuffer: boolean): boolean;
 
 	/**
 	 * 
 	 * @param {Boolean} preserveDepthBuffer 
 	 */
-	setPreserveDepthbuffer(preserveDepthBuffer: boolean): boolean;
+	setPreserveDepthBuffer(preserveDepthBuffer: boolean): boolean;
 
 	/**
 	 * 
@@ -520,30 +520,30 @@ export interface vtkRenderer extends vtkViewport {
 	setUseShadows(useShadows: boolean): boolean;
 
 	/**
-	 * 
+	 * Specify the rendering window in which to draw.
 	 * @param {vtkRenderWindow} renderWindow 
 	 */
 	setRenderWindow(renderWindow: vtkRenderWindow): void;
 
 	/**
-	 * 
+	 * Remove an actor from the list of actors.
 	 * @param {vtkProp} actor 
 	 */
 	removeActor(actor: vtkProp): void;
 
 	/**
-	 * 
+	 * Remove all actors from the list of actors.
 	 */
 	removeAllActors(): void;
 
 	/**
-	 * 
-	 * @param {vtkVolume} volume 
+	 * Remove a volume from the list of volumes.
+	 * @param {vtkVolume} volume The volume object to remove.
 	 */
 	removeVolume(volume: vtkVolume): void;
 
 	/**
-	 * 
+	 * Remove all volumes from the list of volumes.
 	 */
 	removeAllVolumes(): void;
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Reported on the forum https://discourse.vtk.org/t/vtkrenderer-setpreservecolorbuffer-typo-in-either-the-d-ts-or-the-js-same-with-setpreservedepthbuffer/13303
### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
