### PR TITLE
fix(volumeMapper): error handling when computed scale is not available

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.d.ts
+++ b/Sources/Rendering/OpenGL/Texture/index.d.ts
@@ -176,6 +176,23 @@ export interface vtkOpenGLTexture extends vtkViewNode {
   getOpenGLWrapMode(vtktype: Wrap): any;
 
   /**
+   * Updates the data array to match the required data type for OpenGL.
+   *
+   * This function takes the input data and converts it to the appropriate
+   * format required by the OpenGL texture, based on the specified data type.
+   *
+   * @param {string} dataType - The original data type of the input data.
+   * @param {Array} data - The input data array that needs to be updated.
+   * @param {boolean} [depth=false] - Indicates whether the data is a 3D array.
+   * @returns {Array} The updated data array that matches the OpenGL data type.
+   */
+  updateArrayDataTypeForGL(
+    dataType: VtkDataTypes,
+    data: any,
+    depth?: boolean
+  ): void;
+
+  /**
    * Creates a 2D texture from raw data.
    * @param width The width of the texture.
    * @param height The height of the texture.
@@ -323,6 +340,15 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @returns {number} The maximum texture size.
    */
   getMaximumTextureSize(ctx: any): number;
+
+  /**
+   * Public API to disable half float usage.
+   * Half float is automatically enabled when creating the texture,
+   * but users may want to disable it in certain cases
+   * (e.g., streaming data where the full range is not yet available).
+   * @param useHalfFloat - whether to use half float
+   */
+  enableUseHalfFloat(useHalfFloat: boolean): void;
 }
 
 /**

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -612,10 +612,19 @@ function vtkOpenGLTexture(publicAPI, model) {
     }
   };
 
-  //----------------------------------------------------------------------------
-  function updateArrayDataType(dataType, data, depth = false) {
+  /**
+   * Updates the data array to match the required data type for OpenGL.
+   *
+   * This function takes the input data and converts it to the appropriate
+   * format required by the OpenGL texture, based on the specified data type.
+   *
+   * @param {string} dataType - The original data type of the input data.
+   * @param {Array} data - The input data array that needs to be updated.
+   * @param {boolean} [depth=false] - Indicates whether the data is a 3D array.
+   * @returns {Array} The updated data array that matches the OpenGL data type.
+   */
+  publicAPI.updateArrayDataTypeForGL = (dataType, data, depth = false) => {
     const pixData = [];
-
     let pixCount = model.width * model.height * model.components;
     if (depth) {
       pixCount *= model.depth;
@@ -693,7 +702,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     }
 
     return pixData;
-  }
+  };
 
   //----------------------------------------------------------------------------
   function scaleTextureToHighestPowerOfTwo(data) {
@@ -856,7 +865,7 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     // Create an array of texture with one texture
     const dataArray = [data];
-    const pixData = updateArrayDataType(dataType, dataArray);
+    const pixData = publicAPI.updateArrayDataTypeForGL(dataType, dataArray);
     const scaledData = scaleTextureToHighestPowerOfTwo(pixData);
 
     // Source texture data from the PBO.
@@ -944,7 +953,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     publicAPI.createTexture();
     publicAPI.bind();
 
-    const pixData = updateArrayDataType(dataType, data);
+    const pixData = publicAPI.updateArrayDataTypeForGL(dataType, data);
     const scaledData = scaleTextureToHighestPowerOfTwo(pixData);
 
     // invert the data because opengl is messed up with cube maps
@@ -1364,7 +1373,7 @@ function vtkOpenGLTexture(publicAPI, model) {
     publicAPI.create2DFromRaw(width, height, numComps, dataType, data);
   };
 
-  publicAPI.updateVolumeScaleForOpenGL = (dataType, numComps) => {
+  publicAPI.updateVolumeInfoForGL = (dataType, numComps) => {
     let isScalingApplied = false;
 
     // Initialize volume info if it doesn't exist
@@ -1438,7 +1447,10 @@ function vtkOpenGLTexture(publicAPI, model) {
     let dataTypeToUse = dataType;
     let dataToUse = data;
 
-    if (!publicAPI.updateVolumeScaleForOpenGL(dataTypeToUse, numComps)) {
+    if (
+      !publicAPI.updateVolumeInfoForGL(dataTypeToUse, numComps) &&
+      dataToUse
+    ) {
       const numPixelsIn = width * height * depth;
       const scaleOffsetsCopy = structuredClone(model.volumeInfo);
       // otherwise convert to float
@@ -1484,7 +1496,11 @@ function vtkOpenGLTexture(publicAPI, model) {
     // Create an array of texture with one texture
     const dataArray = [dataToUse];
     const is3DArray = true;
-    const pixData = updateArrayDataType(dataTypeToUse, dataArray, is3DArray);
+    const pixData = publicAPI.updateArrayDataTypeForGL(
+      dataTypeToUse,
+      dataArray,
+      is3DArray
+    );
     const scaledData = scaleTextureToHighestPowerOfTwo(pixData);
 
     // Source texture data from the PBO.

--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1846,6 +1846,11 @@ function vtkOpenGLTexture(publicAPI, model) {
 
     return -1;
   };
+
+  // set use half float
+  publicAPI.setUseHalfFloat = (use) => {
+    model.useHalfFloat = use;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -707,7 +707,7 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
 
     // In some situations, we might not have computed the scale and offset
     // for the data range, or it might not be needed.
-    if (volInfo.dataComputedScale?.length) {
+    if (volInfo?.dataComputedScale?.length) {
       const minVals = [];
       const maxVals = [];
       for (let i = 0; i < 4; i++) {

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -705,34 +705,38 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
     const volInfo = model.scalarTexture.getVolumeInfo();
     const ipScalarRange = model.renderable.getIpScalarRange();
 
-    const minVals = [];
-    const maxVals = [];
-    for (let i = 0; i < 4; i++) {
-      // convert iprange from 0-1 into data range values
-      minVals[i] =
-        ipScalarRange[0] * volInfo.dataComputedScale[i] +
-        volInfo.dataComputedOffset[i];
-      maxVals[i] =
-        ipScalarRange[1] * volInfo.dataComputedScale[i] +
-        volInfo.dataComputedOffset[i];
-      // convert data ranges into texture values
-      minVals[i] = (minVals[i] - volInfo.offset[i]) / volInfo.scale[i];
-      maxVals[i] = (maxVals[i] - volInfo.offset[i]) / volInfo.scale[i];
+    // In some situations, we might not have computed the scale and offset
+    // for the data range, or it might not be needed.
+    if (volInfo.dataComputedScale?.length) {
+      const minVals = [];
+      const maxVals = [];
+      for (let i = 0; i < 4; i++) {
+        // convert iprange from 0-1 into data range values
+        minVals[i] =
+          ipScalarRange[0] * volInfo.dataComputedScale[i] +
+          volInfo.dataComputedOffset[i];
+        maxVals[i] =
+          ipScalarRange[1] * volInfo.dataComputedScale[i] +
+          volInfo.dataComputedOffset[i];
+        // convert data ranges into texture values
+        minVals[i] = (minVals[i] - volInfo.offset[i]) / volInfo.scale[i];
+        maxVals[i] = (maxVals[i] - volInfo.offset[i]) / volInfo.scale[i];
+      }
+      program.setUniform4f(
+        'ipScalarRangeMin',
+        minVals[0],
+        minVals[1],
+        minVals[2],
+        minVals[3]
+      );
+      program.setUniform4f(
+        'ipScalarRangeMax',
+        maxVals[0],
+        maxVals[1],
+        maxVals[2],
+        maxVals[3]
+      );
     }
-    program.setUniform4f(
-      'ipScalarRangeMin',
-      minVals[0],
-      minVals[1],
-      minVals[2],
-      minVals[3]
-    );
-    program.setUniform4f(
-      'ipScalarRangeMax',
-      maxVals[0],
-      maxVals[1],
-      maxVals[2],
-      maxVals[3]
-    );
 
     // if we have a zbuffer texture then set it
     if (model.zBufferTexture !== null) {


### PR DESCRIPTION


### Context

computed range is only used for `additive` and `average` blend mode, and for other blend modes it is not needed at all, so it can be skipped for performance reasons

This PR refactors the code to allow direct usage of `create3DFromRaw`. Previously, applications had to use `create3DFilterableFromRaw` or `create3DFilterableFromDataArray`, which required passing in the full, large data array. With this refactoring, `create3DFromRaw` can be used directly, which may be preferable for applications that stream data.

### Results

Nothing changes, only error handling and refactoring

### Changes
Add a check to only use it when available


- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: latest master
  - **OS**: macOS
  - **Browser**: Chrome

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
