### PR TITLE
fix(Property): get/setShading doesn't exist

### DIFF
--- a/Sources/Rendering/Core/Property/index.d.ts
+++ b/Sources/Rendering/Core/Property/index.d.ts
@@ -161,11 +161,6 @@ export interface vtkProperty extends vtkObject {
   getRepresentationAsString(): string;
 
   /**
-   * Check if the shading is set.
-   */
-  getShading(): boolean;
-
-  /**
    * Get the specular lighting coefficient.
    * @default 0
    */
@@ -442,12 +437,6 @@ export interface vtkProperty extends vtkObject {
    * Set representation to 1 means `WIREFRAM`'
    */
   setRepresentationToWireframe(): boolean;
-
-  /**
-   * Enable/Disable shading.
-   * @param {Boolean} shading
-   */
-  setShading(shading: boolean): boolean;
 
   /**
    * Set the specular lighting coefficient.


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

`property.getShading()` doesn't exist. https://discourse.vtk.org/t/vtkjs-shading-comparison-to-python/14108/1

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

Since these methods don't exist, drop them from the types.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
N/A