### PR TITLE
docs(shapewidgetexample): fix ellipse coverage in oblique mode

### DIFF
--- a/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ShapeWidget/example/index.js
@@ -354,22 +354,16 @@ reader
       const maxRadius = Math.ceil(Math.max(ijkRadius[0], ijkRadius[1]));
       const ellipseBounds = [
         -maxRadius,
-        0,
-        0,
-        maxRadius,
-        0,
-        0,
-        0,
         -maxRadius,
         0,
-        0,
+        maxRadius,
         maxRadius,
         0,
-        (-maxRadius * Math.sqrt(2)) / 2,
-        (-maxRadius * Math.sqrt(2)) / 2,
+        -maxRadius,
+        maxRadius,
         0,
-        (maxRadius * Math.sqrt(2)) / 2,
-        (maxRadius * Math.sqrt(2)) / 2,
+        maxRadius,
+        -maxRadius,
         0,
       ];
       ijkToWorldMatrix.apply(ellipseBounds);


### PR DESCRIPTION

### Context
In oblique mode, depending on the plane normal, the compute histogram function was not covering the entire ellipse.

### Results
All the voxels in the ellipse are now covered.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome
