### PR TITLE
Share GPU ressources across render windows

### DIFF
--- a/Examples/Rendering/ManyRenderWindows/index.js
+++ b/Examples/Rendering/ManyRenderWindows/index.js
@@ -1,0 +1,166 @@
+import '@kitware/vtk.js/favicon';
+
+// Load the rendering pieces we want to use (for both WebGL and WebGPU)
+import '@kitware/vtk.js/Rendering/Misc/RenderingAPIs';
+import '@kitware/vtk.js/Rendering/Profiles/Volume';
+
+import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
+import vtkHttpDataSetReader from '@kitware/vtk.js/IO/Core/HttpDataSetReader';
+import vtkInteractorStyleTrackballCamera from '@kitware/vtk.js/Interaction/Style/InteractorStyleTrackballCamera';
+import vtkPiecewiseFunction from '@kitware/vtk.js/Common/DataModel/PiecewiseFunction';
+import vtkRenderer from '@kitware/vtk.js/Rendering/Core/Renderer';
+import vtkRenderWindow from '@kitware/vtk.js/Rendering/Core/RenderWindow';
+import vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
+import vtkVolume from '@kitware/vtk.js/Rendering/Core/Volume';
+import vtkVolumeMapper from '@kitware/vtk.js/Rendering/Core/VolumeMapper';
+
+// Force the loading of HttpDataAccessHelper to support gzip decompression
+import '@kitware/vtk.js/IO/Core/DataAccessHelper/HttpDataAccessHelper';
+
+// ----------------------------------------------------------------------------
+// Background colors
+// ----------------------------------------------------------------------------
+
+async function createActor() {
+  const actor = vtkVolume.newInstance();
+  const mapper = vtkVolumeMapper.newInstance();
+  mapper.setSampleDistance(0.7);
+  mapper.setVolumetricScatteringBlending(0);
+  mapper.setLocalAmbientOcclusion(0);
+  mapper.setLAOKernelSize(10);
+  mapper.setLAOKernelRadius(5);
+  mapper.setComputeNormalFromOpacity(true);
+  actor.setMapper(mapper);
+
+  const ctfun = vtkColorTransferFunction.newInstance();
+  ctfun.addRGBPoint(0, 0, 0, 0);
+  ctfun.addRGBPoint(95, 1.0, 1.0, 1.0);
+  ctfun.addRGBPoint(225, 0.66, 0.66, 0.5);
+  ctfun.addRGBPoint(255, 0.3, 0.3, 0.5);
+  const ofun = vtkPiecewiseFunction.newInstance();
+  ofun.addPoint(100.0, 0.0);
+  ofun.addPoint(255.0, 1.0);
+  actor.getProperty().setRGBTransferFunction(0, ctfun);
+  actor.getProperty().setScalarOpacity(0, ofun);
+  actor.getProperty().setInterpolationTypeToLinear();
+  actor.getProperty().setShade(true);
+  actor.getProperty().setAmbient(0.3);
+  actor.getProperty().setDiffuse(1);
+  actor.getProperty().setSpecular(1);
+  actor.setScale(0.003, 0.003, 0.003);
+  actor.setPosition(1, 1, -1.1);
+
+  const reader = vtkHttpDataSetReader.newInstance({ fetchGzip: true });
+  await reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`);
+  await reader.loadData();
+  const imageData = reader.getOutputData();
+
+  mapper.setInputData(imageData);
+
+  return actor;
+}
+
+const mainRenderWindow = vtkRenderWindow.newInstance();
+const mainRenderWindowView = mainRenderWindow.newAPISpecificView();
+mainRenderWindow.addView(mainRenderWindowView);
+
+const rootContainer = document.createElement('div');
+rootContainer.style.display = 'flex';
+rootContainer.style['align-items'] = 'center';
+rootContainer.style['justify-content'] = 'space-between';
+rootContainer.style['flex-wrap'] = 'wrap';
+document.body.appendChild(rootContainer);
+
+function applyStyle(element) {
+  const width = Math.floor(200 + Math.random() * 200);
+  const height = Math.floor(200 + Math.random() * 200);
+  element.style.width = `${width}px`;
+  element.style.height = `${height}px`;
+  element.style.margin = '20px';
+  element.style.border = 'solid 2px #333';
+  return element;
+}
+
+function addRenderWindow() {
+  // Create a child renderwindow
+  const renderWindow = vtkRenderWindow.newInstance();
+  mainRenderWindow.addRenderWindow(renderWindow);
+
+  // Create the corresponding view
+  const renderWindowView = mainRenderWindowView.addMissingNode(renderWindow);
+
+  // Create a container for the view
+  const container = applyStyle(document.createElement('div'));
+  rootContainer.appendChild(container);
+  renderWindowView.setContainer(container);
+
+  // Resize the view to the size of the container
+  // Ideally, we would use a resize observer to resize the view and
+  // call resizeFromChildRenderWindows on the main view when the container is resized
+  const containerBounds = container.getBoundingClientRect();
+  const pixRatio = window.devicePixelRatio;
+  const dimensions = [
+    containerBounds.width * pixRatio,
+    containerBounds.height * pixRatio,
+  ];
+  renderWindowView.setSize(...dimensions);
+  const canvas = renderWindowView.getCanvas();
+  canvas.style.width = `${container.clientWidth}px`;
+  canvas.style.height = `${container.clientHeight}px`;
+
+  // Add an interactor to the view
+  const interactor = vtkRenderWindowInteractor.newInstance();
+  interactor.setView(renderWindowView);
+  interactor.initialize();
+  interactor.bindEvents(canvas);
+  interactor.setInteractorStyle(
+    vtkInteractorStyleTrackballCamera.newInstance()
+  );
+
+  return renderWindow;
+}
+
+// ----------------------------------------------------------------------------
+// Fill up page
+// ----------------------------------------------------------------------------
+
+const childRenderWindows = [];
+createActor().then((actor) => {
+  // Main view has to be initialized before the first "render" from a child render window
+  // We initialize before creating the child render windows because the interactor initialization calls "render" on them
+  mainRenderWindowView.initialize();
+
+  for (let i = 0; i < 64; i++) {
+    const childRenderWindow = addRenderWindow();
+
+    // Create the corresponding renderer
+    const background = [
+      0.5 * Math.random() + 0.25,
+      0.5 * Math.random() + 0.25,
+      0.5 * Math.random() + 0.25,
+    ];
+    const renderer = vtkRenderer.newInstance({ background });
+    childRenderWindow.addRenderer(renderer);
+
+    // Add the actor and reset camera
+    renderer.addActor(actor);
+    const camera = renderer.getActiveCamera();
+    camera.yaw(90);
+    camera.roll(90);
+    camera.azimuth(Math.random() * 360);
+    renderer.resetCamera();
+
+    childRenderWindows.push(childRenderWindow);
+  }
+
+  mainRenderWindowView.resizeFromChildRenderWindows();
+  mainRenderWindow.render();
+});
+
+// ----------------------------------------------------------------------------
+// Globals
+// ----------------------------------------------------------------------------
+
+global.rw = mainRenderWindow;
+global.glrw = mainRenderWindowView;
+global.childRw = childRenderWindows;

--- a/Sources/Rendering/Core/RenderWindow/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindow/index.d.ts
@@ -9,6 +9,7 @@ export interface IRenderWindowInitialValues {
 	interactor?: any,
 	neverRendered?: boolean,
 	numberOfLayers?: number
+	childRenderWindows?: vtkRenderWindow[],
 }
 
 interface IStatistics {
@@ -41,6 +42,12 @@ export interface vtkRenderWindow extends vtkObject {
 	 * @param {vtkRenderer} renderer The vtkRenderer instance.
 	 */
 	addRenderer(renderer: vtkRenderer): void;
+
+	/**
+	 * Add a child render window
+	 * @param {vtkRenderWindow} renderWindow The vtkRenderWindow instance.
+	 */
+	addRenderWindow(renderWindow: vtkRenderWindow): void;
 
 	/**
 	 * Add renderer
@@ -86,6 +93,16 @@ export interface vtkRenderWindow extends vtkObject {
 	 * 
 	 */
 	getRenderersByReference(): vtkRenderer[];
+
+	/**
+	 * 
+	 */
+	getChildRenderWindows(): vtkRenderWindow[];
+
+	/**
+	 * 
+	 */
+	getChildRenderWindowsByReference(): vtkRenderWindow[];
 
 	/**
 	 * 

--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -143,6 +143,15 @@ function vtkRenderWindow(publicAPI, model) {
       )
       .filter((i) => !!i);
   };
+
+  publicAPI.addRenderWindow = (child) => {
+    if (model.childRenderWindows.includes(child)) {
+      return false;
+    }
+    model.childRenderWindows.push(child);
+    publicAPI.modified();
+    return true;
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -156,6 +165,7 @@ const DEFAULT_VALUES = {
   interactor: null,
   neverRendered: true,
   numberOfLayers: 1,
+  childRenderWindows: [],
 };
 
 // ----------------------------------------------------------------------------
@@ -173,7 +183,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'defaultViewAPI',
   ]);
   macro.get(publicAPI, model, ['neverRendered']);
-  macro.getArray(publicAPI, model, ['renderers']);
+  macro.getArray(publicAPI, model, ['renderers', 'childRenderWindows']);
   macro.moveToProtected(publicAPI, model, ['views']);
   macro.event(publicAPI, model, 'completion');
 

--- a/Sources/Rendering/OpenGL/ForwardPass/index.js
+++ b/Sources/Rendering/OpenGL/ForwardPass/index.js
@@ -28,11 +28,11 @@ function vtkForwardPass(publicAPI, model) {
     const numlayers = viewNode.getRenderable().getNumberOfLayers();
 
     // iterate over renderers
-    const renderers = viewNode.getChildren();
+    const renderers = viewNode.getRenderable().getRenderersByReference();
     for (let i = 0; i < numlayers; i++) {
       for (let index = 0; index < renderers.length; index++) {
-        const renNode = renderers[index];
-        const ren = viewNode.getRenderable().getRenderers()[index];
+        const ren = renderers[index];
+        const renNode = viewNode.getViewNodeFor(ren);
 
         if (ren.getDraw() && ren.getLayer() === i) {
           // check for both opaque and volume actors

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -18,6 +18,7 @@ export interface IOpenGLRenderWindowInitialValues {
 	shaderCache?: null;
 	initialized?: boolean;
 	context?: WebGLRenderingContext | WebGL2RenderingContext;
+	context2D?: CanvasRenderingContext2D;
 	canvas?: HTMLCanvasElement;
 	cursorVisibility?: boolean;
 	cursor?: string;
@@ -38,13 +39,6 @@ export interface ICaptureOptions {
 	resetCamera?: boolean;
 	size?: Size;
 	scale?: number
-}
-
-export interface I3DContextOptions {
-    preserveDrawingBuffer?: boolean;
-    depth?: boolean;
-    alpha?: boolean;
-    powerPreference?: string;
 }
 
 type vtkOpenGLRenderWindowBase = vtkObject & Omit<vtkAlgorithm,
@@ -228,9 +222,44 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
 
 	/**
 	 *
-	 * @param {I3DContextOptions} options
+	 * @param {WebGLContextAttributes} options
 	 */
-	get3DContext(options: I3DContextOptions): Nullable<WebGLRenderingContext>;
+	get3DContext(options: WebGLContextAttributes): Nullable<WebGLRenderingContext>;
+
+	/**
+	 *
+	 * @param {CanvasRenderingContext2DSettings} options
+	 */
+	get2DContext(options: CanvasRenderingContext2DSettings): Nullable<CanvasRenderingContext2D>;
+
+	/**
+	 * Copy the content of the root parent, if there is one, to the canvas
+	 */
+	copyParentContent(): void;
+
+	/**
+	 * Resize this render window using the size of its children
+	 * The new size of the renderwindow is the size of the bounding box
+	 * containing all the child render windows
+	 */
+	resizeFromChildRenderWindows(): void;
+
+	/**
+	 * Returns the last ancestor of type vtkOpenGLRenderWindow if there is one
+	 * If there is no parent vtkOpenGLRenderWindow, returns undefined
+	 */
+	getRootOpenGLRenderWindow(): vtkOpenGLRenderWindow | undefined;
+
+	/**
+	 * The context 2D is created during initialization instead of the WebGL context
+	 * when there is a parent render window
+	 */
+	getContext2D(): CanvasRenderingContext2D | undefined;
+
+	/**
+	 *
+	 */
+	setContext2D(context2D: CanvasRenderingContext2D | undefined): boolean;
 
 	/**
 	 *

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -22,7 +22,7 @@ const SCREENSHOT_PLACEHOLDER = {
   height: '100%',
 };
 
-const rootParentMethodsToProxy = [
+const parentMethodsToProxy = [
   'activateTexture',
   'deactivateTexture',
   'disableCullFace',
@@ -198,7 +198,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
   publicAPI.initialize = () => {
     if (!model.initialized) {
       // Set root parent if there is one
-      // Some methods of the root parent are proxied (see rootParentMethodsToProxy)
+      // Some methods of the root parent are proxied (see parentMethodsToProxy)
       model.rootOpenGLRenderWindow = publicAPI.getLastAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
@@ -1258,7 +1258,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   // Proxy some methods if needed
   const publicAPIBeforeProxy = { ...publicAPI };
-  rootParentMethodsToProxy.forEach((methodName) => {
+  parentMethodsToProxy.forEach((methodName) => {
     publicAPI[methodName] = (...args) => {
       if (model.rootOpenGLRenderWindow) {
         // Proxy only methods when the render window has a parent

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -5,7 +5,9 @@ import vtkForwardPass from 'vtk.js/Sources/Rendering/OpenGL/ForwardPass';
 import vtkOpenGLHardwareSelector from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector';
 import vtkShaderCache from 'vtk.js/Sources/Rendering/OpenGL/ShaderCache';
 import vtkOpenGLTextureUnitManager from 'vtk.js/Sources/Rendering/OpenGL/TextureUnitManager';
-import vtkOpenGLViewNodeFactory from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
+import vtkOpenGLViewNodeFactory, {
+  registerOverride,
+} from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
 import vtkRenderPass from 'vtk.js/Sources/Rendering/SceneGraph/RenderPass';
 import vtkRenderWindowViewNode from 'vtk.js/Sources/Rendering/SceneGraph/RenderWindowViewNode';
 import { createContextProxyHandler } from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow/ContextProxy';
@@ -1206,9 +1208,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   model._glInformation = null;
 
   model.myFactory = vtkOpenGLViewNodeFactory.newInstance();
-  /* eslint-disable no-use-before-define */
-  model.myFactory.registerOverride('vtkRenderWindow', newInstance);
-  /* eslint-enable no-use-before-define */
 
   model.shaderCache = vtkShaderCache.newInstance();
   model.shaderCache.setOpenGLRenderWindow(publicAPI);
@@ -1263,3 +1262,6 @@ export default {
   pushMonitorGLContextCount,
   popMonitorGLContextCount,
 };
+
+// Register ourself to OpenGL backend if imported
+registerOverride('vtkRenderWindow', newInstance);

--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -137,19 +137,14 @@ function vtkOpenGLRenderer(publicAPI, model) {
     if (!model.renderable.getTransparent()) {
       const background = model.renderable.getBackgroundByReference();
       // renderable ensures that background has 4 entries.
-      model.context.clearColor(
-        background[0],
-        background[1],
-        background[2],
-        background[3]
-      );
+      gl.clearColor(background[0], background[1], background[2], background[3]);
       clearMask |= gl.COLOR_BUFFER_BIT;
     }
 
     if (!model.renderable.getPreserveDepthBuffer()) {
       gl.clearDepth(1.0);
       clearMask |= gl.DEPTH_BUFFER_BIT;
-      model.context.depthMask(true);
+      gl.depthMask(true);
     }
 
     gl.colorMask(true, true, true, true);

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1663,10 +1663,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const tex = model._openGLRenderWindow.getGraphicsResourceForObject(scalars);
     // rebuild the scalarTexture if the data has changed
     toString = `${image.getMTime()}A${scalars.getMTime()}`;
-    const reBuildTex =
-      !tex?.vtkObj ||
-      tex?.hash !== toString ||
-      model.scalarTextureString !== toString;
+    const reBuildTex = !tex?.vtkObj || tex?.hash !== toString;
     if (reBuildTex) {
       // Build the textures
       const dims = image.getDimensions();
@@ -1683,17 +1680,15 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         scalars,
         model.renderable.getPreferSizeOverAccuracy()
       );
-      model.scalarTextureString = toString;
       if (scalars) {
         model._openGLRenderWindow.setGraphicsResourceForObject(
           scalars,
           model.scalarTexture,
-          model.scalarTextureString
+          toString
         );
       }
     } else {
       model.scalarTexture = tex.vtkObj;
-      model.scalarTextureString = tex.hash;
     }
 
     if (!model.tris.getCABO().getElementCount()) {

--- a/Sources/Rendering/SceneGraph/ViewNode/index.d.ts
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.d.ts
@@ -67,6 +67,12 @@ export interface vtkViewNode extends vtkObject {
 	getFirstAncestorOfType(type: any): void;
 
 	/**
+	 * Find the last parent/grandparent of the desired type
+	 * @param type 
+	 */
+	getLastAncestorOfType(type: any): void;
+
+	/**
 	 * 
 	 */
 	getMyFactory(): any;

--- a/Sources/Rendering/SceneGraph/ViewNode/index.d.ts
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.d.ts
@@ -20,10 +20,12 @@ export interface IViewNodeInitialValues {
 export interface vtkViewNode extends vtkObject {
 
 	/**
-	 * 
+	 * Add a child view node to this node, created from the renderable given as argument
+	 * If the node creation fails or the argument is falsy, returns undefined
+	 * Otherwise, returns the newly created node or the existing node
 	 * @param dobj 
 	 */
-	addMissingNode(dobj: any): void;
+	addMissingNode(dobj: any): vtkViewNode | undefined;
 
 	/**
 	 * 

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -70,6 +70,20 @@ function vtkViewNode(publicAPI, model) {
     return model._parent.getFirstAncestorOfType(type);
   };
 
+  publicAPI.getLastAncestorOfType = (type) => {
+    if (!model._parent) {
+      return null;
+    }
+    const lastAncestor = model._parent.getLastAncestorOfType(type);
+    if (lastAncestor) {
+      return lastAncestor;
+    }
+    if (model._parent.isA(type)) {
+      return model._parent;
+    }
+    return null;
+  };
+
   // add a missing node/child for the passed in renderables. This should
   // be called only in between prepareNodes and removeUnusedNodes
   publicAPI.addMissingNode = (dobj) => {

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -139,6 +139,10 @@ function vtkViewNode(publicAPI, model) {
       if (cindex === -1) {
         child.setParent(publicAPI);
         model.children.push(child);
+        const childRenderable = child.getRenderable();
+        if (childRenderable) {
+          model._renderableChildMap.set(childRenderable, child);
+        }
       }
       child.setVisited(true);
     }

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -88,22 +88,27 @@ function vtkViewNode(publicAPI, model) {
   // be called only in between prepareNodes and removeUnusedNodes
   publicAPI.addMissingNode = (dobj) => {
     if (!dobj) {
-      return;
+      return undefined;
     }
-    const result = model._renderableChildMap.get(dobj);
+
     // if found just mark as visited
+    const result = model._renderableChildMap.get(dobj);
     if (result !== undefined) {
       result.setVisited(true);
-    } else {
-      // otherwise create a node
-      const newNode = publicAPI.createViewNode(dobj);
-      if (newNode) {
-        newNode.setParent(publicAPI);
-        newNode.setVisited(true);
-        model._renderableChildMap.set(dobj, newNode);
-        model.children.push(newNode);
-      }
+      return result;
     }
+
+    // otherwise create a node
+    const newNode = publicAPI.createViewNode(dobj);
+    if (newNode) {
+      newNode.setParent(publicAPI);
+      newNode.setVisited(true);
+      model._renderableChildMap.set(dobj, newNode);
+      model.children.push(newNode);
+      return newNode;
+    }
+
+    return undefined;
   };
 
   // add missing nodes/children for the passed in renderables. This should
@@ -115,20 +120,7 @@ function vtkViewNode(publicAPI, model) {
 
     for (let index = 0; index < dataObjs.length; ++index) {
       const dobj = dataObjs[index];
-      const result = model._renderableChildMap.get(dobj);
-      // if found just mark as visited
-      if (result !== undefined) {
-        result.setVisited(true);
-      } else {
-        // otherwise create a node
-        const newNode = publicAPI.createViewNode(dobj);
-        if (newNode) {
-          newNode.setParent(publicAPI);
-          newNode.setVisited(true);
-          model._renderableChildMap.set(dobj, newNode);
-          model.children.push(newNode);
-        }
-      }
+      publicAPI.addMissingNode(dobj);
     }
   };
 

--- a/Sources/Rendering/SceneGraph/ViewNodeFactory/index.d.ts
+++ b/Sources/Rendering/SceneGraph/ViewNodeFactory/index.d.ts
@@ -12,14 +12,6 @@ export interface vtkViewNodeFactory extends vtkObject {
 	 * @param dataObject 
 	 */
 	createNode(dataObject: any): void;
-
-	/**
-	 * Give a function pointer to a class that will manufacture a vtkViewNode
-	 * when given a class name string.
-	 * @param className 
-	 * @param func 
-	 */
-	registerOverride(className: any, func: any): void;
 }
 
 /**

--- a/Sources/Rendering/SceneGraph/ViewNodeFactory/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNodeFactory/index.js
@@ -37,10 +37,6 @@ function vtkViewNodeFactory(publicAPI, model) {
     vn.setMyFactory(publicAPI);
     return vn;
   };
-
-  publicAPI.registerOverride = (className, func) => {
-    model.overrides[className] = func;
-  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/WebGPU/RenderWindow/index.js
+++ b/Sources/Rendering/WebGPU/RenderWindow/index.js
@@ -4,7 +4,9 @@ import vtkForwardPass from 'vtk.js/Sources/Rendering/WebGPU/ForwardPass';
 import vtkWebGPUBuffer from 'vtk.js/Sources/Rendering/WebGPU/Buffer';
 import vtkWebGPUDevice from 'vtk.js/Sources/Rendering/WebGPU/Device';
 import vtkWebGPUHardwareSelector from 'vtk.js/Sources/Rendering/WebGPU/HardwareSelector';
-import vtkWebGPUViewNodeFactory from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
+import vtkWebGPUViewNodeFactory, {
+  registerOverride,
+} from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
 import vtkRenderPass from 'vtk.js/Sources/Rendering/SceneGraph/RenderPass';
 import vtkRenderWindowViewNode from 'vtk.js/Sources/Rendering/SceneGraph/RenderWindowViewNode';
 import HalfFloat from 'vtk.js/Sources/Common/Core/HalfFloat';
@@ -600,9 +602,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   vtkRenderWindowViewNode.extend(publicAPI, model, initialValues);
 
   model.myFactory = vtkWebGPUViewNodeFactory.newInstance();
-  /* eslint-disable no-use-before-define */
-  model.myFactory.registerOverride('vtkRenderWindow', newInstance);
-  /* eslint-enable no-use-before-define */
 
   // setup default forward pass rendering
   model.renderPasses[0] = vtkForwardPass.newInstance();
@@ -658,3 +657,6 @@ export default {
   newInstance,
   extend,
 };
+
+// Register ourself to WebGPU backend if imported
+registerOverride('vtkRenderWindow', newInstance);


### PR DESCRIPTION
Add possibility to share a single context for several render windows.
This enables GPU ressource sharing accross render windows.

This feature uses `drawImage` from the main WebGL context to the child render window's canvas. It is slow if there are a lot of render windows on Firefox: see [this issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1163426).