### PR TITLE
Fix screenshots with scaling or size argument

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -598,6 +598,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
           // remember the main canvas original size, then resize it
           model._screenshot.originalSize = model.size;
           model.size = model._screenshot.size;
+          model.rootOpenGLRenderWindow?.resizeFromChildRenderWindows();
           model._screenshot.size = null;
 
           // process the resize
@@ -1075,10 +1076,10 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
         model.renderPasses[index].traverse(publicAPI, null);
       }
     }
+    publicAPI.copyParentContent();
     if (model.notifyStartCaptureImage) {
       getCanvasDataURL();
     }
-    publicAPI.copyParentContent();
     const childrenRW = model.renderable.getChildRenderWindowsByReference();
     for (let i = 0; i < childrenRW.length; ++i) {
       publicAPI.getViewNodeFor(childrenRW[i])?.traverseAllPasses();


### PR DESCRIPTION
The screenshot feature did not work with several renderwindows linked to a root render window.

To reproduce the issue, you can edit the `ManyRenderWindows` example.
Change the action of the `Remove render window` button to make screenshots.
To do so, at the line `button.addEventListener`, replace the listener using this code:
```js
  button.addEventListener('click', () => {
    renderWindowView.captureNextImage(null, { scale: 5 }).then((result) => {
      const newWindow = window.open('');
      newWindow.document.write(`<img src="${result}" alt="Image Preview" />`);
    });
    renderWindow.render();
  });
```