### PR TITLE
fix(LineWidget): onModified memory leak

### DIFF
--- a/Sources/Widgets/Widgets3D/LineWidget/index.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/index.js
@@ -160,7 +160,7 @@ function vtkLineWidget(publicAPI, model) {
     model.widgetState.getMoveHandle().setOrigin(center);
   });
 
-  model.widgetState.getPositionOnLine().onModified(() => {
+  let linePosSub = model.widgetState.getPositionOnLine().onModified(() => {
     updateTextPosition(model);
   });
 
@@ -169,6 +169,11 @@ function vtkLineWidget(publicAPI, model) {
     model.manipulator ||
       vtkPlanePointManipulator.newInstance({ useCameraNormal: true })
   );
+
+  publicAPI.delete = macro.chain(publicAPI.delete, () => {
+    linePosSub.unsubscribe();
+    linePosSub = null;
+  });
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

#3062 reported a memory leak with vtkLineWidget. It remains to be seen if widgets generally leak memory.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- Line widget no longer leaks memory

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
N/A