### PR TITLE
Fix interactive orientation widget

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleImage/index.js
+++ b/Sources/Interaction/Style/InteractorStyleImage/index.js
@@ -15,7 +15,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
   publicAPI.superHandleMouseMove = publicAPI.handleMouseMove;
   publicAPI.handleMouseMove = (callData) => {
     const pos = callData.position;
-    const renderer = callData.pokedRenderer;
+    const renderer = model.getRenderer(callData);
 
     switch (model.state) {
       case States.IS_WINDOW_LEVEL:
@@ -101,7 +101,7 @@ function vtkInteractorStyleImage(publicAPI, model) {
 
   //--------------------------------------------------------------------------
   publicAPI.handleMouseWheel = (callData) => {
-    const camera = callData.pokedRenderer.getActiveCamera();
+    const camera = model.getRenderer(callData).getActiveCamera();
 
     let distance = camera.getDistance();
     distance += callData.spinY;
@@ -115,7 +115,8 @@ function vtkInteractorStyleImage(publicAPI, model) {
       distance = range[1];
     }
     camera.setDistance(distance);
-    const props = callData.pokedRenderer
+    const props = model
+      .getRenderer(callData)
       .getViewProps()
       .filter((prop) => prop.isA('vtkImageSlice'));
     props.forEach((prop) => {

--- a/Sources/Interaction/Style/InteractorStyleManipulator/index.js
+++ b/Sources/Interaction/Style/InteractorStyleManipulator/index.js
@@ -300,7 +300,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       // register the manipulator for this device
       model.currentVRManipulators.set(ed.device, manipulator);
 
-      manipulator.onButton3D(publicAPI, ed.pokedRenderer, model.state, ed);
+      manipulator.onButton3D(publicAPI, model.getRenderer(ed), model.state, ed);
 
       if (ed.pressed) {
         publicAPI.startCameraPose();
@@ -322,7 +322,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     const manipulator = model.currentVRManipulators.get(ed.device);
 
     if (manipulator && model.state === States.IS_CAMERA_POSE) {
-      manipulator.onMove3D(publicAPI, ed.pokedRenderer, model.state, ed);
+      manipulator.onMove3D(publicAPI, model.getRenderer(ed), model.state, ed);
     }
   };
 
@@ -350,7 +350,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       model.currentManipulator.startInteraction();
       model.currentManipulator.onButtonDown(
         model._interactor,
-        callData.pokedRenderer,
+        model.getRenderer(callData),
         callData.position
       );
       model._interactor.requestAnimation(publicAPI.onButtonDown);
@@ -452,7 +452,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       model.currentWheelManipulator = manipulator;
       model.currentWheelManipulator.onStartScroll(
         model._interactor,
-        callData.pokedRenderer,
+        model.getRenderer(callData),
         callData.spinY
       );
       model.currentWheelManipulator.startInteraction();
@@ -485,7 +485,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     ) {
       model.currentWheelManipulator.onScroll(
         model._interactor,
-        callData.pokedRenderer,
+        model.getRenderer(callData),
         callData.spinY,
         model.cachedMousePosition
       );
@@ -499,7 +499,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
     if (model.currentManipulator && model.currentManipulator.onMouseMove) {
       model.currentManipulator.onMouseMove(
         model._interactor,
-        callData.pokedRenderer,
+        model.getRenderer(callData),
         callData.position
       );
       publicAPI.invokeInteractionEvent(INTERACTION_EVENT);
@@ -515,7 +515,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       .forEach((manipulator) => {
         manipulator.onKeyPress(
           model._interactor,
-          callData.pokedRenderer,
+          model.getRenderer(callData),
           callData.key
         );
         publicAPI.invokeInteractionEvent(INTERACTION_EVENT);
@@ -529,7 +529,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       .forEach((manipulator) => {
         manipulator.onKeyDown(
           model._interactor,
-          callData.pokedRenderer,
+          model.getRenderer(callData),
           callData.key
         );
         publicAPI.invokeInteractionEvent(INTERACTION_EVENT);
@@ -543,7 +543,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       .forEach((manipulator) => {
         manipulator.onKeyUp(
           model._interactor,
-          callData.pokedRenderer,
+          model.getRenderer(callData),
           callData.key
         );
         publicAPI.invokeInteractionEvent(INTERACTION_EVENT);
@@ -652,7 +652,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       if (manipulator && manipulator.isPinchEnabled()) {
         manipulator.onPinch(
           model._interactor,
-          callData.pokedRenderer,
+          model.getRenderer(callData),
           callData.scale
         );
         actionCount++;
@@ -672,7 +672,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       if (manipulator && manipulator.isPanEnabled()) {
         manipulator.onPan(
           model._interactor,
-          callData.pokedRenderer,
+          model.getRenderer(callData),
           callData.translation
         );
         actionCount++;
@@ -692,7 +692,7 @@ function vtkInteractorStyleManipulator(publicAPI, model) {
       if (manipulator && manipulator.isRotateEnabled()) {
         manipulator.onRotate(
           model._interactor,
-          callData.pokedRenderer,
+          model.getRenderer(callData),
           callData.rotation
         );
         actionCount++;

--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -22,7 +22,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
   // Public API methods
   publicAPI.handleMouseMove = (callData) => {
     const pos = callData.position;
-    const renderer = callData.pokedRenderer;
+    const renderer = model.getRenderer(callData);
 
     switch (model.state) {
       case States.IS_ROTATE:
@@ -87,7 +87,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
   publicAPI.updateCameraPose = (ed) => {
     // move the world in the direction of the
     // controller
-    const camera = ed.pokedRenderer.getActiveCamera();
+    const camera = model.getRenderer(ed).getActiveCamera();
     const oldTrans = camera.getPhysicalTranslation();
 
     // look at the y axis to determine how fast / what direction to move
@@ -198,7 +198,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.handlePinch = (callData) => {
     publicAPI.dollyByFactor(
-      callData.pokedRenderer,
+      model.getRenderer(callData),
       callData.scale / model.previousScale
     );
     model.previousScale = callData.scale;
@@ -206,13 +206,13 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.handlePan = (callData) => {
-    const camera = callData.pokedRenderer.getActiveCamera();
+    const camera = model.getRenderer(callData).getActiveCamera();
 
     // Calculate the focal depth since we'll be using it a lot
     let viewFocus = camera.getFocalPoint();
 
     viewFocus = publicAPI.computeWorldToDisplay(
-      callData.pokedRenderer,
+      model.getRenderer(callData),
       viewFocus[0],
       viewFocus[1],
       viewFocus[2]
@@ -222,7 +222,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
     const trans = callData.translation;
     const lastTrans = model.previousTranslation;
     const newPickPoint = publicAPI.computeDisplayToWorld(
-      callData.pokedRenderer,
+      model.getRenderer(callData),
       viewFocus[0] + trans[0] - lastTrans[0],
       viewFocus[1] + trans[1] - lastTrans[1],
       focalDepth
@@ -231,7 +231,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
     // Has to recalc old mouse point since the viewport has moved,
     // so can't move it outside the loop
     const oldPickPoint = publicAPI.computeDisplayToWorld(
-      callData.pokedRenderer,
+      model.getRenderer(callData),
       viewFocus[0],
       viewFocus[1],
       focalDepth
@@ -258,7 +258,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
     );
 
     if (model._interactor.getLightFollowCamera()) {
-      callData.pokedRenderer.updateLightsGeometryToFollowCamera();
+      model.getRenderer(callData).updateLightsGeometryToFollowCamera();
     }
 
     camera.orthogonalizeViewUp();
@@ -268,7 +268,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.handleRotate = (callData) => {
-    const camera = callData.pokedRenderer.getActiveCamera();
+    const camera = model.getRenderer(callData).getActiveCamera();
     camera.roll(callData.rotation - model.previousRotation);
     camera.orthogonalizeViewUp();
     model.previousRotation = callData.rotation;
@@ -416,7 +416,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
   //----------------------------------------------------------------------------
   publicAPI.handleMouseWheel = (callData) => {
     const dyf = 1 - callData.spinY / model.zoomFactor;
-    publicAPI.dollyByFactor(callData.pokedRenderer, dyf);
+    publicAPI.dollyByFactor(model.getRenderer(callData), dyf);
   };
 
   //----------------------------------------------------------------------------

--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.d.ts
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.d.ts
@@ -145,6 +145,13 @@ export interface vtkOrientationMarkerWidget extends vtkObject {
    * Updates the orientation widget viewport size.
    */
   updateViewport(): void;
+
+  /**
+   * An instance of this class will spawn its own renderer, by default non interactive.
+   * This behavior is configurable through the interactiveRenderer property when initializing the instance.
+   * @returns true if the renderer was created as interactive, false otherwise.
+   */
+  getInteractiveRenderer(): boolean;
 }
 
 /**

--- a/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
+++ b/Sources/Interaction/Widgets/OrientationMarkerWidget/index.js
@@ -148,7 +148,7 @@ function vtkOrientationMarkerWidget(publicAPI, model) {
       }
       // Highest number is foreground
       selfRenderer.setLayer(renderWindow.getNumberOfLayers() - 1);
-      selfRenderer.setInteractive(false);
+      selfRenderer.setInteractive(model.interactiveRenderer);
 
       selfRenderer.addViewProp(model.actor);
       model.actor.setVisibility(true);
@@ -281,6 +281,7 @@ export const DEFAULT_VALUES = {
   minPixelSize: 50,
   maxPixelSize: 200,
   parentRenderer: null,
+  interactiveRenderer: false,
 };
 
 // ----------------------------------------------------------------------------
@@ -291,7 +292,12 @@ export function extend(publicAPI, model, initialValues = {}) {
   // Build VTK API
   macro.obj(publicAPI, model);
 
-  macro.get(publicAPI, model, ['enabled', 'viewportCorner', 'viewportSize']);
+  macro.get(publicAPI, model, [
+    'enabled',
+    'viewportCorner',
+    'viewportSize',
+    'interactiveRenderer',
+  ]);
 
   // NOTE: setting these while the widget is enabled will
   // not update the widget.

--- a/Sources/Rendering/Core/InteractorStyle/index.d.ts
+++ b/Sources/Rendering/Core/InteractorStyle/index.d.ts
@@ -1,5 +1,7 @@
 import { EventHandler, vtkSubscription } from '../../../interfaces';
+import { Nullable } from '../../../types';
 import vtkInteractorObserver from '../InteractorObserver';
+import vtkRenderer from '../Renderer';
 
 export interface vtkInteractorStyle extends vtkInteractorObserver {
   /**
@@ -210,6 +212,19 @@ export interface vtkInteractorStyle extends vtkInteractorObserver {
    * Handles a keypress.
    */
   handleKeyPress(callData: unknown): void;
+
+  /**
+   * Explicitly defines a renderer to be used for event handling.
+   * If never called or called with null, the pokedRenderer of the event will be used.
+   *
+   * @param {Nullable<vtkRenderer>} renderer
+   */
+  setFocusedRenderer(renderer: Nullable<vtkRenderer>): boolean;
+
+  /**
+   * Get the renderer used for event handling, returns null if not set.
+   */
+  getFocusedRenderer(): Nullable<vtkRenderer>;
 }
 
 export interface IInteractorStyleInitialValues {

--- a/Sources/Rendering/Core/InteractorStyle/index.js
+++ b/Sources/Rendering/Core/InteractorStyle/index.js
@@ -55,6 +55,9 @@ function vtkInteractorStyle(publicAPI, model) {
     };
   });
 
+  model.getRenderer = (callData) =>
+    model.focusedRenderer || callData.pokedRenderer;
+
   //----------------------------------------------------------------------------
   publicAPI.handleKeyPress = (callData) => {
     const rwi = model._interactor;
@@ -62,13 +65,13 @@ function vtkInteractorStyle(publicAPI, model) {
     switch (callData.key) {
       case 'r':
       case 'R':
-        callData.pokedRenderer.resetCamera();
+        model.getRenderer(callData).resetCamera();
         rwi.render();
         break;
 
       case 'w':
       case 'W':
-        ac = callData.pokedRenderer.getActors();
+        ac = model.getRenderer(callData).getActors();
         ac.forEach((anActor) => {
           const prop = anActor.getProperty();
           if (prop.setRepresentationToWireframe) {
@@ -80,7 +83,7 @@ function vtkInteractorStyle(publicAPI, model) {
 
       case 's':
       case 'S':
-        ac = callData.pokedRenderer.getActors();
+        ac = model.getRenderer(callData).getActors();
         ac.forEach((anActor) => {
           const prop = anActor.getProperty();
           if (prop.setRepresentationToSurface) {
@@ -92,7 +95,7 @@ function vtkInteractorStyle(publicAPI, model) {
 
       case 'v':
       case 'V':
-        ac = callData.pokedRenderer.getActors();
+        ac = model.getRenderer(callData).getActors();
         ac.forEach((anActor) => {
           const prop = anActor.getProperty();
           if (prop.setRepresentationToPoints) {
@@ -125,6 +128,8 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   // Inheritance
   vtkInteractorObserver.extend(publicAPI, model, initialValues);
+
+  macro.setGet(publicAPI, model, ['focusedRenderer']);
 
   // Object specific methods
   vtkInteractorStyle(publicAPI, model);

--- a/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/helpers.d.ts
+++ b/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/helpers.d.ts
@@ -1,0 +1,73 @@
+import vtkAbstractWidget from '../../../Widgets/Core/AbstractWidget';
+import vtkCamera from '../../../Rendering/Core/Camera';
+import vtkInteractiveOrientationWidget from '../InteractiveOrientationWidget';
+import vtkOrientationMarkerWidget from '../../../Interaction/Widgets/OrientationMarkerWidget';
+import vtkRenderer from '../../../Rendering/Core/Renderer';
+import vtkRenderWindowInteractor from '../../../Rendering/Core/RenderWindowInteractor';
+import vtkWidgetManager from '../../../Widgets/Core/WidgetManager';
+import { vtkSubscription } from '../../../interfaces';
+import { Bounds, Vector3 } from '../../../types';
+
+export function majorAxis(
+  vec3: Vector3,
+  idxA: number,
+  idxB: number
+): [number, number, number];
+
+/**
+ * Create a new vtkOrientationMarkerWidget instance from the provided interactor and parentRenderer and sensible defaults.
+ *
+ * @param {vtkRenderWindowInteractor} interactor
+ * @param {vtkRenderer} parentRenderer
+ * @returns {vtkOrientationMarkerWidget}
+ */
+export function createOrientationMarkerWidget(
+  interactor: vtkRenderWindowInteractor,
+  parentRenderer: vtkRenderer
+): vtkOrientationMarkerWidget;
+
+/**
+ * Create a new vtkInteractiveOrientationWidget instance and place it at the given bounds.
+ *
+ * @param {Bounds} bounds
+ * @returns {vtkInteractiveOrientationWidget}
+ */
+export function createInteractiveOrientationWidget(
+  bounds: Bounds
+): vtkInteractiveOrientationWidget;
+
+/**
+ * Create a new vtkOrientationMarkerWidget alongside with a new vtkInteractiveOrientationWidget with sensible defaults.
+ *
+ * @param {vtkWidgetManager} widgetManager
+ * @param {vtkRenderWindowInteractor} interactor
+ * @param {vtkRenderer} mainRenderer
+ * @returns {Object} the constructed widget instances
+ */
+export function createInteractiveOrientationMarkerWidget(
+  widgetManager: vtkWidgetManager,
+  interactor: vtkRenderWindowInteractor,
+  mainRenderer: vtkRenderer
+): {
+  interactiveOrientationWidget: vtkInteractiveOrientationWidget;
+  orientationMarkerWidget: vtkOrientationMarkerWidget;
+};
+
+/**
+ * Listen to OrientationChange events on the given view widget.
+ * The event handler will align the provided camera and update the provided vtkOrientationMarkerWidget instance.
+ *
+ * @param {vtkAbstractWidget} viewWidget Must be a vtkInteractiveOrientationWidget view widget
+ * @param {vtkCamera} camera The camera instance to upate when orientation changes
+ * @param {vtkOrientationMarkerWidget} orientationMarkerWidget The instance to update when orientation changes
+ * @param {vtkWidgetManager} widgetManager
+ * @param {Function} render A callback that should render the view
+ * @returns {vtkSubscription} the corresponding event subscription, can be used to unsubscribe from the event
+ */
+export function alignCameraOnViewWidgetOrientationChange(
+  viewWidget: vtkAbstractWidget,
+  camera: vtkCamera,
+  orientationMarkerWidget: vtkOrientationMarkerWidget,
+  widgetManager: vtkWidgetManager,
+  render: () => void
+): vtkSubscription;

--- a/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/helpers.js
+++ b/Sources/Widgets/Widgets3D/InteractiveOrientationWidget/helpers.js
@@ -1,0 +1,99 @@
+import * as vtkMath from '@kitware/vtk.js/Common/Core/Math';
+import vtkOrientationMarkerWidget from '@kitware/vtk.js/Interaction/Widgets/OrientationMarkerWidget';
+import vtkAxesActor from '@kitware/vtk.js/Rendering/Core/AxesActor';
+import vtkInteractiveOrientationWidget from '@kitware/vtk.js/Widgets/Widgets3D/InteractiveOrientationWidget';
+
+export function majorAxis(vec3, idxA, idxB) {
+  const axis = [0, 0, 0];
+  const idx = Math.abs(vec3[idxA]) > Math.abs(vec3[idxB]) ? idxA : idxB;
+  const value = vec3[idx] > 0 ? 1 : -1;
+  axis[idx] = value;
+  return axis;
+}
+
+export function createOrientationMarkerWidget(interactor, parentRenderer) {
+  const axes = vtkAxesActor.newInstance();
+
+  const orientationWidget = vtkOrientationMarkerWidget.newInstance({
+    actor: axes,
+    interactor,
+    interactiveRenderer: true,
+    viewportSize: 0.1,
+    minPixelSize: 100,
+    maxPixelSize: 300,
+    parentRenderer,
+  });
+  orientationWidget.setEnabled(true);
+  orientationWidget.setViewportCorner(
+    vtkOrientationMarkerWidget.Corners.BOTTOM_LEFT
+  );
+
+  return orientationWidget;
+}
+
+export function createInteractiveOrientationWidget(bounds) {
+  const widget = vtkInteractiveOrientationWidget.newInstance();
+  widget.placeWidget(bounds);
+  widget.setBounds(bounds.map((v) => v * 0.45));
+
+  return widget;
+}
+
+export function createInteractiveOrientationMarkerWidget(
+  widgetManager,
+  interactor,
+  mainRenderer
+) {
+  const orientationMarkerWidget = createOrientationMarkerWidget(
+    interactor,
+    mainRenderer
+  );
+  interactor.getInteractorStyle().setFocusedRenderer(mainRenderer);
+
+  widgetManager.setRenderer(orientationMarkerWidget.getRenderer());
+
+  const widget = createInteractiveOrientationWidget(
+    orientationMarkerWidget.getActor().getBounds()
+  );
+
+  return {
+    interactiveOrientationWidget: widget,
+    orientationMarkerWidget,
+  };
+}
+
+export function alignCameraOnViewWidgetOrientationChange(
+  viewWidget,
+  camera,
+  orientationMarkerWidget,
+  widgetManager,
+  render
+) {
+  return viewWidget.onOrientationChange(({ up, direction, action, event }) => {
+    const focalPoint = camera.getFocalPoint();
+    const position = camera.getPosition();
+    const viewUp = camera.getViewUp();
+
+    const distance = Math.sqrt(
+      vtkMath.distance2BetweenPoints(position, focalPoint)
+    );
+    camera.setPosition(
+      focalPoint[0] + direction[0] * distance,
+      focalPoint[1] + direction[1] * distance,
+      focalPoint[2] + direction[2] * distance
+    );
+
+    if (direction[0]) {
+      camera.setViewUp(majorAxis(viewUp, 1, 2));
+    }
+    if (direction[1]) {
+      camera.setViewUp(majorAxis(viewUp, 0, 2));
+    }
+    if (direction[2]) {
+      camera.setViewUp(majorAxis(viewUp, 0, 1));
+    }
+
+    orientationMarkerWidget.updateMarkerOrientation();
+    render();
+  });
+}


### PR DESCRIPTION
### Context
See https://github.com/Kitware/vtk-js/issues/2858

### Results
A solution is provided to make widget works as intended.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

The provided solution expose a new API on InteractorStyle to force an explicit renderer instead of using the event poked renderer.
The second change is to make the OrientationMarkerWidget self renderer interactive.
Third fix is in the example itself, it consists of calling `setParentRenderer` on the OrientationMarkerWidget instance with the renderer that should be used for camera synchronization.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->
