### PR TITLE
feat: Add WebXR to default Rendering export

### DIFF
--- a/Sources/Rendering/WebXR/RenderWindowHelper/index.js
+++ b/Sources/Rendering/WebXR/RenderWindowHelper/index.js
@@ -1,8 +1,8 @@
 import macro from 'vtk.js/Sources/macros';
 import Constants from 'vtk.js/Sources/Rendering/WebXR/RenderWindowHelper/Constants';
-import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
-import vtkLineSource from '@kitware/vtk.js/Filters/Sources/LineSource';
-import vtkMapper from '@kitware/vtk.js/Rendering/Core/Mapper';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkLineSource from 'vtk.js/Sources/Filters/Sources/LineSource';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import { GET_UNDERLYING_CONTEXT } from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow/ContextProxy';
 import { vec3 } from 'gl-matrix';
 
@@ -397,4 +397,5 @@ export const newInstance = macro.newInstance(
 export default {
   newInstance,
   extend,
+  ...Constants,
 };

--- a/Sources/Rendering/WebXR/index.js
+++ b/Sources/Rendering/WebXR/index.js
@@ -1,0 +1,5 @@
+import vtkRenderWindowHelper from './RenderWindowHelper';
+
+export default {
+  vtkRenderWindowHelper,
+};

--- a/Sources/Rendering/index.js
+++ b/Sources/Rendering/index.js
@@ -3,6 +3,7 @@ import Misc from './Misc';
 import OpenGL from './OpenGL';
 import SceneGraph from './SceneGraph';
 import WebGPU from './WebGPU';
+import WebXR from './WebXR';
 
 export default {
   Core,
@@ -10,4 +11,5 @@ export default {
   OpenGL,
   SceneGraph,
   WebGPU,
+  WebXR,
 };


### PR DESCRIPTION
WebXR wasn't exposed in the file sent by CDNs
See [this post](https://discourse.vtk.org/t/vtkxrrenderwindow-is-web-served-vtk-js-service/14554) in the discourse