### PR TITLE
fix(computehistogram): use implicit function for vtkImageData.compute…

### DIFF
--- a/Sources/Common/DataModel/Box/index.d.ts
+++ b/Sources/Common/DataModel/Box/index.d.ts
@@ -1,5 +1,6 @@
 import { vtkObject } from '../../../interfaces';
 import { Bounds, Vector3 } from '../../../types';
+import vtkImplicitFunction from '../ImplicitFunction';
 
 export interface IBoxInitialValues {
   bbox?: Bounds;
@@ -12,7 +13,7 @@ export interface IBoxIntersections {
   x2: Vector3;
 }
 
-export interface vtkBox extends vtkObject {
+export interface vtkBox extends vtkImplicitFunction {
   /**
    * Add the bounds for the box.
    * @param {Bounds} bounds

--- a/Sources/Common/DataModel/Box/index.js
+++ b/Sources/Common/DataModel/Box/index.js
@@ -1,5 +1,6 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
+import vtkImplicitFunction from 'vtk.js/Sources/Common/DataModel/ImplicitFunction';
 
 // ----------------------------------------------------------------------------
 // Global methods
@@ -209,7 +210,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Object methods
-  macro.obj(publicAPI, model);
+  vtkImplicitFunction.extend(publicAPI, model, initialValues);
 
   vtkBox(publicAPI, model);
 }

--- a/Sources/Common/DataModel/Cone/index.d.ts
+++ b/Sources/Common/DataModel/Cone/index.d.ts
@@ -13,7 +13,7 @@ export interface vtkCone extends vtkObject {
    * Given the point x evaluate the cone equation.
    * @param {Vector3} x The point coordinate.
    */
-  evaluateFunction(x: Vector3): number[];
+  evaluateFunction(x: Vector3): number;
 
   /**
    * Given the point x evaluate the equation for the cone gradient.
@@ -54,11 +54,7 @@ export function newInstance(initialValues?: IConeInitialValues): vtkCone;
 
 /**
  * vtkCone computes the implicit function and/or gradient for a cone. vtkCone is
- * a concrete implementation of vtkImplicitFunction. TODO: Currently the cone's
- * axis of rotation is along the x-axis with the apex at the origin. To
- * transform this to a different location requires the application of a
- * transformation matrix. This can be performed by supporting transforms at the
- * implicit function level, and should be added.
+ * a concrete implementation of vtkImplicitFunction.
  */
 export declare const vtkCone: {
   newInstance: typeof newInstance;

--- a/Sources/Common/DataModel/Cylinder/index.d.ts
+++ b/Sources/Common/DataModel/Cylinder/index.d.ts
@@ -1,5 +1,6 @@
 import { vtkObject } from '../../../interfaces';
 import { Vector3 } from '../../../types';
+import vtkImplicitFunction from '../ImplicitFunction';
 
 /**
  *
@@ -10,13 +11,13 @@ export interface ICylinderInitialValues {
   axis?: number[];
 }
 
-export interface vtkCylinder extends vtkObject {
+export interface vtkCylinder extends vtkImplicitFunction {
   /**
    * Given the point xyz (three floating value) evaluate the cylinder
    * equation.
    * @param {Vector3} xyz The point coordinate.
    */
-  evaluateFunction(xyz: Vector3): number[];
+  evaluateFunction(xyz: Vector3): number;
 
   /**
    * Given the point xyz (three floating values) evaluate the equation for the

--- a/Sources/Common/DataModel/Cylinder/index.js
+++ b/Sources/Common/DataModel/Cylinder/index.js
@@ -1,5 +1,6 @@
 import macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import vtkImplicitFunction from 'vtk.js/Sources/Common/DataModel/ImplicitFunction';
 
 // ----------------------------------------------------------------------------
 // Global methods
@@ -85,7 +86,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Object methods
-  macro.obj(publicAPI, model);
+  vtkImplicitFunction.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['radius']);
   macro.setGetArray(publicAPI, model, ['center', 'axis'], 3);
 

--- a/Sources/Common/DataModel/ImageData/index.d.ts
+++ b/Sources/Common/DataModel/ImageData/index.d.ts
@@ -27,7 +27,6 @@ export interface vtkImageData extends vtkDataSet {
    * `voxelFunc(index, bounds)` is an optional function that is called with
    * the `[i,j,k]` index and index `bounds`, expected to return truthy if the
    * data point should be counted in the histogram, and falsey if not.
-   * @param {Bounds} worldBounds The bounds of the world.
    * @param [voxelFunc]
    */
   computeHistogram(worldBounds: Bounds, voxelFunc?: any): IComputeHistogram;

--- a/Sources/Common/DataModel/ImageData/index.js
+++ b/Sources/Common/DataModel/ImageData/index.js
@@ -237,7 +237,7 @@ function vtkImageData(publicAPI, model) {
 
   publicAPI.getCenter = () => vtkBoundingBox.getCenter(publicAPI.getBounds());
 
-  publicAPI.computeHistogram = (worldBounds, voxelFunc = null) => {
+  publicAPI.computeHistogram = (worldBounds, voxelFunction = null) => {
     const bounds = [0, 0, 0, 0, 0, 0];
     publicAPI.worldToIndexBounds(worldBounds, bounds);
 
@@ -278,7 +278,7 @@ function vtkImageData(publicAPI, model) {
       for (let y = point1[1]; y <= point2[1]; y++) {
         let index = point1[0] + y * yStride + z * zStride;
         for (let x = point1[0]; x <= point2[0]; x++) {
-          if (!voxelFunc || voxelFunc([x, y, z], bounds)) {
+          if (!voxelFunction || voxelFunction([x, y, z], bounds)) {
             const pixel = pixels[index];
 
             if (pixel > maximum) maximum = pixel;

--- a/Sources/Common/DataModel/ImplicitBoolean/index.js
+++ b/Sources/Common/DataModel/ImplicitBoolean/index.js
@@ -1,5 +1,6 @@
 import macro from 'vtk.js/Sources/macros';
 import Constants from 'vtk.js/Sources/Common/DataModel/ImplicitBoolean/Constants';
+import vtkImplicitFunction from 'vtk.js/Sources/Common/DataModel/ImplicitFunction';
 
 const { Operation } = Constants;
 
@@ -71,7 +72,7 @@ function vtkImplicitBoolean(publicAPI, model) {
       value = Number.MAX_VALUE;
       for (let i = 0; i < model.functions.length; ++i) {
         const f = model.functions[i];
-        const v = f.evaluateFunction(xyz);
+        const v = f.functionValue(xyz);
         if (v < value) {
           value = v;
         }
@@ -80,14 +81,14 @@ function vtkImplicitBoolean(publicAPI, model) {
       value = -Number.MAX_VALUE;
       for (let i = 0; i < model.functions.length; ++i) {
         const f = model.functions[i];
-        const v = f.evaluateFunction(xyz);
+        const v = f.functionValue(xyz);
         if (v > value) {
           value = v;
         }
       }
     } else {
       const firstF = model.functions[0];
-      value = firstF.evaluateFunction(xyz);
+      value = firstF.functionValue(xyz);
       for (let i = 1; i < model.functions.length; ++i) {
         const f = model.functions[i];
         const v = -1.0 * f.evaluateFunction(xyz);
@@ -133,7 +134,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Object methods
-  macro.obj(publicAPI, model);
+  vtkImplicitFunction.extend(publicAPI, model, initialValues);
 
   macro.setGet(publicAPI, model, ['operation']);
 

--- a/Sources/Common/DataModel/ImplicitFunction/index.d.ts
+++ b/Sources/Common/DataModel/ImplicitFunction/index.d.ts
@@ -1,0 +1,68 @@
+import { vtkObject } from '../../../interfaces';
+import { Vector3 } from '../../../types';
+import { vtkTransform } from '../../Transform/Transform';
+
+/**
+ *
+ */
+export interface IImplicitFunctionInitialValues {
+  transform?: vtkTransform;
+}
+
+export interface vtkImplicitFunction extends vtkObject {
+  /**
+   * Given the point x evaluate the function.
+   * @see functionValue
+   * @param {Vector3} x The point coordinate.
+   */
+  evaluateFunction(x: Vector3): number;
+
+  /**
+   * Evaluate function at position x-y-z and return value. Point x[3] is
+   * transformed through transform (if provided).
+   * @see evaluateFunction
+   * @param {Vector3} x The point coordinate.
+   */
+  functionValue(x: Vector3): number;
+
+  /**
+   * Get the transform. undefined by default
+   */
+  getTransform(): vtkTransform;
+
+  /**
+   * Set the transform to apply on all points.
+   * @param {vtkTransform} transform The transform to apply
+   */
+  setTransform(transform: vtkTransform): boolean;
+}
+
+/**
+ * Method used to decorate a given object (publicAPI+model) with vtkImplicitFunction characteristics.
+ *
+ * @param publicAPI object on which methods will be bounds (public)
+ * @param model object on which data structure will be bounds (protected)
+ * @param {IImplicitFunctionInitialValues} [initialValues] (default: {})
+ */
+export function extend(
+  publicAPI: object,
+  model: object,
+  initialValues?: IImplicitFunctionInitialValues
+): void;
+
+/**
+ * Method used to create a new instance of vtkImplicitFunction.
+ * @param {IImplicitFunctionInitialValues} [initialValues] for pre-setting some of its content
+ */
+export function newInstance(
+  initialValues?: IImplicitFunctionInitialValues
+): vtkImplicitFunction;
+
+/**
+ * vtkImplicitFunction computes the implicit function and/or gradient for a function.
+ */
+export declare const vtkImplicitFunction: {
+  newInstance: typeof newInstance;
+  extend: typeof extend;
+};
+export default vtkImplicitFunction;

--- a/Sources/Common/DataModel/ImplicitFunction/index.js
+++ b/Sources/Common/DataModel/ImplicitFunction/index.js
@@ -1,6 +1,4 @@
 import macro from 'vtk.js/Sources/macros';
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
-import vtkImplicitFunction from 'vtk.js/Sources/Common/DataModel/ImplicitFunction';
 
 // ----------------------------------------------------------------------------
 // Global methods
@@ -11,25 +9,23 @@ import vtkImplicitFunction from 'vtk.js/Sources/Common/DataModel/ImplicitFunctio
 // ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
-// vtkCone methods
+// vtkImplicitFunction methods
 // ----------------------------------------------------------------------------
 
-function vtkCone(publicAPI, model) {
-  // Set our className
-  model.classHierarchy.push('vtkCone');
+function vtkImplicitFunction(publicAPI, model) {
+  model.classHierarchy.push('vtkImplicitFunction');
 
-  publicAPI.evaluateFunction = (x) => {
-    const tanTheta = Math.tan(vtkMath.radiansFromDegrees(model.angle));
-    const retVal =
-      x[1] * x[1] + x[2] * x[2] - x[0] * x[0] * tanTheta * tanTheta;
-
-    return retVal;
+  publicAPI.functionValue = (xyz) => {
+    if (!model.transform) {
+      return publicAPI.evaluateFunction(xyz);
+    }
+    const transformedXYZ = [];
+    model.transform.transformPoint(xyz, transformedXYZ);
+    return publicAPI.evaluateFunction(transformedXYZ);
   };
 
-  publicAPI.evaluateGradient = (x) => {
-    const tanTheta = Math.tan(vtkMath.radiansFromDegrees(model.angle));
-    const retVal = [-2.0 * x[0] * tanTheta * tanTheta, 2.0 * x[1], 2.0 * x[2]];
-    return retVal;
+  publicAPI.evaluateFunction = (_xyz) => {
+    macro.vtkErrorMacro('not implemented');
   };
 }
 
@@ -37,7 +33,7 @@ function vtkCone(publicAPI, model) {
 // Object factory
 // ----------------------------------------------------------------------------
 const DEFAULT_VALUES = {
-  angle: 15.0,
+  // transform : null
 };
 
 // ----------------------------------------------------------------------------
@@ -46,15 +42,16 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Object methods
-  vtkImplicitFunction.extend(publicAPI, model, initialValues);
-  macro.setGet(publicAPI, model, ['angle']);
+  macro.obj(publicAPI, model);
 
-  vtkCone(publicAPI, model);
+  macro.setGet(publicAPI, model, ['transform']);
+
+  vtkImplicitFunction(publicAPI, model);
 }
 
 // ----------------------------------------------------------------------------
 
-export const newInstance = macro.newInstance(extend, 'vtkCone');
+export const newInstance = macro.newInstance(extend, 'vtkImplicitFunction');
 
 // ----------------------------------------------------------------------------
 

--- a/Sources/Common/DataModel/Plane/index.d.ts
+++ b/Sources/Common/DataModel/Plane/index.d.ts
@@ -1,5 +1,6 @@
 import { vtkObject } from '../../../interfaces';
 import { Vector3 } from '../../../types';
+import vtkImplicitFunction from '../ImplicitFunction';
 
 /**
  *
@@ -16,7 +17,7 @@ interface IIntersectWithLine {
   x: Vector3;
 }
 
-export interface vtkPlane extends vtkObject {
+export interface vtkPlane extends vtkImplicitFunction {
   /**
    * Get the distance of a point x to a plane defined by n (x-p0) = 0.
    * The normal n must be magnitude = 1.

--- a/Sources/Common/DataModel/Plane/index.js
+++ b/Sources/Common/DataModel/Plane/index.js
@@ -1,5 +1,6 @@
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import macro from 'vtk.js/Sources/macros';
+import vtkImplicitFunction from 'vtk.js/Sources/Common/DataModel/ImplicitFunction';
 
 const PLANE_TOLERANCE = 1.0e-6;
 const COINCIDE = 'coincide';
@@ -282,7 +283,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Object methods
-  macro.obj(publicAPI, model);
+  vtkImplicitFunction.extend(publicAPI, model, initialValues);
 
   macro.setGetArray(publicAPI, model, ['normal', 'origin'], 3);
 

--- a/Sources/Common/DataModel/Sphere/index.d.ts
+++ b/Sources/Common/DataModel/Sphere/index.d.ts
@@ -1,18 +1,18 @@
-import { vtkObject } from '../../../interfaces';
-import { Bounds, Vector3 } from '../../../types';
+import { Vector3 } from '../../../types';
+import vtkImplicitFunction from '../ImplicitFunction';
 
 export interface ISphereInitialValues {
-  radius?: number;
+  radius?: number | Vector3;
   center?: Vector3;
 }
 
-export interface vtkSphere extends vtkObject {
+export interface vtkSphere extends vtkImplicitFunction {
   /**
    * Given the point xyz (three floating value) evaluate the sphere
    * equation.
    * @param {Vector3} xyz The point coordinate.
    */
-  evaluateFunction(xyz: Vector3): number[];
+  evaluateFunction(xyz: Vector3): number;
 
   /**
    * Given the point xyz (three floating values) evaluate the equation for the
@@ -34,7 +34,7 @@ export interface vtkSphere extends vtkObject {
   /**
    * Get the radius of the sphere.
    */
-  getRadius(): number;
+  getRadius(): number | Vector3;
 
   /**
    * Set the center of the sphere.
@@ -57,10 +57,11 @@ export interface vtkSphere extends vtkObject {
   setCenterFrom(center: Vector3): boolean;
 
   /**
-   * Set the radius of the sphere.
-   * @param {Number} radius The radius of the sphere.
+   * Set the radius of the sphere. Radius must be > 0.
+   * It can also be an array of 3 positive values for ellipsoids
+   * @param {Number|Vector3} radius The radius of the sphere.
    */
-  setRadius(radius: number): boolean;
+  setRadius(radius: number | Vector3): boolean;
 }
 
 /**
@@ -90,13 +91,6 @@ export function newInstance(initialValues?: ISphereInitialValues): vtkSphere;
 declare function evaluate(radius: number, center: Vector3, x: Vector3): number;
 
 /**
- *
- * @param {Vector3} point
- * @param {Bounds} bounds
- */
-declare function isPointIn3DEllipse(point: Vector3, bounds: Bounds): boolean;
-
-/**
  * vtkSphere provides methods for creating a 1D cubic spline object from given
  * parameters, and allows for the calculation of the spline value and derivative
  * at any given point inside the spline intervals.
@@ -105,6 +99,5 @@ export declare const vtkSphere: {
   newInstance: typeof newInstance;
   extend: typeof extend;
   evaluate: typeof evaluate;
-  isPointIn3DEllipse: typeof isPointIn3DEllipse;
 };
 export default vtkSphere;

--- a/Sources/Common/DataModel/Sphere/index.js
+++ b/Sources/Common/DataModel/Sphere/index.js
@@ -1,35 +1,27 @@
 import macro from 'vtk.js/Sources/macros';
-import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
-
-const VTK_SMALL_NUMBER = 1e-12;
+import vtkImplicitFunction from 'vtk.js/Sources/Common/DataModel/ImplicitFunction';
 
 // ----------------------------------------------------------------------------
 // Global methods
 // ----------------------------------------------------------------------------
 
-function evaluate(radius, center, x) {
-  return (
-    (x[0] - center[0]) * (x[0] - center[0]) +
-    (x[1] - center[1]) * (x[1] - center[1]) +
-    (x[2] - center[2]) * (x[2] - center[2]) -
-    radius * radius
-  );
-}
+function evaluate(radius, center, xyz) {
+  if (!Array.isArray(radius)) {
+    const retVal =
+      (xyz[0] - center[0]) * (xyz[0] - center[0]) +
+      (xyz[1] - center[1]) * (xyz[1] - center[1]) +
+      (xyz[2] - center[2]) * (xyz[2] - center[2]) -
+      radius * radius;
 
-function isPointIn3DEllipse(point, bounds) {
-  const center = vtkBoundingBox.getCenter(bounds);
-  let scale3 = vtkBoundingBox.computeScale3(bounds);
-  scale3 = scale3.map((x) => Math.max(Math.abs(x), VTK_SMALL_NUMBER));
-
-  const radius = [
-    (point[0] - center[0]) / scale3[0],
-    (point[1] - center[1]) / scale3[1],
-    (point[2] - center[2]) / scale3[2],
+    return retVal;
+  }
+  const r = [
+    (xyz[0] - center[0]) / radius[0],
+    (xyz[1] - center[1]) / radius[1],
+    (xyz[2] - center[2]) / radius[2],
   ];
 
-  return (
-    radius[0] * radius[0] + radius[1] * radius[1] + radius[2] * radius[2] <= 1
-  );
+  return r[0] * r[0] + r[1] * r[1] + r[2] * r[2] - 1;
 }
 
 // ----------------------------------------------------------------------------
@@ -38,7 +30,6 @@ function isPointIn3DEllipse(point, bounds) {
 
 export const STATIC = {
   evaluate,
-  isPointIn3DEllipse,
 };
 
 // ----------------------------------------------------------------------------
@@ -49,15 +40,8 @@ function vtkSphere(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkSphere');
 
-  publicAPI.evaluateFunction = (xyz) => {
-    const retVal =
-      (xyz[0] - model.center[0]) * (xyz[0] - model.center[0]) +
-      (xyz[1] - model.center[1]) * (xyz[1] - model.center[1]) +
-      (xyz[2] - model.center[2]) * (xyz[2] - model.center[2]) -
-      model.radius * model.radius;
-
-    return retVal;
-  };
+  publicAPI.evaluateFunction = (xyz) =>
+    evaluate(model.radius, model.center, xyz);
 
   publicAPI.evaluateGradient = (xyz) => {
     const retVal = [
@@ -84,7 +68,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   // Object methods
-  macro.obj(publicAPI, model);
+  vtkImplicitFunction.extend(publicAPI, model, initialValues);
   macro.setGet(publicAPI, model, ['radius']);
   macro.setGetArray(publicAPI, model, ['center'], 3);
 


### PR DESCRIPTION
…Histogram

The ShapeWidget example was demoing computeHistogram results. However this does not work when the slice is in arbitrary plane. Rely on implicit functions to precisely compute histogram.

BREAKING CHANGE: computeHistogram no longer takes a voxelFunc but takes as 2nd parameter a vtkImplicitFunction

### Context
If the ellipse widget is not axis aligned, the computeHistogram function returns incorrect values.

### Results
computeHistogram now computes correctly the ellipse area.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome
