### PR TITLE
fix(OpenGL/Framebuffer): size can be null

### DIFF
--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -225,12 +225,8 @@ function vtkFramebuffer(publicAPI, model) {
   };
 
   publicAPI.getSize = () => {
-    const size = [0, 0];
-    if (model.glFramebuffer !== null) {
-      size[0] = model.glFramebuffer.width;
-      size[1] = model.glFramebuffer.height;
-    }
-    return size;
+    if (model.glFramebuffer == null) return null;
+    return [model.glFramebuffer.width, model.glFramebuffer.height];
   };
 
   publicAPI.populateFramebuffer = () => {

--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -357,7 +357,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
       model.framebuffer.setOpenGLRenderWindow(model._openGLRenderWindow);
       model.framebuffer.saveCurrentBindingsAndBuffers();
       const fbSize = model.framebuffer.getSize();
-      if (fbSize[0] !== size[0] || fbSize[1] !== size[1]) {
+      if (!fbSize || fbSize[0] !== size[0] || fbSize[1] !== size[1]) {
         model.framebuffer.create(size[0], size[1]);
         // this calls model.framebuffer.bind()
         model.framebuffer.populateFramebuffer();

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -218,10 +218,8 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   };
 
   publicAPI.getFramebufferSize = () => {
-    if (model.activeFramebuffer) {
-      return model.activeFramebuffer.getSize();
-    }
-    return model.size;
+    const fbSize = model.activeFramebuffer?.getSize();
+    return fbSize || model.size;
   };
 
   publicAPI.getPixelData = (x1, y1, x2, y2) => {

--- a/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/index.js
@@ -202,7 +202,8 @@ function vtkLineIntegralConvolution2D(publicAPI, model) {
     const gl = model.context;
 
     let fb = model.framebuffer;
-    if (!fb || size[0] !== fb.getSize()[0] || size[1] !== fb.getSize()[1]) {
+    const fbSize = fb.getSize();
+    if (!fb || !fbSize || size[0] !== fbSize || size[1] !== fbSize) {
       fb = vtkFrameBuffer.newInstance();
       fb.setOpenGLRenderWindow(model._openGLRenderWindow);
       fb.saveCurrentBindingsAndBuffers();

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1218,7 +1218,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         model.framebuffer.populateFramebuffer();
       } else {
         const fbSize = model.framebuffer.getSize();
-        if (fbSize[0] !== size[0] || fbSize[1] !== size[1]) {
+        if (!fbSize || fbSize[0] !== size[0] || fbSize[1] !== size[1]) {
           model.framebuffer.create(size[0], size[1]);
           model.framebuffer.populateFramebuffer();
         }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
If the OpenGL render window has [0,0] size, it's possible for the associated framebuffer to not be correctly initialized ([see these lines](https://github.com/Kitware/vtk-js/blob/b9988635d1beed28a1b13f7c5e1ac8b668b77e6c/Sources/Rendering/OpenGL/ForwardPass/index.js#L60-L68)). The resulting error is opaque (errors in `renderPieceStart`) and is not indicative of the root cause.

### Results
If the framebuffer is not yet initialized, return null as the size. This matches some existing usages of `framebuffer.getSize()` that checks for null-ness.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] vtkFramebuffer.getSize() now can return null
- [x] Updated usages of framebuffer.getSize() to handle the null case

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
