### PR TITLE
fix(outlineThickness): allow 0 thickness per segment index

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -1376,7 +1376,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       // Assuming labelOutlineThicknessArray contains the thickness for each segment
       for (let i = 0; i < lWidth; ++i) {
         // Retrieve the thickness value for the current segment index.
-        // If the value is undefined, use the first element's value as a default, otherwise use the value (event if 0)
+        // If the value is undefined, use the first element's value as a default, otherwise use the value (even if 0)
         const thickness =
           typeof labelOutlineThicknessArray[i] !== 'undefined'
             ? labelOutlineThicknessArray[i]

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -1376,9 +1376,11 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       // Assuming labelOutlineThicknessArray contains the thickness for each segment
       for (let i = 0; i < lWidth; ++i) {
         // Retrieve the thickness value for the current segment index.
-        // If the value is undefined, null, or 0, use the first element's value as a default.
+        // If the value is undefined, use the first element's value as a default, otherwise use the value (event if 0)
         const thickness =
-          labelOutlineThicknessArray[i] || labelOutlineThicknessArray[0];
+          typeof labelOutlineThicknessArray[i] !== 'undefined'
+            ? labelOutlineThicknessArray[i]
+            : labelOutlineThicknessArray[0];
         lTable[i] = thickness;
       }
       model.labelOutlineThicknessTexture.releaseGraphicsResources(

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1782,9 +1782,12 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       // Assuming labelOutlineThicknessArray contains the thickness for each segment
       for (let i = 0; i < lWidth; ++i) {
         // Retrieve the thickness value for the current segment index.
-        // If the value is undefined, null, or 0, use the first element's value as a default.
+        // If the value is undefined, use the first element's value as a default, otherwise use the value (event if 0)
         const thickness =
-          labelOutlineThicknessArray[i] || labelOutlineThicknessArray[0];
+          typeof labelOutlineThicknessArray[i] !== 'undefined'
+            ? labelOutlineThicknessArray[i]
+            : labelOutlineThicknessArray[0];
+
         lTable[i] = thickness;
       }
 

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1782,7 +1782,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       // Assuming labelOutlineThicknessArray contains the thickness for each segment
       for (let i = 0; i < lWidth; ++i) {
         // Retrieve the thickness value for the current segment index.
-        // If the value is undefined, use the first element's value as a default, otherwise use the value (event if 0)
+        // If the value is undefined, use the first element's value as a default, otherwise use the value (even if 0)
         const thickness =
           typeof labelOutlineThicknessArray[i] !== 'undefined'
             ? labelOutlineThicknessArray[i]


### PR DESCRIPTION
### Context

Incorrect logic prevents each segment from having a 0 outline. The previous logic defaulted to the first segment when the thickness was 0. The accurate approach should be to default to the first segment when it is undefined, as it should be permissible to set any segment's thickness to 0.

### Results

`labelMap.actor.getProperty().setLabelOutlineThickness([3, 0]);` (segment 1 (red)-> 3 , segment 2 (green) -> 0)


**Previously** 

<img width="970" alt="CleanShot 2024-04-23 at 22 48 31@2x" src="https://github.com/Kitware/vtk-js/assets/7490180/e7aeaf65-ed82-4037-8978-8d3518340abb">


**After**


<img width="890" alt="CleanShot 2024-04-23 at 22 47 55@2x" src="https://github.com/Kitware/vtk-js/assets/7490180/db6c079d-7fb5-4833-a190-ba83c2bbafac">



### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
