### PR TITLE
Fix color mapping for direct scalars

### DIFF
--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -414,7 +414,7 @@ function vtkMapper(publicAPI, model) {
   };
 
   publicAPI.canUseTextureMapForColoring = (scalars, cellFlag) => {
-    if (cellFlag) {
+    if (cellFlag && !(model.colorMode === ColorMode.DIRECT_SCALARS)) {
       return true; // cell data always use textures.
     }
 


### PR DESCRIPTION
Coloring was broken when using direct scalars with cellData

See [this comment](https://github.com/Kitware/vtk-js/pull/3075#discussion_r1676413103) that explains the issue
See [this comment](https://github.com/Kitware/vtk-js/pull/3095#issuecomment-2256835425) that asks for a separate PR
To merge before #3095 