### PR TITLE
fix(WidgetManager): cross-renderer widget usage

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -183,6 +183,17 @@ function vtkWidgetManager(publicAPI, model) {
     }
   }
 
+  const deactivateAllWidgets = () => {
+    let wantRender = false;
+    for (let i = 0; i < model.widgets.length; i++) {
+      const w = model.widgets[i];
+      wantRender ||= !!w.getActiveState();
+      w.deactivateAllHandles();
+    }
+
+    if (wantRender) model._interactor.render();
+  };
+
   const handleEvent = async (callData, fromTouchEvent = false) => {
     if (
       !model.isAnimating &&
@@ -192,6 +203,8 @@ function vtkWidgetManager(publicAPI, model) {
       const callID = Symbol('UpdateSelection');
       model._currentUpdateSelectionCallID = callID;
       await updateSelection(callData, fromTouchEvent, callID);
+    } else {
+      deactivateAllWidgets();
     }
   };
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Widgets should not remain in an active state if interaction occurs outside of the containing renderer.

An alternative to deactivating all widgets in the widget manager in such a scenario is to filter out interaction events at the widget level that are not targeting the widget's renderer. Such an alternative has the benefit of allowing widgets to remain active for future in-renderer interactions.

I'm still figuring out if this change might break any existing expectations.

Addresses #3144. 

### Results

- Fixes #3144, and probably any other widget that operates in a overlapping renderer
### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Fixes to vtkWidgetManager
### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
