### PR TITLE
refactor(glyph3dmapper): Typescript definition

### DIFF
--- a/Sources/Rendering/Core/Glyph3DMapper/index.d.ts
+++ b/Sources/Rendering/Core/Glyph3DMapper/index.d.ts
@@ -12,17 +12,65 @@ interface IPrimitiveCount {
 export interface IGlyph3DMapperInitialValues extends IMapperInitialValues {
   orient?: boolean;
   orientationMode?: OrientationModes;
-  orientationArray?: number[];
+  orientationArray?: string;
   scaling?: boolean;
   scaleFactor?: number;
   scaleMode?: ScaleModes;
-  scaleArray?: number[];
+  scaleArray?: string;
   matrixArray?: number[];
   normalArray?: number[];
   colorArray?: number[];
 }
 
 export interface vtkGlyph3DMapper extends vtkMapper {
+  /**
+   * Get the bounds for this mapper as [xmin, xmax, ymin, ymax,zmin, zmax].
+   * @return {Bounds} The bounds for the mapper.
+   */
+  getBounds(): Bounds;
+
+  /**
+   *
+   */
+  buildArrays(): void;
+
+  /**
+   *
+   */
+  getPrimitiveCount(): IPrimitiveCount;
+
+  /**
+   * Get scale mode
+   * @default `SCALE_BY_MAGNITUDE`
+   */
+  getScaleMode(): ScaleModes;
+
+  /**
+   * Get scale factor to scale object by.
+   */
+  getScaleFactor(): number;
+
+  /**
+   * Get scale mode as string
+   */
+  getScaleModeAsString(): string;
+
+  /**
+   * Sets the name of the array to use as scale values.
+   * @param {String} arrayName Name of the array
+   */
+  setScaleArray(arrayName: Nullable<string>): boolean;
+
+  /**
+   * Gets the name of the array used as scale values.
+   */
+  getScaleArray(): string;
+
+  /**
+   * Get scale mode as array
+   */
+  getScaleArrayData(): number[];
+
   /**
    * An orientation array is a vtkDataArray with 3 components. The first
    * component is the angle of rotation along the X axis. The second component
@@ -49,47 +97,15 @@ export interface vtkGlyph3DMapper extends vtkMapper {
   getOrientationArrayData(): number[];
 
   /**
-   * Get scale factor to scale object by.
-   */
-  getScaleFactor(): number;
-
-  /**
-   * Get scale mode
-   * @default `SCALE_BY_MAGNITUDE`
-   */
-  getScaleMode(): ScaleModes;
-
-  /**
-   * Get scale mode as string
-   */
-  getScaleModeAsString(): string;
-
-  /**
-   * Get scale mode as array
-   */
-  getScaleArrayData(): number[];
-
-  /**
-   * Get the bounds for this mapper as [xmin, xmax, ymin, ymax,zmin, zmax].
-   * @return {Bounds} The bounds for the mapper.
-   */
-  getBounds(): Bounds;
-
-  /**
-   *
-   */
-  buildArrays(): void;
-
-  /**
-   *
-   */
-  getPrimitiveCount(): IPrimitiveCount;
-
-  /**
    * Sets the name of the array to use as orientation.
    * @param {String} arrayName Name of the array
    */
   setOrientationArray(arrayName: Nullable<string>): boolean;
+
+  /**
+   * Gets the name of the array used as orientation values.
+   */
+  getOrientationArray(): string;
 
   /**
    * Orientation mode indicates if the OrientationArray provides the direction


### PR DESCRIPTION
The mapper expects array name strings for the scale and orientation arrays. This change ensures that the typescript definition reflects the same.

BREAKING CHANGE: scaleArray and orientationArray changed API from `number[]` to `string`

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
The Glyph3DMapper had inconsistent API typescript definitions for scale and orientation array parameters.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
