### PR TITLE
chore(github): update workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        node: [18, 20]
+        node: [20, 22]
     name: ${{ matrix.os }} and node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
@@ -38,9 +38,9 @@ jobs:
         run: xvfb-run --auto-servernum npm run test -- --browsers Chrome,Firefox
       - name: Archive test results
         if: github.event_name != 'merge_group' && (success() || failure())
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
-          name: test-results
+          name: test-results-${{ matrix.runs_on }}-node_${{ matrix.node }}
           path: Utilities/TestResults/Test-Report.html
           retention-days: 15

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: |
           npm ci
@@ -38,7 +38,7 @@ jobs:
         run: xvfb-run --auto-servernum npm run test -- --browsers Chrome,Firefox
       - name: Archive test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: Utilities/TestResults/Test-Report.html


### PR DESCRIPTION
This PR updates the github workflows:
- Run on node v20 and v22
- Use actions/upload-artifact@v4, as v3 is deprecated