### PR TITLE
fix(imagemapper): change slice interaction to use window size instead…

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleImage/index.js
+++ b/Sources/Interaction/Style/InteractorStyleImage/index.js
@@ -206,7 +206,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
       viewportHeight = 2.0 * distance * Math.tan(0.5 * angle);
     }
 
-    const size = rwi.getView().getViewportSize(renderer);
+    const size = rwi.getView().getSize();
     const delta = (dy * viewportHeight) / size[1];
     distance += delta;
 


### PR DESCRIPTION
… of viewport

This will ensure that different sized viewports in the same window will exhibit the same behavior.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.

- [ ] Documentation and TypeScript definitions were updated to match those changes
-->

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
