### PR TITLE
fix(anglewidget): add bounds to AngleWidget

### DIFF
--- a/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/behavior.js
@@ -1,5 +1,6 @@
 import macro from 'vtk.js/Sources/macros';
 import { add } from 'vtk.js/Sources/Common/Core/Math';
+import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import vtkPointPicker from 'vtk.js/Sources/Rendering/Core/PointPicker';
 
 const MAX_POINTS = 3;
@@ -10,6 +11,18 @@ export default function widgetBehavior(publicAPI, model) {
 
   const picker = vtkPointPicker.newInstance();
   picker.setPickFromList(1);
+
+  publicAPI.getBounds = () =>
+    model.widgetState
+      .getHandleList()
+      .reduce(
+        (bounds, handle) =>
+          vtkBoundingBox.inflate(
+            vtkBoundingBox.addPoint(bounds, ...handle.getOrigin()),
+            publicAPI.getScaleInPixels() ? 0 : handle.getScale1() / 2
+          ),
+        [...vtkBoundingBox.INIT_BOUNDS]
+      );
 
   // --------------------------------------------------------------------------
   // Display 2D

--- a/Sources/Widgets/Widgets3D/AngleWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/AngleWidget/example/index.js
@@ -42,7 +42,7 @@ widgetManager.setRenderer(renderer);
 const widget = vtkAngleWidget.newInstance();
 // widget.placeWidget(cube.getOutputData().getBounds());
 
-widgetManager.addWidget(widget);
+const widgetInView = widgetManager.addWidget(widget);
 
 renderer.resetCamera();
 widgetManager.enablePicking();
@@ -53,6 +53,8 @@ fullScreenRenderer.getInteractor().render();
 // -----------------------------------------------------------
 
 fullScreenRenderer.addController(controlPanel);
+
+widgetInView.onEndInteractionEvent(() => renderer.resetCameraClippingRange());
 
 widget.getWidgetState().onModified(() => {
   document.querySelector('#angle').innerText = widget.getAngle();


### PR DESCRIPTION
This makes sure the angle widget actual bounds are considered when computing camera clipping ranges.

### Context
Fix #3178.

Widgets by default have a hardcoded bounds of [-1,1,-1,1,-1,1].
No matter where the handles are placed, the bounds did not change.

### Results
By returning accurate bounds, it is possible to reset the camera clipping ranges.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: 14.0.0
  - **OS**: Windows 10
  - **Browser**: Chrome
