### PR TITLE
fix(Colors): fix UInt8Clamped array color definition

### DIFF
--- a/Sources/Common/Core/DataArray/Constants.js
+++ b/Sources/Common/Core/DataArray/Constants.js
@@ -15,6 +15,7 @@ export const VtkDataTypes = {
   CHAR: 'Int8Array',
   SIGNED_CHAR: 'Int8Array',
   UNSIGNED_CHAR: 'Uint8Array',
+  UNSIGNED_CHAR_CLAMPED: 'Uint8ClampedArray', // should be used for VTK.js internal purpose only
   SHORT: 'Int16Array',
   UNSIGNED_SHORT: 'Uint16Array',
   INT: 'Int32Array',

--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -206,7 +206,8 @@ function vtkScalarsToColors(publicAPI, model) {
     // map scalars through lookup table only if needed
     if (
       (colorMode === ColorMode.DEFAULT &&
-        scalars.getDataType() === VtkDataTypes.UNSIGNED_CHAR) ||
+        (scalars.getDataType() === VtkDataTypes.UNSIGNED_CHAR ||
+          scalars.getDataType() === VtkDataTypes.UNSIGNED_CHAR_CLAMPED)) ||
       (colorMode === ColorMode.DIRECT_SCALARS && scalars)
     ) {
       newColors = publicAPI.convertToRGBA(


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
This PR fixes a bug in vtk.js when one creates a color definition with UInt8Clamped array structure

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
