### PR TITLE
fix(imagereslicemapper): be less sensitive for "snapping" to nearest …

### DIFF
--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -1131,6 +1131,10 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
     shaders.Fragment = FSSource;
   };
 
+  /**
+   * Returns true if the normal is almost axis aligned.
+   * Has a side effect to normalize the vector.
+   */
   function isVectorAxisAligned(n) {
     vtkMath.normalize(n);
     const tmpN = [0, 0, 0];
@@ -1138,7 +1142,7 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
       vec3.zero(tmpN);
       tmpN[i] = 1.0;
       const dotP = vtkMath.dot(n, tmpN);
-      if (dotP < -0.999 || dotP > 0.999) {
+      if (dotP < -0.999999 || dotP > 0.999999) {
         return [true, i];
       }
     }


### PR DESCRIPTION
…orthogonal axis

When using the vtkImageResliceMapper in conjunction with the ResliceCursorWidget(RWC), there was a case when the RCW lines were displayed partly being the slice when the slice plane was being snapped to the nearest orthogonal axis.

### Context
When rotating the ResliceCursorWidget near an orthogonal axis, the RCW line was being displayed partly in front of the slice and partly behind the slice. This is because the slice was snapped to the nearest orthogonal axis.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome
