### PR TITLE
fix(WidgetManager): call modified on widget remove

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -343,6 +343,7 @@ function vtkWidgetManager(publicAPI, model) {
   }
 
   function onWidgetRemoved() {
+    publicAPI.modified();
     model._renderer.getRenderWindow().getInteractor().render();
     publicAPI.renderWidgets();
   }

--- a/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
+++ b/Sources/Widgets/Core/WidgetManager/test/testWidgetManager.js
@@ -29,6 +29,35 @@ test('Test vtkWidgetManager', (t) => {
   container.removeChild(rwContainer);
 });
 
+test('Test vtkWidgetManager add/remove onModified calls', (t) => {
+  const container = document.querySelector('body');
+  const rwContainer = document.createElement('div');
+  container.appendChild(rwContainer);
+  const grw = vtkGenericRenderWindow.newInstance({ listenWindowResize: false });
+  grw.setContainer(rwContainer);
+
+  const widgetManager = vtkWidgetManager.newInstance();
+  widgetManager.setRenderer(grw.getRenderer());
+
+  let modifiedCount = 0;
+  const onModified = () => {
+    modifiedCount++;
+  };
+  const sub = widgetManager.onModified(onModified);
+
+  const widget = vtkPolyLineWidget.newInstance();
+  widgetManager.addWidget(widget);
+  t.equal(modifiedCount, 1, 'Add triggers onModified');
+
+  widgetManager.removeWidget(widget);
+  t.equal(modifiedCount, 2, 'Remove triggers onModified');
+
+  t.end();
+
+  container.removeChild(rwContainer);
+  sub.unsubscribe();
+});
+
 test.onlyIfWebGL('Test getPixelWorldHeightAtCoord', (t) => {
   const gc = testUtils.createGarbageCollector(t);
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The widget manager does not trigger onModified when removing widgets.

### Results
The widget manager will begin triggering onModified when removing widgets.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] widget manager changes to trigger onModified on widget removal

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
