### PR TITLE
Fix projection slab thickness unit in ImageCPRMapper

### DIFF
--- a/Sources/Rendering/Core/ImageCPRMapper/example/controller.html
+++ b/Sources/Rendering/Core/ImageCPRMapper/example/controller.html
@@ -44,7 +44,7 @@
   <tr>
     <td>Number of samples</td>
     <td>
-      <input id='projectionSamples' type='range' min='1' max='101' value='1' step="2"/>
+      <input id='projectionSamples' type='range' min='1' max='501' value='1' step="2"/>
     </td>
   </tr>
 </table>

--- a/Sources/Rendering/Core/ImageCPRMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageCPRMapper/example/index.js
@@ -421,8 +421,15 @@ projectionModeEl.addEventListener('input', (ev) => {
 });
 
 projectionThicknessEl.addEventListener('input', (ev) => {
-  const thickness = Number.parseFloat(projectionThicknessEl.value, 10);
-  mapper.setProjectionSlabThickness(thickness);
+  const thicknessRatio = Number.parseFloat(projectionThicknessEl.value, 10);
+  const image = mapper.getInputData();
+  if (image) {
+    const spacing = image.getSpacing();
+    const dimensions = image.getDimensions();
+    const diagonal = vec3.len(vec3.mul([], spacing, dimensions));
+    const thickness = diagonal * thicknessRatio;
+    mapper.setProjectionSlabThickness(thickness);
+  }
   renderWindow.render();
 });
 mapper.setProjectionSlabThickness(0.1);

--- a/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
@@ -664,7 +664,7 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
     ];
     if (useProjection) {
       tcoordFSDec.push(
-        'uniform vec3 spacing;',
+        'uniform vec3 volumeSizeMC;',
         'uniform int projectionSlabNumberOfSamples;',
         'uniform float projectionConstantOffset;',
         'uniform float projectionStepLength;'
@@ -821,7 +821,7 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
 
       // Loop on all the samples of the projection
       tcoordFSImpl.push(
-        'vec3 projectionScaledDirection = projectionDirection / spacing;',
+        'vec3 projectionScaledDirection = projectionDirection / volumeSizeMC;',
         'vec3 projectionStep = projectionStepLength * projectionScaledDirection;',
         'vec3 projectionStartPosition = volumePosTC + projectionConstantOffset * projectionScaledDirection;',
         'vec4 tvalue = initialProjectionTextureValue;',
@@ -1092,12 +1092,14 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
     if (model.renderable.isProjectionEnabled()) {
       const image = model.currentImageDataInput;
       const spacing = image.getSpacing();
+      const dimensions = image.getDimensions();
       const projectionSlabThickness =
         model.renderable.getProjectionSlabThickness();
       const projectionSlabNumberOfSamples =
         model.renderable.getProjectionSlabNumberOfSamples();
 
-      program.setUniform3fArray('spacing', spacing);
+      const volumeSize = vec3.mul([], spacing, dimensions);
+      program.setUniform3fArray('volumeSizeMC', volumeSize);
       program.setUniformi(
         'projectionSlabNumberOfSamples',
         projectionSlabNumberOfSamples


### PR DESCRIPTION
Documentation says for the projection slab thickness:

>  Thickness of the projection slab in image coordinates (NOT in voxels)
> Usually in millimeters if the spacing of the input image is set from a DICOM

But the implementation used voxels as unit which doesn't make a lot of sense as it can vary along axes

This PR fixes the unit of this value and the example accordingly.