### PR TITLE
fix(VectorText): fix perLetterFaceColors

### DIFF
--- a/Sources/Rendering/Core/VectorText/Utils.js
+++ b/Sources/Rendering/Core/VectorText/Utils.js
@@ -459,7 +459,8 @@ function addTriangle(
     uvArray.push(uv[0], uv[1]);
   });
   if (colorArray && color) {
-    for (let i = 0; i < 3; ++i) colorArray.push(color[0], color[1], color[2]);
+    for (let i = 0; i < 3; ++i)
+      colorArray.push(color[0] * 255, color[1] * 255, color[2] * 255);
   }
 }
 
@@ -512,7 +513,8 @@ function addQuad(
   uvArray.push(uvs[3][0], uvs[3][1]);
 
   if (colorArray && color) {
-    for (let i = 0; i < 6; ++i) colorArray.push(color[0], color[1], color[2]);
+    for (let i = 0; i < 6; ++i)
+      colorArray.push(color[0] * 255, color[1] * 255, color[2] * 255);
   }
 }
 

--- a/Sources/Rendering/Core/VectorText/index.js
+++ b/Sources/Rendering/Core/VectorText/index.js
@@ -328,7 +328,7 @@ function vtkVectorText(publicAPI, model) {
     let letterIndex = 0;
     model.shapes.forEach((shape) => {
       let color = null;
-      if (typeof model.perLetterFaceColors === 'function') {
+      if (model.perLetterFaceColors) {
         color = model.perLetterFaceColors(letterIndex) || [1, 1, 1];
       }
       addShape(shape, offsetSize, color);
@@ -356,12 +356,12 @@ function vtkVectorText(publicAPI, model) {
     polyData.setPolys(cells);
 
     // Set points (vertices)
-    polyData.getPoints().setData(new Float32Array(model.verticesArray), 3);
+    polyData.getPoints().setData(Float32Array.from(model.verticesArray), 3);
 
     // Set texture coordinates
     const da = vtkDataArray.newInstance({
       numberOfComponents: 2,
-      values: new Float32Array(model.uvArray),
+      values: Float32Array.from(model.uvArray),
       name: 'TEXCOORD_0',
     });
     pointData.addArray(da);
@@ -371,7 +371,7 @@ function vtkVectorText(publicAPI, model) {
     if (model.colorArray && model.colorArray.length) {
       const ca = vtkDataArray.newInstance({
         numberOfComponents: 3,
-        values: new Float32Array(model.colorArray),
+        values: Uint8Array.from(model.colorArray),
         name: 'Colors',
       });
       pointData.addArray(ca);


### PR DESCRIPTION
fixes #3311

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ ] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
