### PR TITLE
OrderIndependentTranslucentPass: restore scissor box + viewport

### DIFF
--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -327,6 +327,11 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
     gl.depthFunc(gl.LEQUAL);
     model.translucentRGBATexture.deactivate();
     model.translucentRTexture.deactivate();
+
+    // restore scissor + viewport from renderer
+    const ts = renNode.getTiledSizeAndOrigin();
+    gl.scissor(ts.lowerLeftU, ts.lowerLeftV, ts.usize, ts.vsize);
+    gl.viewport(ts.lowerLeftU, ts.lowerLeftV, ts.usize, ts.vsize);
   };
 
   publicAPI.getShaderReplacement = () => {


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

The OrderIndependentTranslucentPass was not restoring the original scissor box + viewport parameters. This caused issues under scenarios with the following properties:
* the renderer is smaller than the render window
* the renderer's scene has multiple geometries
* one or more of the geometries is translucent

<img width="1056" alt="image" src="https://github.com/Kitware/vtk-js/assets/1812167/364cce58-2f25-4720-b5f9-b0bd1a94c5d7">


### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

Corrected rendering (the wireframe geometry is now correctly inside the blue box):

<img width="1058" alt="image" src="https://github.com/Kitware/vtk-js/assets/1812167/4c64f6be-0018-4915-ac97-4d2723c561c0">


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] OrderIndependentTranslucentPass fixed

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
