### PR TITLE
fix(WebGPU): Handle edge visibility for both triangles and triangle strips

### DIFF
--- a/Sources/Rendering/WebGPU/PolyDataMapper/index.js
+++ b/Sources/Rendering/WebGPU/PolyDataMapper/index.js
@@ -52,7 +52,12 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
     // and they handle the rendering of that cell array
     const cellMappers = [];
     let cellOffset = 0;
-    for (let i = PrimitiveTypes.Points; i <= PrimitiveTypes.Triangles; i++) {
+    // Handle all primitive types including strips
+    for (
+      let i = PrimitiveTypes.Points;
+      i <= PrimitiveTypes.TriangleStrips;
+      i++
+    ) {
       if (prims[i].getNumberOfValues() > 0) {
         if (!model.primitives[i]) {
           model.primitives[i] = publicAPI.createCellArrayMapper();
@@ -70,26 +75,44 @@ function vtkWebGPUPolyDataMapper(publicAPI, model) {
       }
     }
 
+    // Handle edge visibility for both triangles and triangle strips
     if (model.WebGPUActor.getRenderable().getProperty().getEdgeVisibility()) {
-      for (
-        let i = PrimitiveTypes.TriangleEdges;
-        i <= PrimitiveTypes.TriangleStripEdges;
-        i++
-      ) {
-        if (prims[i - 2].getNumberOfValues() > 0) {
-          if (!model.primitives[i]) {
-            model.primitives[i] = publicAPI.createCellArrayMapper();
-          }
-          const cellMapper = model.primitives[i];
-          cellMapper.setCellArray(prims[i - 2]);
-          cellMapper.setCurrentInput(poly);
-          cellMapper.setCellOffset(model.primitives[i - 2].getCellOffset());
-          cellMapper.setPrimitiveType(i);
-          cellMapper.setRenderable(model.renderable);
-          cellMappers.push(cellMapper);
-        } else {
-          model.primitives[i] = null;
+      // Handle triangle edges
+      if (prims[PrimitiveTypes.Triangles].getNumberOfValues() > 0) {
+        const i = PrimitiveTypes.TriangleEdges;
+        if (!model.primitives[i]) {
+          model.primitives[i] = publicAPI.createCellArrayMapper();
         }
+        const cellMapper = model.primitives[i];
+        cellMapper.setCellArray(prims[PrimitiveTypes.Triangles]);
+        cellMapper.setCurrentInput(poly);
+        cellMapper.setCellOffset(
+          model.primitives[PrimitiveTypes.Triangles].getCellOffset()
+        );
+        cellMapper.setPrimitiveType(i);
+        cellMapper.setRenderable(model.renderable);
+        cellMappers.push(cellMapper);
+      } else {
+        model.primitives[PrimitiveTypes.TriangleEdges] = null;
+      }
+
+      // Handle triangle strip edges
+      if (prims[PrimitiveTypes.TriangleStrips].getNumberOfValues() > 0) {
+        const i = PrimitiveTypes.TriangleStripEdges;
+        if (!model.primitives[i]) {
+          model.primitives[i] = publicAPI.createCellArrayMapper();
+        }
+        const cellMapper = model.primitives[i];
+        cellMapper.setCellArray(prims[PrimitiveTypes.TriangleStrips]);
+        cellMapper.setCurrentInput(poly);
+        cellMapper.setCellOffset(
+          model.primitives[PrimitiveTypes.TriangleStrips].getCellOffset()
+        );
+        cellMapper.setPrimitiveType(i);
+        cellMapper.setRenderable(model.renderable);
+        cellMappers.push(cellMapper);
+      } else {
+        model.primitives[PrimitiveTypes.TriangleStripEdges] = null;
       }
     }
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
fixes #3125

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
![image](https://github.com/user-attachments/assets/ca5ba491-360e-4980-8bac-a081af0bc46b)


### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
