### PR TITLE
Add the possibility to create a hole at the center of a LineHandleRepresentation

### DIFF
--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -167,6 +167,14 @@ for (let i = 0; i < 4; i++) {
     obj.interactor.setInteractorStyle(vtkInteractorStyleImage.newInstance());
     obj.widgetInstance = obj.widgetManager.addWidget(widget, xyzToViewType[i]);
     obj.widgetInstance.setScaleInPixels(true);
+    obj.widgetInstance.setHoleWidth(50);
+    obj.widgetInstance.setInfiniteLine(false);
+    widgetState
+      .getStatesWithLabel('line')
+      .forEach((state) => state.setScale3(4, 4, 300));
+    widgetState
+      .getStatesWithLabel('center')
+      .forEach((state) => state.setOpacity(128));
     obj.widgetInstance.setKeepOrthogonality(checkboxOrthogonality.checked);
     obj.widgetInstance.setCursorStyles(appCursorStyles);
     obj.widgetManager.enablePicking();

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/helpers.js
@@ -318,10 +318,7 @@ export function updateState(
       ?.setHandleNormal(
         widgetState.getPlanes()[planeNameToViewType[planeName]].normal
       );
-    const scale = vtkMath.normalize(direction);
-    const scale3 = lineHandle.getScale3();
-    scale3[2] = 2 * scale;
-    lineHandle.setScale3(scale3);
+    vtkMath.normalize(direction);
     const right =
       widgetState.getPlanes()[planeNameToViewType[inPlaneName]].normal;
     const up = vtkMath.cross(direction, right, []);

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.d.ts
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.d.ts
@@ -70,6 +70,14 @@ export interface vtkResliceCursorWidget<
 
   getScaleInPixels(): boolean;
 
+  setHoleWidth(holeWidth: number): boolean;
+
+  getHoleWidth(): number;
+
+  setInfiniteLine(infiniteLine: boolean): boolean;
+
+  getInfiniteLine(): boolean;
+
   setRotationHandlePosition(position: number): boolean;
 
   getRotationHandlePosition(): number;

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.js
@@ -34,7 +34,7 @@ const { vtkErrorMacro } = macro;
 function vtkResliceCursorWidget(publicAPI, model) {
   model.classHierarchy.push('vtkResliceCursorWidget');
 
-  model.methodsToLink = ['scaleInPixels'];
+  model.methodsToLink = ['scaleInPixels', 'holeWidth', 'infiniteLine'];
 
   // --------------------------------------------------------------------------
   // Private methods


### PR DESCRIPTION
This is very handy for the reslice cursor widget as we can now avoid occluding the region of interest for the viewed slice.
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/5408315f-fb6b-44d1-8440-b144adcc106e)|![image](https://github.com/user-attachments/assets/4634bcc3-9f6b-4cef-9be4-5ae3ede358d9)|
|Infinite lines|300px line (150 + 150)|
|No hole|50px hole|
|Fully opaque center sphere|Semi transparent center sphere|