### PR TITLE
fix the judgement of model.useLookupTableScalarRange

### DIFF
--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -156,7 +156,7 @@ function vtkMapper(publicAPI, model) {
     const toString = `${publicAPI.getMTime()}${scalars.getMTime()}${alpha}`;
     if (model.colorBuildString === toString) return;
 
-    if (!model.useLookupTableScalarRange) {
+    if (model.useLookupTableScalarRange) {
       publicAPI
         .getLookupTable()
         .setRange(model.scalarRange[0], model.scalarRange[1]);


### PR DESCRIPTION
### Context
when I use mapper, set the parameter "useLookupTableScalarRange" for "true". It seems the lookupTable did not work, So I set it "false"  ,the lookupTable will work. 
I look up the source of vtkMapper, the original version is "if (!model.useLookupTableScalarRange)"
It is more reasonable is the judgement is " if (model.useLookupTableScalarRange)" ,Right?
### Results
useLookupTableScalarRange work as expected


### Changes
delete the "!"

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**:  latest master
  - **OS**:  Windows 10
  - **Browser**:   Chrome 126

