### PR TITLE
feat(PBR): add for support for combined RM/ORM texture

### DIFF
--- a/Sources/IO/Geometry/GLTFImporter/Reader.js
+++ b/Sources/IO/Geometry/GLTFImporter/Reader.js
@@ -252,25 +252,18 @@ async function createPropertyFromGLTFMaterial(model, material, actor) {
       }
     }
 
+    // Handle metallic-roughness texture (metallicRoughnessTexture)
     if (pbr.metallicRoughnessTexture) {
       const extensions = pbr.metallicRoughnessTexture.extensions;
       const tex = pbr.metallicRoughnessTexture.texture;
       const sampler = tex.sampler;
-      const metallicImage = await loadImage(tex.source, 'b');
-      const metallicTex = createVTKTextureFromGLTFTexture(
-        metallicImage,
+      const rmImage = await loadImage(tex.source);
+      const rmTex = createVTKTextureFromGLTFTexture(
+        rmImage,
         sampler,
         extensions
       );
-      property.setMetallicTexture(metallicTex);
-
-      const roughnessImage = await loadImage(tex.source, 'g');
-      const roughnessTex = createVTKTextureFromGLTFTexture(
-        roughnessImage,
-        sampler,
-        extensions
-      );
-      property.setRoughnessTexture(roughnessTex);
+      property.setRMTexture(rmTex);
     }
 
     // Handle ambient occlusion texture (occlusionTexture)

--- a/Sources/Rendering/Core/Property/index.d.ts
+++ b/Sources/Rendering/Core/Property/index.d.ts
@@ -1,5 +1,5 @@
 import { vtkObject } from '../../../interfaces';
-import { RGBColor } from '../../../types';
+import { Nullable, RGBColor } from '../../../types';
 import { Interpolation, Representation, Shading } from './Constants';
 import { vtkTexture } from '../../Core/Texture';
 
@@ -14,6 +14,8 @@ export interface IPropertyInitialValues {
   normalTexture?: vtkTexture;
   ambientOcclusionTexture?: vtkTexture;
   emissionTexture?: vtkTexture;
+  RMTexture?: vtkTexture;
+  ORMTexture?: vtkTexture;
   edgeColor?: RGBColor;
   ambient?: number;
   diffuse?: number;
@@ -216,32 +218,42 @@ export interface vtkProperty extends vtkObject {
   /**
    * Get the diffuse texture.
    */
-  getDiffuseTexture(): vtkTexture;
+  getDiffuseTexture(): Nullable<vtkTexture>;
 
   /**
    * Get the metallic texture.
    */
-  getMetallicTexture(): vtkTexture;
+  getMetallicTexture(): Nullable<vtkTexture>;
+
+  /**
+   * Get the roughness & metallic texture.
+   */
+  getRMTexture(): Nullable<vtkTexture>;
+
+  /**
+   * Get the occlusion, roughness & metallic texture.
+   */
+  getORMTexture(): Nullable<vtkTexture>;
 
   /**
    * Get the roughness texture.
    */
-  getRoughnessTexture(): vtkTexture;
+  getRoughnessTexture(): Nullable<vtkTexture>;
 
   /**
    * Get the normal texture.
    */
-  getNormalTexture(): vtkTexture;
+  getNormalTexture(): Nullable<vtkTexture>;
 
   /**
    * Get the ambient occlusion texture.
    */
-  getAmbientOcclusionTexture(): vtkTexture;
+  getAmbientOcclusionTexture(): Nullable<vtkTexture>;
 
   /**
    * Get the emission texture.
    */
-  getEmissionTexture(): vtkTexture;
+  getEmissionTexture(): Nullable<vtkTexture>;
 
   /**
    * Set the ambient lighting coefficient.
@@ -499,6 +511,18 @@ export interface vtkProperty extends vtkObject {
    * @param {vtkTexture} roughnessTexture
    */
   setRoughnessTexture(roughnessTexture: vtkTexture): boolean;
+
+  /**
+   * Set the roughness & metallic texture.
+   * @param {vtkTexture} RMTexture
+   */
+  setRMTexture(RMTexture: vtkTexture): boolean;
+
+  /**
+   * Set the occlusion, roughness & metallic texture.
+   * @param {vtkTexture} ORMTexture
+   */
+  setORMTexture(ORMTexture: vtkTexture): boolean;
 
   /**
    * Set the normal texture.

--- a/Sources/Rendering/Core/Property/index.js
+++ b/Sources/Rendering/Core/Property/index.js
@@ -127,6 +127,9 @@ const DEFAULT_VALUES = {
 
   shading: false,
   materialName: null,
+
+  ORMTexture: null,
+  RMTexture: null,
 };
 
 // ----------------------------------------------------------------------------
@@ -162,6 +165,8 @@ export function extend(publicAPI, model, initialValues = {}) {
     'normalTexture',
     'ambientOcclusionTexture',
     'emissionTexture',
+    'ORMTexture',
+    'RMTexture',
   ]);
   macro.setGetArray(
     publicAPI,


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Add for support for combined RM/ORM texture

fixes #2961

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
