### PR TITLE
refactor(OpenGL/Texture): use named parameters

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,6 +1,8 @@
 ## From 32.x to 33
 
 - **vtkMapper**: many properties have moved to `vtkVolumeProperty`. The full list of changed methods is: `getAnisotropy`, `getComputeNormalFromOpacity`, `getFilterMode`, `getFilterModeAsString`, `getGlobalIlluminationReach`, `getIpScalarRange`, `getIpScalarRangeByReference`, `getLAOKernelRadius`, `getLAOKernelSize`, `getLocalAmbientOcclusion`, `getPreferSizeOverAccuracy`, `getVolumetricScatteringBlending`, `setAnisotropy`, `setAverageIPScalarRange`, `setComputeNormalFromOpacity`, `setFilterMode`, `setFilterModeToNormalized`, `setFilterModeToOff`, `setFilterModeToRaw`, `setGlobalIlluminationReach`, `setIpScalarRange`, `setIpScalarRangeFrom`, `setLAOKernelRadius`, `setLAOKernelSize`, `setLocalAmbientOcclusion`, `setPreferSizeOverAccuracy`, `setVolumetricScatteringBlending`.
+- **vtkOpenGLTexture**: The public `create2D*` and `create3D*` methods used to have positional parameters. These methods now use named parameters via passing in an object record.
+
 ## From 31.x to 32
 
 - **vtkMapper**: remove `mapScalarsToTexture` from the public API. The function becomes protected and its API changes. This shouldn't cause any issue in most cases.

--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -244,13 +244,13 @@ function vtkFramebuffer(publicAPI, model) {
     texture.setOpenGLRenderWindow(model._openGLRenderWindow);
     texture.setMinificationFilter(Filter.LINEAR);
     texture.setMagnificationFilter(Filter.LINEAR);
-    texture.create2DFromRaw(
-      model.glFramebuffer.width,
-      model.glFramebuffer.height,
-      4,
-      VtkDataTypes.UNSIGNED_CHAR,
-      null
-    );
+    texture.create2DFromRaw({
+      width: model.glFramebuffer.width,
+      height: model.glFramebuffer.height,
+      numComps: 4,
+      dataType: VtkDataTypes.UNSIGNED_CHAR,
+      data: null,
+    });
     publicAPI.setColorBuffer(texture);
 
     // for now do not count on having a depth buffer texture

--- a/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
@@ -213,13 +213,13 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
         model.context.getExtension('EXT_texture_norm16')
       );
       model.volumeTexture.resetFormatAndType();
-      model.volumeTexture.create3DFilterableFromDataArray(
-        dims[0],
-        dims[1],
-        dims[2],
-        scalars,
-        model.renderable.getPreferSizeOverAccuracy()
-      );
+      model.volumeTexture.create3DFilterableFromDataArray({
+        width: dims[0],
+        height: dims[1],
+        depth: dims[2],
+        dataArray: scalars,
+        preferSizeOverAccuracy: model.renderable.getPreferSizeOverAccuracy(),
+      });
       model._openGLRenderWindow.setGraphicsResourceForObject(
         scalars,
         model.volumeTexture,
@@ -246,14 +246,13 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
       property.setUpdatedExtents([]);
 
       const dims = image.getDimensions();
-      model.volumeTexture.create3DFilterableFromDataArray(
-        dims[0],
-        dims[1],
-        dims[2],
-        scalars,
-        false,
-        updatedExtents
-      );
+      model.volumeTexture.create3DFilterableFromDataArray({
+        width: dims[0],
+        height: dims[1],
+        depth: dims[2],
+        dataArray: scalars,
+        updatedExtents,
+      });
     }
 
     // Rebuild the color texture if needed
@@ -309,13 +308,13 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
           }
         }
         model.colorTexture.resetFormatAndType();
-        model.colorTexture.create2DFromRaw(
-          cWidth,
-          textureHeight,
-          3,
-          VtkDataTypes.UNSIGNED_CHAR,
-          cTable
-        );
+        model.colorTexture.create2DFromRaw({
+          width: cWidth,
+          height: textureHeight,
+          numComps: 3,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: cTable,
+        });
       } else {
         for (let i = 0; i < cWidth * 3; ++i) {
           cTable[i] = (255.0 * i) / ((cWidth - 1) * 3);
@@ -323,13 +322,13 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
           cTable[i + 2] = (255.0 * i) / ((cWidth - 1) * 3);
         }
         model.colorTexture.resetFormatAndType();
-        model.colorTexture.create2DFromRaw(
-          cWidth,
-          1,
-          3,
-          VtkDataTypes.UNSIGNED_CHAR,
-          cTable
-        );
+        model.colorTexture.create2DFromRaw({
+          width: cWidth,
+          height: 1,
+          numComps: 3,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: cTable,
+        });
       }
 
       if (firstColorTransferFunc) {
@@ -407,24 +406,24 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
           }
         }
         model.pwfTexture.resetFormatAndType();
-        model.pwfTexture.create2DFromRaw(
-          pwfWidth,
-          textureHeight,
-          1,
-          VtkDataTypes.FLOAT,
-          pwfFloatTable
-        );
+        model.pwfTexture.create2DFromRaw({
+          width: pwfWidth,
+          height: textureHeight,
+          numComps: 1,
+          dataType: VtkDataTypes.FLOAT,
+          data: pwfFloatTable,
+        });
       } else {
         // default is opaque
         pwfTable.fill(255.0);
         model.pwfTexture.resetFormatAndType();
-        model.pwfTexture.create2DFromRaw(
-          pwfWidth,
-          1,
-          1,
-          VtkDataTypes.UNSIGNED_CHAR,
-          pwfTable
-        );
+        model.pwfTexture.create2DFromRaw({
+          width: pwfWidth,
+          height: 1,
+          numComps: 1,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: pwfTable,
+        });
       }
       if (firstPwFunc) {
         model._openGLRenderWindow.setGraphicsResourceForObject(

--- a/Sources/Rendering/OpenGL/ImageMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageMapper/index.js
@@ -1001,26 +1001,26 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           }
         }
         model.colorTexture.resetFormatAndType();
-        model.colorTexture.create2DFromRaw(
-          cWidth,
-          textureHeight,
-          3,
-          VtkDataTypes.UNSIGNED_CHAR,
-          cTable
-        );
+        model.colorTexture.create2DFromRaw({
+          width: cWidth,
+          height: textureHeight,
+          numComps: 3,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: cTable,
+        });
       } else {
         for (let i = 0; i < cWidth * 3; ++i) {
           cTable[i] = (255.0 * i) / ((cWidth - 1) * 3);
           cTable[i + 1] = (255.0 * i) / ((cWidth - 1) * 3);
           cTable[i + 2] = (255.0 * i) / ((cWidth - 1) * 3);
         }
-        model.colorTexture.create2DFromRaw(
-          cWidth,
-          1,
-          3,
-          VtkDataTypes.UNSIGNED_CHAR,
-          cTable
-        );
+        model.colorTexture.create2DFromRaw({
+          width: cWidth,
+          height: 1,
+          numComps: 3,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: cTable,
+        });
       }
 
       if (firstColorTransferFunc) {
@@ -1109,23 +1109,23 @@ function vtkOpenGLImageMapper(publicAPI, model) {
           }
         }
         model.pwfTexture.resetFormatAndType();
-        model.pwfTexture.create2DFromRaw(
-          pwfWidth,
-          textureHeight,
-          1,
-          VtkDataTypes.FLOAT,
-          pwfFloatTable
-        );
+        model.pwfTexture.create2DFromRaw({
+          width: pwfWidth,
+          height: textureHeight,
+          numComps: 1,
+          dataType: VtkDataTypes.FLOAT,
+          data: pwfFloatTable,
+        });
       } else {
         // default is opaque
         pwfTable.fill(255.0);
-        model.pwfTexture.create2DFromRaw(
-          pwfWidth,
-          1,
-          1,
-          VtkDataTypes.UNSIGNED_CHAR,
-          pwfTable
-        );
+        model.pwfTexture.create2DFromRaw({
+          width: pwfWidth,
+          height: 1,
+          numComps: 1,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: pwfTable,
+        });
       }
 
       if (firstPwFunc) {
@@ -1344,15 +1344,16 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       // Don't share this resource as `scalars` is created in this function
       // so it is impossible to share
       model.openGLTexture.resetFormatAndType();
-      model.openGLTexture.create2DFilterableFromRaw(
-        dims[0],
-        dims[1],
-        numComp,
-        imgScalars.getDataType(),
-        scalars,
-        model.renderable.getPreferSizeOverAccuracy?.(),
-        ranges
-      );
+      model.openGLTexture.create2DFilterableFromRaw({
+        width: dims[0],
+        height: dims[1],
+        numComps: numComp,
+        dataType: imgScalars.getDataType(),
+        data: scalars,
+        preferSizeOverAccuracy:
+          !!model.renderable.getPreferSizeOverAccuracy?.(),
+        ranges,
+      });
       model.openGLTexture.activate();
       model.openGLTexture.sendParameters();
       model.openGLTexture.deactivate();
@@ -1439,13 +1440,13 @@ function vtkOpenGLImageMapper(publicAPI, model) {
       model.labelOutlineThicknessTexture.setMagnificationFilter(Filter.NEAREST);
 
       // Create a 2D texture (acting as 1D) from the raw data
-      model.labelOutlineThicknessTexture.create2DFromRaw(
-        lWidth,
-        lHeight,
-        1,
-        VtkDataTypes.UNSIGNED_CHAR,
-        lTable
-      );
+      model.labelOutlineThicknessTexture.create2DFromRaw({
+        width: lWidth,
+        height: lHeight,
+        numComps: 1,
+        dataType: VtkDataTypes.UNSIGNED_CHAR,
+        data: lTable,
+      });
 
       if (labelOutlineThicknessArray) {
         model._openGLRenderWindow.setGraphicsResourceForObject(

--- a/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageResliceMapper/index.js
@@ -318,12 +318,12 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
           model.context.getExtension('EXT_texture_norm16')
         );
         newScalarTexture.resetFormatAndType();
-        newScalarTexture.create3DFilterableFromDataArray(
-          dims[0],
-          dims[1],
-          dims[2],
-          scalars
-        );
+        newScalarTexture.create3DFilterableFromDataArray({
+          width: dims[0],
+          height: dims[1],
+          depth: dims[2],
+          dataArray: scalars,
+        });
         model._openGLRenderWindow.setGraphicsResourceForObject(
           scalars,
           newScalarTexture,
@@ -340,14 +340,13 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
         actorProperty.setUpdatedExtents([]);
 
         const dims = imageData.getDimensions();
-        model.scalarTextures[component].create3DFilterableFromDataArray(
-          dims[0],
-          dims[1],
-          dims[2],
-          scalars,
-          false,
-          updatedExtents
-        );
+        model.scalarTextures[component].create3DFilterableFromDataArray({
+          width: dims[0],
+          height: dims[1],
+          depth: dims[2],
+          dataArray: scalars,
+          updatedExtents,
+        });
       }
 
       replaceGraphicsResource(
@@ -409,13 +408,13 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
           }
         }
         newColorTexture.resetFormatAndType();
-        newColorTexture.create2DFromRaw(
-          cWidth,
-          textureHeight,
-          3,
-          VtkDataTypes.UNSIGNED_CHAR,
-          cTable
-        );
+        newColorTexture.create2DFromRaw({
+          width: cWidth,
+          height: textureHeight,
+          numComps: 3,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: cTable,
+        });
       } else {
         for (let column = 0; column < cWidth * 3; ++column) {
           const opacity = (255.0 * column) / ((cWidth - 1) * 3);
@@ -427,13 +426,13 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
           }
         }
         newColorTexture.resetFormatAndType();
-        newColorTexture.create2DFromRaw(
-          cWidth,
-          1,
-          3,
-          VtkDataTypes.UNSIGNED_CHAR,
-          cTable
-        );
+        newColorTexture.create2DFromRaw({
+          width: cWidth,
+          height: 1,
+          numComps: 3,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: cTable,
+        });
       }
 
       if (firstColorTransferFunc) {
@@ -506,24 +505,24 @@ function vtkOpenGLImageResliceMapper(publicAPI, model) {
           }
         }
         newOpacityTexture.resetFormatAndType();
-        newOpacityTexture.create2DFromRaw(
-          pwfWidth,
-          textureHeight,
-          1,
-          VtkDataTypes.FLOAT,
-          pwfFloatTable
-        );
+        newOpacityTexture.create2DFromRaw({
+          width: pwfWidth,
+          height: textureHeight,
+          numComps: 1,
+          dataType: VtkDataTypes.FLOAT,
+          data: pwfFloatTable,
+        });
       } else {
         // default is opaque
         pwfTable.fill(255.0);
         newOpacityTexture.resetFormatAndType();
-        newOpacityTexture.create2DFromRaw(
-          pwfWidth,
-          textureHeight,
-          1,
-          VtkDataTypes.UNSIGNED_CHAR,
-          pwfTable
-        );
+        newOpacityTexture.create2DFromRaw({
+          width: pwfWidth,
+          height: textureHeight,
+          numComps: 1,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: pwfTable,
+        });
       }
       if (firstPwFunc) {
         model._openGLRenderWindow.setGraphicsResourceForObject(

--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -103,35 +103,35 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
     model.translucentRGBATexture.setFormat(gl.RGBA);
     model.translucentRGBATexture.setOpenGLDataType(gl.HALF_FLOAT);
     model.translucentRGBATexture.setOpenGLRenderWindow(viewNode);
-    model.translucentRGBATexture.create2DFromRaw(
-      size[0],
-      size[1],
-      4,
-      'Float32Array',
-      null
-    );
+    model.translucentRGBATexture.create2DFromRaw({
+      width: size[0],
+      height: size[1],
+      numComps: 4,
+      dataType: 'Float32Array',
+      data: null,
+    });
 
     model.translucentRTexture = vtkOpenGLTexture.newInstance();
     model.translucentRTexture.setInternalFormat(gl.R16F);
     model.translucentRTexture.setFormat(gl.RED);
     model.translucentRTexture.setOpenGLDataType(gl.HALF_FLOAT);
     model.translucentRTexture.setOpenGLRenderWindow(viewNode);
-    model.translucentRTexture.create2DFromRaw(
-      size[0],
-      size[1],
-      1,
-      'Float32Array',
-      null
-    );
+    model.translucentRTexture.create2DFromRaw({
+      width: size[0],
+      height: size[1],
+      numComps: 1,
+      dataType: 'Float32Array',
+      data: null,
+    });
 
     model.translucentZTexture = vtkOpenGLTexture.newInstance();
     model.translucentZTexture.setOpenGLRenderWindow(viewNode);
-    model.translucentZTexture.createDepthFromRaw(
-      size[0],
-      size[1],
-      'Float32Array',
-      null
-    );
+    model.translucentZTexture.createDepthFromRaw({
+      width: size[0],
+      height: size[1],
+      dataType: 'Float32Array',
+      data: null,
+    });
 
     model.framebuffer.setColorBuffer(model.translucentRGBATexture, 0);
     model.framebuffer.setColorBuffer(model.translucentRTexture, 1);

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1843,13 +1843,13 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       const input = model.renderable.getColorTextureMap();
       const ext = input.getExtent();
       const inScalars = input.getPointData().getScalars();
-      tex.create2DFromRaw(
-        ext[1] - ext[0] + 1,
-        ext[3] - ext[2] + 1,
-        inScalars.getNumberOfComponents(),
-        inScalars.getDataType(),
-        inScalars.getData()
-      );
+      tex.create2DFromRaw({
+        width: ext[1] - ext[0] + 1,
+        height: ext[3] - ext[2] + 1,
+        numComps: inScalars.getNumberOfComponents(),
+        dataType: inScalars.getDataType(),
+        data: inScalars.getData(),
+      });
       tex.activate();
       tex.sendParameters();
       tex.deactivate();

--- a/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/pingpong.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/LineIntegralConvolution2D/pingpong.js
@@ -66,7 +66,13 @@ function allocateBuffer(openGLRenderWindow, [width, height], filter, wrapping) {
   });
   texture.setOpenGLRenderWindow(openGLRenderWindow);
   texture.setInternalFormat(gl.RGBA32F);
-  texture.create2DFromRaw(width, height, 4, 'Float32Array', null);
+  texture.create2DFromRaw({
+    width,
+    height,
+    numComps: 4,
+    dataType: 'Float32Array',
+    data: null,
+  });
   texture.activate();
   texture.sendParameters();
   texture.deactivate();

--- a/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICInterface/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICInterface/index.js
@@ -268,7 +268,13 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
         autoParameters: false,
       });
       texture.setOpenGLRenderWindow(model._openGLRenderWindow);
-      texture.create2DFromRaw(length, length, 4, 'Float32Array', values);
+      texture.create2DFromRaw({
+        width: length,
+        height: length,
+        numComps: 4,
+        dataType: 'Float32Array',
+        data: values,
+      });
       texture.activate();
       texture.sendParameters();
       texture.deactivate();
@@ -328,7 +334,13 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
     });
     texture.setOpenGLRenderWindow(openGLRenderWindow);
     texture.setInternalFormat(gl.RGBA32F);
-    texture.create2DFromRaw(...model.size, 4, 'Float32Array', null);
+    texture.create2DFromRaw({
+      width: model.size[0],
+      height: model.size[1],
+      numComps: 4,
+      dataType: 'Float32Array',
+      data: null,
+    });
     texture.activate();
     texture.sendParameters();
     texture.deactivate();
@@ -343,7 +355,12 @@ function vtkOpenGLSurfaceLICInterface(publicAPI, model) {
       autoParameters: false,
     });
     texture.setOpenGLRenderWindow(openGLRenderWindow);
-    texture.createDepthFromRaw(...model.size, 'Float32Array', null);
+    texture.createDepthFromRaw({
+      width: model.size[0],
+      height: model.size[1],
+      dataType: 'Float32Array',
+      data: null,
+    });
     texture.activate();
     texture.sendParameters();
     texture.deactivate();

--- a/Sources/Rendering/OpenGL/Texture/index.d.ts
+++ b/Sources/Rendering/OpenGL/Texture/index.d.ts
@@ -199,17 +199,24 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @param numComps The number of components in the texture.
    * @param dataType The data type of the texture.
    * @param data The raw data for the texture.
-   * @param flip Whether to flip the texture vertically.
+   * @param flip Whether to flip the texture vertically. Defaults to false.
    * @returns {boolean} True if the texture was successfully created, false otherwise.
    */
-  create2DFromRaw(
-    width: number,
-    height: number,
-    numComps: number,
-    dataType: VtkDataTypes,
-    data: any,
-    flip: boolean
-  ): boolean;
+  create2DFromRaw({
+    width,
+    height,
+    numComps,
+    dataType,
+    data,
+    flip,
+  }: {
+    width: number;
+    height: number;
+    numComps: number;
+    dataType: VtkDataTypes;
+    data: any;
+    flip?: boolean;
+  }): boolean;
 
   /**
    * Creates a cube texture from raw data.
@@ -218,17 +225,21 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @param numComps The number of components in the texture.
    * @param dataType The data type of the texture.
    * @param data The raw data for the texture.
-   * @param flip Whether to flip the texture vertically.
    * @returns {boolean} True if the cube texture was successfully created, false otherwise.
    */
-  createCubeFromRaw(
-    width: number,
-    height: number,
-    numComps: number,
-    dataType: VtkDataTypes,
-    data: any,
-    flip: boolean
-  ): boolean;
+  createCubeFromRaw({
+    width,
+    height,
+    numComps,
+    dataType,
+    data,
+  }: {
+    width: number;
+    height: number;
+    numComps: number;
+    dataType: VtkDataTypes;
+    data: any;
+  }): boolean;
 
   /**
    * Creates a 2D texture from an image.
@@ -248,15 +259,23 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @param [ranges] The precomputed ranges of the data (optional). Provided to prevent computation of the data ranges.
    * @returns {boolean} True if the texture was successfully created, false otherwise.
    */
-  create2DFilterableFromRaw(
-    width: number,
-    height: number,
-    numComps: number,
-    dataType: VtkDataTypes,
-    data: any,
-    preferSizeOverAccuracy?: boolean,
-    ranges?: vtkRange[]
-  ): boolean;
+  create2DFilterableFromRaw({
+    width,
+    height,
+    numComps,
+    dataType,
+    data,
+    preferSizeOverAccuracy,
+    ranges,
+  }: {
+    width: number;
+    height: number;
+    numComps: number;
+    dataType: VtkDataTypes;
+    data: any;
+    preferSizeOverAccuracy?: boolean;
+    ranges?: vtkRange[];
+  }): boolean;
 
   /**
    * Creates a 2D filterable texture from a data array, with a preference for size over accuracy if necessary.
@@ -266,12 +285,17 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @param preferSizeOverAccuracy Whether to prefer texture size over accuracy.
    * @returns {boolean} True if the texture was successfully created, false otherwise.
    */
-  create2DFilterableFromDataArray(
-    width: number,
-    height: number,
-    dataArray: any,
-    preferSizeOverAccuracy: boolean
-  ): boolean;
+  create2DFilterableFromDataArray({
+    width,
+    height,
+    dataArray,
+    preferSizeOverAccuracy,
+  }: {
+    width: number;
+    height: number;
+    dataArray: any;
+    preferSizeOverAccuracy?: boolean;
+  }): boolean;
 
   /**
    * Creates a 3D texture from raw data.
@@ -287,15 +311,23 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @param updatedExtents Only update the specified extents (default: [])
    * @returns {boolean} True if the texture was successfully created, false otherwise.
    */
-  create3DFromRaw(
-    width: number,
-    height: number,
-    depth: number,
-    numComps: number,
-    dataType: VtkDataTypes,
-    data: any,
-    updatedExtents?: Extent[]
-  ): boolean;
+  create3DFromRaw({
+    width,
+    height,
+    depth,
+    numComps,
+    dataType,
+    data,
+    updatedExtents,
+  }: {
+    width: number;
+    height: number;
+    depth: number;
+    numComps: number;
+    dataType: VtkDataTypes;
+    data: any;
+    updatedExtents?: Extent[];
+  }): boolean;
 
   /**
    * Creates a 3D filterable texture from raw data, with a preference for size over accuracy if necessary.
@@ -307,7 +339,7 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @param depth The depth of the texture.
    * @param numComps The number of components in the texture.
    * @param dataType The data type of the texture.
-   * @param values The raw data for the texture.
+   * @param data The raw data for the texture.
    * @param preferSizeOverAccuracy Whether to prefer texture size over accuracy.
    * @param [ranges] The precomputed ranges of the data (optional). Provided to
    * @param updatedExtents Only update the specified extents (default: [])
@@ -315,17 +347,27 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @returns {boolean} True if the texture was successfully created, false
    * otherwise.
    */
-  create3DFilterableFromRaw(
-    width: number,
-    height: number,
-    depth: number,
-    numComps: number,
-    dataType: VtkDataTypes,
-    values: any,
-    preferSizeOverAccuracy: boolean,
-    ranges?: vtkRange[],
-    updatedExtents?: Extent[]
-  ): boolean;
+  create3DFilterableFromRaw({
+    width,
+    height,
+    depth,
+    numComps,
+    dataType,
+    data,
+    preferSizeOverAccuracy,
+    ranges,
+    updatedExtents,
+  }: {
+    width: number;
+    height: number;
+    depth: number;
+    numComps: number;
+    dataType: VtkDataTypes;
+    data: any;
+    preferSizeOverAccuracy?: boolean;
+    ranges?: vtkRange[];
+    updatedExtents?: Extent[];
+  }): boolean;
 
   /**
    * Creates a 3D filterable texture from a data array, with a preference for size over accuracy if necessary.
@@ -340,14 +382,20 @@ export interface vtkOpenGLTexture extends vtkViewNode {
    * @param updatedExtents Only update the specified extents (default: [])
    * @returns {boolean} True if the texture was successfully created, false otherwise.
    */
-  create3DFilterableFromDataArray(
-    width: number,
-    height: number,
-    depth: number,
-    dataArray: any,
-    preferSizeOverAccuracy: boolean,
-    updatedExtents?: Extent[]
-  ): boolean;
+  create3DFilterableFromDataArray({
+    width,
+    height,
+    depth,
+    dataArray,
+    preferSizeOverAccuracy,
+  }: {
+    width: number;
+    height: number;
+    depth: number;
+    dataArray: any;
+    preferSizeOverAccuracy?: boolean;
+    updatedExtents?: Extent[];
+  }): boolean;
 
   /**
    * Sets the OpenGL render window in which the texture will be used.

--- a/Sources/Rendering/OpenGL/VolumeMapper/index.js
+++ b/Sources/Rendering/OpenGL/VolumeMapper/index.js
@@ -1514,13 +1514,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       }
       model.jitterTexture.setMinificationFilter(Filter.NEAREST);
       model.jitterTexture.setMagnificationFilter(Filter.NEAREST);
-      model.jitterTexture.create2DFromRaw(
-        32,
-        32,
-        1,
-        VtkDataTypes.FLOAT,
-        jitterArray
-      );
+      model.jitterTexture.create2DFromRaw({
+        width: 32,
+        height: 32,
+        numComps: 1,
+        dataType: VtkDataTypes.FLOAT,
+        data: jitterArray,
+      });
     }
 
     const volumeProperties = actor.getProperties();
@@ -1586,25 +1586,25 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         (model.context.getExtension('OES_texture_float') &&
           model.context.getExtension('OES_texture_float_linear'))
       ) {
-        newOpacityTexture.create2DFromRaw(
-          oWidth,
-          2 * numIComps,
-          1,
-          VtkDataTypes.FLOAT,
-          ofTable
-        );
+        newOpacityTexture.create2DFromRaw({
+          width: oWidth,
+          height: 2 * numIComps,
+          numComps: 1,
+          dataType: VtkDataTypes.FLOAT,
+          data: ofTable,
+        });
       } else {
         const oTable = new Uint8ClampedArray(oSize);
         for (let i = 0; i < oSize; ++i) {
           oTable[i] = 255.0 * ofTable[i];
         }
-        newOpacityTexture.create2DFromRaw(
-          oWidth,
-          2 * numIComps,
-          1,
-          VtkDataTypes.UNSIGNED_CHAR,
-          oTable
-        );
+        newOpacityTexture.create2DFromRaw({
+          width: oWidth,
+          height: 2 * numIComps,
+          numComps: 1,
+          dataType: VtkDataTypes.UNSIGNED_CHAR,
+          data: oTable,
+        });
       }
       if (firstScalarOpacityFunc) {
         model._openGLRenderWindow.setGraphicsResourceForObject(
@@ -1667,13 +1667,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       newColorTexture.setMinificationFilter(Filter.LINEAR);
       newColorTexture.setMagnificationFilter(Filter.LINEAR);
 
-      newColorTexture.create2DFromRaw(
-        cWidth,
-        2 * numIComps,
-        3,
-        VtkDataTypes.UNSIGNED_CHAR,
-        cTable
-      );
+      newColorTexture.create2DFromRaw({
+        width: cWidth,
+        height: 2 * numIComps,
+        numComps: 3,
+        dataType: VtkDataTypes.UNSIGNED_CHAR,
+        data: cTable,
+      });
       model._openGLRenderWindow.setGraphicsResourceForObject(
         firstColorTransferFunc,
         newColorTexture,
@@ -1714,13 +1714,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
           model.context.getExtension('EXT_texture_norm16')
         );
         newScalarTexture.resetFormatAndType();
-        newScalarTexture.create3DFilterableFromDataArray(
-          dims[0],
-          dims[1],
-          dims[2],
-          scalars,
-          volumeProperty.getPreferSizeOverAccuracy()
-        );
+        newScalarTexture.create3DFilterableFromDataArray({
+          width: dims[0],
+          height: dims[1],
+          depth: dims[2],
+          dataArray: scalars,
+          preferSizeOverAccuracy: volumeProperty.getPreferSizeOverAccuracy(),
+        });
         model._openGLRenderWindow.setGraphicsResourceForObject(
           scalars,
           newScalarTexture,
@@ -1737,14 +1737,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
         volumeProperty.setUpdatedExtents([]);
 
         const dims = imageData.getDimensions();
-        model.scalarTextures[component].create3DFilterableFromDataArray(
-          dims[0],
-          dims[1],
-          dims[2],
-          scalars,
-          false,
-          updatedExtents
-        );
+        model.scalarTextures[component].create3DFilterableFromDataArray({
+          width: dims[0],
+          height: dims[1],
+          depth: dims[2],
+          dataArray: scalars,
+          updatedExtents,
+        });
       }
 
       replaceGraphicsResource(
@@ -1794,13 +1793,13 @@ function vtkOpenGLVolumeMapper(publicAPI, model) {
       newLabelOutlineThicknessTexture.setMagnificationFilter(Filter.NEAREST);
 
       // Create a 2D texture (acting as 1D) from the raw data
-      newLabelOutlineThicknessTexture.create2DFromRaw(
-        lWidth,
-        lHeight,
-        1,
-        VtkDataTypes.UNSIGNED_CHAR,
-        lTable
-      );
+      newLabelOutlineThicknessTexture.create2DFromRaw({
+        width: lWidth,
+        height: lHeight,
+        numComps: 1,
+        dataType: VtkDataTypes.UNSIGNED_CHAR,
+        data: lTable,
+      });
 
       if (labelOutlineThicknessArray) {
         model._openGLRenderWindow.setGraphicsResourceForObject(

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -8,6 +8,10 @@ import ClassHierarchy from './Common/Core/ClassHierarchy';
 
 let globalMTime = 0;
 
+export const requiredParam = (name) => {
+  throw new Error(`Named parameter '${name}' is missing`);
+};
+
 export const VOID = Symbol('void');
 
 function getCurrentGlobalMTime() {
@@ -1816,4 +1820,5 @@ export default {
   vtkWarningMacro,
   // vtk.js internal use
   objectSetterMap,
+  requiredParam,
 };


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

The create* methods have enough parameters to warrant using named parameters.

Closes #3222 

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

- vtkOpenGLTexture `create*` methods now use named parameters

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
