### PR TITLE
Expose log in scalarbaractor example

### DIFF
--- a/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
+++ b/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
@@ -71,4 +71,10 @@
       <input type="number" id="numberOfColors" value="256" min="1"></input>
     </td>
   </tr>
+  <tr>
+    <td>Log:</td>
+    <td>
+      <input type="checkbox" id="log">
+    </td>
+  </tr>
 </table>


### PR DESCRIPTION

### Context
Improve vtkScalarBarActor example to demonstrate the Log scale.

### Results
Adds a "Log" checkbox to the vtkScalarBarActor example.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome
