### PR TITLE
fix(ImageProperty): color + opacity funcs can be null

### DIFF
--- a/Sources/Rendering/Core/ImageProperty/index.d.ts
+++ b/Sources/Rendering/Core/ImageProperty/index.d.ts
@@ -1,4 +1,5 @@
 import { vtkObject } from '../../../interfaces';
+import { Nullable } from '../../../types';
 import vtkColorTransferFunction from '../ColorTransferFunction';
 import vtkPiecewiseFunction from '../../../Common/DataModel/PiecewiseFunction';
 import { InterpolationType } from './Constants';
@@ -79,13 +80,13 @@ export interface vtkImageProperty extends vtkObject {
    * Get the component weighting function.
    * @param {Number} [idx]
    */
-  getPiecewiseFunction(idx?: number): vtkPiecewiseFunction;
+  getPiecewiseFunction(idx?: number): Nullable<vtkPiecewiseFunction>;
 
   /**
    * Get the currently set RGB transfer function.
    * @param {Number} [idx]
    */
-  getRGBTransferFunction(idx?: number): vtkColorTransferFunction;
+  getRGBTransferFunction(idx?: number): Nullable<vtkColorTransferFunction>;
 
   /**
    * Alias to get the piecewise function (backwards compatibility)
@@ -176,7 +177,10 @@ export interface vtkImageProperty extends vtkObject {
    * @param {Number} index
    * @param {vtkPiecewiseFunction} func
    */
-  setPiecewiseFunction(index: number, func: vtkPiecewiseFunction): boolean;
+  setPiecewiseFunction(
+    index: number,
+    func: Nullable<vtkPiecewiseFunction>
+  ): boolean;
 
   /**
    * Set the color of a volume to an RGB transfer function
@@ -185,7 +189,7 @@ export interface vtkImageProperty extends vtkObject {
    */
   setRGBTransferFunction(
     index: number,
-    func: vtkColorTransferFunction
+    func: Nullable<vtkColorTransferFunction>
   ): boolean;
 
   /**
@@ -193,7 +197,10 @@ export interface vtkImageProperty extends vtkObject {
    * @param {Number} index
    * @param {vtkPiecewiseFunction} func
    */
-  setScalarOpacity(index: number, func: vtkPiecewiseFunction): boolean;
+  setScalarOpacity(
+    index: number,
+    func: Nullable<vtkPiecewiseFunction>
+  ): boolean;
 
   /**
    * Use the range that is set on the lookup table, instead of setting the range from the


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
`imageProperty.setRGBTransferFunction(index, null)` and `imageProperty.setScalarOpacity(index, null)` should be allowed in the types.

### Results
Types are fixed to allow null functions.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
N/A