### PR TITLE
fix(Texture): Prevent GL_INVALID_OPERATION when updating texture data

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.d.ts
+++ b/Sources/Rendering/OpenGL/Texture/index.d.ts
@@ -219,6 +219,26 @@ export interface vtkOpenGLTexture extends vtkViewNode {
   }): boolean;
 
   /**
+   * Updates existing 2D texture data without recreating the texture.
+   * This method uses texSubImage2D to efficiently update texture data when
+   * the texture dimensions and format haven't changed, avoiding GL_INVALID_OPERATION
+   * errors that occur when trying to recreate immutable WebGL2 textures.
+   * @param data The raw data for the texture update.
+   * @param dataType The data type of the texture data.
+   * @param flip Whether to flip the texture vertically. Defaults to false.
+   * @returns {boolean} True if the texture was successfully updated, false otherwise.
+   */
+  update2DFromRaw({
+    data,
+    dataType,
+    flip,
+  }: {
+    data: any;
+    dataType: VtkDataTypes;
+    flip?: boolean;
+  }): boolean;
+
+  /**
    * Creates a cube texture from raw data.
    * @param width The width of each face of the cube texture.
    * @param height The height of each face of the cube texture.

--- a/Sources/Rendering/OpenGL/Texture/test/testTextureDataUpdate.js
+++ b/Sources/Rendering/OpenGL/Texture/test/testTextureDataUpdate.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-await-in-loop */
+import test from 'tape';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkPlaneSource from 'vtk.js/Sources/Filters/Sources/PlaneSource';
+import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+
+test.onlyIfWebGL(
+  'Test Texture Data Update Without GL_INVALID_OPERATION',
+  async (t) => {
+    const gc = testUtils.createGarbageCollector();
+
+    // Helper function to check for GL errors
+    // Dont want to see GL_INVALID_OPERATION: glTexStorage2D: Texture is immutable.
+    function checkGLError(gl) {
+      const error = gl.getError();
+      if (error !== gl.NO_ERROR) {
+        const errorMsg =
+          error === gl.INVALID_OPERATION
+            ? 'GL_INVALID_OPERATION detected'
+            : `GL Error ${error} (0x${error.toString(16)})`;
+        t.fail(errorMsg);
+        t.end();
+        return true;
+      }
+      return false;
+    }
+
+    // Create render setup
+    const container = gc.registerDOMElement(document.createElement('div'));
+    document.querySelector('body').appendChild(container);
+
+    const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+    const renderer = gc.registerResource(vtkRenderer.newInstance());
+    renderWindow.addRenderer(renderer);
+
+    const glwindow = gc.registerResource(vtkOpenGLRenderWindow.newInstance());
+    glwindow.setContainer(container);
+    renderWindow.addView(glwindow);
+    glwindow.setSize(64, 64);
+
+    // Create textured plane
+    const plane = gc.registerResource(vtkPlaneSource.newInstance());
+    const mapper = gc.registerResource(vtkMapper.newInstance());
+    mapper.setInputConnection(plane.getOutputPort());
+
+    const actor = gc.registerResource(vtkActor.newInstance());
+    actor.setMapper(mapper);
+    renderer.addActor(actor);
+
+    // Create texture with red data
+    const texture = gc.registerResource(vtkTexture.newInstance());
+    const imageData = gc.registerResource(vtkImageData.newInstance());
+    imageData.setDimensions(64, 64, 1);
+
+    const data = new Uint8Array(64 * 64 * 3).fill(255); // red
+    const scalars = gc.registerResource(
+      vtkDataArray.newInstance({
+        numberOfComponents: 3,
+        values: data,
+      })
+    );
+    imageData.getPointData().setScalars(scalars);
+    texture.setInputData(imageData);
+    actor.addTexture(texture);
+
+    renderWindow.render();
+
+    // Update texture to green
+    data.fill(0);
+    for (let i = 1; i < data.length; i += 3) {
+      data[i] = 255; // green channel
+    }
+    scalars.modified();
+    imageData.modified();
+    texture.modified();
+
+    renderWindow.render();
+
+    // Check for GL errors
+    if (checkGLError(glwindow.getContext())) {
+      gc.releaseResources();
+      return;
+    }
+
+    t.pass('No GL errors occurred during texture update');
+    gc.releaseResources();
+  }
+);


### PR DESCRIPTION
### TODO
- [ ] I think we need account for datatype changes, among other tings =/

## Prevent GL_INVALID_OPERATION when updating texture data in WebGL2

I would think this warning has been disccused before but could not find an issue regarding this...

### Context

WebGL2 textures created with `texStorage2D` are immutable, causing browser console warnings:

```
GL_INVALID_OPERATION: glTexStorage2D: Texture is immutable.
```

This occurs when `texture.modified()` triggers recreation of existing textures, such as when updating video textures or other dynamic content. The warning appears because vtk.js attempts to call `texStorage2D` again on already-immutable textures.

Console log showing the error pattern:

- Initial texture creation: `texStorage2D` + `texSubImage2D` (works)
- Texture update: `texture.modified()` → attempts `texStorage2D` again (fails)

Want this to update a texture with a video stream.

### Results

**Before:** Browser console shows GL_INVALID_OPERATION warnings on every texture update

**After:** Clean texture updates without any WebGL errors

The texture data still updates correctly in both cases, but the warnings are eliminated.

### Changes

- **Added:** `update2DFromRaw()` method that uses `texSubImage2D` for data-only updates
- **Modified:** `render()` method to detect when only texture data changes (same dimensions/components)

API additions:

- `publicAPI.update2DFromRaw({ data, dataType, flip })` - Updates existing texture data without recreation

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] semantic-release commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: latest master
  - **OS**: Linux
  - **Browser**: Chrome WebGL2

**Test coverage:**

- Unit test verifies no GL_INVALID_OPERATION errors during texture updates