### PR TITLE
Fix imagemapper blending and rerendering

### DIFF
--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -1354,7 +1354,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
   publicAPI.updatelabelOutlineThicknessTexture = (image) => {
     const labelOutlineThicknessArray = image
       .getProperty()
-      .getLabelOutlineThickness();
+      .getLabelOutlineThicknessByReference();
 
     const lTex = model._openGLRenderWindow.getGraphicsResourceForObject(
       labelOutlineThicknessArray

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -370,7 +370,7 @@ function vtkOpenGLImageMapper(publicAPI, model) {
                   int actualThickness = int(textureValue * 255.0);
 
                   if (segmentIndex == 0){
-                    gl_FragData[0] = vec4(0.0, 1.0, 1.0, 0.0);
+                    gl_FragData[0] = vec4(0.0, 0.0, 0.0, 0.0);
                     return;
                   }
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Two issues:
1. Constant label outline thickness texture re-uploads when nothing changes
2. Incorrect blending between two labelmaps with label outline turned on
  - I am not yet sure if there is an underlying bug in the OIT implementation, and I haven't spent the time to debug this further. The second commit fixes the issue with minimal changes.

FYI @sedghi 

### Results
- Only update the label outline thickness texture when the underlying array reference actually changes
- Blending two labelmaps with label outline on works.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
