### PR TITLE
chore(github): move off of 20.04 (deprecated)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         node: [22]
     name: ${{ matrix.os }} and node ${{ matrix.node }}
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pr-checks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Check and lint PR
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   publish:
     name: Publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Updates the github runners from 20.04: https://github.com/actions/runner-images/issues/11101