### PR TITLE
Feature/log scalar bar

### DIFF
--- a/Sources/Common/Core/ScalarsToColors/Constants.js
+++ b/Sources/Common/Core/ScalarsToColors/Constants.js
@@ -11,7 +11,13 @@ export const ScalarMappingTarget = {
   RGBA: 4,
 };
 
+export const Scale = {
+  LINEAR: 0,
+  LOG10: 1,
+};
+
 export default {
   VectorMode,
   ScalarMappingTarget,
+  Scale,
 };

--- a/Sources/Common/Core/ScalarsToColors/index.js
+++ b/Sources/Common/Core/ScalarsToColors/index.js
@@ -3,7 +3,7 @@ import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import Constants from 'vtk.js/Sources/Common/Core/ScalarsToColors/Constants';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper/Constants'; // Need to go inside Constants otherwise dependency loop
 
-const { ScalarMappingTarget, VectorMode } = Constants;
+const { ScalarMappingTarget, Scale, VectorMode } = Constants;
 const { VtkDataTypes } = vtkDataArray;
 const { ColorMode } = vtkMapper;
 const { vtkErrorMacro } = macro;
@@ -553,6 +553,7 @@ const DEFAULT_VALUES = {
   annotationArray: null,
   annotatedValueMap: null,
   indexedLookup: false,
+  scale: Scale.LINEAR,
 };
 
 // ----------------------------------------------------------------------------

--- a/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
+++ b/Sources/Rendering/Core/ScalarBarActor/example/controlPanel.html
@@ -2,13 +2,13 @@
   <tr>
     <td>Min:</td>
     <td>
-      <input type="number" id="min" value="0"></input>
+      <input type="number" id="min" value="0.1"></input>
     </td>
   </tr>
   <tr>
     <td>Max:</td>
     <td>
-      <input type="number" id="max" value="0.25">
+      <input type="number" id="max" value="1000">
     </td>
   </tr>
   <tr>

--- a/Sources/Rendering/Core/ScalarBarActor/example/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/example/index.js
@@ -13,6 +13,8 @@ import vtkScalarBarActor from '@kitware/vtk.js/Rendering/Core/ScalarBarActor';
 import vtkColorTransferFunction from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction';
 import { Scale } from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/Constants';
 import vtkLookupTable from '@kitware/vtk.js/Common/Core/LookupTable';
+import vtkAppendPolyData from '@kitware/vtk.js/Filters/General/AppendPolyData';
+import vtkColorMaps from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
 import controlPanel from './controlPanel.html';
 
@@ -26,61 +28,110 @@ const renderWindow = fullScreenRenderer.getRenderWindow();
 fullScreenRenderer.addController(controlPanel);
 
 // ----------------------------------------------------------------------------
-// Add a cube source
+// Add a cone sources: one for linear, one for log
 // ----------------------------------------------------------------------------
-const cone = vtkConeSource.newInstance();
-cone.update();
-const npts = cone.getOutputData().getPoints().getNumberOfPoints();
+const minInput = document.querySelector('#min');
+const maxInput = document.querySelector('#max');
+
+const linSteps = 40;
+const linearCone = vtkConeSource.newInstance({ resolution: linSteps });
+linearCone.update();
+const npts = linearCone.getOutputData().getPoints().getNumberOfPoints();
+
+const minValue = 0.1;
+const maxValue = 1000;
+minInput.value = minValue;
+maxInput.value = maxValue;
+
+// Linearly spaced points
+const linStep = (maxValue - minValue) / (linSteps - 1);
 const scalars = vtkDataArray.newInstance({ size: npts });
 for (let i = 0; i < npts; ++i) {
-  scalars.setTuple(i, [i / npts]);
+  scalars.setTuple(i, [minValue + (i - 1) * linStep]);
 }
-cone.getOutputData().getPointData().setScalars(scalars);
+scalars.setTuple(0, [undefined]);
+
+linearCone.getOutputData().getPointData().setScalars(scalars);
+
+const logSteps = 40;
+const logCone = vtkConeSource.newInstance({
+  resolution: logSteps,
+  direction: [-1.0, 0.0, 0.0],
+  center: [-1.0, 0.0, 0.0],
+  height: 0.5,
+});
+logCone.update();
+const nptsLog = logCone.getOutputData().getPoints().getNumberOfPoints();
+
+// Define the output range
+const minOutput = Math.log10(minValue || 0.0001);
+const maxOutput = Math.log10(maxValue);
+
+const powersCounts = maxOutput - minOutput + 1;
+
+const scalarsLog = vtkDataArray.newInstance({ size: nptsLog });
+const stepDivisor = nptsLog / powersCounts;
+for (let i = 0; i < nptsLog; ++i) {
+  // Logarithmically spaced points
+  const power = minOutput + Math.floor(i / stepDivisor);
+  scalarsLog.setTuple(i, [10 ** power]);
+}
+// Point 0 is at the top of the cone, make it undefined
+scalarsLog.setTuple(0, [undefined]);
+logCone.getOutputData().getPointData().setScalars(scalarsLog);
+
+const appendPolyData = vtkAppendPolyData.newInstance();
+appendPolyData.setInputConnection(linearCone.getOutputPort());
+appendPolyData.addInputConnection(logCone.getOutputPort());
 
 const mapper = vtkMapper.newInstance();
-mapper.setInputData(cone.getOutputData());
+mapper.setInputData(appendPolyData.getOutputData());
+
 let lut = mapper.getLookupTable();
 
 const actor = vtkActor.newInstance();
+actor.getProperty().setAmbient(0.6);
+actor.getProperty().setDiffuse(0.4);
 actor.setMapper(mapper);
-
 renderer.addActor(actor);
 renderer.resetCamera();
 renderWindow.render();
 
 const scalarBarActor = vtkScalarBarActor.newInstance();
+
 renderer.addActor(scalarBarActor);
 scalarBarActor.setScalarsToColors(lut);
 
 // Change the number of ticks (TODO: add numberOfTicks to ScalarBarActor)
-function generateTicks(numberOfTicks) {
+function generateTicks(numberOfTicks, useLogScale = false) {
   return (helper) => {
     const lastTickBounds = helper.getLastTickBounds();
     // compute tick marks for axes
-    const scale = d3
-      .scaleLinear()
-      .domain([0.0, 1.0])
-      .range([lastTickBounds[0], lastTickBounds[1]]);
-    const samples = scale.ticks(numberOfTicks);
-    const ticks = samples.map((tick) => scale(tick));
+    const scale = useLogScale ? d3.scaleLog() : d3.scaleLinear();
+    scale.domain([lastTickBounds[0], lastTickBounds[1]]).range([0, 1]);
+
+    const ticks = scale.ticks(numberOfTicks);
+    const tickPositions = ticks.map((tick) => scale(tick));
+
     // Replace minus "\u2212" with hyphen-minus "\u002D" so that parseFloat() works
     formatDefaultLocale({ minus: '\u002D' });
-    const format = scale.tickFormat(
-      ticks[0],
-      ticks[ticks.length - 1],
-      numberOfTicks
-    );
-    const tickStrings = ticks
-      .map(format)
-      .map((tick) => Number(parseFloat(tick).toPrecision(12)).toPrecision()); // d3 sometimes adds unwanted whitespace
+    const format = scale.tickFormat(ticks[0], ticks[ticks.length - 1]);
+    const tickStrings = ticks.map(format).map((tick) => {
+      if (tick === '') {
+        return '';
+      }
+      return Number(parseFloat(tick).toPrecision(12)).toPrecision();
+    }); // d3 sometimes adds unwanted whitespace
+
     helper.setTicks(ticks);
     helper.setTickStrings(tickStrings);
+    helper.setTickPositions(tickPositions);
   };
 }
-scalarBarActor.setGenerateTicks(generateTicks(10));
+
+scalarBarActor.setGenerateTicks(generateTicks(10, false));
 
 const logInput = document.querySelector('#log');
-const minInput = document.querySelector('#min');
 const updateMinInputColor = () => {
   minInput.style.color =
     logInput.checked && parseFloat(minInput.value) === 0 ? 'red' : null;
@@ -95,7 +146,6 @@ const onMinChanged = () => {
 minInput.addEventListener('input', onMinChanged);
 onMinChanged();
 
-const maxInput = document.querySelector('#max');
 const onMaxChanged = () => {
   mapper.setUseLookupTableScalarRange(true);
   lut.setRange(lut.getRange()[0], parseFloat(maxInput.value));
@@ -137,51 +187,74 @@ document
     renderWindow.render();
   });
 
-document
-  .querySelector('#useColorTransferFunction')
-  .addEventListener('change', (event) => {
-    const useColorTransferFunction = event.target.checked;
+const useColorTransferFunctionInput = document.querySelector(
+  '#useColorTransferFunction'
+);
 
-    const discretizeInput = document.querySelector('#discretize');
-    discretizeInput.disabled = !useColorTransferFunction;
-    logInput.disabled = !useColorTransferFunction;
-    const numberOfColorsInput = document.querySelector('#numberOfColors');
+function updateScalarBarActor() {
+  const useColorTransferFunction = useColorTransferFunctionInput.checked;
 
-    if (useColorTransferFunction) {
-      const discretize = discretizeInput.checked;
-      const scale = logInput.checked ? Scale.LOG10 : Scale.LINEAR;
-      const numberOfValues = parseInt(numberOfColorsInput.value, 10);
-      const ctf = vtkColorTransferFunction.newInstance({
-        discretize,
-        numberOfValues,
-        scale,
-      });
-      ctf.addRGBPoint(1.0, 0.0, 1.0, 0.0);
-      ctf.addRGBPoint(0.0, 0.0, 0.0, 1.0);
-      mapper.setLookupTable(ctf);
-    } else {
-      const numberOfColors = parseInt(numberOfColorsInput.value, 10);
-      mapper.setLookupTable(vtkLookupTable.newInstance({ numberOfColors }));
-    }
-    lut = mapper.getLookupTable();
-    lut.setRange(parseFloat(minInput.value), parseFloat(maxInput.value));
-    scalarBarActor.setScalarsToColors(lut);
-    renderWindow.render();
-  });
+  const discretizeInput = document.querySelector('#discretize');
+  discretizeInput.disabled = !useColorTransferFunction;
+  logInput.disabled = !useColorTransferFunction;
+  const numberOfColorsInput = document.querySelector('#numberOfColors');
+  const numberOfColors = parseInt(numberOfColorsInput.value, 10);
+
+  const scale = logInput.checked ? Scale.LOG10 : Scale.LINEAR;
+  if (useColorTransferFunction) {
+    const discretize = discretizeInput.checked;
+    console.log(
+      `Create colorTransferFunction with, scale: ${scale}, discretize: ${discretize}, numberOfColors: ${numberOfColors}`
+    );
+    const ctf = vtkColorTransferFunction.newInstance({
+      discretize,
+      numberOfValues: numberOfColors,
+      scale,
+    });
+    const preset = vtkColorMaps.getPresetByName('Rainbow Desaturated');
+    ctf.applyColorMap(preset);
+    // white (transparent) color for values below the range, is transparency working for scalarbar?
+    ctf.setNanColor([1, 1, 1, 1]);
+
+    mapper.setLookupTable(ctf);
+  } else {
+    mapper.setLookupTable(vtkLookupTable.newInstance({ numberOfColors }));
+  }
+  lut = mapper.getLookupTable();
+
+  lut.setRange(parseFloat(minInput.value), parseFloat(maxInput.value));
+
+  scalarBarActor.setScalarsToColors(lut);
+  scalarBarActor.modified();
+  renderWindow.render();
+}
+
+useColorTransferFunctionInput.addEventListener('change', () => {
+  updateScalarBarActor();
+});
+
 document.querySelector('#discretize').addEventListener('change', (event) => {
   if (lut.isA('vtkColorTransferFunction')) {
     lut.setDiscretize(event.target.checked);
     renderWindow.render();
   }
 });
+
 logInput.addEventListener('change', (event) => {
   const useLog = event.target.checked;
-  if (lut.isA('vtkColorTransferFunction')) {
-    lut.setScale(useLog ? Scale.LOG10 : Scale.LINEAR);
-    renderWindow.render();
+  if (useLog && parseFloat(minInput.value) === 0) {
+    minInput.value = minValue || 0.0001;
   }
+  if (useLog && parseFloat(maxInput.value) < 1) {
+    maxInput.value = maxValue;
+  }
+
+  scalarBarActor.setGenerateTicks(generateTicks(10, useLog));
+
   updateMinInputColor();
+  updateScalarBarActor();
 });
+
 document
   .querySelector('#numberOfColors')
   .addEventListener('change', (event) => {

--- a/Sources/Rendering/Core/ScalarBarActor/index.js
+++ b/Sources/Rendering/Core/ScalarBarActor/index.js
@@ -701,10 +701,13 @@ function vtkScalarBarActorHelper(publicAPI, model) {
       (tickSeg.corners[2][spacedAxis] - tickSeg.corners[0][spacedAxis]);
     const ticks = publicAPI.getTicks();
     const tickStrings = publicAPI.getTickStrings();
+    const tickPositions = publicAPI.getTickPositions();
     for (let t = 0; t < ticks.length; t++) {
-      const tickPos =
-        (ticks[t] - model.lastTickBounds[0]) /
-        (model.lastTickBounds[1] - model.lastTickBounds[0]);
+      // If tickPositions is not set, use a normalized position
+      const tickPos = tickPositions
+        ? tickPositions[t]
+        : (ticks[t] - model.lastTickBounds[0]) /
+          (model.lastTickBounds[1] - model.lastTickBounds[0]);
       tmpv3[spacedAxis] = tickSegmentStart + tickSegmentSize * tickPos;
       publicAPI.createPolyDataForOneLabel(
         tickStrings[t],
@@ -820,6 +823,7 @@ const newScalarBarActorHelper = macro.newInstance(
       'topTitle',
       'ticks',
       'tickStrings',
+      'tickPositions',
     ]);
     macro.get(publicAPI, model, [
       'lastSize',


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
There was some half-way implemented disabled log scaling code in ColorTransferFunction.
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
Polydata and scalar bar mapping can now work in really log10 scale. Guardrails against negative values are not heavily invested in.

The first commit introduces ability to output scalar bar ticks to any location with the addition of `tickPositions` property.

Second commit fixes Mapper and ColorTransferFunction to handle log scaling correctly. Fixes and a second cone with log scaled values are added to ScalarBar example.

|  | Linear | Logarithmic |
| --| -- | --| 
| Example |  ![Screenshot 2025-04-07 at 14 28 12](https://github.com/user-attachments/assets/57df3f85-e7de-4274-8626-129c98d480e1) |  ![Screenshot 2025-04-07 at 14 28 18](https://github.com/user-attachments/assets/20ee9347-43d8-44c5-97f4-38a68e0fd422) | 
| Log side | ![Screenshot 2025-04-07 at 14 35 12](https://github.com/user-attachments/assets/bf465b31-3a88-4d34-a820-c2585cf0f3f9) |  ![Screenshot 2025-04-07 at 14 35 16](https://github.com/user-attachments/assets/c51c53e2-dc78-4792-a3e3-402c1be276da) |
| Linear |  ![Screenshot 2025-04-07 at 14 35 47](https://github.com/user-attachments/assets/ae42a241-ca09-458e-bcc7-af4fd0459ed1) |  ![Screenshot 2025-04-07 at 14 35 42](https://github.com/user-attachments/assets/48b5de3b-d0f6-499a-ab47-6178065823c8) |

Log scaled side before fixes...there's something going on but the values of color vs. scalar bar are off.

| Linear | Logarithmic | 
| -- | -- |
| ![Screenshot 2025-04-07 at 14 42 39](https://github.com/user-attachments/assets/b4e2ed06-b5a0-4486-9870-c1cacdc7ac69) |  ![Screenshot 2025-04-07 at 14 42 46](https://github.com/user-attachments/assets/331d6d45-f110-4005-a04d-5a610882dc65) |



<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [X] Tested environment:
  - **vtk.js**: 32.13
  - **OS**: Mac 15.3
  - **Browser**: Chrome 135.0.7049.42, Safari 18.3.1, Firefox 137.0

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
