### PR TITLE
feat(ImageMapper): array-based outline opacity

### DIFF
--- a/Examples/Rendering/ImageLabelOutline/index.js
+++ b/Examples/Rendering/ImageLabelOutline/index.js
@@ -76,8 +76,11 @@ function createLabelmap(backgroundImageData) {
   labelMap.actor.getProperty().setUseLabelOutline(true);
   // Label outline thickness is for first segment -> 2 (positioned at array index 0), second segment -> 4
   // (positioned at array index 4)
-  labelMap.actor.getProperty().setLabelOutlineThickness([2, 1, 1, 1, 4]);
-  labelMap.actor.getProperty().setLabelOutlineOpacity(1.0);
+  labelMap.actor.getProperty().setLabelOutlineThickness([4, 1, 1, 1, 8]);
+  // Sets the outline opacity similarly to the outline thickness
+  labelMap.actor.getProperty().setLabelOutlineOpacity([0.5, 1, 1, 1, 0.8]);
+  // or you can set a global outline opacity
+  // labelMap.actor.getProperty().setLabelOutlineOpacity(1.0);
 
   // This is very important to make sure the labelmap is rendered
   // correctly

--- a/Sources/Rendering/Core/ImageProperty/index.d.ts
+++ b/Sources/Rendering/Core/ImageProperty/index.d.ts
@@ -106,15 +106,21 @@ export interface vtkImageProperty extends vtkObject {
   getUseLabelOutline(): boolean;
 
   /**
-   * Set the 0 to 1 opacity of the label outline.
-   * @param {Number} opacity
+   * Set opacity of the label outline.
+   *
+   * Opacity must be between 0 and 1.
+   * If the given opacity is a number, the opacity will apply to all outline segments.
+   * If the given opacity is an array of numbers, each opacity value will apply to the
+   * label equal to the opacity value's index + 1. (This is the same behavior as setLabelOutlineThickness).
+   *
+   * @param {Number | Number[]} opacity
    */
-  setLabelOutlineOpacity(opacity: number): boolean;
+  setLabelOutlineOpacity(opacity: number | number[]): boolean;
 
   /**
    * Get the 0 to 1 opacity of the label outline.
    */
-  getLabelOutlineOpacity(): number;
+  getLabelOutlineOpacity(): number | number[];
 
   /**
    * gets the label outline thickness


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Label outlines now have finer-grained opacity controls. Each label can now specify its own outline opacity via setLabelOutlineOpacity(array).

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes
- [x] Added guards to prevent label outline+thickness texture generation when useLabelOutline is false
- [x] Add support for specifying label outline opacity as an array
- [x] Removed an unused `outlineThickness` uniform and an unused `labelOutlineThicknessTextureString` model property
- [x] Trigger shader rebuilding whenever the ImageProperty changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
