### PR TITLE
fix(vtkStringArray): add `empty: true` to `newClone` implementation

### DIFF
--- a/Sources/Common/Core/StringArray/index.js
+++ b/Sources/Common/Core/StringArray/index.js
@@ -52,6 +52,7 @@ function vtkStringArray(publicAPI, model) {
     newInstance({
       name: model.name,
       numberOfComponents: model.numberOfComponents,
+      empty: true,
     });
   /* eslint-enable no-use-before-define */
 


### PR DESCRIPTION
### Context
Resolves #3036. 

### Results
The error described in the issue is no longer raised.

### Changes
This PR includes only a one-line change, adding `empty: true` to the `newInstance` call in `newClone`, as suggested by @finetjul 

### Testing
The following code raises an error on master and does not raise an error on this branch:
```
import vtkStringArray from 'vtk.js/Sources/Common/Core/StringArray';

const arr = vtkStringArray.newInstance({
  name: 'testArray',
  size: 1,
});
arr.setData(['foo'], 1);
console.log(arr);

const copy = arr.newClone();
```

### Environment

- vtk.js version: 29.10.0
- Browsers: Chrome Version 122.0.6261.111 and Firefox 124.0
- OS: Ubuntu 20.04
