### PR TITLE
Add getter and setter for resetCameraOnFirstRender in view proxy

### DIFF
--- a/Sources/Proxy/Core/ViewProxy/index.js
+++ b/Sources/Proxy/Core/ViewProxy/index.js
@@ -660,7 +660,11 @@ function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   macro.obj(publicAPI, model);
-  macro.setGet(publicAPI, model, ['name', 'disableAnimation']);
+  macro.setGet(publicAPI, model, [
+    'name',
+    'disableAnimation',
+    'resetCameraOnFirstRender',
+  ]);
   macro.get(publicAPI, model, [
     'annotationOpacity',
     'camera',


### PR DESCRIPTION
Add `resetCameraOnFirstRender` in the setGet macro

It was possible to set it when creating the view proxy (defaults to true), but it is reset to `true` when rendering with an empty representation list which is sometimes undesirable
