### PR TITLE
fix(Triangle): use TypedArray

### DIFF
--- a/Sources/Common/DataModel/Triangle/index.js
+++ b/Sources/Common/DataModel/Triangle/index.js
@@ -1,4 +1,4 @@
-import macro from 'vtk.js/Sources/macros';
+import macro, { TYPED_ARRAYS } from 'vtk.js/Sources/macros';
 import vtkCell from 'vtk.js/Sources/Common/DataModel/Cell';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkLine from 'vtk.js/Sources/Common/DataModel/Line';
@@ -614,12 +614,9 @@ function vtkTriangle(publicAPI, model) {
    * @param {Number[]} derivs - The derivatives.
    */
   publicAPI.derivatives = (subId, pcoords, values, dim, derivs) => {
-    const x0 = [];
-    const x1 = [];
-    const x2 = [];
-    model.points.getPoint(0, x0);
-    model.points.getPoint(1, x1);
-    model.points.getPoint(2, x2);
+    const x0 = model.points.getPoint(0);
+    const x1 = model.points.getPoint(1);
+    const x2 = model.points.getPoint(2);
 
     const n = [];
     const v10 = [];
@@ -627,11 +624,8 @@ function vtkTriangle(publicAPI, model) {
     const v = [];
     computeNormal(x0, x1, x2, n);
 
-    for (let i = 0; i < 3; i++) {
-      v10[i] = x1[i] - x0[i];
-      v[i] = x2[i] - x0[i];
-    }
-
+    vtkMath.subtract(x1, x0, v10);
+    vtkMath.subtract(x2, x0, v);
     vtkMath.cross(n, v10, v20);
 
     const lenX = vtkMath.normalize(v10); // check for degenerate triangle
@@ -658,7 +652,7 @@ function vtkTriangle(publicAPI, model) {
     const J = [v1[0] - v0[0], v1[1] - v0[1], v2[0] - v0[0], v2[1] - v0[1]];
 
     // Compute inverse Jacobian (expects flat array)
-    const JI = new Array(4).fill(0.0);
+    const JI = macro.newTypedArray(TYPED_ARRAYS.Float64Array, 4);
     vtkMath.invertMatrix(J, JI, 2); // returns flat array [JI00, JI01, JI10, JI11]
 
     // Compute derivatives


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
