### PR TITLE
Fix static vtkMapper coincident topology functions 

### DIFF
--- a/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
+++ b/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper.js
@@ -29,7 +29,10 @@ const staticOffsetModel = {
   Line: { factor: 1, offset: -1 },
   Point: { factor: 0, offset: -2 },
 };
-const staticOffsetAPI = {};
+const noOp = () => undefined;
+const staticOffsetAPI = {
+  modified: noOp,
+};
 
 addCoincidentTopologyMethods(
   staticOffsetAPI,
@@ -58,9 +61,11 @@ function implementCoincidentTopologyMethods(publicAPI, model) {
   Object.keys(otherStaticMethods).forEach((methodName) => {
     publicAPI[methodName] = otherStaticMethods[methodName];
   });
-  Object.keys(staticOffsetAPI).forEach((methodName) => {
-    publicAPI[methodName] = staticOffsetAPI[methodName];
-  });
+  Object.keys(staticOffsetAPI)
+    .filter((methodName) => methodName !== 'modified') // don't override instance's modified
+    .forEach((methodName) => {
+      publicAPI[methodName] = staticOffsetAPI[methodName];
+    });
 
   addCoincidentTopologyMethods(
     publicAPI,

--- a/Sources/Rendering/Core/Mapper/test/testCoincidentTopologyHelper.js
+++ b/Sources/Rendering/Core/Mapper/test/testCoincidentTopologyHelper.js
@@ -1,0 +1,38 @@
+import test from 'tape';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+
+test('Test calling CoincidentTopologyHelper static functions', async (t) => {
+  const gc = testUtils.createGarbageCollector(t);
+
+  // set back to starting/default values to avoid side effects for other tests
+  const startingParameters =
+    vtkMapper.getResolveCoincidentTopologyPolygonOffsetParameters();
+  vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters({
+    factor: -3,
+    offset: -3,
+  });
+  vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters(
+    startingParameters
+  );
+  const endingParameters =
+    vtkMapper.getResolveCoincidentTopologyPolygonOffsetParameters();
+  t.deepEqual(
+    startingParameters,
+    endingParameters,
+    'Initial PolygonOffset parameters after get and set are matching'
+  );
+
+  const startingLineParameters =
+    vtkMapper.getResolveCoincidentTopologyLineOffsetParameters();
+  vtkMapper.setResolveCoincidentTopologyLineOffsetParameters(-3, -3);
+  vtkMapper.setResolveCoincidentTopologyLineOffsetParameters(
+    startingLineParameters
+  );
+
+  t.ok('rendering', 'CoincidentTopologyHelper functions called without error');
+
+  // Free memory, end the test
+  gc.releaseResources();
+});


### PR DESCRIPTION
When calling the static mapper `vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters`, there is an error because the "class" does not have a publicAPI  with a `modified()` function.  `publicAPI.modifed()` is called by macros.js object setter macro.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Does not error now when calling `vtkMapper.setResolveCoincidentTopologyPolygonOffsetParameters`.  


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
The error fix involved adding a noOp `modified` function.  Alternatives could be to check if `publicAPI` has `modified` in macros.js or upgrade the Mapper static object with macros.js' `function obj(publicAPI = {}, model = {})` "constructor."   

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
