### PR TITLE
fix(GenericRenderWindow): remove event listeners

### DIFF
--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.js
@@ -119,6 +119,12 @@ function vtkFullScreenRenderWindow(publicAPI, model) {
     publicAPI.setControllerVisibility(!model.controllerVisibility);
   };
 
+  function handleKeypress(e) {
+    if (String.fromCharCode(e.charCode) === 'c') {
+      publicAPI.toggleControllerVisibility();
+    }
+  }
+
   publicAPI.addController = (html) => {
     model.controlContainer = document.createElement('div');
     applyStyle(
@@ -130,11 +136,7 @@ function vtkFullScreenRenderWindow(publicAPI, model) {
 
     publicAPI.setControllerVisibility(model.controllerVisibility);
 
-    model.rootContainer.addEventListener('keypress', (e) => {
-      if (String.fromCharCode(e.charCode) === 'c') {
-        publicAPI.toggleControllerVisibility();
-      }
-    });
+    model.rootContainer.addEventListener('keypress', handleKeypress);
   };
 
   // Update BG color
@@ -156,6 +158,10 @@ function vtkFullScreenRenderWindow(publicAPI, model) {
   publicAPI.delete = macro.chain(
     publicAPI.setContainer,
     model.apiSpecificRenderWindow.delete,
+    () => {
+      model.rootContainer?.removeEventListener('keypress', handleKeypress);
+      window.removeEventListener('resize', publicAPI.resize);
+    },
     publicAPI.delete
   );
 

--- a/Sources/Rendering/Misc/GenericRenderWindow/index.js
+++ b/Sources/Rendering/Misc/GenericRenderWindow/index.js
@@ -80,6 +80,9 @@ function vtkGenericRenderWindow(publicAPI, model) {
   publicAPI.delete = macro.chain(
     publicAPI.setContainer,
     model._apiSpecificRenderWindow.delete,
+    () => {
+      window.removeEventListener('resize', publicAPI.resize);
+    },
     publicAPI.delete
   );
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

GenericRenderWindow doesn't clean up event listeners on delete. https://discourse.paraview.org/t/need-help-getboundingclientrect-error-on-screen-resize/14911/2

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Event listeners are cleaned up on delete.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
N/A