### PR TITLE
chore: deprecate gh-pages in favor of pages action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,33 @@ jobs:
           git config --global user.name "Github Actions"
           git config --global user.email "sebastien.jourdain@kitware.com"
           npm run semantic-release
+  deploy_docs:
+    if: github.ref == 'refs/heads/master'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm ci
       - name: Build API docs
-        if: github.ref == 'refs/heads/master'
         run: npm run doc:generate-api
-      - name: Publish docs
-        if: github.ref == 'refs/heads/master'
-        env:
-          GIT_PUBLISH_URL: https://${{ secrets.GH_PUBLISH_CREDS }}@github.com/Kitware/vtk-js.git
-        run: npm run doc:publish
+      - name: Build docs
+        run: npm run doc:minified
+      - name: Upload docs as a Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./Documentation/build-tmp/public/
+      - name: Deploy docs
+        uses: actions/deploy-pages@v4

--- a/Documentation/content/index.pug
+++ b/Documentation/content/index.pug
@@ -11,7 +11,7 @@ ul#intro-feature-list
       .intro-feature-icon
         i.fa.fa-cloud-download
       h3.intro-feature-title
-        a(href="https://www.npmjs.com/package/vtk.js").link Releases
+        a(href="https://www.npmjs.com/package/@kitware/vtk.js").link Releases
         img(style="padding-left: 25px",src="https://badge.fury.io/js/vtk.js.svg")
       p.intro-feature-desc VTK.js is a JavaScript library available for scientific visualization in your browser. The library is available via #[a(href="https://www.npmjs.com/package/vtk.js").link NPM] and #[a(href="https://www.npmjs.com/package/@kitware/vtk.js").link (NPM ESM)] or #[a(href="https://unpkg.com/vtk.js").link unpkg.com] CDN so it can directly be imported as a script tag inside your Web page like shown if that #[a(href="https://codepen.io/jourdain/pen/RQZWYa").link CodePen] example.
 
@@ -40,4 +40,4 @@ ul#intro-feature-list
       p.intro-feature-desc VTK/Web Discourse is here to help you find any existing discussion
 
 div#intro-get-started-wrap
-  a(href="https://blog.kitware.com/vtk-js-the-visualization-toolkit-on-the-web/", id="intro-get-started-link") Want to read more?
+  a(href="https://blog.kitware.com/vtk-js-the-visualization-toolkit-on-the-web/", id="intro-get-started-link") Want to learn more?

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "lint": "eslint Sources Examples",
     "doc": "kw-doc -c ./Documentation/config.js",
     "doc:www": "npm t -- --single-run && kw-doc -c ./Documentation/config.js -s",
-    "doc:publish": "kw-doc -c ./Documentation/config.js -mp",
+    "doc:minified": "kw-doc -c ./Documentation/config.js -m",
     "doc:generate-api": "node ./Documentation/generate-api-docs.js",
     "example": "node ./Utilities/ExampleRunner/example-runner-cli.js -c ./Documentation/config.js",
     "example:https": "node ./Utilities/ExampleRunner/example-runner-cli.js --server-type https -c ./Documentation/config.js",


### PR DESCRIPTION
Constantly adding to the gh-pages branch bloats the repo size. Instead, use the deploy-pages action to publish the website.