### PR TITLE
feat(WidgetManager): customize cursor styles

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.d.ts
+++ b/Sources/Widgets/Core/WidgetManager/index.d.ts
@@ -171,6 +171,23 @@ export interface vtkWidgetManager extends vtkObject {
    * Release the focus.
    */
   releaseFocus(): void;
+
+  /**
+   * Sets the default cursor styles.
+   *
+   * Known style keys:
+   * - default: when not interacting with a widget
+   * - hover: when hovering over a widget.
+   *
+   * If a known style key is not present, the cursor style will not be changed.
+   * @param {Record<string, string>} cursorStyles
+   */
+  setCursorStyles(cursorStyles: Record<string, string>): boolean;
+
+  /**
+   * Retrieves the current cursor styles.
+   */
+  getCursorStyles(): Record<string, string>;
 }
 
 export interface IWidgetManagerInitialValues {

--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -151,7 +151,12 @@ function vtkWidgetManager(publicAPI, model) {
     }
 
     // Default cursor behavior
-    model._apiSpecificRenderWindow.setCursor(widget ? 'pointer' : 'default');
+    const cursorStyles = publicAPI.getCursorStyles();
+    const style = widget ? 'hover' : 'default';
+    const cursor = cursorStyles[style];
+    if (cursor) {
+      model._apiSpecificRenderWindow.setCursor(cursor);
+    }
 
     model.activeWidget = null;
     let wantRender = false;
@@ -461,7 +466,7 @@ function vtkWidgetManager(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 
-const DEFAULT_VALUES = {
+const defaultValues = (initialValues = {}) => ({
   // _camera: null,
   // _selector: null,
   // _currentUpdateSelectionCallID: null,
@@ -476,16 +481,25 @@ const DEFAULT_VALUES = {
   previousSelectedData: null,
   widgetInFocus: null,
   captureOn: CaptureOn.MOUSE_MOVE,
-};
+  ...initialValues,
+
+  cursorStyles: initialValues.cursorStyles
+    ? { ...initialValues.cursorStyles }
+    : {
+        default: 'default',
+        hover: 'pointer',
+      },
+});
 
 // ----------------------------------------------------------------------------
 
 export function extend(publicAPI, model, initialValues = {}) {
-  Object.assign(model, DEFAULT_VALUES, initialValues);
+  Object.assign(model, defaultValues(initialValues));
 
   macro.obj(publicAPI, model);
   macro.setGet(publicAPI, model, [
     'captureOn',
+    'cursorStyles',
     { type: 'enum', name: 'viewType', enum: ViewTypes },
   ]);
   macro.get(publicAPI, model, [


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
https://discourse.vtk.org/t/cannot-change-default-cursor-or-reslicecursorwidget/13609/3

The widget manager doesn't support customizing the default cursor styles.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
The widget manager now exposes an API to configure the default + hover cursor styles.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes
- `vtkWidgetManager.setCursorStyles()` API added.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
