### PR TITLE
Fix resolve coincident topology api

### DIFF
--- a/Sources/Rendering/Core/ImageArrayMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageArrayMapper/index.d.ts
@@ -6,11 +6,9 @@ import { Bounds, Nullable } from '../../../types';
 import { SlicingMode } from '../ImageMapper/Constants';
 import vtkImageData from '../../../Common/DataModel/ImageData';
 import vtkCollection from '../../../Common/DataModel/Collection';
-
-interface ICoincidentTopology {
-  factor: number;
-  offset: number;
-}
+import CoincidentTopologyHelper, {
+  StaticCoincidentTopologyMethods,
+} from '../Mapper/CoincidentTopologyHelper';
 
 interface ISliceToSubSlice {
   imageIndex: number;
@@ -23,7 +21,9 @@ export interface IImageArrayMapperInitialValues
   sliceToSubSliceMap: ISliceToSubSlice[];
 }
 
-export interface vtkImageArrayMapper extends vtkAbstractImageMapper {
+export interface vtkImageArrayMapper
+  extends vtkAbstractImageMapper,
+    CoincidentTopologyHelper {
   /**
    *
    * @param inputData set input as a vtkCollection of vtkImageData objects.
@@ -102,124 +102,6 @@ export interface vtkImageArrayMapper extends vtkAbstractImageMapper {
   getSubSlice(slice?: number): number;
 
   /**
-   *
-   */
-  getResolveCoincidentTopology(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyAsString(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetFaces(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param resolveCoincidentTopology
-   * @default false
-   */
-  setResolveCoincidentTopology(resolveCoincidentTopology: boolean): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param value
-   */
-  setResolveCoincidentTopologyPolygonOffsetFaces(value: number): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToDefault(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToOff(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToPolygonOffset(): boolean;
-
-  /**
    * Set the slicing mode.
    * @param {Number} mode The slicing mode.
    */
@@ -273,5 +155,5 @@ export declare const vtkImageArrayMapper: {
   newInstance: typeof newInstance;
   extend: typeof extend;
   SlicingMode: typeof SlicingMode;
-};
+} & StaticCoincidentTopologyMethods;
 export default vtkImageArrayMapper;

--- a/Sources/Rendering/Core/ImageCPRMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageCPRMapper/index.d.ts
@@ -9,11 +9,9 @@ import vtkImageData from '../../../Common/DataModel/ImageData';
 import vtkPolyData from '../../../Common/DataModel/PolyData';
 import vtkPolyLine from '../../../Common/DataModel/PolyLine';
 import { ProjectionMode } from './Constants';
-
-interface ICoincidentTopology {
-  factor: number;
-  offset: number;
-}
+import CoincidentTopologyHelper, {
+  StaticCoincidentTopologyMethods,
+} from '../Mapper/CoincidentTopologyHelper';
 
 type TOrientation = mat4 | mat3 | quat | vec3;
 
@@ -29,7 +27,9 @@ export interface IImageCPRMapperInitialValues
   normalDirection: vec3;
 }
 
-export interface vtkImageCPRMapper extends vtkAbstractMapper3D {
+export interface vtkImageCPRMapper
+  extends vtkAbstractMapper3D,
+    CoincidentTopologyHelper {
   /**
    * @returns the width of the image in model coordinates of the input volume
    */
@@ -307,124 +307,6 @@ export interface vtkImageCPRMapper extends vtkAbstractMapper3D {
    * @param imageData
    */
   setImageConnection(imageData: vtkOutputPort): void;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopology(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyAsString(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetFaces(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param resolveCoincidentTopology
-   * @default false
-   */
-  setResolveCoincidentTopology(resolveCoincidentTopology: boolean): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param value
-   */
-  setResolveCoincidentTopologyPolygonOffsetFaces(value: number): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToDefault(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToOff(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToPolygonOffset(): boolean;
 }
 
 /**
@@ -483,5 +365,5 @@ export function newInstance(
 export declare const vtkImageCPRMapper: {
   newInstance: typeof newInstance;
   extend: typeof extend;
-};
+} & StaticCoincidentTopologyMethods;
 export default vtkImageCPRMapper;

--- a/Sources/Rendering/Core/ImageMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageMapper/index.d.ts
@@ -5,15 +5,13 @@ import vtkAbstractImageMapper, {
 import { Bounds, Nullable, Vector3 } from '../../../types';
 import { SlicingMode } from './Constants';
 import vtkImageData from '../../../Common/DataModel/ImageData';
+import CoincidentTopologyHelper, {
+  StaticCoincidentTopologyMethods,
+} from '../Mapper/CoincidentTopologyHelper';
 
 interface IClosestIJKAxis {
   ijkMode: SlicingMode;
   flip: boolean;
-}
-
-interface ICoincidentTopology {
-  factor: number;
-  offset: number;
 }
 
 export interface IImageMapperInitialValues
@@ -23,7 +21,9 @@ export interface IImageMapperInitialValues
   sliceAtFocalPoint?: boolean;
 }
 
-export interface vtkImageMapper extends vtkAbstractImageMapper {
+export interface vtkImageMapper
+  extends vtkAbstractImageMapper,
+    CoincidentTopologyHelper {
   /**
    * Returns the IJK slice value from a world position or XYZ slice value
    * @param {Vector3 | number} [pos] World point or XYZ slice value
@@ -62,36 +62,6 @@ export interface vtkImageMapper extends vtkAbstractImageMapper {
   getRenderToRectangle(): boolean;
 
   /**
-   *
-   */
-  getResolveCoincidentTopology(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyAsString(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetFaces(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
-
-  /**
    * Return currently active image. By default, there can only be one image
    * for this mapper, if an input is set.
    */
@@ -121,94 +91,6 @@ export interface vtkImageMapper extends vtkAbstractImageMapper {
    * @param {IClosestIJKAxis} closestIJKAxis The axis object.
    */
   setClosestIJKAxis(closestIJKAxis: IClosestIJKAxis): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param resolveCoincidentTopology
-   * @default false
-   */
-  setResolveCoincidentTopology(resolveCoincidentTopology: boolean): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param value
-   */
-  setResolveCoincidentTopologyPolygonOffsetFaces(value: number): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToDefault(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToOff(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToPolygonOffset(): boolean;
 
   /**
    *
@@ -329,5 +211,5 @@ export declare const vtkImageMapper: {
   newInstance: typeof newInstance;
   extend: typeof extend;
   SlicingMode: typeof SlicingMode;
-};
+} & StaticCoincidentTopologyMethods;
 export default vtkImageMapper;

--- a/Sources/Rendering/Core/ImageResliceMapper/index.d.ts
+++ b/Sources/Rendering/Core/ImageResliceMapper/index.d.ts
@@ -6,11 +6,9 @@ import vtkPlane from '../../../Common/DataModel/Plane';
 import vtkPolyData from '../../../Common/DataModel/PolyData';
 import { Bounds, Nullable, Vector3 } from '../../../types';
 import { SlabTypes } from './Constants';
-
-interface ICoincidentTopology {
-  factor: number;
-  offset: number;
-}
+import CoincidentTopologyHelper, {
+  StaticCoincidentTopologyMethods,
+} from '../Mapper/CoincidentTopologyHelper';
 
 export interface IImageResliceMapperInitialValues
   extends IAbstractImageMapperInitialValues {
@@ -21,7 +19,9 @@ export interface IImageResliceMapperInitialValues
   slicePolyData?: vtkPolyData;
 }
 
-export interface vtkImageResliceMapper extends vtkAbstractImageMapper {
+export interface vtkImageResliceMapper
+  extends vtkAbstractImageMapper,
+    CoincidentTopologyHelper {
   /**
    * Get the bounds for this mapper as [xmin, xmax, ymin, ymax,zmin, zmax].
    * @return {Bounds} The bounds for the mapper.
@@ -32,36 +32,6 @@ export interface vtkImageResliceMapper extends vtkAbstractImageMapper {
    *
    */
   getIsOpaque(): boolean;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopology(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyAsString(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetFaces(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
 
   /**
    *
@@ -92,94 +62,6 @@ export interface vtkImageResliceMapper extends vtkAbstractImageMapper {
    * Get the custom polydata used to slice the volume with.
    */
   getSlicePolyData(): vtkPolyData;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setRelativeCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param resolveCoincidentTopology
-   * @default false
-   */
-  setResolveCoincidentTopology(resolveCoincidentTopology: boolean): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyLineOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPointOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   * @param value
-   */
-  setResolveCoincidentTopologyPolygonOffsetFaces(value: number): boolean;
-
-  /**
-   *
-   * @param {Number} factor
-   * @param {Number} offset
-   */
-  setResolveCoincidentTopologyPolygonOffsetParameters(
-    factor: number,
-    offset: number
-  ): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToDefault(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToOff(): boolean;
-
-  /**
-   *
-   */
-  setResolveCoincidentTopologyToPolygonOffset(): boolean;
 
   /**
    *
@@ -266,5 +148,5 @@ export function newInstance(
 export declare const vtkImageResliceMapper: {
   newInstance: typeof newInstance;
   extend: typeof extend;
-};
+} & StaticCoincidentTopologyMethods;
 export default vtkImageResliceMapper;

--- a/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.d.ts
+++ b/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.d.ts
@@ -3,6 +3,11 @@ export interface ICoincidentTopology {
   offset: number;
 }
 
+export enum Resolve {
+  Off,
+  PolygonOffset,
+}
+
 export interface StaticCoincidentTopologyMethods {
   /**
    *
@@ -88,12 +93,12 @@ export interface StaticCoincidentTopologyMethods {
    *
    * @param mode
    */
-  setResolveCoincidentTopology(mode?: number): boolean;
+  setResolveCoincidentTopology(mode?: Resolve): boolean;
 
   /**
    *
    */
-  getResolveCoincidentTopology(): number;
+  getResolveCoincidentTopology(): Resolve;
 
   /**
    *
@@ -117,10 +122,7 @@ export interface StaticCoincidentTopologyMethods {
 }
 
 export default interface CoincidentTopologyHelper
-  extends Omit<
-    StaticCoincidentTopologyMethods,
-    'setResolveCoincidentTopology' | 'getResolveCoincidentTopology'
-  > {
+  extends StaticCoincidentTopologyMethods {
   /**
    *
    * @param {ICoincidentTopology} params
@@ -174,17 +176,6 @@ export default interface CoincidentTopologyHelper
     factor: number,
     offset: number
   ): boolean;
-
-  /**
-   *
-   * @param resolveCoincidentTopology
-   */
-  setResolveCoincidentTopology(resolveCoincidentTopology: boolean): boolean;
-
-  /**
-   *
-   */
-  getResolveCoincidentTopology(): boolean;
 
   /**
    *

--- a/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.d.ts
+++ b/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.d.ts
@@ -1,0 +1,203 @@
+export interface ICoincidentTopology {
+  factor: number;
+  offset: number;
+}
+
+export interface StaticCoincidentTopologyMethods {
+  /**
+   *
+   * @param {ICoincidentTopology} params
+   */
+  setResolveCoincidentTopologyPolygonOffsetParameters(
+    params: ICoincidentTopology
+  ): boolean;
+
+  /**
+   *
+   * @param {ICoincidentTopology} params
+   */
+  setResolveCoincidentTopologyLineOffsetParameters(
+    params: ICoincidentTopology
+  ): boolean;
+
+  /**
+   *
+   * @param {ICoincidentTopology} params
+   */
+  setResolveCoincidentTopologyPointOffsetParameters(
+    params: ICoincidentTopology
+  ): boolean;
+
+  /**
+   *
+   * @param {Number} factor
+   * @param {Number} offset
+   */
+  setResolveCoincidentTopologyPolygonOffsetParameters(
+    factor: number,
+    offset: number
+  ): boolean;
+
+  /**
+   *
+   * @param {Number} factor
+   * @param {Number} offset
+   */
+  setResolveCoincidentTopologyLineOffsetParameters(
+    factor: number,
+    offset: number
+  ): boolean;
+
+  /**
+   *
+   * @param {Number} factor
+   * @param {Number} offset
+   */
+  setResolveCoincidentTopologyPointOffsetParameters(
+    factor: number,
+    offset: number
+  ): boolean;
+
+  /**
+   *
+   */
+  getResolveCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
+
+  /**
+   *
+   */
+  getResolveCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
+
+  /**
+   *
+   */
+  getResolveCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
+
+  /**
+   *
+   */
+  getResolveCoincidentTopologyPolygonOffsetFaces(): ICoincidentTopology;
+
+  /**
+   *
+   * @param {Number} value
+   */
+  setResolveCoincidentTopologyPolygonOffsetFaces(value: number): boolean;
+
+  /**
+   *
+   * @param mode
+   */
+  setResolveCoincidentTopology(mode?: number): boolean;
+
+  /**
+   *
+   */
+  getResolveCoincidentTopology(): number;
+
+  /**
+   *
+   */
+  setResolveCoincidentTopologyToDefault(): boolean;
+
+  /**
+   *
+   */
+  setResolveCoincidentTopologyToOff(): boolean;
+
+  /**
+   *
+   */
+  setResolveCoincidentTopologyToPolygonOffset(): boolean;
+
+  /**
+   *
+   */
+  getResolveCoincidentTopologyAsString(): string;
+}
+
+export default interface CoincidentTopologyHelper
+  extends Omit<
+    StaticCoincidentTopologyMethods,
+    'setResolveCoincidentTopology' | 'getResolveCoincidentTopology'
+  > {
+  /**
+   *
+   * @param {ICoincidentTopology} params
+   */
+  setRelativeCoincidentTopologyLineOffsetParameters(
+    params: ICoincidentTopology
+  ): boolean;
+
+  /**
+   *
+   * @param {ICoincidentTopology} params
+   */
+  setRelativeCoincidentTopologyPointOffsetParameters(
+    params: ICoincidentTopology
+  ): boolean;
+
+  /**
+   *
+   * @param {ICoincidentTopology} params
+   */
+  setRelativeCoincidentTopologyPolygonOffsetParameters(
+    params: ICoincidentTopology
+  ): boolean;
+
+  /**
+   *
+   * @param {Number} factor
+   * @param {Number} offset
+   */
+  setRelativeCoincidentTopologyLineOffsetParameters(
+    factor: number,
+    offset: number
+  ): boolean;
+
+  /**
+   *
+   * @param {Number} factor
+   * @param {Number} offset
+   */
+  setRelativeCoincidentTopologyPointOffsetParameters(
+    factor: number,
+    offset: number
+  ): boolean;
+
+  /**
+   *
+   * @param {Number} factor
+   * @param {Number} offset
+   */
+  setRelativeCoincidentTopologyPolygonOffsetParameters(
+    factor: number,
+    offset: number
+  ): boolean;
+
+  /**
+   *
+   * @param resolveCoincidentTopology
+   */
+  setResolveCoincidentTopology(resolveCoincidentTopology: boolean): boolean;
+
+  /**
+   *
+   */
+  getResolveCoincidentTopology(): boolean;
+
+  /**
+   *
+   */
+  getCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
+
+  /**
+   *
+   */
+  getCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
+
+  /**
+   *
+   */
+  getCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
+}

--- a/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
+++ b/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
@@ -5,8 +5,26 @@ import macro from 'vtk.js/Sources/macros';
 function addCoincidentTopologyMethods(publicAPI, model, nameList) {
   nameList.forEach((item) => {
     publicAPI[`get${item.method}`] = () => model[item.key];
-    publicAPI[`set${item.method}`] = (factor, offset) => {
-      model[item.key] = { factor, offset };
+    publicAPI[`set${item.method}`] = function setCoincidentTopologyParams(
+      factor,
+      offset
+    ) {
+      let newFactor;
+      let newOffset;
+      if (arguments.length === 1) {
+        // first param is an object containing the properties
+        ({ factor: newFactor, offset: newOffset } = factor);
+      } else {
+        newFactor = factor;
+        newOffset = offset;
+      }
+
+      const changed =
+        model[item.key]?.factor !== newFactor ||
+        model[item.key]?.offset !== newOffset;
+
+      model[item.key] = { factor: newFactor, offset: newOffset };
+      return changed;
     };
   });
 }

--- a/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
+++ b/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
@@ -54,8 +54,6 @@ function implementCoincidentTopologyMethods(publicAPI, model) {
     model.resolveCoincidentTopology = false;
   }
 
-  macro.setGet(publicAPI, model, ['resolveCoincidentTopology']);
-
   // Relative methods
   model.topologyOffset = {
     Polygon: { factor: 0, offset: 0 },
@@ -70,6 +68,8 @@ function implementCoincidentTopologyMethods(publicAPI, model) {
   Object.keys(staticOffsetAPI).forEach((methodName) => {
     publicAPI[methodName] = staticOffsetAPI[methodName];
   });
+
+  macro.setGet(publicAPI, model, ['resolveCoincidentTopology']);
 
   addCoincidentTopologyMethods(
     publicAPI,

--- a/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
+++ b/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
@@ -1,31 +1,22 @@
 /* eslint-disable arrow-body-style */
-import otherStaticMethods from 'vtk.js/Sources/Rendering/Core/Mapper/Static';
+import otherStaticMethods, {
+  Resolve,
+} from 'vtk.js/Sources/Rendering/Core/Mapper/Static';
 import macro from 'vtk.js/Sources/macros';
+
+export { Resolve } from 'vtk.js/Sources/Rendering/Core/Mapper/Static';
 
 function addCoincidentTopologyMethods(publicAPI, model, nameList) {
   nameList.forEach((item) => {
     publicAPI[`get${item.method}`] = () => model[item.key];
-    publicAPI[`set${item.method}`] = function setCoincidentTopologyParams(
-      factor,
-      offset
-    ) {
-      let newFactor;
-      let newOffset;
-      if (arguments.length === 1) {
-        // first param is an object containing the properties
-        ({ factor: newFactor, offset: newOffset } = factor);
-      } else {
-        newFactor = factor;
-        newOffset = offset;
+    publicAPI[`set${item.method}`] = macro.objectSetterMap.object(
+      publicAPI,
+      model,
+      {
+        name: item.key,
+        params: ['factor', 'offset'],
       }
-
-      const changed =
-        model[item.key]?.factor !== newFactor ||
-        model[item.key]?.offset !== newOffset;
-
-      model[item.key] = { factor: newFactor, offset: newOffset };
-      return changed;
-    };
+    );
   });
 }
 
@@ -54,6 +45,8 @@ function implementCoincidentTopologyMethods(publicAPI, model) {
     model.resolveCoincidentTopology = false;
   }
 
+  macro.setGet(publicAPI, model, ['resolveCoincidentTopology']);
+
   // Relative methods
   model.topologyOffset = {
     Polygon: { factor: 0, offset: 0 },
@@ -68,8 +61,6 @@ function implementCoincidentTopologyMethods(publicAPI, model) {
   Object.keys(staticOffsetAPI).forEach((methodName) => {
     publicAPI[methodName] = staticOffsetAPI[methodName];
   });
-
-  macro.setGet(publicAPI, model, ['resolveCoincidentTopology']);
 
   addCoincidentTopologyMethods(
     publicAPI,
@@ -119,4 +110,5 @@ export default {
   staticOffsetAPI,
   otherStaticMethods,
   CATEGORIES,
+  Resolve,
 };

--- a/Sources/Rendering/Core/Mapper/Static.js
+++ b/Sources/Rendering/Core/Mapper/Static.js
@@ -11,7 +11,9 @@ export function getResolveCoincidentTopologyPolygonOffsetFaces() {
 }
 
 export function setResolveCoincidentTopologyPolygonOffsetFaces(value) {
+  const changed = resolveCoincidentTopologyPolygonOffsetFaces === value;
   resolveCoincidentTopologyPolygonOffsetFaces = value;
+  return changed;
 }
 
 export function getResolveCoincidentTopology() {
@@ -19,19 +21,21 @@ export function getResolveCoincidentTopology() {
 }
 
 export function setResolveCoincidentTopology(mode = 0) {
+  const changed = resolveCoincidentTopology === mode;
   resolveCoincidentTopology = mode;
+  return changed;
 }
 
 export function setResolveCoincidentTopologyToDefault() {
-  setResolveCoincidentTopology(0); // VTK_RESOLVE_OFF
+  return setResolveCoincidentTopology(0); // VTK_RESOLVE_OFF
 }
 
 export function setResolveCoincidentTopologyToOff() {
-  setResolveCoincidentTopology(0); // VTK_RESOLVE_OFF
+  return setResolveCoincidentTopology(0); // VTK_RESOLVE_OFF
 }
 
 export function setResolveCoincidentTopologyToPolygonOffset() {
-  setResolveCoincidentTopology(1); // VTK_RESOLVE_POLYGON_OFFSET
+  return setResolveCoincidentTopology(1); // VTK_RESOLVE_POLYGON_OFFSET
 }
 
 export function getResolveCoincidentTopologyAsString() {

--- a/Sources/Rendering/Core/Mapper/Static.js
+++ b/Sources/Rendering/Core/Mapper/Static.js
@@ -1,5 +1,10 @@
-let resolveCoincidentTopologyPolygonOffsetFaces = 1;
-let resolveCoincidentTopology = 0;
+export const Resolve = {
+  Off: 0,
+  PolygonOffset: 1,
+};
+
+let resolveCoincidentTopologyPolygonOffsetFaces = Resolve.PolygonOffset;
+let resolveCoincidentTopology = Resolve.Off;
 
 export const RESOLVE_COINCIDENT_TOPOLOGY_MODE = [
   'VTK_RESOLVE_OFF',
@@ -27,15 +32,15 @@ export function setResolveCoincidentTopology(mode = 0) {
 }
 
 export function setResolveCoincidentTopologyToDefault() {
-  return setResolveCoincidentTopology(0); // VTK_RESOLVE_OFF
+  return setResolveCoincidentTopology(Resolve.Off);
 }
 
 export function setResolveCoincidentTopologyToOff() {
-  return setResolveCoincidentTopology(0); // VTK_RESOLVE_OFF
+  return setResolveCoincidentTopology(Resolve.Off);
 }
 
 export function setResolveCoincidentTopologyToPolygonOffset() {
-  return setResolveCoincidentTopology(1); // VTK_RESOLVE_POLYGON_OFFSET
+  return setResolveCoincidentTopology(Resolve.PolygonOffset);
 }
 
 export function getResolveCoincidentTopologyAsString() {
@@ -43,6 +48,7 @@ export function getResolveCoincidentTopologyAsString() {
 }
 
 export default {
+  Resolve,
   getResolveCoincidentTopologyAsString,
   getResolveCoincidentTopologyPolygonOffsetFaces,
   getResolveCoincidentTopology,

--- a/Sources/Rendering/Core/Mapper/index.d.ts
+++ b/Sources/Rendering/Core/Mapper/index.d.ts
@@ -4,6 +4,9 @@ import vtkAbstractMapper3D, {
 } from '../AbstractMapper3D';
 import { ColorMode, GetArray, ScalarMode } from './Constants';
 import vtkDataArray from '../../../Common/Core/DataArray';
+import CoincidentTopologyHelper, {
+  StaticCoincidentTopologyMethods,
+} from './CoincidentTopologyHelper';
 
 interface IPrimitiveCount {
   points: number;
@@ -15,11 +18,6 @@ interface IPrimitiveCount {
 interface IAbstractScalars {
   cellFlag: boolean;
   scalars: Nullable<vtkDataArray>;
-}
-
-interface ICoincidentTopology {
-  factor: number;
-  offset: number;
 }
 
 interface IScalarToTextureCoordinate {
@@ -43,7 +41,9 @@ export interface IMapperInitialValues extends IAbstractMapper3DInitialValues {
   customShaderAttributes?: any;
 }
 
-export interface vtkMapper extends vtkAbstractMapper3D {
+export interface vtkMapper
+  extends vtkAbstractMapper3D,
+    CoincidentTopologyHelper {
   /**
    *
    */
@@ -139,21 +139,6 @@ export interface vtkMapper extends vtkAbstractMapper3D {
    * @return {Bounds} The bounds for the mapper.
    */
   getBounds(): Bounds;
-
-  /**
-   *
-   */
-  getCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
-
-  /**
-   *
-   */
-  getCoincidentTopologyPointOffsetParameter(): ICoincidentTopology;
 
   /**
    * Get the array name to color by.
@@ -515,10 +500,6 @@ export interface vtkMapper extends vtkAbstractMapper3D {
   setInterpolateScalarsBeforeMapping(
     interpolateScalarsBeforeMapping: boolean
   ): boolean;
-
-  setResolveCoincidentTopologyToPolygonOffset(): boolean;
-
-  setResolveCoincidentTopologyToOff(): boolean;
 }
 
 /**
@@ -539,80 +520,6 @@ export function extend(
  * @param {IMapperInitialValues} [initialValues] for pre-setting some of its content
  */
 export function newInstance(initialValues?: IMapperInitialValues): vtkMapper;
-
-/**
- *
- */
-export function getResolveCoincidentTopologyAsString(): string;
-
-/**
- *
- */
-export function getResolveCoincidentTopologyPolygonOffsetFaces(): ICoincidentTopology;
-
-/**
- *
- */
-export function getResolveCoincidentTopology(): ICoincidentTopology;
-
-/**
- *
- * @param {Number} [mode]
- */
-export function setResolveCoincidentTopology(mode?: number): boolean;
-
-/**
- *
- * @param value
- */
-export function setResolveCoincidentTopologyPolygonOffsetFaces(
-  value: any
-): boolean;
-
-/**
- *
- */
-export function setResolveCoincidentTopologyToDefault(): boolean;
-
-/**
- *
- */
-export function setResolveCoincidentTopologyToOff(): boolean;
-
-/**
- *
- */
-export function setResolveCoincidentTopologyToPolygonOffset(): boolean;
-
-/**
- *
- */
-export function getRelativeCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
-
-/**
- *
- */
-export function getRelativeCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
-
-/**
- *
- */
-export function getRelativeCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
-
-/**
- *
- */
-export function getResolveCoincidentTopologyLineOffsetParameters(): ICoincidentTopology;
-
-/**
- *
- */
-export function getResolveCoincidentTopologyPointOffsetParameters(): ICoincidentTopology;
-
-/**
- *
- */
-export function getResolveCoincidentTopologyPolygonOffsetParameters(): ICoincidentTopology;
 
 /**
  * vtkMapper is an abstract class to specify interface between data and
@@ -650,22 +557,8 @@ export function getResolveCoincidentTopologyPolygonOffsetParameters(): ICoincide
 export declare const vtkMapper: {
   newInstance: typeof newInstance;
   extend: typeof extend;
-  getResolveCoincidentTopologyAsString: typeof getResolveCoincidentTopologyAsString;
-  getResolveCoincidentTopologyPolygonOffsetFaces: typeof getResolveCoincidentTopologyPolygonOffsetFaces;
-  getResolveCoincidentTopology: typeof getResolveCoincidentTopology;
-  setResolveCoincidentTopology: typeof setResolveCoincidentTopology;
-  setResolveCoincidentTopologyPolygonOffsetFaces: typeof setResolveCoincidentTopologyPolygonOffsetFaces;
-  setResolveCoincidentTopologyToDefault: typeof setResolveCoincidentTopologyToDefault;
-  setResolveCoincidentTopologyToOff: typeof setResolveCoincidentTopologyToOff;
-  setResolveCoincidentTopologyToPolygonOffset: typeof setResolveCoincidentTopologyToPolygonOffset;
-  getRelativeCoincidentTopologyLineOffsetParameters: typeof getRelativeCoincidentTopologyLineOffsetParameters;
-  getRelativeCoincidentTopologyPointOffsetParameters: typeof getRelativeCoincidentTopologyPointOffsetParameters;
-  getRelativeCoincidentTopologyPolygonOffsetParameters: typeof getRelativeCoincidentTopologyPolygonOffsetParameters;
-  getResolveCoincidentTopologyLineOffsetParameters: typeof getResolveCoincidentTopologyLineOffsetParameters;
-  getResolveCoincidentTopologyPointOffsetParameters: typeof getResolveCoincidentTopologyPointOffsetParameters;
-  getResolveCoincidentTopologyPolygonOffsetParameters: typeof getResolveCoincidentTopologyPolygonOffsetParameters;
   ColorMode: typeof ColorMode;
   ScalarMode: typeof ScalarMode;
   GetArray: typeof GetArray;
-};
+} & StaticCoincidentTopologyMethods;
 export default vtkMapper;

--- a/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
@@ -16,6 +16,7 @@ import vtkPolyDataVS from 'vtk.js/Sources/Rendering/OpenGL/glsl/vtkPolyDataVS.gl
 import vtkPolyDataFS from 'vtk.js/Sources/Rendering/OpenGL/glsl/vtkPolyDataFS.glsl';
 
 import { registerOverride } from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
+import { Resolve } from 'vtk.js/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper';
 
 const { vtkErrorMacro } = macro;
 
@@ -80,7 +81,9 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
   };
 
   publicAPI.getCoincidentParameters = (ren, actor) => {
-    if (model.renderable.getResolveCoincidentTopology()) {
+    if (
+      model.renderable.getResolveCoincidentTopology() === Resolve.PolygonOffset
+    ) {
       return model.renderable.getCoincidentTopologyPolygonOffsetParameters();
     }
     return null;

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -18,6 +18,7 @@ import { InterpolationType } from 'vtk.js/Sources/Rendering/Core/ImageProperty/C
 import vtkPolyDataVS from 'vtk.js/Sources/Rendering/OpenGL/glsl/vtkPolyDataVS.glsl';
 import vtkPolyDataFS from 'vtk.js/Sources/Rendering/OpenGL/glsl/vtkPolyDataFS.glsl';
 import vtkReplacementShaderMapper from 'vtk.js/Sources/Rendering/OpenGL/ReplacementShaderMapper';
+import { Resolve } from 'vtk.js/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper';
 
 import { registerOverride } from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
 
@@ -133,7 +134,11 @@ function vtkOpenGLImageMapper(publicAPI, model) {
   };
 
   publicAPI.getCoincidentParameters = (ren, actor) => {
-    if (model.renderable.getResolveCoincidentTopology()) {
+    if (
+      // backwards compat with code that (errorneously) set this to boolean
+      // eslint-disable-next-line eqeqeq
+      model.renderable.getResolveCoincidentTopology() == Resolve.PolygonOffset
+    ) {
       return model.renderable.getCoincidentTopologyPolygonOffsetParameters();
     }
     return null;
@@ -359,7 +364,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
               ...splitStringOnEnter(
                 `
                 #ifdef vtkImageLabelOutlineOn
-                  vec3 centerPosIS = fragCoordToIndexSpace(gl_FragCoord); 
+                  vec3 centerPosIS = fragCoordToIndexSpace(gl_FragCoord);
                   float centerValue = texture2D(texture1, centerPosIS.xy).r;
                   bool pixelOnBorder = false;
                   vec3 tColor = texture2D(colorTexture1, vec2(centerValue * cscale0 + cshift0, 0.5)).rgb;

--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -24,6 +24,7 @@ import { InterpolationType } from 'vtk.js/Sources/Rendering/Core/ImageProperty/C
 import { Representation } from 'vtk.js/Sources/Rendering/Core/Property/Constants';
 import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 import { registerOverride } from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
+import { Resolve } from 'vtk.js/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper';
 
 const { vtkErrorMacro } = macro;
 
@@ -118,7 +119,11 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
   };
 
   publicAPI.getCoincidentParameters = (ren, actor) => {
-    if (model.renderable.getResolveCoincidentTopology()) {
+    if (
+      // backwards compat with code that (errorneously) set this to boolean
+      // eslint-disable-next-line eqeqeq
+      model.renderable.getResolveCoincidentTopology() == Resolve.PolygonOffset
+    ) {
       return model.renderable.getCoincidentTopologyPolygonOffsetParameters();
     }
     return null;

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -18,6 +18,7 @@ import { registerOverride } from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactor
 
 import { PassTypes } from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelector/Constants';
 import vtkDataSet from 'vtk.js/Sources/Common/DataModel/DataSet';
+import { Resolve } from 'vtk.js/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper';
 
 const { FieldAssociations } = vtkDataSet;
 
@@ -859,7 +860,10 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
     };
     const prop = actor.getProperty();
     if (
-      model.renderable.getResolveCoincidentTopology() ||
+      // backwards compat with code that (errorneously) set this to boolean
+      // eslint-disable-next-line eqeqeq
+      model.renderable.getResolveCoincidentTopology() ==
+        Resolve.PolygonOffset ||
       (prop.getEdgeVisibility() &&
         prop.getRepresentation() === Representation.SURFACE)
     ) {

--- a/Sources/Testing/testMacro.js
+++ b/Sources/Testing/testMacro.js
@@ -44,6 +44,7 @@ const DEFAULT_VALUES = {
   _myProp12: [12],
   _myProp13: 13,
   myObjectProp: { foo: 1 },
+  myParameterizedObjectProp: { foo: 1, bar: 2 },
   _onMyObjectPropChanged: (publicAPI, model) => {
     ++model._onMyObjectPropChangedCallsCount;
   },
@@ -89,6 +90,13 @@ function extend(publicAPI, model, initialValues = {}) {
 
   // Object member variables
   macro.setGet(publicAPI, model, [{ name: 'myObjectProp', type: 'object' }]);
+  macro.setGet(publicAPI, model, [
+    {
+      name: 'myParameterizedObjectProp',
+      type: 'object',
+      params: ['foo', 'bar'],
+    },
+  ]);
 
   // Object specific methods
   myClass(publicAPI, model);
@@ -449,6 +457,27 @@ test('Macro methods object tests', (t) => {
     myTestClass.getMyObjectProp(),
     { foo: 2 },
     'Getter shall return a copy'
+  );
+
+  myTestClass.setMyParameterizedObjectProp({ foo: 12, bar: 89, baz: 13 });
+  t.deepEqual(
+    myTestClass.getMyParameterizedObjectProp(),
+    { foo: 12, bar: 89, baz: 13 },
+    'Setter changes on a different object'
+  );
+
+  myTestClass.setMyParameterizedObjectProp(16, 52);
+  t.deepEqual(
+    myTestClass.getMyParameterizedObjectProp(),
+    { foo: 16, bar: 52 },
+    'Object setter with multiple arguments'
+  );
+
+  myTestClass.setMyParameterizedObjectProp(1, 2, 3);
+  t.deepEqual(
+    myTestClass.getMyParameterizedObjectProp(),
+    { foo: 1, bar: 2 },
+    'Object setter ignores extraneous arguments'
   );
 
   t.end();

--- a/Sources/Widgets/Representations/CircleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/CircleContextRepresentation/index.js
@@ -2,6 +2,7 @@ import macro from 'vtk.js/Sources/macros';
 import vtkCircleSource from 'vtk.js/Sources/Filters/Sources/CircleSource';
 import vtkGlyphRepresentation from 'vtk.js/Sources/Widgets/Representations/GlyphRepresentation';
 import { Behavior } from 'vtk.js/Sources/Widgets/Representations/WidgetRepresentation/Constants';
+import { Resolve } from 'vtk.js/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper';
 
 // ----------------------------------------------------------------------------
 // vtkCircleContextRepresentation methods
@@ -16,7 +17,7 @@ function vtkCircleContextRepresentation(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   model._pipeline.actor.getProperty().setOpacity(0.2);
-  model._pipeline.mapper.setResolveCoincidentTopology(true);
+  model._pipeline.mapper.setResolveCoincidentTopology(Resolve.PolygonOffset);
   model._pipeline.mapper.setRelativeCoincidentTopologyPolygonOffsetParameters(
     -1,
     -1

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -519,8 +519,22 @@ const objectSetterMap = {
     };
   },
   object(publicAPI, model, field) {
+    if (field.params?.length === 1) {
+      vtkWarningMacro(
+        'Setter of type "object" with a single "param" field is not supported'
+      );
+    }
     const onChanged = `_on${_capitalize(field.name)}Changed`;
-    return (value) => {
+    return (...args) => {
+      let value;
+      if (args.length > 1 && field.params?.length) {
+        value = field.params.reduce(
+          (acc, prop, idx) => Object.assign(acc, { [prop]: args[idx] }),
+          {}
+        );
+      } else {
+        value = args[0];
+      }
       if (!DeepEqual(model[field.name], value)) {
         const previousValue = model[field.name];
         model[field.name] = value;
@@ -1800,4 +1814,6 @@ export default {
   vtkLogMacro,
   vtkOnceErrorMacro,
   vtkWarningMacro,
+  // vtk.js internal use
+  objectSetterMap,
 };


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
- `mapper.set({ relativeCoincidentTopologyLineOffsetParameters: { factor, offset } })` does not work because the coincident topology setters do not support single-object parameters. This is (mostly) inconsistent with how we expect setters to work.
- Refactored the coincident topology helper types to reduce repetition and inconsistencies with type definitions across mappers.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- improved types and coincident topology API

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
N/A