### PR TITLE
fix(OBJReader): Add support for negative indices

### DIFF
--- a/Sources/IO/Misc/OBJReader/index.js
+++ b/Sources/IO/Misc/OBJReader/index.js
@@ -37,9 +37,20 @@ function begin(splitMode) {
 
 function faceMap(str) {
   const idxs = str.split('/').map((i) => Number(i));
-  const vertexIdx = idxs[0] - 1;
-  const textCoordIdx = idxs[1] ? idxs[1] - 1 : vertexIdx;
-  const vertexNormal = idxs[2] ? idxs[2] - 1 : vertexIdx;
+  const vertexIdx = idxs[0] > 0 ? idxs[0] - 1 : data.v.length / 3 + idxs[0];
+  let textCoordIdx;
+  if (idxs[1]) {
+    textCoordIdx = idxs[1] > 0 ? idxs[1] - 1 : data.vt.length / 2 + idxs[1];
+  } else {
+    textCoordIdx = vertexIdx;
+  }
+
+  let vertexNormal;
+  if (idxs[2]) {
+    vertexNormal = idxs[2] > 0 ? idxs[2] - 1 : data.vn.length / 3 + idxs[2];
+  } else {
+    vertexNormal = vertexIdx;
+  }
   return [vertexIdx, textCoordIdx, vertexNormal];
 }
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
According to the Wavefront OBJ spec ([here](https://paulbourke.net/dataformats/obj/) and [here](https://www.martinreddy.net/gfx/3d/OBJ.spec)), indices specified in the face elements (the `f` lines) may be negative. In that case, they refer to a vertex data counting up the list (e.g. -1 is the vertex data element immediately before the current line, -2 is the one before that, and so on...).

The current OBJReader implementation doesn't take into account the fact that these indices can be negative, leading to incorrect data lookup and overall an incorrect polydata.

![image](https://github.com/user-attachments/assets/22303317-66ef-4e5c-be81-c29fcff0a384)
  

### Results
Here's an example textured cube that contains negative indices for 2 faces:
- Before:
![Screenshot from 2024-07-26 15-10-32](https://github.com/user-attachments/assets/1815a732-b992-4149-af5e-1fbbfc255f97)

- After: 
![Screenshot from 2024-07-26 15-14-03](https://github.com/user-attachments/assets/5debe532-92d9-452d-b518-d319396f03ca)

### Changes
-  Updated `faceMap` function in `OBJReader` to take into account negative indices. 

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Linux Ubuntu 24-04
  - **Browser**: Chrome 126.0.6478.126
- Test cube files: [link](https://filebin.net/n6ybiv3u4soo9wux)