### PR TITLE
fix(ImageProperty): add types of label outline funcs

### DIFF
--- a/Sources/Rendering/Core/ImageProperty/index.d.ts
+++ b/Sources/Rendering/Core/ImageProperty/index.d.ts
@@ -95,6 +95,28 @@ export interface vtkImageProperty extends vtkObject {
   getScalarOpacity(idx?: number): vtkPiecewiseFunction;
 
   /**
+   * Enable label outline rendering.
+   * @param {Boolean} useLabelOutline
+   */
+  setUseLabelOutline(useLabelOutline: boolean): boolean;
+
+  /**
+   * Check if label outline rendering.
+   */
+  getUseLabelOutline(): boolean;
+
+  /**
+   * Set the 0 to 1 opacity of the label outline.
+   * @param {Number} opacity
+   */
+  setLabelOutlineOpacity(opacity: number): boolean;
+
+  /**
+   * Get the 0 to 1 opacity of the label outline.
+   */
+  getLabelOutlineOpacity(): number;
+
+  /**
    * gets the label outline thickness
    */
   getLabelOutlineThickness(): number;


### PR DESCRIPTION
Add typescript types to vtkImageProperty

setUseLabelOutline
getUseLabelOutline
setLabelOutlineOpacity
getLabelOutlineOpacity

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

