### PR TITLE
WebXR: add prop interactions through targetRaySpace of XRInputSources

### DIFF
--- a/Sources/Interaction/Manipulators/3DControllerModelSelectorManipulator/index.d.ts
+++ b/Sources/Interaction/Manipulators/3DControllerModelSelectorManipulator/index.d.ts
@@ -1,0 +1,19 @@
+import vtkCompositeVRManipulator from '../CompositeVRManipulator';
+
+export interface vtk3DControllerModelSelectorManipulator
+  extends vtkCompositeVRManipulator {}
+
+export interface I3DControllerModelSelectorManipulatorInitialValues
+  extends vtkCompositeVRManipulator {}
+
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: I3DControllerModelSelectorManipulatorInitialValues
+): void;
+
+export const vtk3DControllerModelSelectorManipulator: {
+  extend: typeof extend;
+};
+
+export default vtk3DControllerModelSelectorManipulator;

--- a/Sources/Interaction/Manipulators/3DControllerModelSelectorManipulator/index.js
+++ b/Sources/Interaction/Manipulators/3DControllerModelSelectorManipulator/index.js
@@ -115,6 +115,8 @@ function vtk3DControllerModelSelectorManipulator(publicAPI, model) {
     const camera = renderer.getActiveCamera();
     camera.getPhysicalToWorldMatrix(physicalToWorldMatrix);
 
+    const { targetPosition, targetOrientation } = eventData;
+
     // Since targetPosition is in physical coordinates,
     // transform it using the physicalToWorldMatrix to get it in world coordinates
     const targetRayWorldPosition = vec3.transformMat4(
@@ -160,7 +162,7 @@ function vtk3DControllerModelSelectorManipulator(publicAPI, model) {
   const currentTargetRayWorldPosition = new Float64Array(3);
   const currentTargetRayOrientation = new Float64Array(4);
 
-  publicAPI.onMove3D = (_interactorStyle, renderer, _state, eventData) => {
+  publicAPI.onMove3D = (interactorStyle, renderer, state, eventData) => {
     // If we are not interacting with any prop, we have nothing to do.
     // Also check for dragable
     if (state !== States.IS_CAMERA_POSE || pickedProp == null) {

--- a/Sources/Interaction/Manipulators/3DControllerModelSelectorManipulator/index.js
+++ b/Sources/Interaction/Manipulators/3DControllerModelSelectorManipulator/index.js
@@ -1,0 +1,235 @@
+import macro from 'vtk.js/Sources/macros';
+import vtkCompositeVRManipulator from 'vtk.js/Sources/Interaction/Manipulators/CompositeVRManipulator';
+import {
+  Device,
+  Input,
+} from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor/Constants';
+import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import { vec3, vec4, mat4, quat } from 'gl-matrix';
+
+// ----------------------------------------------------------------------------
+// vtk3DControllerModelSelectorManipulator methods
+// ----------------------------------------------------------------------------
+
+function vtk3DControllerModelSelectorManipulator(publicAPI, model) {
+  model.classHierarchy.push('vtk3DControllerModelSelectorManipulator');
+
+  let pickedActor;
+
+  function positionProp(
+    prop,
+    physicalPosition,
+    physicalOrientation,
+    physicalToWorldMatrix
+  ) {
+    const worldPosition = vec4.fromValues(...physicalPosition, 1.0);
+    vec4.transformMat4(worldPosition, worldPosition, physicalToWorldMatrix);
+
+    const lastWorldPosition = vec4.fromValues(
+      ...model.lastPhysicalPosition,
+      1.0
+    );
+    vec4.transformMat4(
+      lastWorldPosition,
+      lastWorldPosition,
+      physicalToWorldMatrix
+    );
+
+    const translation = [];
+    vec3.subtract(translation, worldPosition, lastWorldPosition);
+
+    const worldOrientation = quat.normalize([], physicalOrientation);
+    const lastWorldOrientation = quat.normalize(
+      [],
+      model.lastPhysicalOrientation
+    );
+
+    const lastWorldOrientationConjugated = quat.conjugate(
+      [],
+      lastWorldOrientation
+    );
+    const orientation = [];
+    quat.multiply(
+      orientation,
+      worldOrientation,
+      lastWorldOrientationConjugated
+    );
+
+    quat.normalize(orientation, orientation);
+    const axis = [];
+    const angle = quat.getAxisAngle(axis, orientation);
+
+    const matrix = [...mat4.transpose([], prop.getMatrix())];
+
+    const transform = mat4.create();
+    mat4.translate(transform, transform, worldPosition);
+    mat4.rotate(transform, transform, angle, axis);
+    mat4.translate(transform, transform, vec3.negate([], worldPosition));
+    mat4.translate(transform, transform, translation);
+
+    const [currentPropW, ...currentPropOrientationAxis] = [
+      ...prop.getOrientationWXYZ(),
+    ];
+
+    mat4.multiply(transform, transform, matrix);
+    const matTranslation = mat4.getTranslation([], transform);
+    const matScaling = mat4.getScaling([], transform);
+    const matRotation = mat4.getRotation([], transform);
+
+    const currentPropOrientation = quat.setAxisAngle(
+      [],
+      currentPropOrientationAxis,
+      vtkMath.radiansFromDegrees(currentPropW)
+    );
+
+    const currentPropOrientationConjugated = quat.conjugate(
+      [],
+      currentPropOrientation
+    );
+    const newPropOrientation = [];
+    quat.multiply(
+      newPropOrientation,
+      currentPropOrientationConjugated,
+      matRotation
+    );
+
+    quat.normalize(newPropOrientation, newPropOrientation);
+
+    const newPropOrientationAxis = [];
+    const newPropOrientationAngle = quat.getAxisAngle(
+      newPropOrientationAxis,
+      newPropOrientation
+    );
+
+    // Update the prop internal matrix
+    prop.setPosition(...matTranslation);
+    prop.setScale(...matScaling);
+    prop.rotateWXYZ(
+      vtkMath.degreesFromRadians(newPropOrientationAngle),
+      ...newPropOrientationAxis
+    );
+  }
+
+  publicAPI.onButton3D = (
+    interactorStyle,
+    renderer,
+    state,
+    device,
+    input,
+    pressed,
+    targetPosition,
+    targetOrientation
+  ) => {
+    const camera = renderer.getActiveCamera();
+    const physicalToWorldMatrix = [];
+    camera.getPhysicalToWorldMatrix(physicalToWorldMatrix);
+
+    const targetRayPos = vec3.fromValues(
+      targetPosition.x,
+      targetPosition.y,
+      targetPosition.z
+    );
+
+    const targetRayDirection = camera.physicalOrientationToWorldDirection([
+      targetOrientation.x,
+      targetOrientation.y,
+      targetOrientation.z,
+      targetOrientation.w,
+    ]);
+    const targetRayWorldPos = [];
+    vec3.transformMat4(targetRayWorldPos, targetRayPos, physicalToWorldMatrix);
+
+    const dist = renderer.getActiveCamera().getClippingRange()[1];
+
+    if (pressed) {
+      const wp1 = [...targetRayWorldPos, 1.0];
+      const wp2 = [
+        wp1[0] - targetRayDirection[0] * dist,
+        wp1[1] - targetRayDirection[1] * dist,
+        wp1[2] - targetRayDirection[2] * dist,
+        1.0,
+      ];
+
+      // do the picking, lookup picked actors and take action if we have some.
+      model.picker.pick3DPoint(wp1, wp2, renderer);
+      const actors = model.picker.getActors();
+
+      if (actors.length > 0) {
+        pickedActor = actors[0];
+      }
+    } else {
+      model.lastPhysicalOrientation = null;
+      model.lastPhysicalPosition = null;
+      pickedActor = null;
+    }
+  };
+
+  publicAPI.onMove3D = (interactorStyle, renderer, state, eventData) => {
+    if (pickedActor == null) {
+      return;
+    }
+
+    const camera = renderer.getActiveCamera();
+    const physicalToWorldMatrix = [];
+    camera.getPhysicalToWorldMatrix(physicalToWorldMatrix);
+
+    const targetRayPosition = vec3.fromValues(
+      eventData.targetPosition.x,
+      eventData.targetPosition.y,
+      eventData.targetPosition.z
+    );
+
+    const wxyz = quat.fromValues(
+      eventData.targetOrientation.x,
+      eventData.targetOrientation.y,
+      eventData.targetOrientation.z,
+      eventData.targetOrientation.w
+    ); // orientation is a unit quaternion.
+
+    if (model.lastPhysicalOrientation && model.lastPhysicalPosition) {
+      positionProp(
+        pickedActor,
+        targetRayPosition,
+        [...wxyz],
+        physicalToWorldMatrix
+      );
+    }
+
+    model.lastPhysicalOrientation = [...wxyz];
+    model.lastPhysicalPosition = [...targetRayPosition];
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  device: Device.RightController,
+  input: Input.TrackPad,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  macro.setGet(publicAPI, model, ['picker']);
+  macro.get(publicAPI, model, ['lastPhysicalPosition', 'lastPhysicalPosition']);
+  macro.obj(publicAPI, model);
+  vtkCompositeVRManipulator.extend(publicAPI, model, initialValues);
+
+  // Object specific methods
+  vtk3DControllerModelSelectorManipulator(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(
+  extend,
+  'vtk3DControllerModelSelectorManipulator'
+);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Manipulators/CompositeVRManipulator/index.d.ts
+++ b/Sources/Interaction/Manipulators/CompositeVRManipulator/index.d.ts
@@ -1,28 +1,28 @@
 import { States } from '../../../Rendering/Core/InteractorStyle/Constants';
 import vtkRenderer from '../../../Rendering/Core/Renderer';
-import vtkRenderWindowInteractor from '../../../Rendering/Core/RenderWindowInteractor';
+import vtkInteractorObserver from '../../../Rendering/Core/InteractorObserver';
 import {
   Device,
   Input,
 } from '../../../Rendering/Core/RenderWindowInteractor/Constants';
+import {
+  I3DEvent,
+  IButton3DEvent,
+} from '../../../Rendering/Core/RenderWindowInteractor';
 
 export interface vtkCompositeVRManipulator {
   onButton3D(
-    interactor: vtkRenderWindowInteractor,
+    interactorStyle: vtkInteractorObserver,
     renderer: vtkRenderer,
     state: States,
-    device: Device,
-    input: Input,
-    pressed: boolean
+    eventData: IButton3DEvent
   ): void;
 
   onMove3D(
-    interactor: vtkRenderWindowInteractor,
+    interactorStyle: vtkInteractorObserver,
     renderer: vtkRenderer,
     state: States,
-    device: Device,
-    input: Input,
-    pressed: boolean
+    eventData: I3DEvent
   ): void;
 }
 

--- a/Sources/Interaction/Manipulators/CompositeVRManipulator/index.js
+++ b/Sources/Interaction/Manipulators/CompositeVRManipulator/index.js
@@ -12,22 +12,8 @@ function vtkCompositeVRManipulator(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkCompositeVRManipulator');
 
-  publicAPI.onButton3D = (
-    interactor,
-    renderer,
-    state,
-    device,
-    input,
-    pressed
-  ) => {};
-  publicAPI.onMove3D = (
-    interactor,
-    renderer,
-    state,
-    device,
-    input,
-    pressed
-  ) => {};
+  publicAPI.onButton3D = (interactorStyle, renderer, state, eventData) => {};
+  publicAPI.onMove3D = (interactorStyle, renderer, state, eventData) => {};
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Interaction/Manipulators/VRButtonPanManipulator/index.js
+++ b/Sources/Interaction/Manipulators/VRButtonPanManipulator/index.js
@@ -14,22 +14,15 @@ function vtkVRButtonPanManipulator(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkVRButtonPanManipulator');
 
-  publicAPI.onButton3D = (
-    interactorStyle,
-    renderer,
-    state,
-    device,
-    input,
-    pressed
-  ) => {
-    if (pressed) {
+  publicAPI.onButton3D = (interactorStyle, renderer, state, eventData) => {
+    if (eventData.pressed) {
       interactorStyle.startCameraPose();
     } else if (state === States.IS_CAMERA_POSE) {
       interactorStyle.endCameraPose();
     }
   };
 
-  publicAPI.onMove3D = (interactorStyle, renderer, state, data) => {
+  publicAPI.onMove3D = (interactorStyle, renderer, state, eventData) => {
     if (state !== States.IS_CAMERA_POSE) {
       return;
     }
@@ -40,13 +33,15 @@ function vtkVRButtonPanManipulator(publicAPI, model) {
     const oldTrans = camera.getPhysicalTranslation();
 
     // look at the y axis to determine how fast / what direction to move
-    const speed = data.gamepad.axes[1];
+    const speed = eventData.gamepad.axes[1];
 
     // 0.05 meters / frame movement
     const pscale = speed * 0.05 * camera.getPhysicalScale();
 
     // convert orientation to world coordinate direction
-    const dir = camera.physicalOrientationToWorldDirection(data.orientation);
+    const dir = camera.physicalOrientationToWorldDirection(
+      eventData.orientation
+    );
 
     camera.setPhysicalTranslation(
       oldTrans[0] + dir[0] * pscale,

--- a/Sources/Interaction/Style/InteractorStyleHMDXR/example/controller.html
+++ b/Sources/Interaction/Style/InteractorStyleHMDXR/example/controller.html
@@ -1,0 +1,7 @@
+<table>
+    <tr>
+        <td>
+        <button class='vrbutton' style="width: 100%">Send To VR</button>
+        </td>
+    </tr>
+</table>

--- a/Sources/Interaction/Style/InteractorStyleHMDXR/example/index.js
+++ b/Sources/Interaction/Style/InteractorStyleHMDXR/example/index.js
@@ -1,0 +1,133 @@
+// For streamlined VR development install the WebXR emulator extension
+// https://github.com/MozillaReality/WebXR-emulator-extension
+
+import '@kitware/vtk.js/favicon';
+
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import '@kitware/vtk.js/Rendering/Profiles/Geometry';
+
+import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
+import vtkConeSource from '@kitware/vtk.js/Filters/Sources/ConeSource';
+import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
+import vtkWebXRRenderWindowHelper from '@kitware/vtk.js/Rendering/WebXR/RenderWindowHelper';
+import vtkMapper from '@kitware/vtk.js/Rendering/Core/Mapper';
+import { XrSessionTypes } from '@kitware/vtk.js/Rendering/WebXR/RenderWindowHelper/Constants';
+
+import vtkInteractorStyleHMDXR from '@kitware/vtk.js/Interaction/Style/InteractorStyleHMDXR';
+import vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
+
+// Force DataAccessHelper to have access to various data source
+import '@kitware/vtk.js/IO/Core/DataAccessHelper/HtmlDataAccessHelper';
+import '@kitware/vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+import '@kitware/vtk.js/IO/Core/DataAccessHelper/JSZipDataAccessHelper';
+
+import vtkResourceLoader from '@kitware/vtk.js/IO/Core/ResourceLoader';
+
+// Custom UI controls, including button to start XR session
+import controlPanel from './controller.html';
+
+// Dynamically load WebXR polyfill from CDN for WebVR and Cardboard API backwards compatibility
+if (navigator.xr === undefined) {
+  vtkResourceLoader
+    .loadScript(
+      'https://cdn.jsdelivr.net/npm/webxr-polyfill@latest/build/webxr-polyfill.js'
+    )
+    .then(() => {
+      // eslint-disable-next-line no-new, no-undef
+      new WebXRPolyfill();
+    });
+}
+
+// ----------------------------------------------------------------------------
+// Standard rendering code setup
+// ----------------------------------------------------------------------------
+
+function createRenderingPipeline(filter) {
+  const mapper = vtkMapper.newInstance();
+  mapper.setInputConnection(filter.getOutputPort());
+
+  const actor = vtkActor.newInstance();
+  actor.setMapper(mapper);
+
+  return actor;
+}
+
+const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
+  background: [0, 0, 0],
+});
+
+const interactor = vtkRenderWindowInteractor.newInstance();
+interactor.setView(fullScreenRenderer.getApiSpecificRenderWindow());
+interactor.initialize();
+
+const interactorStyle = vtkInteractorStyleHMDXR.newInstance();
+interactor.setInteractorStyle(interactorStyle);
+
+const renderer = fullScreenRenderer.getRenderer();
+const renderWindow = fullScreenRenderer.getRenderWindow();
+const XRHelper = vtkWebXRRenderWindowHelper.newInstance({
+  renderWindow: fullScreenRenderer.getApiSpecificRenderWindow(),
+  drawControllersRay: true,
+});
+
+const coneSource1 = vtkConeSource.newInstance({ height: 100.0, radius: 50 });
+
+const coneSource2 = vtkConeSource.newInstance({
+  height: 50.0,
+  radius: 20,
+});
+
+const coneSource3 = vtkConeSource.newInstance({
+  height: 50.0,
+  radius: 20,
+});
+
+const coneActor1 = createRenderingPipeline(coneSource1);
+const coneActor2 = createRenderingPipeline(coneSource2);
+const coneActor3 = createRenderingPipeline(coneSource3);
+
+coneActor3.setDragable(false);
+
+renderer.addActor(coneActor1);
+renderer.addActor(coneActor2);
+renderer.addActor(coneActor3);
+
+coneActor1.setPosition(0.0, 0.0, -20.0);
+coneActor2.setPosition(50.0, 0.0, -20.0);
+coneActor3.setPosition(-50.0, 0.0, -20.0);
+
+renderer.resetCamera();
+renderWindow.render();
+
+// -----------------------------------------------------------
+// UI control handling
+// -----------------------------------------------------------
+
+fullScreenRenderer.addController(controlPanel);
+const vrbutton = document.querySelector('.vrbutton');
+
+vrbutton.addEventListener('click', (e) => {
+  if (vrbutton.textContent === 'Send To VR') {
+    XRHelper.startXR(XrSessionTypes.HmdVR);
+    vrbutton.textContent = 'Return From VR';
+  } else {
+    XRHelper.stopXR();
+    vrbutton.textContent = 'Send To VR';
+  }
+});
+
+// -----------------------------------------------------------
+// Make some variables global so that you can inspect and
+// modify objects in your browser's developer console:
+// -----------------------------------------------------------
+
+global.coneSource1 = coneSource1;
+global.coneSource2 = coneSource2;
+global.coneSource3 = coneSource3;
+
+global.coneActor1 = coneSource1;
+global.coneActor2 = coneSource2;
+global.coneActor3 = coneSource3;
+
+global.renderer = renderer;
+global.renderWindow = renderWindow;

--- a/Sources/Interaction/Style/InteractorStyleHMDXR/index.d.ts
+++ b/Sources/Interaction/Style/InteractorStyleHMDXR/index.d.ts
@@ -1,0 +1,22 @@
+import vtkInteractorStyleManipulator, { IInteractorStyleManipulatorInitialValues } from '../../../Interaction/Style/InteractorStyleManipulator';
+
+export interface vtkInteractorStyleHMDXR extends vtkInteractorStyleManipulator {}
+
+export interface IInteractorStyleHMDXRInitialValues extends IInteractorStyleManipulatorInitialValues {}
+
+export function newInstance(
+  initialValues?: IInteractorStyleHMDXRInitialValues
+): vtkInteractorStyleHMDXR;
+
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: IInteractorStyleHMDXRInitialValues
+): void;
+
+export const vtkInteractorStyleHMDXR: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+};
+
+export default vtkInteractorStyleHMDXR;

--- a/Sources/Interaction/Style/InteractorStyleHMDXR/index.js
+++ b/Sources/Interaction/Style/InteractorStyleHMDXR/index.js
@@ -1,0 +1,52 @@
+import macro from 'vtk.js/Sources/macros';
+import vtkInteractorStyleManipulator from 'vtk.js/Sources/Interaction/Style/InteractorStyleManipulator';
+import vtk3DControllerModelSelectorManipulator from 'vtk.js/Sources/Interaction/Manipulators/3DControllerModelSelectorManipulator';
+
+import {
+  Device,
+  Input,
+} from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor/Constants';
+
+function vtkInteractorStyleHMDXR(publicAPI, model) {
+  model.classHierarchy.push('vtkInteractorStyleHMDXR');
+
+  const leftHandManipulator =
+    vtk3DControllerModelSelectorManipulator.newInstance({
+      device: Device.LeftController,
+      input: Input.A,
+    });
+  const rightHandManipulator =
+    vtk3DControllerModelSelectorManipulator.newInstance({
+      device: Device.RightController,
+      input: Input.A,
+    });
+
+  publicAPI.addVRManipulator(leftHandManipulator);
+  publicAPI.addVRManipulator(rightHandManipulator);
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Inheritance
+  vtkInteractorStyleManipulator.extend(publicAPI, model, initialValues);
+
+  // Object specific methods
+  vtkInteractorStyleHMDXR(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(extend, 'vtkInteractorStyleHMDXR');
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -301,7 +301,9 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
         model.state,
         ed.device,
         ed.input,
-        ed.pressed
+        ed.pressed,
+        ed.targetPosition,
+        ed.targetOrientation
       );
       if (ed.pressed) {
         publicAPI.startCameraPose();

--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -709,7 +709,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues) => ({
   cachedMousePosition: null,
   currentManipulator: null,
   currentWheelManipulator: null,
@@ -719,12 +719,13 @@ const DEFAULT_VALUES = {
   // gestureManipulators: null,
   centerOfRotation: [0, 0, 0],
   rotationFactor: 1,
-};
+  ...initialValues,
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   // Inheritance
   vtkInteractorStyle.extend(publicAPI, model, initialValues);

--- a/Sources/Rendering/Core/Prop3D/index.d.ts
+++ b/Sources/Rendering/Core/Prop3D/index.d.ts
@@ -1,4 +1,4 @@
-import { mat4 } from "gl-matrix";
+import { mat4, quat } from "gl-matrix";
 import { Bounds, Vector3, Range } from "../../../types";
 import vtkProp, { IPropInitialValues } from "../Prop";
 
@@ -89,6 +89,13 @@ export interface vtkProp3D extends vtkProp {
 	getOrientationWXYZ(): number[];
 
 	/**
+	 * Get the orientation quaternion of the Prop3D.
+	 * out is optional and will be created if not supplied.
+	 * @param {quat | undefined} out
+	 */
+	getOrientationQuaternion(out?: quat): quat;
+
+	/**
 	 * Get a reference to the Prop3D’s 4x4 composite matrix.
 	 * Get the matrix from the position, origin, scale and orientation This
 	 * matrix is cached, so multiple GetMatrix() calls will be efficient.
@@ -166,6 +173,14 @@ export interface vtkProp3D extends vtkProp {
 	 * @param {Number} z The z coordinate.
 	 */
 	rotateWXYZ(degrees: number, x: number, y: number, z: number): void;
+
+	/**
+	 * Rotate the Prop3D by the provided orientation quaternion.
+	 * If the provided quaternion is identity (~epsilon), this function does nothing.
+	 * The quaternion should follow the gl-matrix convention: [x,y,z,w]
+	 * @param {quat} orientationQuaternion The quaternion to rotate the prop by.
+	 */
+	rotateQuaternion(orientationQuaternion: quat): void;
 
 	/**
 	 * Orientation is specified as X, Y and Z rotations in that order,

--- a/Sources/Rendering/Core/Prop3D/index.js
+++ b/Sources/Rendering/Core/Prop3D/index.js
@@ -5,6 +5,8 @@ import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkProp from 'vtk.js/Sources/Rendering/Core/Prop';
 
+const VTK_EPSILON = 1e-6;
+
 // ----------------------------------------------------------------------------
 // vtkProp3D methods
 // ----------------------------------------------------------------------------
@@ -27,6 +29,9 @@ function vtkProp3D(publicAPI, model) {
     const w = quat.getAxisAngle(oaxis, q);
     return [vtkMath.degreesFromRadians(w), oaxis[0], oaxis[1], oaxis[2]];
   };
+
+  publicAPI.getOrientationQuaternion = (out = []) =>
+    mat4.getRotation(out, model.rotation);
 
   publicAPI.rotateX = (val) => {
     if (val === 0.0) {
@@ -78,6 +83,19 @@ function vtkProp3D(publicAPI, model) {
     const quatMat = new Float64Array(16);
     mat4.fromQuat(quatMat, q);
     mat4.multiply(model.rotation, model.rotation, quatMat);
+    publicAPI.modified();
+  };
+
+  publicAPI.rotateQuaternion = (orientationQuaternion) => {
+    if (Math.abs(orientationQuaternion[3]) >= 1 - VTK_EPSILON) {
+      return;
+    }
+
+    const oriQuatMat = mat4.fromQuat(
+      new Float64Array(16),
+      orientationQuaternion
+    );
+    mat4.multiply(model.rotation, model.rotation, oriQuatMat);
     publicAPI.modified();
   };
 

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -81,6 +81,20 @@ export interface IRenderWindowInteractorEvent {
 	type: InteractorEventType;
 }
 
+export interface I3DEvent {
+	gamepad: Gamepad;
+	position: DOMPointReadOnly;
+	orientation: DOMPointReadOnly;
+	targetPosition: DOMPointReadOnly;
+	targetOrientation: DOMPointReadOnly;
+	device: Device;
+}
+
+export interface IButton3DEvent extends I3DEvent {
+	pressed: boolean;
+	input: Input;
+}
+
 export interface vtkRenderWindowInteractor extends vtkObject {
 
 	/**
@@ -678,10 +692,11 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 	animationEvent(args: any): any;
 
 	/**
-	 *
+	 * Triggers the 'Button3D' event.
+	 * 
 	 * @param args
 	 */
-	button3DEvent(args: any): any;
+	button3DEvent(eventPayload: IButton3DEvent): void;
 
 	/**
 	 *
@@ -804,10 +819,11 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 	mouseWheelEvent(args: any): any;
 
 	/**
-	 *
-	 * @param args
+	 * Triggers the 'Move3D' event.
+	 * 
+	 * @param eventPayload
 	 */
-	move3DEvent(args: any): any;
+	move3DEvent(eventPayload: I3DEvent): void;
 
 	/**
 	 *

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -601,56 +601,75 @@ function vtkRenderWindowInteractor(publicAPI, model) {
         inputSource.gripSpace == null
           ? null
           : xrFrame.getPose(inputSource.gripSpace, xrRefSpace);
-      const gp = inputSource.gamepad;
+
+      const targetRayPose =
+        inputSource.gripSpace == null
+          ? null
+          : xrFrame.getPose(inputSource.targetRaySpace, xrRefSpace);
+
+      const gamepad = inputSource.gamepad;
       const hand = inputSource.handedness;
-      if (gp) {
-        if (!(gp.index in model.lastGamepadValues)) {
-          model.lastGamepadValues[gp.index] = {
-            left: { buttons: {} },
-            right: { buttons: {} },
-            none: { buttons: {} },
-          };
+
+      if (!gamepad) {
+        return;
+      }
+
+      if (!(gamepad.index in model.lastGamepadValues)) {
+        model.lastGamepadValues[gamepad.index] = {
+          left: { buttons: {} },
+          right: { buttons: {} },
+          none: { buttons: {} },
+        };
+      }
+
+      for (let buttonIdx = 0; buttonIdx < gamepad.buttons.length; ++buttonIdx) {
+        if (
+          !(buttonIdx in model.lastGamepadValues[gamepad.index][hand].buttons)
+        ) {
+          model.lastGamepadValues[gamepad.index][hand].buttons[
+            buttonIdx
+          ] = false;
         }
-        for (let b = 0; b < gp.buttons.length; ++b) {
-          if (!(b in model.lastGamepadValues[gp.index][hand].buttons)) {
-            model.lastGamepadValues[gp.index][hand].buttons[b] = false;
-          }
-          if (
-            model.lastGamepadValues[gp.index][hand].buttons[b] !==
-              gp.buttons[b].pressed &&
-            gripPose != null
-          ) {
-            publicAPI.button3DEvent({
-              gamepad: gp,
-              position: gripPose.transform.position,
-              orientation: gripPose.transform.orientation,
-              pressed: gp.buttons[b].pressed,
-              device:
-                inputSource.handedness === 'left'
-                  ? Device.LeftController
-                  : Device.RightController,
-              input:
-                deviceInputMap[gp.mapping] && deviceInputMap[gp.mapping][b]
-                  ? deviceInputMap[gp.mapping][b]
-                  : Input.Trigger,
-            });
-            model.lastGamepadValues[gp.index][hand].buttons[b] =
-              gp.buttons[b].pressed;
-          }
-          if (
-            model.lastGamepadValues[gp.index][hand].buttons[b] &&
-            gripPose != null
-          ) {
-            publicAPI.move3DEvent({
-              gamepad: gp,
-              position: gripPose.transform.position,
-              orientation: gripPose.transform.orientation,
-              device:
-                inputSource.handedness === 'left'
-                  ? Device.LeftController
-                  : Device.RightController,
-            });
-          }
+        if (
+          model.lastGamepadValues[gamepad.index][hand].buttons[buttonIdx] !==
+            gamepad.buttons[buttonIdx].pressed &&
+          gripPose != null
+        ) {
+          publicAPI.button3DEvent({
+            gamepad,
+            position: gripPose.transform.position,
+            orientation: gripPose.transform.orientation,
+            targetPosition: targetRayPose.transform.position,
+            targetOrientation: targetRayPose.transform.orientation,
+            pressed: gamepad.buttons[buttonIdx].pressed,
+            device:
+              inputSource.handedness === 'left'
+                ? Device.LeftController
+                : Device.RightController,
+            input:
+              deviceInputMap[gamepad.mapping] &&
+              deviceInputMap[gamepad.mapping][buttonIdx]
+                ? deviceInputMap[gamepad.mapping][buttonIdx]
+                : Input.Trigger,
+          });
+          model.lastGamepadValues[gamepad.index][hand].buttons[buttonIdx] =
+            gamepad.buttons[buttonIdx].pressed;
+        }
+        if (
+          model.lastGamepadValues[gamepad.index][hand].buttons[buttonIdx] &&
+          gripPose != null
+        ) {
+          publicAPI.move3DEvent({
+            gamepad,
+            position: gripPose.transform.position,
+            orientation: gripPose.transform.orientation,
+            targetPosition: targetRayPose.transform.position,
+            targetOrientation: targetRayPose.transform.orientation,
+            device:
+              inputSource.handedness === 'left'
+                ? Device.LeftController
+                : Device.RightController,
+          });
         }
       }
     });


### PR DESCRIPTION
### Context
VTK.js supports for interactions in a WebXR scene currently does not support manipulating props.
Also, it seems like the support of the Microsoft Hololens is not satisfying.

This PR is currently draft and based upon https://github.com/Kitware/vtk-js/pull/3020
Reviewers are kindly asked to make any high-level/architecture/naming feedback. 

### Results
Using the new interactor style (detailed below in the changes section), the support for Microsoft Hololens is now well integrated. The changes should also benefits to other XR Head Mounted Display (HMD) devices, but this has not been tested yet. I will try to test it in the next few days on a Valve Index but as of now, I did not manage to even make it work with VTK.js.
An example is also included for this new interactor style.
I'm aware that there are missing TS headers and doc, those will be added by myself once the project maintainers have validated the code from a high-level perspective.

### Changes
Three main components are introduced:
- An interactor style: `vtkInteractorStyleHMDXR`
- A manipulator: `vtk3DControllerModelSelectorManipulator`
- An API in `vtkWebXRRenderWindowHelper` to enable the rendering of XRInputSources targetRayPose

Those all uses the current event handling and dispatching infrastructure,  and no breaking change is expected.  
The goal for `vtkInteractorStyleHMDXR` would be to gather sensible default interactions for HMD XR devices. It should compose manipulators which are the actual classes that brings the event handling and interactions, etc

`vtk3DControllerModelSelectorManipulator` job is to listen to the `button3D` event to perform prop picking, and to the `move3D` event to position the currently manipulated prop.

- [x] Documentation and TypeScript definitions were updated to match those changes

### Remarks / Issues to be solved
#### Valve Index
Tested successfully, it works greats, except for one bug and one problem.
- with the current code, the gamepad input for the pick action is hardcoded  (`Input.A`). with the Hololens, that is the value you get from the gamepad API. With XR headsets with actual gamepad controller, this would need to be configurable. Typically for certain kind of controller one would expect that the trigger would do the pick action.

~- [ ] make the input trigger for the "pick" action configurable for user code~
=> won't be done, no budget, but I'll open an issue for it
- [x] fix bug (only in valve index). when picking with left controller, it will use the right controller pose during motion for the prop rotation/translation. Though when ending the interaction, the actor will be placed at the right position/orientation (so, from left controller)

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: v29
  - **OS**: Windows on Microsoft Hololens
  - **Browser**: Microsoft Edge