### PR TITLE
Fix rendering when picking with hardware selector in a shared render window

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1087,7 +1087,11 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.copyParentContent = () => {
     const rootParent = model.rootOpenGLRenderWindow;
-    if (!rootParent || !model.context2D) {
+    if (
+      !rootParent ||
+      !model.context2D ||
+      model.children.some((oglRenderer) => !!oglRenderer.getSelector?.())
+    ) {
       return;
     }
     const parentCanvas = rootParent.getCanvas();


### PR DESCRIPTION
When two render windows A and B share the same context using `addRenderWindow` (see ManyRenderWindows example), this is how a render window does its rendering:
- Render in the shared context
- Copy the content of the shared context to the render window canvas

The following issue happened when using the hardware selector with a shared context when A renders, B renders and A uses the hardware selector:
- `A` renders in the shared context and the context of the shared context is copied into `A`'s canvas
- `B` renders in the shared context and the context of the shared context is copied into `B`'s canvas
- `A` renders in the shared context for the hardware selector, which does not actually render something, so the content of the context remains what `B` just put there and then the content of the shared context is copied into `A`'s canvas

The issue is that `A`'s canvas now contains what B just rendered.

To fix the issue, disable copy of the shared context content when a renderer has a selector