### PR TITLE
fix(Glyph3DMapper): shift+scale for large coords

### DIFF
--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -7,8 +7,10 @@ import vtkHardwareSelector from 'vtk.js/Sources/Rendering/OpenGL/HardwareSelecto
 import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
 import vtkOpenGLPolyDataMapper from 'vtk.js/Sources/Rendering/OpenGL/PolyDataMapper';
 import vtkShaderProgram from 'vtk.js/Sources/Rendering/OpenGL/ShaderProgram';
+import { computeCoordShiftAndScale } from 'vtk.js/Sources/Rendering/OpenGL/CellArrayBufferObject/helpers';
 
 import { registerOverride } from 'vtk.js/Sources/Rendering/OpenGL/ViewNodeFactory';
+import { primTypes } from '../Helper';
 
 const { vtkErrorMacro } = macro;
 const { Representation } = vtkProperty;
@@ -17,6 +19,19 @@ const { PassTypes } = vtkHardwareSelector;
 
 const StartEvent = { type: 'StartEvent' };
 const EndEvent = { type: 'EndEvent' };
+
+const MAT4_BYTE_SIZE = 64;
+const MAT4_ELEMENT_COUNT = 16;
+
+function applyShiftScaleToMat(mat, shift, scale) {
+  // the translation component of a 4x4 column-major matrix
+  mat[12] = (mat[12] - shift[0]) * scale[0];
+  mat[13] = (mat[13] - shift[1]) * scale[1];
+  mat[14] = (mat[14] - shift[2]) * scale[2];
+  mat[0] *= scale[0];
+  mat[5] *= scale[1];
+  mat[10] *= scale[2];
+}
 
 // ----------------------------------------------------------------------------
 // vtkOpenGLSphereMapper methods
@@ -630,9 +645,14 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
   };
 
   publicAPI.buildBufferObjects = (ren, actor) => {
+    const garray = model.renderable.getMatrixArray();
+
+    const pts = model.renderable.getInputData(0).getPoints();
+    const { useShiftAndScale, coordShift, coordScale } =
+      computeCoordShiftAndScale(pts);
+
     if (model.hardwareSupport) {
       // update the buffer objects if needed
-      const garray = model.renderable.getMatrixArray();
       const narray = model.renderable.getNormalArray();
       const carray = model.renderable.getColorArray();
       if (!model.matrixBuffer) {
@@ -645,6 +665,19 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
         model.pickBuffer = vtkBufferObject.newInstance();
         model.pickBuffer.setOpenGLRenderWindow(model._openGLRenderWindow);
       }
+
+      if (useShiftAndScale) {
+        const buf = garray.buffer;
+        for (
+          let ptIdx = 0;
+          ptIdx < garray.byteLength;
+          ptIdx += MAT4_BYTE_SIZE
+        ) {
+          const mat = new Float32Array(buf, ptIdx, MAT4_ELEMENT_COUNT);
+          applyShiftScaleToMat(mat, coordShift, coordScale);
+        }
+      }
+
       if (
         model.renderable.getBuildTime().getMTime() >
         model.glyphBOBuildTime.getMTime()
@@ -674,7 +707,18 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
         model.glyphBOBuildTime.modified();
       }
     }
-    return superClass.buildBufferObjects(ren, actor);
+
+    superClass.buildBufferObjects(ren, actor);
+
+    // apply shift + scale to primitives AFTER vtkOpenGLPolyDataMapper.buildBufferObjects
+    // so that the Glyph3DMapper gets the last say in the shift + scale
+    if (useShiftAndScale) {
+      for (let i = primTypes.Start; i < primTypes.End; i++) {
+        model.primitives[i]
+          .getCABO()
+          .setCoordShiftAndScale(coordShift, coordScale);
+      }
+    }
   };
 }
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
The glyphmapper does not handle large coordinates, resulting in jittering

### Results
Large coordinates no longer jitter when using the glyph3dmapper

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Glyph3DMapper now applies a shift+scale when rendering large coordinates

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
