### PR TITLE
feat(stlreader): add removeDuplicateVertices method to vtkSTLReader

### DIFF
--- a/Sources/IO/Geometry/STLReader/example/index.js
+++ b/Sources/IO/Geometry/STLReader/example/index.js
@@ -7,7 +7,7 @@ import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
 import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
 import vtkMapper from '@kitware/vtk.js/Rendering/Core/Mapper';
 import vtkSTLReader from '@kitware/vtk.js/IO/Geometry/STLReader';
-
+import vtkPolyDataNormals from '@kitware/vtk.js/Filters/Core/PolyDataNormals';
 // ----------------------------------------------------------------------------
 // Example code
 // ----------------------------------------------------------------------------
@@ -17,7 +17,9 @@ const mapper = vtkMapper.newInstance({ scalarVisibility: false });
 const actor = vtkActor.newInstance();
 
 actor.setMapper(mapper);
-mapper.setInputConnection(reader.getOutputPort());
+const normals = vtkPolyDataNormals.newInstance();
+normals.setInputConnection(reader.getOutputPort());
+mapper.setInputConnection(normals.getOutputPort());
 
 // ----------------------------------------------------------------------------
 
@@ -54,6 +56,7 @@ function handleFile(event) {
     const fileReader = new FileReader();
     fileReader.onload = function onLoad(e) {
       reader.parseAsArrayBuffer(fileReader.result);
+      reader.removeDuplicateVertices(5);
       update();
     };
     fileReader.readAsArrayBuffer(files[0]);

--- a/Sources/IO/Geometry/STLReader/index.d.ts
+++ b/Sources/IO/Geometry/STLReader/index.d.ts
@@ -94,6 +94,12 @@ export interface vtkSTLReader extends vtkSTLReaderBase {
    * @param {ISTLReaderOptions} [option] The STL reader options.
    */
   setUrl(url: string, option?: ISTLReaderOptions): Promise<string | any>;
+
+  /**
+   *
+   * @param offset
+   */
+  removeDuplicateVertices(offset: number = 5): void;
 }
 
 /**


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Edges could not be hidden when displaying a stl

### Results
![vs](https://github.com/user-attachments/assets/bdd2a6a8-a25b-45b2-a932-a43359296132)


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] TypeScript definitions were updated to match those changes

- [x] Tested environment:
  - **vtk.js**: 32.9.1
  - **OS**: Ubuntu 22.04.3 LTS
  - **Browser**: chrome 112.0.5615.165

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
