### PR TITLE
fix(RenderWindowInteractor):  ensure the container is not empty

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -311,9 +311,10 @@ function vtkRenderWindowInteractor(publicAPI, model) {
         'pointercancel',
         publicAPI.handlePointerCancel
       );
+      container.removeEventListener('keypress', publicAPI.handleKeyPress);
+      container.removeEventListener('keydown', publicAPI.handleKeyDown);
     }
-    container.removeEventListener('keypress', publicAPI.handleKeyPress);
-    container.removeEventListener('keydown', publicAPI.handleKeyDown);
+
     document.removeEventListener('keyup', publicAPI.handleKeyUp);
     document.removeEventListener(
       'pointerlockchange',


### PR DESCRIPTION
### Context

Sometimes the container may be null

### Results

Uncaught TypeError: Cannot read properties of null (reading 'removeEventListener')
    at _unbindEvents (RenderWindowInteractor.js:242:15)
    at publicAPI.setContainer (RenderWindowInteractor.js:994:5)

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [x] Tested environment:
  - **vtk.js**:
  - **OS**:
  - **Browser**: 

