### PR TITLE
fix(vtkdataarray): fix double allocation when using vtkDataArray.resize

### DIFF
--- a/Sources/Common/Core/CellArray/index.d.ts
+++ b/Sources/Common/Core/CellArray/index.d.ts
@@ -39,6 +39,9 @@ export interface vtkCellArray extends vtkDataArray {
 
   /**
    * Insert a cell to this array in the next available slot.
+   * This may re-allocate a new typed array if the current one is not large enough.
+   * If the final size of the array is known up-front, it is more efficient to call
+   * `allocate()` before calling `insertNextCell()` multiple times.
    * @param {Number[]} cellPointIds The list of point ids (NOT prefixed with the number of points)
    * @returns {Number} Idx of where the cell was inserted
    */

--- a/Sources/Common/Core/CellArray/index.js
+++ b/Sources/Common/Core/CellArray/index.js
@@ -68,6 +68,8 @@ function vtkCellArray(publicAPI, model) {
 
   /**
    * When `resize()` is being used, you then MUST use `insertNextCell()`.
+   * @see vtkCellArray#insertNextCell
+   * @see vtkDataArray#allocate
    */
   publicAPI.resize = (requestedNumTuples) => {
     const oldNumTuples = publicAPI.getNumberOfTuples();

--- a/Sources/Common/Core/DataArray/index.d.ts
+++ b/Sources/Common/Core/DataArray/index.d.ts
@@ -168,6 +168,7 @@ export interface vtkDataArray extends vtkObject {
    *
    * @see insertNextTuple
    * @see getNumberOfTuples
+   * @see allocate
    *
    * @param {Number} idx
    * @param {Array<Number>|TypedArray} tuple
@@ -189,6 +190,7 @@ export interface vtkDataArray extends vtkObject {
    * NOTE: May resize the data values array. "Safe" version of setTuple.
    *
    * @see insertTuple
+   * @see allocate
    *
    * @param {Array<Number>|TypedArray} tuple
    * @returns {Number} Index of the inserted tuple.
@@ -304,6 +306,18 @@ export interface vtkDataArray extends vtkObject {
   ): void;
 
   /**
+   * Resize the array to the requested number of extra tuples
+   * (added to the current number of tuples) and preserve data.
+   * model.size WILL NOT be modified.
+   * This is useful before multiple calls to `insertNextTuple()` or `insertNextTuples()`.
+   * @param {Number} extraNumTuples Number of tuples to allocate memory wise.
+   * @see insertNextTuple
+   * @see insertNextTuples
+   * @see allocate
+   */
+  allocate(extraNumTuples: number): void;
+
+  /**
    * Resize the array to the requested number of tuples and preserve data.
    * Increasing the array size may allocate extra memory beyond what was
    * requested.
@@ -318,6 +332,7 @@ export interface vtkDataArray extends vtkObject {
    * @see insertNextTuple
    * @see insertNextTuples
    * @see initialize
+   * @see allocate
    */
   resize(requestedNumTuples: number): boolean;
 

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -149,21 +149,23 @@ function vtkDataArray(publicAPI, model) {
     }
 
     const numComps = publicAPI.getNumberOfComponents();
-    const curNumTuples = model.values.length / (numComps > 0 ? numComps : 1);
-    if (requestedNumTuples === curNumTuples) {
+    const numAllocatedTuples =
+      model.values.length / (numComps > 0 ? numComps : 1);
+    if (requestedNumTuples === numAllocatedTuples) {
       return true;
     }
 
-    if (requestedNumTuples > curNumTuples) {
+    if (requestedNumTuples > numAllocatedTuples) {
       // Requested size is bigger than current size.  Allocate enough
       // memory to fit the requested size and be more than double the
       // currently allocated memory.
       const oldValues = model.values;
       model.values = macro.newTypedArray(
         model.dataType,
-        (requestedNumTuples + curNumTuples) * numComps
+        (requestedNumTuples + numAllocatedTuples) * numComps
       );
       model.values.set(oldValues);
+      // The actual number of tuples is not increased, only memory is allocated.
       return true;
     }
 
@@ -179,6 +181,10 @@ function vtkDataArray(publicAPI, model) {
   publicAPI.dataChange = () => {
     model.ranges = null;
     publicAPI.modified();
+  };
+
+  publicAPI.allocate = (extraNumTuples) => {
+    resize(publicAPI.getNumberOfTuples() + extraNumTuples);
   };
 
   publicAPI.resize = (requestedNumTuples) => {

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -428,3 +428,83 @@ test('Test vtkDataArray findTuple', (t) => {
   t.equal(dataArray.findTuple(Float32Array.from([12, 13, 14])), 4);
   t.end();
 });
+
+test('Test vtkDataArray allocate function', (t) => {
+  // create an empty data array with 3 channel data.
+  const da = vtkDataArray.newInstance({
+    numberOfComponents: 3,
+    empty: true,
+  });
+
+  t.equal(da.getNumberOfTuples(), 0, 'empty');
+
+  da.allocate(2);
+  let oldData = da.getData();
+
+  t.equal(
+    da.getNumberOfTuples(),
+    0,
+    'allocate does not change number of tuples'
+  );
+
+  da.insertNextTuple([1, 2, 3]);
+  da.insertNextTuple([1, 2, 3]);
+
+  t.equal(da.getNumberOfTuples(), 2, 'inserted 2 tuples');
+  t.equal(da.getData().buffer, oldData.buffer, 'no array allocation on insert');
+
+  da.allocate(2);
+
+  t.equal(
+    da.getNumberOfTuples(),
+    2,
+    'allocate does not change number of tuples'
+  );
+  t.notEqual(
+    da.getData().buffer,
+    oldData.buffer,
+    'reallocate array on allocate'
+  );
+  oldData = da.getData();
+
+  da.insertNextTuple([1, 2, 3]);
+  da.insertNextTuple([1, 2, 3]);
+
+  t.ok(da.getNumberOfTuples() === 4, '2 more tuples');
+  t.equal(da.getData().buffer, oldData.buffer, 'no array allocation on insert');
+
+  t.end();
+});
+
+test('Test vtkDataArray resize function', (t) => {
+  // create an empty data array with 3 channel data.
+  const da = vtkDataArray.newInstance({
+    numberOfComponents: 3,
+    empty: true,
+  });
+
+  t.ok(da.getNumberOfTuples() === 0, 'empty');
+
+  da.resize(2);
+
+  t.ok(da.getNumberOfTuples() === 2, 'resize does change the number of tuples');
+
+  da.insertNextTuple([1, 2, 3]);
+  da.insertNextTuple([1, 2, 3]);
+
+  t.ok(da.getNumberOfTuples() === 4, 'inserted 2 tuples');
+
+  const oldData = da.getData();
+  da.resize(2);
+
+  t.ok(da.getNumberOfTuples() === 2, 'resize reduces the number of tuples');
+  t.equal(da.getData().buffer, oldData.buffer, 'no array allocation on shrink');
+
+  da.insertNextTuple([1, 2, 3]);
+  da.insertNextTuple([1, 2, 3]);
+
+  t.ok(da.getNumberOfTuples() === 4, '2 more tuples');
+  t.equal(da.getData().buffer, oldData.buffer, 'no array allocation on shrink');
+
+  t.end();
+});

--- a/Sources/IO/Geometry/DracoReader/index.js
+++ b/Sources/IO/Geometry/DracoReader/index.js
@@ -169,7 +169,7 @@ function getPolyDataFromDracoGeometry(decoder, dracoGeometry) {
   const nCells = indices.length - 2;
 
   const cells = vtkCellArray.newInstance();
-  cells.resize((4 * indices.length) / 3);
+  cells.allocate((4 * indices.length) / 3);
   for (let cellId = 0; cellId < nCells; cellId += 3) {
     const cell = indices.slice(cellId, cellId + 3);
     cells.insertNextCell(cell);

--- a/Sources/IO/Geometry/GLTFImporter/Reader.js
+++ b/Sources/IO/Geometry/GLTFImporter/Reader.js
@@ -142,7 +142,7 @@ async function createPolyDataFromGLTFMesh(primitive) {
         vtkWarningMacro('GL_LINE_LOOP not implemented');
         break;
       default:
-        cells.resize((4 * indices.length) / 3);
+        cells.allocate((4 * indices.length) / 3);
         for (let cellId = 0; cellId < nCells; cellId += 3) {
           const cell = indices.slice(cellId, cellId + 3);
           cells.insertNextCell(cell);


### PR DESCRIPTION
vtkDataArray.resize() actually changes the number of tuples, while vtkDataArray.allocate() simply allocate memory without changing the number of tuples.

fix #3282


### Context
DracoReader produces a cell data array filled with zeros and then with actual cells.
This is because vtkDataArray.resize() first allocate a new array filled with zeros, and insertNextCell() calls do extend the array with new values.

### Results
No more 0-filled array in the DracoReader output cell data array.

### Changes
A new function vtkDataArray.allocate() is added.
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome
