### PR TITLE
fix(GLTFImporter): fix the environment texture path

### DIFF
--- a/Sources/IO/Geometry/GLTFImporter/example/index.js
+++ b/Sources/IO/Geometry/GLTFImporter/example/index.js
@@ -58,7 +58,7 @@ const variantsModels = [
 ];
 
 const environmentTex = createTextureWithMipmap(
-  '/Data/pbr/kiara_dawn_4k.jpg',
+  `${__BASE_PATH__}/data/pbr/kiara_dawn_4k.jpg`,
   8
 );
 renderer.setUseEnvironmentTextureAsBackground(false);
@@ -265,10 +265,13 @@ fetch(`${baseUrl}/${modelsFolder}/model-index.json`)
 
     if (selectedFlavor === 'glTF-Draco') {
       vtkResourceLoader
-        .loadScript('https://unpkg.com/draco3d@1.3.4/draco_decoder_nodejs.js')
+        .loadScript(
+          'https://unpkg.com/draco3dgltf@1.3.6/draco_decoder_gltf_nodejs.js'
+        )
         .then(() => {
           // Set decoder function to the vtk reader
-          reader.setDracoDecoder(window.CreateDracoModule);
+          // eslint-disable-next-line no-undef
+          reader.setDracoDecoder(DracoDecoderModule);
           reader
             .setUrl(url, { binary: true, sceneId: selectedScene })
             .then(reader.onReady(ready));


### PR DESCRIPTION
### Context
Fix the environment texture path

![image](https://github.com/user-attachments/assets/5cf92aa2-0323-4426-b1b7-bef2ca42c8f7)

### Results
![image](https://github.com/user-attachments/assets/a0a68fd5-7f48-4b0c-933d-cb33ec946387)

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
