### PR TITLE
Fix wrong center computation from bounding box

### DIFF
--- a/Examples/Rendering/QuadView/index.js
+++ b/Examples/Rendering/QuadView/index.js
@@ -135,11 +135,7 @@ function createVolumeView(renderer, source) {
 
   // Add one positional light
   const bounds = volume.getBounds();
-  const center = [
-    (bounds[1] - bounds[0]) / 2.0,
-    (bounds[3] - bounds[2]) / 2.0,
-    (bounds[5] - bounds[4]) / 2.0,
-  ];
+  const center = vtkBoundingBox.getCenter(bounds);
   renderer.removeAllLights();
   const light = vtkLight.newInstance();
   const lightPos = [center[0] + 300, center[1] + 50, center[2] - 50];

--- a/Examples/Volume/VolumeMapperLightAndShadow/index.js
+++ b/Examples/Volume/VolumeMapperLightAndShadow/index.js
@@ -101,11 +101,7 @@ function createVolumeShadowViewer(rootContainer, fileContents) {
 
   // Add one positional light
   const bounds = actor.getBounds();
-  const center = [
-    (bounds[1] - bounds[0]) / 2.0,
-    (bounds[3] - bounds[2]) / 2.0,
-    (bounds[5] - bounds[4]) / 2.0,
-  ];
+  const center = vtkBoundingBox.getCenter(bounds);
   renderer.removeAllLights();
   const light = vtkLight.newInstance();
   const lightPos = [center[0] + 300, center[1] + 50, center[2] - 50];


### PR DESCRIPTION
Two examples did the same mistake (there were a copy paste).
They should add the coordinates instead of subtract.
Use `vtkBoundingBox.getCenter` instead.