### PR TITLE
Remove node deletion from "removeNode"

### DIFF
--- a/Examples/Rendering/ManyRenderWindows/index.js
+++ b/Examples/Rendering/ManyRenderWindows/index.js
@@ -193,11 +193,15 @@ function addRenderWindow(actor) {
   const button = createRemoveButton();
   button.addEventListener('click', () => {
     rootContainer.removeChild(container);
-    mainRenderWindow.removeRenderWindow(renderWindow);
-    mainRenderWindowView.removeNode(renderWindowView);
     interactor.delete();
-    renderWindowView.delete();
+
+    // The core renderWindow is managed by the user, so delete it
+    mainRenderWindow.removeRenderWindow(renderWindow);
     renderWindow.delete();
+
+    // The node renderWindowView is managed by vtk.js backend, and removed automatically
+    mainRenderWindowView.removeNode(renderWindowView);
+
     if (mainRenderWindow.getChildRenderWindowsByReference().length === 0) {
       // When there is no child render window anymore, delete the main render window
       // We also release the graphics resources, which is not very import as when the context is destroyed, the resources should be freed

--- a/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
@@ -48,7 +48,9 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
       );
       model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getLastAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.context = model._openGLRenderWindow.getContext();
       model.openGLCamera = model._openGLRenderer.getViewNodeFor(
         model._openGLRenderer.getRenderable().getActiveCamera()

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -67,7 +67,9 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       );
       model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getLastAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.context = model._openGLRenderWindow.getContext();
       model.tris.setOpenGLRenderWindow(model._openGLRenderWindow);
       const ren = model._openGLRenderer.getRenderable();

--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -69,7 +69,9 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
       model._openGLCamera = model._openGLRenderer.getViewNodeFor(
         ren.getActiveCamera()
       );
-      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getLastAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.context = model._openGLRenderWindow.getContext();
       model.tris.setOpenGLRenderWindow(model._openGLRenderWindow);
     }

--- a/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
+++ b/Sources/Rendering/OpenGL/PixelSpaceCallbackMapper/index.js
@@ -17,7 +17,9 @@ function vtkOpenGLPixelSpaceCallbackMapper(publicAPI, model) {
   publicAPI.opaquePass = (prepass, renderPass) => {
     model._openGLRenderer =
       publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
-    model._openGLRenderWindow = model._openGLRenderer.getParent();
+    model._openGLRenderWindow = model._openGLRenderer.getLastAncestorOfType(
+      'vtkOpenGLRenderWindow'
+    );
     const aspectRatio = model._openGLRenderer.getAspectRatio();
     const camera = model._openGLRenderer
       ? model._openGLRenderer.getRenderable().getActiveCamera()

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -55,7 +55,9 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       model.openGLActor = publicAPI.getFirstAncestorOfType('vtkOpenGLActor');
       model._openGLRenderer =
         model.openGLActor.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getLastAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.openGLCamera = model._openGLRenderer.getViewNodeFor(
         model._openGLRenderer.getRenderable().getActiveCamera()
       );

--- a/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
@@ -37,7 +37,9 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
         publicAPI.getFirstAncestorOfType('vtkOpenGLActor2D');
       model._openGLRenderer =
         model.openGLActor2D.getFirstAncestorOfType('vtkOpenGLRenderer');
-      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getLastAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
       model.openGLCamera = model._openGLRenderer.getViewNodeFor(
         model._openGLRenderer.getRenderable().getActiveCamera()
       );

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -27,7 +27,9 @@ function vtkOpenGLTexture(publicAPI, model) {
       model._openGLRenderer =
         publicAPI.getFirstAncestorOfType('vtkOpenGLRenderer');
       // sync renderable properties
-      model._openGLRenderWindow = model._openGLRenderer.getParent();
+      model._openGLRenderWindow = model._openGLRenderer.getLastAncestorOfType(
+        'vtkOpenGLRenderWindow'
+      );
     }
     model.context = model._openGLRenderWindow.getContext();
     if (model.renderable.getInterpolate()) {


### PR DESCRIPTION
If this function deletes a node, it should be called "deleteNode" not "removeNode"
This caused an error in the example `ManyRenderWindows`
