### PR TITLE
fix(mapper.js): fix color texture coordinate mapping when using logarithmic scale

### DIFF
--- a/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
+++ b/Sources/Rendering/Core/ColorTransferFunction/index.d.ts
@@ -312,6 +312,30 @@ export interface vtkColorTransferFunction extends vtkScalarsToColors {
    * @param colorMap
    */
   applyColorMap(colorMap: any): void;
+
+  /**
+   * Get the color space of the color transfer function.
+   * @returns {ColorSpace}
+   */
+  getColorSpace(): ColorSpace;
+
+  /**
+   * Set the color space of the color transfer function.
+   * @param {ColorSpace} colorSpace
+   */
+  setColorSpace(colorSpace: ColorSpace): void;
+
+  /**
+   * Get the scale of the color transfer function.
+   * @returns {Scale}
+   */
+  getScale(): Scale;
+
+  /**
+   * Set the scale of the color transfer function.
+   * @param {Scale} scale
+   */
+  setScale(scale: Scale): void;
 }
 
 /**


### PR DESCRIPTION
Scalars array was already mapped with log scaling but texture coordinates were incorrectly mapped using the linear range and value. Log color mapping was working if scalar interpolation was off when scalars were not directly mapped to textures.

Also added some missing types to ColorTransferFunction.

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

In the following screenshots the first rectangle has point values of 1 everywhere, second has 100 and the last 1000.

| Linear | Log before | Log after |
| -- | -- | --|
|  <img width="715" alt="Screenshot 2025-05-02 at 11 02 06" src="https://github.com/user-attachments/assets/211f6acc-53e0-4f52-989b-ea024ec6d0cb" /> |  <img width="703" alt="Screenshot 2025-05-02 at 11 07 54" src="https://github.com/user-attachments/assets/5c551629-7f7d-4988-b5cb-062b1de026ed" /> |  <img width="709" alt="Screenshot 2025-05-02 at 11 02 24" src="https://github.com/user-attachments/assets/df8ff62d-a2be-4343-8c54-1a1b0b30ed84" /> |




### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [X] Tested environment:
  - **vtk.js**: master (33.0.1)
  - **OS**: MacOS 15.4.
  - **Browser**: Latest Chrome, Firefox and Safari

The scalar bar actor example doesn't really work at all with interpolated values (because of the geometry?) but the rim of the cone can be seen barely to see the change.

| Before | After | 
| -- | -- |
| ![Screenshot 2025-05-02 at 12 01 07](https://github.com/user-attachments/assets/d4b9487a-94f4-4202-8321-52b190c87419) | ![Screenshot 2025-05-02 at 12 00 38](https://github.com/user-attachments/assets/6d7978a6-017f-4e11-85d1-423c160238a7) |


<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
