### PR TITLE
fix(DataArray): warn on default data type

### DIFF
--- a/Sources/Common/Core/DataArray/index.d.ts
+++ b/Sources/Common/Core/DataArray/index.d.ts
@@ -408,6 +408,10 @@ export function extend(
 
 /**
  * Method use to create a new instance of vtkDataArray
+ *
+ * If the provided `values` is a plain Array and `dataType` is not explicitly provided,
+ * then the vtkDataArray data type will be a Float32Array.
+ *
  * @param {object} [initialValues] for pre-setting some of its content
  */
 export function newInstance(initialValues?: object): vtkDataArray;

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -534,6 +534,15 @@ const DEFAULT_VALUES = {
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
+  if (
+    Array.isArray(initialValues.values) &&
+    initialValues.dataType === undefined
+  ) {
+    console.warn(
+      'vtkDataArray.newInstance: no dataType provided, converting to Float32Array'
+    );
+  }
+
   if (!model.empty && !model.values && !model.size) {
     throw new TypeError(
       'Cannot create vtkDataArray object without: size > 0, values'


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context

Addresses #3172. Notify users that data arrays are becoming Float32Arrays when given a plain JS array with no explicit data type.

@sedghi 

### Results
- Code that use data arrays with plain JS arrays and no explicit data type will now log a warning.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
