### PR TITLE
fix: Errors on concurrent access with disabled cache

### DIFF
--- a/Sources/IO/Core/HttpDataSetReader/index.js
+++ b/Sources/IO/Core/HttpDataSetReader/index.js
@@ -205,8 +205,10 @@ function vtkHttpDataSetReader(publicAPI, model) {
       // cacheArrays[arrayId] can be a promise or value
       Promise.resolve(cachedArraysAndPromises[arrayId]).then((cachedArray) => {
         if (array !== cachedArray) {
-          //  Update last access for cache retention rules
-          cachedArraysMetaData[arrayId].lastAccess = new Date();
+          //  Update last access for cache retention rules (if caching is enabled)
+          if (model.maxCacheSize) {
+            cachedArraysMetaData[arrayId].lastAccess = new Date();
+          }
 
           // Assign cached array as result
           Object.assign(array, cachedArray);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The introduction of a cache limit in ``vtkHttpDataSetReader`` introduced a bug where if the cache is disabled and concurrent calls requested the same URL, an uncaught error would be raised.

Error raised due to this issue:
```
VM15652 index.js:4384 Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'lastAccess')
```

### Results
This PR fixes this small issue and adds regression tests to account for this scenario.

### Changes
The only change required is to check if caching is enabled before updating the cache access timestamps on cache entries.

from ``Sources/IO/Core/HttpDataSetReader/index.js``
```javascript
//  Update last access for cache retention rules (if caching is enabled)
if (model.maxCacheSize) {
  cachedArraysMetaData[arrayId].lastAccess = new Date();
}
```

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
To test the fix, the regression test written for this scenario can be used: ``Sources/IO/Core/HttpDataSetReader/test/testHttpDataSetReader.js``
Ideally, an ``only()`` is added to the test in order to only run it and then observe the console of the running browser to check for errors.

- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: 29.5.0
  - **OS**:  Windows 10,
  - **Browser**: Chrome 122.0.6261.70