### PR TITLE
fix: avoid norm16 for textures with linear filtering

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/supportsNorm16Linear.js
+++ b/Sources/Rendering/OpenGL/Texture/supportsNorm16Linear.js
@@ -1,0 +1,129 @@
+/**
+ * Even when the EXT_texture_norm16 extension is present, linear filtering
+ * might not be supported for normalized fixed point textures.
+ *
+ * This is a driver bug. See https://github.com/KhronosGroup/WebGL/issues/3706
+ * @return {boolean}
+ */
+function supportsNorm16Linear() {
+  try {
+    const canvasSize = 4;
+    const texWidth = 2;
+    const texHeight = 1;
+    const texData = new Int16Array([0, 2 ** 15 - 1]);
+    const pixelToCheck = [1, 1];
+
+    const canvas = document.createElement('canvas');
+    canvas.width = canvasSize;
+    canvas.height = canvasSize;
+    const gl = canvas.getContext('webgl2');
+    if (!gl) {
+      return false;
+    }
+
+    const ext = gl.getExtension('EXT_texture_norm16');
+    if (!ext) {
+      return false;
+    }
+
+    const vs = `#version 300 es
+    void main() {
+      gl_PointSize = ${canvasSize.toFixed(1)};
+      gl_Position = vec4(0, 0, 0, 1);
+    }
+  `;
+    const fs = `#version 300 es
+    precision highp float;
+    precision highp int;
+    precision highp sampler2D;
+
+    uniform sampler2D u_image;
+
+    out vec4 color;
+
+    void main() {
+        vec4 intColor = texture(u_image, gl_PointCoord.xy);
+        color = vec4(vec3(intColor.rrr), 1);
+    }
+    `;
+
+    const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vertexShader, vs);
+    gl.compileShader(vertexShader);
+    if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+      return false;
+    }
+
+    const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fragmentShader, fs);
+    gl.compileShader(fragmentShader);
+    if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+      return false;
+    }
+
+    const program = gl.createProgram();
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      return false;
+    }
+
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      ext.R16_SNORM_EXT,
+      texWidth,
+      texHeight,
+      0,
+      gl.RED,
+      gl.SHORT,
+      texData
+    );
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.useProgram(program);
+    gl.drawArrays(gl.POINTS, 0, 1);
+
+    const pixel = new Uint8Array(4);
+    gl.readPixels(
+      pixelToCheck[0],
+      pixelToCheck[1],
+      1,
+      1,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      pixel
+    );
+    const [r, g, b] = pixel;
+
+    const webglLoseContext = gl.getExtension('WEBGL_lose_context');
+    if (webglLoseContext) {
+      webglLoseContext.loseContext();
+    }
+
+    return r === g && g === b && r !== 0;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * @type {boolean | undefined}
+ */
+let supportsNorm16LinearCache;
+
+function supportsNorm16LinearCached() {
+  // Only create a canvas+texture+shaders the first time
+  if (supportsNorm16LinearCache === undefined) {
+    supportsNorm16LinearCache = supportsNorm16Linear();
+  }
+
+  return supportsNorm16LinearCache;
+}
+
+export default supportsNorm16LinearCached;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
On certain hardware, combining linear texture filtering with the normalized fixed point types from EXT_texture_norm16 results in black pixels and a WebGL warning from the browser.
```
[.WebGL-0x7202996900]RENDER WARNING: texture bound to texture unit 0 is not renderable. It might be non-power-of-2 or have incompatible texture filtering (maybe)?
```

According to [this proposed webgpu extension](https://github.com/gpuweb/gpuweb/issues/3839), there are a lot of mobile devices that don't support linear filtering for norm16 (eg Adreno 5XX, 7XX devices). This includes recent flagships like the Samsung Galaxy 24 Ultra, where I found this issue.

~~Unlike floats which have the OES_texture_float_linear extension, it doesn't seem possible to check using webgl if linear filtering is present for norm16 types. It would have been much better to limit the change only when it really is a problem. Not sure if I'm missing anything here, but this seems like a gap in the standard... I might open an issue there to ask~~
I asked: https://github.com/KhronosGroup/WebGL/issues/3706

Also, here's two recent bugs from cornerstone that I think are a manifestation of this problem. Same error message, same black canvas (except turned gray due to window levels)
- https://github.com/cornerstonejs/cornerstone3D/issues/1678
- https://github.com/cornerstonejs/cornerstone3D/issues/1653

The phones mentioned there are Huawei P50, Huawei P60, Huawei Mate 9. These have Adreno/Mali GPUs, matching what the webgpu proposal said.

<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
Texture now acts as if EXT_texture_norm16 is unsupported when LINEAR filtering is chosen. It should fall back to some float type.

### Changes
- disabled norm16 + linear filtering ~~by default~~ when a runtime check determines it won't work
- ~~added override API if someone wants to force it `enableLinearNorm16Ext(useLinearNorm16: boolean): void`~~
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
Unfortunately you need a phone that has a problematic GPU. Like [the previous texture filtering issue](https://github.com/Kitware/vtk-js/pull/3117), I tested this with a modified vtk.js directly in OHIF.

If you do have a phone, I found a useful jsfiddle that reproduces the bug. It directly renders a texture with webgl: https://jsfiddle.net/sedghi/hxLegk5y/
This is how it should look, on a desktop GPU where everything is fine:
![image](https://github.com/user-attachments/assets/b5d862b5-959a-4aa5-9811-879d6fa90e96)

This is how it looks on a phone that has the problem:
![Screenshot_20241219_170531_Chrome](https://github.com/user-attachments/assets/4312c5ba-6fb0-41e0-b970-314becad89ed)

And identical code, but replacing LINEAR with NEAREST fixes the black image:
![image](https://github.com/user-attachments/assets/cbe15c5d-3a77-4e5b-bb07-b6fe21957f65)
