### PR TITLE
Expose cube axes actor tick generation 2

### DIFF
--- a/Examples/Geometry/CubeAxes/index.js
+++ b/Examples/Geometry/CubeAxes/index.js
@@ -44,17 +44,15 @@ const cubeAxes = vtkCubeAxesActor.newInstance();
 cubeAxes.setCamera(renderer.getActiveCamera());
 cubeAxes.setDataBounds(actor.getBounds());
 // Replace ticks from axis 0
-function myGenerateTicks(defaultGenerateTicks) {
-  return (dataBounds) => {
-    const res = defaultGenerateTicks(dataBounds);
-    const scale = d3scale.scaleLinear().domain([dataBounds[0], dataBounds[1]]);
-    res.ticks[0] = d3array.range(dataBounds[0], dataBounds[1], 0.1);
-    const format = scale.tickFormat(res.ticks[0].length);
-    res.tickStrings[0] = res.ticks[0].map(format);
-    return res;
-  };
+function myGenerateTicks(dataBounds) {
+  const res = vtkCubeAxesActor.defaultGenerateTicks(dataBounds);
+  const scale = d3scale.scaleLinear().domain([dataBounds[0], dataBounds[1]]);
+  res.ticks[0] = d3array.range(dataBounds[0], dataBounds[1], 0.1);
+  const format = scale.tickFormat(res.ticks[0].length);
+  res.tickStrings[0] = res.ticks[0].map(format);
+  return res;
 }
-cubeAxes.setGenerateTicks(myGenerateTicks(cubeAxes.getGenerateTicks()));
+cubeAxes.setGenerateTicks(myGenerateTicks);
 renderer.addActor(cubeAxes);
 
 renderer.resetCamera();

--- a/Sources/Rendering/Core/CubeAxesActor/index.js
+++ b/Sources/Rendering/Core/CubeAxesActor/index.js
@@ -81,20 +81,18 @@ function applyTextStyle(ctx, style) {
   ctx.font = `${style.fontStyle} ${style.fontSize}px ${style.fontFamily}`;
 }
 
-function defaultGenerateTicks(publicApi, model) {
-  return (dataBounds) => {
-    const ticks = [];
-    const tickStrings = [];
-    for (let i = 0; i < 3; i++) {
-      const scale = d3
-        .scaleLinear()
-        .domain([dataBounds[i * 2], dataBounds[i * 2 + 1]]);
-      ticks[i] = scale.ticks(5);
-      const format = scale.tickFormat(5);
-      tickStrings[i] = ticks[i].map(format);
-    }
-    return { ticks, tickStrings };
-  };
+function defaultGenerateTicks(dataBounds) {
+  const ticks = [];
+  const tickStrings = [];
+  for (let i = 0; i < 3; i++) {
+    const scale = d3
+      .scaleLinear()
+      .domain([dataBounds[i * 2], dataBounds[i * 2 + 1]]);
+    ticks[i] = scale.ticks(5);
+    const format = scale.tickFormat(5);
+    tickStrings[i] = ticks[i].map(format);
+  }
+  return { ticks, tickStrings };
 }
 
 // many properties of this actor depend on the API specific view The main
@@ -824,7 +822,7 @@ function defaultValues(publicAPI, model, initialValues) {
     axisLabels: null,
     axisTitlePixelOffset: 35.0,
     tickLabelPixelOffset: 12.0,
-    generateTicks: defaultGenerateTicks(publicAPI, model),
+    generateTicks: defaultGenerateTicks,
     ...initialValues,
     axisTextStyle: {
       fontColor: 'white',
@@ -865,7 +863,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   model._tmAtlas = new Map();
 
   // for texture atlas
-  model.tmTexture = vtkTexture.newInstance();
+  model.tmTexture = vtkTexture.newInstance({ resizable: true });
   model.tmTexture.setInterpolate(false);
 
   publicAPI.getProperty().setDiffuse(0.0);
@@ -913,4 +911,9 @@ export const newInstance = macro.newInstance(extend, 'vtkCubeAxesActor');
 
 // ----------------------------------------------------------------------------
 
-export default { newInstance, extend, newCubeAxesActorHelper };
+export default {
+  newInstance,
+  extend,
+  newCubeAxesActorHelper,
+  defaultGenerateTicks,
+};


### PR DESCRIPTION
### Context
Changing the number of ticks requires resizing the associated texture.

### Results
Texture was stretched when number of ticks was changed.
It is now correctly resized.

### Changes
Allow resizing of the texture
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome
