### PR TITLE
vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters errors

### DIFF
--- a/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
+++ b/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
@@ -29,7 +29,10 @@ const staticOffsetModel = {
   Line: { factor: 1, offset: -1 },
   Point: { factor: 0, offset: -2 },
 };
-const staticOffsetAPI = {};
+const noOp = () => undefined;
+const staticOffsetAPI = {
+  modified: noOp,
+};
 
 addCoincidentTopologyMethods(
   staticOffsetAPI,

--- a/Sources/Rendering/Core/Mapper/test/testCoincidentTopologyHelper.js
+++ b/Sources/Rendering/Core/Mapper/test/testCoincidentTopologyHelper.js
@@ -1,0 +1,38 @@
+import test from 'tape';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+
+test('Test calling CoincidentTopologyHelper static functions', async (t) => {
+  const gc = testUtils.createGarbageCollector(t);
+
+  // set back to starting/default values to avoid side effects for other tests
+  const startingParameters =
+    vtkMapper.getResolveCoincidentTopologyPolygonOffsetParameters();
+  vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters({
+    factor: -3,
+    offset: -3,
+  });
+  vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters(
+    startingParameters
+  );
+  const endingParameters =
+    vtkMapper.getResolveCoincidentTopologyPolygonOffsetParameters();
+  t.deepEqual(
+    startingParameters,
+    endingParameters,
+    'Initial PolygonOffset parameters after get and set are matching'
+  );
+
+  const startingLineParameters =
+    vtkMapper.getResolveCoincidentTopologyLineOffsetParameters();
+  vtkMapper.setResolveCoincidentTopologyLineOffsetParameters(-3, -3);
+  vtkMapper.setResolveCoincidentTopologyLineOffsetParameters(
+    startingLineParameters
+  );
+
+  t.ok('rendering', 'CoincidentTopologyHelper functions called without error');
+
+  // Free memory, end the test
+  gc.releaseResources();
+});


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
When calling the static mapper `vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters`, there is an error because the "class" does not have a publicAPI  with a `modified()` function.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Does not error now when calling `vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters`.  

Some other tests are failing after adding the test in this PR.  Seems that calling `setResolveCoincidentTopologyPolygonOffsetParameters` with the initial results of `getResolveCoincidentTopologyPolygonOffsetParameters` does not completely undo the effect?
![image](https://github.com/user-attachments/assets/f52ebdab-9d4a-49d3-8b98-d5659f4cd7e5)



### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
The error fix involved adding a noOp `modified` function.  Alternatives could be to check if `publicAPI` has `modified` in macros.js or upgrade the Mapper static object with macros.js' `function obj(publicAPI = {}, model = {})` "constructor."   

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
