### PR TITLE
docs(RCW): Add some methods to the TS header of RCW behavior

### DIFF
--- a/Sources/Rendering/Core/Renderer/index.d.ts
+++ b/Sources/Rendering/Core/Renderer/index.d.ts
@@ -89,7 +89,7 @@ export interface vtkRenderer extends vtkViewport {
 	/**
 	 * Create and add a light to renderer.
 	 */
-	createLight(): vtkLight;
+	createLight(): void;
 
 	/**
 	 * Compute the bounding box of all the visible props Used in ResetCamera() and ResetCameraClippingRange()
@@ -342,12 +342,12 @@ export interface vtkRenderer extends vtkViewport {
 	getVolumesByReference(): vtkVolume[];
 
 	/**
-	 * Create a new Camera sutible for use with this type of Renderer.
+	 * Create a new Camera suitable for use with this type of Renderer.
 	 */
 	makeCamera(): vtkCamera;
 
 	/**
-	 * Create a new Light sutible for use with this type of Renderer.
+	 * Create a new Light suitable for use with this type of Renderer.
 	 */
 	makeLight(): vtkLight;
 

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.d.ts
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/behavior.d.ts
@@ -1,4 +1,26 @@
+import { Nullable } from "../../../types";
+import { InteractionMethodsName, lineNames } from "./Constants";
 import vtkAbstractWidget from "../../Core/AbstractWidget";
 
+type TLineName = (typeof lineNames)[number];
+
+type TCursorStyles = {
+    [key in InteractionMethodsName]?: string;
+} & {
+  default?: string
+};
+
 export default interface vtkResliceCursorWidgetDefaultInstance extends vtkAbstractWidget {
+    getActiveInteraction(): Nullable<InteractionMethodsName>;
+
+    setKeepOrthogonality(keepOrthogonality: boolean): boolean;
+    getKeepOrthogonality(): boolean;
+
+    setCursorStyles(cursorStyles: TCursorStyles): boolean;
+    getCursorStyles(): TCursorStyles;
+
+    setEnableTranslation(enableTranslation: boolean): void;
+    setEnableRotation(enableRotation: boolean): void;
+
+    getActiveLineName(): TLineName | undefined;
 }


### PR DESCRIPTION
A breaking change of v30 that makes this replacement needed:
```ts
// This
widgetInstance.invokeInternalInteractionEvent();
// becomes this
widgetInstance.invokeInteractionEvent(widgetInstance.getActiveInteraction());
```

Adding `getActiveInteraction` ensures that the project using typescript can keep using it.
Add other functions to avoid doing pull requests for each needed method one by one.