### PR TITLE
Cleanup of resource sharing accross render windows

### DIFF
--- a/Examples/Rendering/ManyRenderWindows/index.js
+++ b/Examples/Rendering/ManyRenderWindows/index.js
@@ -135,7 +135,15 @@ function applyStyle(element) {
   element.style.height = `${height}px`;
   element.style.margin = '20px';
   element.style.border = 'solid 2px #333';
+  element.style['text-align'] = 'center';
   return element;
+}
+
+function createRemoveButton() {
+  const buttonEl = document.createElement('button');
+  buttonEl.innerText = 'Remove render window';
+  buttonEl.style.display = 'inline-block';
+  return buttonEl;
 }
 
 function addRenderWindow() {
@@ -174,6 +182,17 @@ function addRenderWindow() {
   interactor.setInteractorStyle(
     vtkInteractorStyleTrackballCamera.newInstance()
   );
+
+  const button = createRemoveButton();
+  button.addEventListener('click', () => {
+    rootContainer.removeChild(container);
+    mainRenderWindow.removeRenderWindow(renderWindow);
+    mainRenderWindowView.removeNode(renderWindowView);
+    interactor.delete();
+    renderWindow.delete();
+    renderWindowView.delete();
+  });
+  container.appendChild(button);
 
   return renderWindow;
 }

--- a/Sources/Rendering/Core/RenderWindow/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindow/index.d.ts
@@ -149,6 +149,12 @@ export interface vtkRenderWindow extends vtkObject {
   removeRenderer(renderer: vtkRenderer): void;
 
   /**
+   * Remove a child render window added using addRenderWindow(renderWindow)
+   * @param {vtkRenderWindow} renderWindow The vtkRenderWindow instance.
+   */
+  removeRenderWindow(renderWindow: vtkRenderWindow): boolean;
+
+  /**
    * Remove renderer
    * @param view
    */

--- a/Sources/Rendering/Core/RenderWindow/index.js
+++ b/Sources/Rendering/Core/RenderWindow/index.js
@@ -152,6 +152,16 @@ function vtkRenderWindow(publicAPI, model) {
     publicAPI.modified();
     return true;
   };
+
+  publicAPI.removeRenderWindow = (child) => {
+    const childIndex = model.childRenderWindows.findIndex((x) => x === child);
+    if (childIndex < 0) {
+      return false;
+    }
+    model.childRenderWindows.splice(childIndex, 1);
+    publicAPI.modified();
+    return true;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -16,7 +16,7 @@ function vtkOpenGLActor(publicAPI, model) {
   // Builds myself.
   publicAPI.buildPass = (prepass) => {
     if (prepass) {
-      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getLastAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model._openGLRenderer =

--- a/Sources/Rendering/OpenGL/Actor2D/index.js
+++ b/Sources/Rendering/OpenGL/Actor2D/index.js
@@ -17,7 +17,7 @@ function vtkOpenGLActor2D(publicAPI, model) {
       if (!model.renderable) {
         return;
       }
-      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getLastAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model._openGLRenderer =

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -882,19 +882,16 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     }
   };
 
-  publicAPI.getNeedToRebuildBufferObjects = (ren, actor) => {
-    // first do a coarse check
-    if (
-      model.VBOBuildTime.getMTime() < publicAPI.getMTime() ||
-      model.VBOBuildTime.getMTime() < actor.getMTime() ||
-      model.VBOBuildTime.getMTime() < model.renderable.getMTime() ||
-      model.VBOBuildTime.getMTime() < actor.getProperty().getMTime() ||
-      model.VBOBuildTime.getMTime() < model.currentInput.getMTime()
-    ) {
-      return true;
-    }
-    return false;
-  };
+  publicAPI.getNeedToRebuildBufferObjects = (ren, actor) =>
+    model.VBOBuildTime.getMTime() < publicAPI.getMTime() ||
+    model.VBOBuildTime.getMTime() < actor.getMTime() ||
+    model.VBOBuildTime.getMTime() < model.renderable.getMTime() ||
+    model.VBOBuildTime.getMTime() < actor.getProperty().getMTime() ||
+    model.VBOBuildTime.getMTime() < model.currentInput.getMTime() ||
+    !model.openGLTexture?.getHandle() ||
+    !model.colorTexture?.getHandle() ||
+    !model.labelOutlineThicknessTexture?.getHandle() ||
+    !model.pwfTexture?.getHandle();
 
   publicAPI.buildBufferObjects = (ren, actor) => {
     const image = model.currentInput;
@@ -930,7 +927,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model._openGLRenderWindow.getGraphicsResourceForObject(colorTransferFunc);
 
     const reBuildC =
-      !cTex?.vtkObj ||
+      !cTex?.vtkObj?.getHandle() ||
       cTex?.hash !== cfunToString ||
       model.colorTextureString !== cfunToString;
     if (reBuildC) {
@@ -1016,7 +1013,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model._openGLRenderWindow.getGraphicsResourceForObject(pwFunc);
     // rebuild opacity tfun?
     const reBuildPwf =
-      !pwfTex?.vtkObj ||
+      !pwfTex?.vtkObj?.getHandle() ||
       pwfTex?.hash !== pwfunToString ||
       model.pwfTextureString !== pwfunToString;
     if (reBuildPwf) {
@@ -1275,7 +1272,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
       const tex =
         model._openGLRenderWindow.getGraphicsResourceForObject(scalars);
-      if (!tex?.vtkObj) {
+      if (!tex?.vtkObj?.getHandle()) {
         if (model._scalars !== scalars) {
           model._openGLRenderWindow.releaseGraphicsResourcesForObject(
             model._scalars
@@ -1363,7 +1360,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     const toString = `${labelOutlineThicknessArray.join('-')}`;
 
     const reBuildL =
-      !lTex?.vtkObj ||
+      !lTex?.vtkObj?.getHandle() ||
       lTex?.hash !== toString ||
       model.labelOutlineThicknessTextureString !== toString;
 

--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -190,7 +190,10 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
     model.VBOBuildTime.getMTime() < model.renderable.getMTime() ||
     model.VBOBuildTime.getMTime() < actor.getProperty().getMTime() ||
     model.VBOBuildTime.getMTime() < model.currentInput.getMTime() ||
-    model.VBOBuildTime.getMTime() < model.resliceGeom.getMTime();
+    model.VBOBuildTime.getMTime() < model.resliceGeom.getMTime() ||
+    !model.openGLTexture?.getHandle() ||
+    !model.colorTexture?.getHandle() ||
+    !model.pwfTexture?.getHandle();
 
   publicAPI.buildBufferObjects = (ren, actor) => {
     const image = model.currentInput;
@@ -214,7 +217,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
     let toString = `${image.getMTime()}A${scalars.getMTime()}`;
 
     const tex = model._openGLRenderWindow.getGraphicsResourceForObject(scalars);
-    const reBuildTex = !tex?.vtkObj || tex?.hash !== toString;
+    const reBuildTex = !tex?.vtkObj?.getHandle() || tex?.hash !== toString;
     if (reBuildTex) {
       if (!model.openGLTexture) {
         model.openGLTexture = vtkOpenGLTexture.newInstance();
@@ -255,7 +258,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
     const cTex =
       model._openGLRenderWindow.getGraphicsResourceForObject(colorTransferFunc);
     const reBuildC =
-      !cTex?.vtkObj ||
+      !cTex?.vtkObj?.getHandle() ||
       cTex?.hash !== toString ||
       model.colorTextureString !== toString;
     if (reBuildC) {
@@ -332,7 +335,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
       model._openGLRenderWindow.getGraphicsResourceForObject(pwFunc);
     // rebuild opacity tfun?
     const reBuildPwf =
-      !pwfTex?.vtkObj ||
+      !pwfTex?.vtkObj?.getHandle() ||
       pwfTex?.hash !== toString ||
       model.pwfTextureString !== toString;
     if (reBuildPwf) {

--- a/Sources/Rendering/OpenGL/ImageSlice/index.js
+++ b/Sources/Rendering/OpenGL/ImageSlice/index.js
@@ -22,7 +22,7 @@ function vtkOpenGLImageSlice(publicAPI, model) {
       if (!model.renderable) {
         return;
       }
-      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getLastAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model._openGLRenderer =

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1183,10 +1183,11 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
       if (model.context) {
         deleteGLContext();
       }
+      publicAPI.setContainer();
+      publicAPI.setViewStream();
     },
     clearEvents,
-    publicAPI.delete,
-    publicAPI.setViewStream
+    publicAPI.delete
   );
 
   // Do not trigger modified for performance reasons

--- a/Sources/Rendering/OpenGL/Volume/index.js
+++ b/Sources/Rendering/OpenGL/Volume/index.js
@@ -19,7 +19,7 @@ function vtkOpenGLVolume(publicAPI, model) {
       return;
     }
     if (prepass) {
-      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getLastAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model._openGLRenderer =

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1476,7 +1476,10 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       model.VBOBuildTime.getMTime() < actor.getMTime() ||
       model.VBOBuildTime.getMTime() < model.renderable.getMTime() ||
       model.VBOBuildTime.getMTime() < actor.getProperty().getMTime() ||
-      model.VBOBuildTime.getMTime() < model.currentInput.getMTime()
+      model.VBOBuildTime.getMTime() < model.currentInput.getMTime() ||
+      !model.scalarTexture?.getHandle() ||
+      !model.colorTexture?.getHandle() ||
+      !model.labelOutlineThicknessTexture?.getHandle()
     ) {
       return true;
     }
@@ -1614,7 +1617,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const cTex =
       model._openGLRenderWindow.getGraphicsResourceForObject(colorTransferFunc);
     const reBuildC =
-      !cTex?.vtkObj ||
+      !cTex?.vtkObj?.getHandle() ||
       cTex?.hash !== toString ||
       model.colorTextureString !== toString;
     if (reBuildC) {
@@ -1663,7 +1666,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const tex = model._openGLRenderWindow.getGraphicsResourceForObject(scalars);
     // rebuild the scalarTexture if the data has changed
     toString = `${image.getMTime()}A${scalars.getMTime()}`;
-    const reBuildTex = !tex?.vtkObj || tex?.hash !== toString;
+    const reBuildTex = !tex?.vtkObj?.getHandle() || tex?.hash !== toString;
     if (reBuildTex) {
       // Build the textures
       const dims = image.getDimensions();
@@ -1769,7 +1772,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const toString = `${labelOutlineThicknessArray.join('-')}`;
 
     const reBuildL =
-      !lTex?.vtkObj ||
+      !lTex?.vtkObj?.getHandle() ||
       lTex?.hash !== toString ||
       model.labelOutlineThicknessTextureString !== toString;
 

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -144,7 +144,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
   // Renders myself
   publicAPI.volumePass = (prepass, renderPass) => {
     if (prepass) {
-      model._openGLRenderWindow = publicAPI.getFirstAncestorOfType(
+      model._openGLRenderWindow = publicAPI.getLastAncestorOfType(
         'vtkOpenGLRenderWindow'
       );
       model.context = model._openGLRenderWindow.getContext();

--- a/Sources/Rendering/SceneGraph/ViewNode/index.d.ts
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.d.ts
@@ -27,6 +27,14 @@ export interface vtkViewNode extends vtkObject {
   addMissingNode(dobj: any): vtkViewNode | undefined;
 
   /**
+   * Removes a child view node
+   * If the node is not found, returns false
+   * Otherwise, removes the node from the children list and returns true
+   * @param dobj
+   */
+  removeNode(dobj: any): boolean;
+
+  /**
    *
    * @param dataObjs
    */

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -153,6 +153,11 @@ function vtkViewNode(publicAPI, model) {
     if (childIdx < 0) {
       return false;
     }
+    const renderable = child.getRenderable();
+    if (renderable) {
+      model._renderableChildMap.delete(renderable);
+    }
+    child.delete();
     model.children.splice(childIdx, 1);
     return true;
   };

--- a/Sources/Rendering/SceneGraph/ViewNode/index.js
+++ b/Sources/Rendering/SceneGraph/ViewNode/index.js
@@ -148,6 +148,15 @@ function vtkViewNode(publicAPI, model) {
     }
   };
 
+  publicAPI.removeNode = (child) => {
+    const childIdx = model.children.findIndex((x) => x === child);
+    if (childIdx < 0) {
+      return false;
+    }
+    model.children.splice(childIdx, 1);
+    return true;
+  };
+
   publicAPI.prepareNodes = () => {
     for (let index = 0; index < model.children.length; ++index) {
       model.children[index].setVisited(false);


### PR DESCRIPTION
- Avoid crash when releasing of graphics resources using `releaseGraphicsResourcesForObject()` and the released texture is used by other parts of the code
- Add code in the example to show how to release graphics resources by hand (this process should be automated in a near future)
- Add the possibility to remove child render windows and show how to do it in the example
