### PR TITLE
fix(index.d.ts): fix getPixelWorldHeightAtCoord missing parameter

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.d.ts
+++ b/Sources/Widgets/Core/WidgetManager/index.d.ts
@@ -12,6 +12,14 @@ import { vtkObject } from '../../../interfaces';
 import { CaptureOn, ViewTypes } from './Constants';
 import { Nullable } from '../../../types';
 
+export interface IDisplayScaleParams {
+  dispHeightFactor: number;
+  cameraPosition: number[];
+  cameraDir: number[];
+  isParallel: boolean;
+  rendererPixelDims: number[];
+}
+
 export interface ISelectedData {
   requestCount: number;
   propID: number;
@@ -45,7 +53,10 @@ export function extractRenderingComponents(
  * (vertical) distance that matches a display distance of 30px for a coordinate
  * `coord`, you would compute `30 * getPixelWorldHeightAtCoord(coord)`.
  */
-export function getPixelWorldHeightAtCoord(coord: []): Number;
+export function getPixelWorldHeightAtCoord(
+  coord: [],
+  displayScaleParams: IDisplayScaleParams
+): Number;
 
 export interface vtkWidgetManager extends vtkObject {
   /**

--- a/Sources/Widgets/Representations/WidgetRepresentation/index.d.ts
+++ b/Sources/Widgets/Representations/WidgetRepresentation/index.d.ts
@@ -2,13 +2,7 @@ import vtkDataArray from '../../../Common/Core/DataArray';
 import vtkPolyData from '../../../Common/DataModel/PolyData';
 import { vtkObject } from '../../../interfaces';
 import vtkProp from '../../../Rendering/Core/Prop';
-export interface IDisplayScaleParams {
-  dispHeightFactor: number;
-  cameraPosition: number[];
-  cameraDir: number[];
-  isParallel: boolean;
-  rendererPixelDims: number[];
-}
+import { IDisplayScaleParams } from '../../../Widgets/Core/WidgetManager';
 
 export interface IWidgetRepresentationInitialValues {
   labels?: Array<any>;

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.d.ts
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/index.d.ts
@@ -12,14 +12,7 @@ import vtkRenderer from '../../../Rendering/Core/Renderer';
 import vtkPlaneManipulator from '../../Manipulators/PlaneManipulator';
 import { ViewTypes } from '../../../Widgets/Core/WidgetManager/Constants';
 import { Vector2, Vector3 } from '../../../types';
-
-export interface IDisplayScaleParams {
-  dispHeightFactor: number;
-  cameraPosition: Vector3;
-  cameraDir: Vector3;
-  isParallel: false;
-  rendererPixelDims: Vector2;
-}
+import { IDisplayScaleParams } from '../../../Widgets/Core/WidgetManager';
 
 export interface vtkResliceCursorWidget<
   WidgetInstance extends vtkAbstractWidget = vtkResliceCursorWidgetDefaultInstance


### PR DESCRIPTION
### Context
Currently, the `getPixelWorldHeightAtCoord` function in `Sources/Widgets/Core/WidgetManager/index.js` has a second parameter in its implementation, but the corresponding TypeScript definition in `Sources/Widgets/Core/WidgetManager/index.d.ts` is missing this parameter. This discrepancy may lead to type errors for TypeScript users.

Relevant code locations:
- [index.js](https://github.com/Kitware/vtk-js/blob/master/Sources/Widgets/Core/WidgetManager/index.js)
- [index.d.ts](https://github.com/Kitware/vtk-js/blob/master/Sources/Widgets/Core/WidgetManager/index.d.ts)

### Results
This change updates the TypeScript definition to align with the implementation, preventing type errors when using `getPixelWorldHeightAtCoord`.

#### Before Change
```typescript
getPixelWorldHeightAtCoord(coord: number[]): number;
```

#### After Change
```typescript
getPixelWorldHeightAtCoord(coord: number[], displayScaleParams: IDisplayScaleParams): number;
```

### Changes
- [x] Fixed the function definition in `index.d.ts` to include the missing second parameter.
- [x] Ensured TypeScript definitions match the JavaScript implementation.

### PR and Code Checklist
- [x] Followed [semantic-release](https://github.com/semantic-release/semantic-release) commit message guidelines.
- [x] Ran `npm run reformat` to ensure proper code formatting.

### Testing
- [x] Just fill in the missing parameters, there should be no impact, or you can use function overload.
- [x] Tested Environment:
  - **vtk.js**: Latest master
  - **OS**: MacOS
  - **Browser**: Chrome 134.0.6998.166