### PR TITLE
GPU resources garbage collection

### DIFF
--- a/Examples/Rendering/ManyRenderWindows/index.js
+++ b/Examples/Rendering/ManyRenderWindows/index.js
@@ -204,11 +204,6 @@ function addRenderWindow(actor) {
 
     if (mainRenderWindow.getChildRenderWindowsByReference().length === 0) {
       // When there is no child render window anymore, delete the main render window
-      // We also release the graphics resources, which is not very import as when the context is destroyed, the resources should be freed
-      // The release of shared graphics resources is not automatic and can be done by hand when the resource is not needed anymore
-      const imageData = actor.getMapper().getInputData();
-      const scalars = imageData.getPointData().getScalars();
-      mainRenderWindowView.releaseGraphicsResourcesForObject(scalars);
       mainRenderWindowView.delete();
       mainRenderWindow.delete();
     }

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -89,7 +89,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         !oldOglRenderWindow.isDeleted() &&
         oldOglRenderWindow !== model._openGLRenderWindow
       ) {
-        // We unregister ourself when the render window changes
+        // Unregister the mapper when the render window changes
         unregisterGraphicsResources(oldOglRenderWindow);
       }
       model.context = model._openGLRenderWindow.getContext();
@@ -1016,14 +1016,16 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           model.colorTexture,
           cfunToString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._colorTransferFunc,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          colorTransferFunc,
-          publicAPI
-        );
+        if (colorTransferFunc !== model._colorTransferFunc) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            colorTransferFunc,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._colorTransferFunc,
+            publicAPI
+          );
+        }
         model._colorTransferFunc = colorTransferFunc;
       }
     } else {
@@ -1108,14 +1110,16 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           model.pwfTexture,
           pwfunToString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._pwFunc,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          pwFunc,
-          publicAPI
-        );
+        if (pwFunc !== model._pwFunc) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            pwFunc,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._pwFunc,
+            publicAPI
+          );
+        }
         model._pwFunc = pwFunc;
       }
     } else {
@@ -1406,14 +1410,16 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           model.labelOutlineThicknessTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._labelOutlineThicknessArray,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          labelOutlineThicknessArray,
-          publicAPI
-        );
+        if (labelOutlineThicknessArray !== model._labelOutlineThicknessArray) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            labelOutlineThicknessArray,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._labelOutlineThicknessArray,
+            publicAPI
+          );
+        }
         model._labelOutlineThicknessArray = labelOutlineThicknessArray;
       }
     } else {

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -929,7 +929,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model._openGLRenderWindow.getGraphicsResourceForObject(colorTransferFunc);
 
     const reBuildC =
-      !cTex?.vtkObj?.getHandle() ||
+      !cTex?.oglObject?.getHandle() ||
       cTex?.hash !== cfunToString ||
       model.colorTextureString !== cfunToString;
     if (reBuildC) {
@@ -1002,7 +1002,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         );
       }
     } else {
-      model.colorTexture = cTex.vtkObj;
+      model.colorTexture = cTex.oglObject;
       model.colorTextureString = cTex.hash;
     }
 
@@ -1015,7 +1015,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model._openGLRenderWindow.getGraphicsResourceForObject(pwFunc);
     // rebuild opacity tfun?
     const reBuildPwf =
-      !pwfTex?.vtkObj?.getHandle() ||
+      !pwfTex?.oglObject?.getHandle() ||
       pwfTex?.hash !== pwfunToString ||
       model.pwfTextureString !== pwfunToString;
     if (reBuildPwf) {
@@ -1092,7 +1092,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         );
       }
     } else {
-      model.pwfTexture = pwfTex.vtkObj;
+      model.pwfTexture = pwfTex.oglObject;
       model.pwfTextureString = pwfTex.hash;
     }
 
@@ -1274,7 +1274,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
 
       const tex =
         model._openGLRenderWindow.getGraphicsResourceForObject(scalars);
-      if (!tex?.vtkObj?.getHandle()) {
+      if (!tex?.oglObject?.getHandle()) {
         if (model._scalars !== scalars) {
           model._openGLRenderWindow.releaseGraphicsResourcesForObject(
             model._scalars
@@ -1296,7 +1296,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           model.VBOBuildString
         );
       } else {
-        model.openGLTexture = tex.vtkObj;
+        model.openGLTexture = tex.oglObject;
         model.VBOBuildString = tex.hash;
       }
       model.openGLTexture.activate();
@@ -1362,7 +1362,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
     const toString = `${labelOutlineThicknessArray.join('-')}`;
 
     const reBuildL =
-      !lTex?.vtkObj?.getHandle() ||
+      !lTex?.oglObject?.getHandle() ||
       lTex?.hash !== toString ||
       model.labelOutlineThicknessTextureString !== toString;
 
@@ -1408,7 +1408,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         );
       }
     } else {
-      model.labelOutlineThicknessTexture = lTex.vtkObj;
+      model.labelOutlineThicknessTexture = lTex.oglObject;
       model.labelOutlineThicknessTextureString = lTex.hash;
     }
   };

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -89,6 +89,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
         !oldOglRenderWindow.isDeleted() &&
         oldOglRenderWindow !== model._openGLRenderWindow
       ) {
+        // We unregister ourself when the render window changes
         unregisterGraphicsResources(oldOglRenderWindow);
       }
       model.context = model._openGLRenderWindow.getContext();
@@ -1462,10 +1463,10 @@ const DEFAULT_VALUES = {
   lastHaveSeenDepthRequest: false,
   haveSeenDepthRequest: false,
   lastTextureComponents: 0,
-  _scalars: null,
-  _colorTransferFunc: null,
-  _pwFunc: null,
-  _labelOutlineThicknessArray: null,
+  // _scalars: null,
+  // _colorTransferFunc: null,
+  // _pwFunc: null,
+  // _labelOutlineThicknessArray: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -85,6 +85,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
         !oldOglRenderWindow.isDeleted() &&
         oldOglRenderWindow !== model._openGLRenderWindow
       ) {
+        // We unregister ourself when the render window changes
         unregisterGraphicsResources(oldOglRenderWindow);
       }
       model.context = model._openGLRenderWindow.getContext();
@@ -1326,9 +1327,9 @@ const DEFAULT_VALUES = {
   colorTexture: null,
   pwfTexture: null,
   _externalOpenGLTexture: false,
-  _scalars: null,
-  _colorTransferFunc: null,
-  _pwFunc: null,
+  // _scalars: null,
+  // _colorTransferFunc: null,
+  // _pwFunc: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -219,7 +219,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
     let toString = `${image.getMTime()}A${scalars.getMTime()}`;
 
     const tex = model._openGLRenderWindow.getGraphicsResourceForObject(scalars);
-    const reBuildTex = !tex?.vtkObj?.getHandle() || tex?.hash !== toString;
+    const reBuildTex = !tex?.oglObject?.getHandle() || tex?.hash !== toString;
     if (reBuildTex) {
       if (!model.openGLTexture) {
         model.openGLTexture = vtkOpenGLTexture.newInstance();
@@ -247,7 +247,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
         );
       }
     } else {
-      model.openGLTexture = tex.vtkObj;
+      model.openGLTexture = tex.oglObject;
     }
 
     const ppty = actor.getProperty();
@@ -260,7 +260,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
     const cTex =
       model._openGLRenderWindow.getGraphicsResourceForObject(colorTransferFunc);
     const reBuildC =
-      !cTex?.vtkObj?.getHandle() ||
+      !cTex?.oglObject?.getHandle() ||
       cTex?.hash !== toString ||
       model.colorTextureString !== toString;
     if (reBuildC) {
@@ -324,7 +324,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
         );
       }
     } else {
-      model.colorTexture = cTex.vtkObj;
+      model.colorTexture = cTex.oglObject;
       model.colorTextureString = cTex.hash;
     }
 
@@ -337,7 +337,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
       model._openGLRenderWindow.getGraphicsResourceForObject(pwFunc);
     // rebuild opacity tfun?
     const reBuildPwf =
-      !pwfTex?.vtkObj?.getHandle() ||
+      !pwfTex?.oglObject?.getHandle() ||
       pwfTex?.hash !== toString ||
       model.pwfTextureString !== toString;
     if (reBuildPwf) {
@@ -404,7 +404,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
         );
       }
     } else {
-      model.pwfTexture = pwfTex.vtkObj;
+      model.pwfTexture = pwfTex.oglObject;
       model.pwfTextureString = pwfTex.hash;
     }
 

--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -85,7 +85,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
         !oldOglRenderWindow.isDeleted() &&
         oldOglRenderWindow !== model._openGLRenderWindow
       ) {
-        // We unregister ourself when the render window changes
+        // Unregister the mapper when the render window changes
         unregisterGraphicsResources(oldOglRenderWindow);
       }
       model.context = model._openGLRenderWindow.getContext();
@@ -252,14 +252,16 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
           model.openGLTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._scalars,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          scalars,
-          publicAPI
-        );
+        if (scalars !== model._scalars) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            scalars,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._scalars,
+            publicAPI
+          );
+        }
         model._scalars = scalars;
       }
     } else {
@@ -330,14 +332,16 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
           model.colorTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._colorTransferFunc,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          colorTransferFunc,
-          publicAPI
-        );
+        if (colorTransferFunc !== model._colorTransferFunc) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            colorTransferFunc,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._colorTransferFunc,
+            publicAPI
+          );
+        }
         model._colorTransferFunc = colorTransferFunc;
       }
     } else {
@@ -411,14 +415,16 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
           model.pwfTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._pwFunc,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          pwFunc,
-          publicAPI
-        );
+        if (pwFunc !== model._pwFunc) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            pwFunc,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._pwFunc,
+            publicAPI
+          );
+        }
         model._pwFunc = pwFunc;
       }
     } else {

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -454,9 +454,9 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
    * the cached resource.
    * @return {Object} Dictionary with the graphics resource and string hash
    */
-  getGraphicsResourceForObject(
-    vtkObj: vtkCellArray | vtkDataArray | vtkPoints
-  ): { gObj: vtkOpenGLTexture | vtkBufferObject; hash: string };
+  getGraphicsResourceForObject<T extends vtkCellArray | vtkDataArray | vtkPoints>(
+    vtkObj: T
+  ): { coreObject: T, oglObject: vtkOpenGLTexture | vtkBufferObject; hash: string };
 
   /**
    * Get approximate graphics memory usage, in bytes, for the context. This is a simple computation

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -441,8 +441,8 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
    */
   setGraphicsResourceForObject(
     vtkObj: vtkCellArray | vtkDataArray | vtkPoints,
-    gObj: vtkOpenGLTexture | vtkBufferObject,
-    hash: string
+    gObj: Nullable<vtkOpenGLTexture | vtkBufferObject>,
+    hash: Nullable<string>
   ): void;
 
   /**
@@ -454,9 +454,17 @@ export interface vtkOpenGLRenderWindow extends vtkOpenGLRenderWindowBase {
    * the cached resource.
    * @return {Object} Dictionary with the graphics resource and string hash
    */
-  getGraphicsResourceForObject<T extends vtkCellArray | vtkDataArray | vtkPoints>(
+  getGraphicsResourceForObject<
+    T extends vtkCellArray | vtkDataArray | vtkPoints
+  >(
     vtkObj: T
-  ): { coreObject: T, oglObject: vtkOpenGLTexture | vtkBufferObject; hash: string };
+  ):
+    | {
+        coreObject: T;
+        oglObject: Nullable<vtkOpenGLTexture | vtkBufferObject>;
+        hash: Nullable<string>;
+      }
+    | undefined;
 
   /**
    * Get approximate graphics memory usage, in bytes, for the context. This is a simple computation

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -164,6 +164,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         !oldOglRenderWindow.isDeleted() &&
         oldOglRenderWindow !== model._openGLRenderWindow
       ) {
+        // We unregister ourself when the render window changes
         unregisterGraphicsResources(oldOglRenderWindow);
       }
       model.context = model._openGLRenderWindow.getContext();
@@ -1894,10 +1895,10 @@ const DEFAULT_VALUES = {
   projectionToView: null,
   avgWindowArea: 0.0,
   avgFrameTime: 0.0,
-  _scalars: null,
-  _scalarOpacityFunc: null,
-  _colorTransferFunc: null,
-  _labelOutlineThicknessArray: null,
+  // _scalars: null,
+  // _scalarOpacityFunc: null,
+  // _colorTransferFunc: null,
+  // _labelOutlineThicknessArray: null,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -164,7 +164,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         !oldOglRenderWindow.isDeleted() &&
         oldOglRenderWindow !== model._openGLRenderWindow
       ) {
-        // We unregister ourself when the render window changes
+        // Unregister the mapper when the render window changes
         unregisterGraphicsResources(oldOglRenderWindow);
       }
       model.context = model._openGLRenderWindow.getContext();
@@ -1612,14 +1612,16 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           model.opacityTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._scalarOpacityFunc,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          scalarOpacityFunc,
-          publicAPI
-        );
+        if (scalarOpacityFunc !== model._scalarOpacityFunc) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            scalarOpacityFunc,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._scalarOpacityFunc,
+            publicAPI
+          );
+        }
         model._scalarOpacityFunc = scalarOpacityFunc;
       }
     } else {
@@ -1671,14 +1673,16 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           model.colorTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._colorTransferFunc,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          colorTransferFunc,
-          publicAPI
-        );
+        if (colorTransferFunc !== model._colorTransferFunc) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            colorTransferFunc,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._colorTransferFunc,
+            publicAPI
+          );
+        }
         model._colorTransferFunc = colorTransferFunc;
       }
     } else {
@@ -1714,14 +1718,16 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           model.scalarTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._scalars,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          scalars,
-          publicAPI
-        );
+        if (scalars !== model._scalars) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            scalars,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._scalars,
+            publicAPI
+          );
+        }
         model._scalars = scalars;
       }
     } else {
@@ -1848,14 +1854,16 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           model.labelOutlineThicknessTexture,
           toString
         );
-        model._openGLRenderWindow.unregisterGraphicsResourceUser(
-          model._labelOutlineThicknessArray,
-          publicAPI
-        );
-        model._openGLRenderWindow.registerGraphicsResourceUser(
-          labelOutlineThicknessArray,
-          publicAPI
-        );
+        if (labelOutlineThicknessArray !== model._labelOutlineThicknessArray) {
+          model._openGLRenderWindow.registerGraphicsResourceUser(
+            labelOutlineThicknessArray,
+            publicAPI
+          );
+          model._openGLRenderWindow.unregisterGraphicsResourceUser(
+            model._labelOutlineThicknessArray,
+            publicAPI
+          );
+        }
         model._labelOutlineThicknessArray = labelOutlineThicknessArray;
       }
     } else {

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1534,7 +1534,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       numIComps
     );
     const reBuildOp =
-      !opTex.vtkObj ||
+      !opTex?.oglObject ||
       opTex.hash !== toString ||
       model.opacityTextureString !== toString;
     if (reBuildOp) {
@@ -1603,7 +1603,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         );
       }
     } else {
-      model.opacityTexture = opTex.vtkObj;
+      model.opacityTexture = opTex.oglObject;
       model.opacityTextureString = opTex.hash;
     }
 
@@ -1617,7 +1617,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const cTex =
       model._openGLRenderWindow.getGraphicsResourceForObject(colorTransferFunc);
     const reBuildC =
-      !cTex?.vtkObj?.getHandle() ||
+      !cTex?.oglObject?.getHandle() ||
       cTex?.hash !== toString ||
       model.colorTextureString !== toString;
     if (reBuildC) {
@@ -1657,7 +1657,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         );
       }
     } else {
-      model.colorTexture = cTex.vtkObj;
+      model.colorTexture = cTex.oglObject;
       model.colorTextureString = cTex.hash;
     }
 
@@ -1666,7 +1666,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const tex = model._openGLRenderWindow.getGraphicsResourceForObject(scalars);
     // rebuild the scalarTexture if the data has changed
     toString = `${image.getMTime()}A${scalars.getMTime()}`;
-    const reBuildTex = !tex?.vtkObj?.getHandle() || tex?.hash !== toString;
+    const reBuildTex = !tex?.oglObject?.getHandle() || tex?.hash !== toString;
     if (reBuildTex) {
       // Build the textures
       const dims = image.getDimensions();
@@ -1691,7 +1691,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         );
       }
     } else {
-      model.scalarTexture = tex.vtkObj;
+      model.scalarTexture = tex.oglObject;
     }
 
     if (!model.tris.getCABO().getElementCount()) {
@@ -1772,7 +1772,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const toString = `${labelOutlineThicknessArray.join('-')}`;
 
     const reBuildL =
-      !lTex?.vtkObj?.getHandle() ||
+      !lTex?.oglObject?.getHandle() ||
       lTex?.hash !== toString ||
       model.labelOutlineThicknessTextureString !== toString;
 
@@ -1820,7 +1820,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         );
       }
     } else {
-      model.labelOutlineThicknessTexture = lTex.vtkObj;
+      model.labelOutlineThicknessTexture = lTex.oglObject;
       model.labelOutlineThicknessTextureString = lTex.hash;
     }
   };


### PR DESCRIPTION
Add garbage collection of shared graphics resources.
The render window now owns the shared resources.
Owners of graphics resources are responsible to register and unregister their usage of graphics resources.
Remove sharing of `scalars` from the cpu image reslice mapper, as it owns the scalars and doesn't share them as the volume mapper and the gpu image reslice mapper do.
Users don't have to do anything - except using a parent RenderWindow - to use this feature.