### PR TITLE
fix(VolumeMapper): Fix typo in volume mapper example

### DIFF
--- a/Sources/Rendering/Core/VolumeMapper/example/index.js
+++ b/Sources/Rendering/Core/VolumeMapper/example/index.js
@@ -184,7 +184,7 @@ function updateForceNearestElem(comp) {
     });
     forceNearestElem.appendChild(checkboxElem);
     const labelElem = document.createElement('label');
-    labelElem.innerText = `Force linear interpolation for component ${c}`;
+    labelElem.innerText = `Force nearest interpolation for component ${c}`;
     forceNearestElem.appendChild(labelElem);
     forceNearestElem.appendChild(document.createElement('br'));
   }


### PR DESCRIPTION
Typo in the `VolumeMapper` example

Force linear interpolation -> Force **nearest** interpolation
