### PR TITLE
fix(picker): opacity test for volume picking

### DIFF
--- a/Sources/Rendering/Core/Picker/index.js
+++ b/Sources/Rendering/Core/Picker/index.js
@@ -116,12 +116,14 @@ function vtkPicker(publicAPI, model) {
     // Note that only vtkProp3D's can be picked by vtkPicker.
     props.forEach((prop) => {
       const mapper = prop.getMapper();
-      const propIsNotFullyTranslucent =
-        prop.getProperty?.()?.getOpacity() > 0.0;
+
+      const propIsFullyTranslucent =
+        prop.getProperty?.().getOpacity?.() === 0.0;
+
       const pickable =
         prop.getNestedPickable() &&
         prop.getNestedVisibility() &&
-        propIsNotFullyTranslucent;
+        !propIsFullyTranslucent;
 
       if (!pickable) {
         // prop cannot be picked


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
latest changes on `vtkPicker` introduced regression on volume picking.

### Results
fix `VolumePicker` example

### Changes
fix testing for opacity + add test for `vtkPicker` usage with `vtkVolume`

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
