### PR TITLE
fix(ImageOutline): allow zero outline by hiding it

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -351,11 +351,6 @@ function vtkOpenGLImageMapper(publicAPI, model) {
                     return;
                   }
 
-                  if (actualThickness == 0) {
-                    gl_FragData[0] = vec4(0.0, 0.0, 1.0, 1.0);
-                    return;
-                  }
-
                   for (int i = -actualThickness; i <= actualThickness; i++) {
                     for (int j = -actualThickness; j <= actualThickness; j++) {
                       if (i == 0 || j == 0) {

--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -1039,9 +1039,6 @@ vec4 getColorForValue(vec4 tValue, vec3 posIS, vec3 tstep)
 
   int actualThickness = int(textureValue * 255.0);
 
-  if (actualThickness == 0) {
-    return vec4(0, 0, 1, 1);
-  }
 
   // If it is the background (segment index 0), we should quickly bail out. 
   // Previously, this was determined by tColor.a, which was incorrect as it


### PR DESCRIPTION
### Context
There seems to be a left out debugging statement (by me), in the older PR which prevents the zero outline value
One should be able to turn off the outline for one segment by setting it to 0. 

`labelMap.actor.getProperty().setLabelOutlineThickness([0, 3]);`


Right now it makes it blue (meant for debugging)

<img width="1004" alt="CleanShot 2024-04-11 at 14 25 38@2x" src="https://github.com/Kitware/vtk-js/assets/7490180/5ff1a1c8-e88a-4834-aa54-b793583e4196">

After 


<img width="1157" alt="CleanShot 2024-04-11 at 14 31 02@2x" src="https://github.com/Kitware/vtk-js/assets/7490180/f1e385c5-22d9-4cb9-b969-87b967c24c5c">


### Results
You can now set the outline to 0 and the outline for that segment will be off

### Changes
Removed the debugging if statement

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: Latest
  - **OS**: macOS Ventura
  - **Browser**: Latest Chrome

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
