### PR TITLE
docs(shapewidget): programmatically place shape widgets

### DIFF
--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/controlPanel.html
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/controlPanel.html
@@ -22,11 +22,14 @@
         <option name="ellipseWidget" selected>ellipseWidget</option>
         <option name="circleWidget">circleWidget</option>
       </select>
-      </td>
+    </td>
   </tr>
   <tr>
     <td>
       <button class="reset">reset</button>
+    </td>
+    <td>
+      <button class="place">place</button>
     </td>
   </tr>
 </table>

--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -346,6 +346,33 @@ document.querySelector('.widget').addEventListener('input', (ev) => {
   }
 });
 
+document.querySelector('.place').addEventListener('click', () => {
+  if (activeWidget !== 'rectangleWidget') {
+    const widget = widgets[activeWidget];
+    const widgetIndex = activeWidget === 'ellipseWidget' ? 1 : 2;
+    const handle =
+      activeWidget === 'ellipseWidget'
+        ? scene.ellipseHandle
+        : scene.circleHandle;
+    const coord1 = [0, 0, 0];
+    const coord2 = [100, 100, 100];
+    const slicePos = image.imageMapper.getSlice();
+    const axis = image.imageMapper.getSlicingMode() % 3;
+    coord1[axis] = slicePos;
+    coord2[axis] = slicePos;
+    handle.grabFocus();
+    handle.placePoint1(coord1);
+    handle.placePoint2(coord2);
+    // Place circle
+    handle.setCorners(coord1, coord2);
+    // Recompute text position
+    handle.invokeInteractionEvent();
+    handle.loseFocus();
+    updateWidgetVisibility(widget, coord1, axis, widgetIndex);
+    scene.renderWindow.render();
+  }
+});
+
 document.querySelector('.reset').addEventListener('click', () => {
   resetWidgets();
   scene.renderWindow.render();


### PR DESCRIPTION


### Context
It is not easy to place an ellipse widget programatically.
https://discourse.vtk.org/t/how-to-programmatically-add-the-ellipsewidget/14199/2


### Results
Update the existing ShapeWidget example.
It's not perfect though...

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome
