### PR TITLE
fix(webxr): remove controllers rays when stopping XR

### DIFF
--- a/Sources/Rendering/WebXR/RenderWindowHelper/index.js
+++ b/Sources/Rendering/WebXR/RenderWindowHelper/index.js
@@ -173,6 +173,15 @@ function vtkWebXRRenderWindowHelper(publicAPI, model) {
       const gl = model.renderWindow.get3DContext();
       gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
+      // Remove controllers ray
+      const ren = model.renderWindow.getRenderable().getRenderers()[0];
+      model.xrSession.inputSources.forEach((inputSource) => {
+        if (model.inputSourceToRay[inputSource.handedness]) {
+          ren.removeActor(model.inputSourceToRay[inputSource.handedness].actor);
+          model.inputSourceToRay[inputSource.handedness].visible = false;
+        }
+      });
+
       await model.xrSession.end().catch((error) => {
         if (!(error instanceof DOMException)) {
           throw error;


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
When using `vtkWebXRRenderWindowHelper` with `drawControllersRay=true`, rays are drawn to represent the controllers
but they are not removed when stopping the XR session. This leads to the camera not being centered correctly.

Here's a comparison of before starting the XR session and after stopping it:
![before](https://github.com/user-attachments/assets/efadb80f-66d4-4c25-b637-54e233a6a721)
![after](https://github.com/user-attachments/assets/42a53912-e6dd-4ca4-a7c2-5c40af66abfc)


### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Thanks to this small fix, the rays' actors are removed when exiting the XR session, and the camera can be re-centered 

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
When `vtkWebXRRenderWindowHelper.stopXR()` is called, every ray's actor is removed so they are not visible anymore.
- [x] Documentation and TypeScript definitions were updated to match those changes
  - No changes in definitions

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: latest master ([413f07a](https://github.com/Kitware/vtk-js/commit/413f07a1cd4fe0166e3e5564a4e1899260dc01b1))
  - **OS**: Windows 11 WSL2 Debian 12
  - **Browser**: Chromium 133.0.6943.98

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
