### PR TITLE
fix(colortransferfunction): add access to set/get Scale

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/index.js
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.js
@@ -1324,9 +1324,10 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, [
     'useAboveRangeColor',
     'useBelowRangeColor',
-    'colorSpace',
     'discretize',
     'numberOfValues',
+    { type: 'enum', name: 'colorSpace', enum: ColorSpace },
+    { type: 'enum', name: 'scale', enum: Scale },
   ]);
 
   macro.setArray(


### PR DESCRIPTION
In this case issue was created in vtk discourse

Discourse post thread: https://discourse.vtk.org/t/set-desired-scale-in-vtkcolortransferfunction/13736

Results:
Now you can access the Scale variable.

Changes:
Simply added access to changing the value of the Scale variable by the user with getScale() and setScale() in vtkColorTransferFunction, which was not there for some reason.