### PR TITLE
fix: force half float in texture if it's exact and OES_texture_float_linear is not available

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -408,7 +408,8 @@ function vtkOpenGLTexture(publicAPI, model) {
     return result;
   };
 
-  publicAPI.useHalfFloat = () => model.canUseHalfFloat;
+  publicAPI.useHalfFloat = () =>
+    model.enableUseHalfFloat && model.canUseHalfFloat;
 
   //----------------------------------------------------------------------------
   publicAPI.setInternalFormat = (iFormat) => {


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The origin of the problem is this bug in OHIF, a consumer of vtk: https://github.com/OHIF/Viewers/issues/4286
For certain mobile Android devices, instead of rendering a texture, the canvas was solid gray/black. It happens regardless of OS version/browser, but eventually I narrowed it down to devices that use Mali GPUs (which is likely because they don't support OES_texture_float_linear).

Since it was working everywhere previously and I had a good version of OHIF, I bisected until this [first bad commit](https://github.com/OHIF/Viewers/commit/21e8a2bd0b7cc72f90a31e472d285d761be15d30), which among other things, bumps the version of vtk.js from `29.3.0` to `29.7.0`. After checking all the vtk versions in that range, I found that `29.5.0` was the last good one, and `29.5.1` was the first bad one with gray/black canvases. This issue has been present on master ever since.

Luckily (or unluckily) this was a patch release that only included 2 commits. Of them, the relevant one is [this](https://github.com/Kitware/vtk-js/commit/4eb4e630fb0ea33e2a1e6939270159ea5d0dc5eb).

The commit changed the texture format to sometimes use *32F versions, and added this warning: 
![image](https://github.com/user-attachments/assets/b6082b11-c02a-4fa9-8207-4a4074f9fca3)
The problem with using full floats is in webgl2 they aren't texture filterable without OES_texture_float_linear, while half floats are always filterable even without the extension. Using full floats triggers the warning/black textures.

I assume all of these are the same problem and would be fixed by this change:
- https://github.com/Kitware/vtk-js/issues/3030
- https://github.com/cornerstonejs/cornerstone3D/issues/1152
- https://github.com/OHIF/Viewers/issues/4286

<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
With this change, canvases are no longer black in OHIF and render the images again everywhere.

<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
This change forces half floats in cases where:
1. Full floats would have been used instead
2. The extension for texture filtering is not supported in the gl context
3. The data can be stored accurately in half floats

I don't know if there's any way to solve this if the data doesn't fit in halfs, maybe with another option similar to preferSizeOverAccuracy.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
I only reproduced this on Androids with Mali GPUs. I would assume it happens on any device that supports webgl2 but not OES_texture_float_linear. 
If you have such a device, you can see the problem here (a gray square is rendered, instead of an image of a brain CT): https://viewer.ohif.org/viewer?StudyInstanceUIDs=2.16.840.1.114362.1.11972228.22789312658.616067305.306.2

For testing the changes, the easiest way I know is to clone, compile and run [OHIF](https://github.com/OHIF/Viewers), and configure resolutions in its package.json to use these changes in vtk:
```
  "resolutions": {
    "@kitware/vtk.js": "link:../vtk-js/dist/esm",
``` 
Then open this: http://localhost:3000/viewer?StudyInstanceUIDs=2.16.840.1.114362.1.11972228.22789312658.616067305.306.2

With the changes enabled you should see the brain CT, without the changes you should not.