### PR TITLE
fix(RWInteractor): async requestPointerLock

### DIFF
--- a/Sources/Interaction/Manipulators/MouseCameraTrackballFirstPersonManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballFirstPersonManipulator/index.js
@@ -22,7 +22,9 @@ function vtkMouseCameraTrackballFirstPersonManipulator(publicAPI, model) {
   publicAPI.onButtonDown = (interactor, renderer, position) => {
     if (model.usePointerLock && !interactor.isPointerLocked()) {
       Object.assign(internal, { interactor, renderer });
-      interactor.requestPointerLock();
+      Promise.resolve(interactor.requestPointerLock()).then(() => {
+        publicAPI.startPointerLockInteraction();
+      });
     }
   };
 

--- a/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
+++ b/Sources/Interaction/Manipulators/MouseRangeManipulator/index.js
@@ -256,8 +256,9 @@ function vtkMouseRangeManipulator(publicAPI, model) {
     // we don't interfere with other events such as doubleClick,
     // for this reason we don't call this from `onButtonDown`
     if (model.usePointerLock && !interactor.isPointerLocked()) {
-      interactor.requestPointerLock();
-      publicAPI.startPointerLockEvent(interactor, renderer);
+      Promise.resolve(interactor.requestPointerLock()).then(() => {
+        publicAPI.startPointerLockEvent(interactor, renderer);
+      });
     }
 
     if (!position) {

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -1204,7 +1204,7 @@ export interface vtkRenderWindowInteractor extends vtkObject {
   /**
    *
    */
-  requestPointerLock(): void;
+  requestPointerLock(): Promise<void> | undefined;
 
   /**
    *

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -549,8 +549,9 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   //----------------------------------------------------------------------
   publicAPI.requestPointerLock = () => {
     if (model.container) {
-      model.container.requestPointerLock();
+      return model.container.requestPointerLock();
     }
+    return undefined;
   };
 
   //----------------------------------------------------------------------


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Chrome 131+ now requests permissions for pointer lock. We need to ensure that pointer lock is achieved before continuing with interactions.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
- [x] support async requestPointerLock

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] all calls to requestPointerLock have been updated
- [x] examine whether methods calling requestPointerLock should be made async

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
