### PR TITLE
fix(ImplicitPlaneWidget): jumpy behavior

### DIFF
--- a/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ImplicitPlaneWidget/index.js
@@ -47,16 +47,32 @@ function widgetBehavior(publicAPI, model) {
       return macro.VOID;
     }
 
-    model.lineManipulator.setWidgetOrigin(model.widgetState.getOrigin());
-    model.planeManipulator.setWidgetOrigin(model.widgetState.getOrigin());
+    model.lineManipulator.setWidgetOrigin(model.activeState.getOrigin());
+    model.lineManipulator.setWidgetNormal(model.activeState.getNormal());
+    model.planeManipulator.setWidgetOrigin(model.activeState.getOrigin());
+    model.planeManipulator.setWidgetNormal(model.activeManipulator.getNormal());
     model.trackballManipulator.reset(callData); // setup trackball delta
+    model.trackballManipulator.setWidgetNormal(model.activeState.getNormal());
 
-    // updates worldDelta
-    model.lineManipulator.handleEvent(callData, model._apiSpecificRenderWindow);
-    model.planeManipulator.handleEvent(
-      callData,
-      model._apiSpecificRenderWindow
-    );
+    // update worldDelta with the proper manipulator
+    let activeManipulator = null;
+    switch (model.activeState.getUpdateMethodName()) {
+      case 'updateFromOrigin':
+        activeManipulator = model.planeManipulator;
+        break;
+      case 'updateFromPlane':
+        activeManipulator = model.lineManipulator;
+        break;
+      case 'updateFromNormal':
+        activeManipulator = model.trackballManipulator;
+        break;
+      default:
+      // skip
+    }
+
+    if (activeManipulator) {
+      activeManipulator.handleEvent(callData, model._apiSpecificRenderWindow);
+    }
 
     if (model.dragable) {
       model._draggingWidgetOrigin = model.widgetState.getOrigin();


### PR DESCRIPTION
Manipulators need to have their normals set prior to handleEvent.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
ImplicitWidget still exhibits jumpy behavior.

### Results
Fixes jumpy behavior.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] ImplicitWidget: avoid jumpy behavior by setting manipulator normals

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
