### PR TITLE
3303 reuse previous output

### DIFF
--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -198,9 +198,10 @@ function vtkDataArray(publicAPI, model) {
     return false;
   };
 
-  // FIXME, to rename into "clear()" or "reset()"
+  // Restore the array to initial state
   publicAPI.initialize = () => {
     publicAPI.resize(0);
+    return publicAPI;
   };
 
   publicAPI.getElementComponentSize = () => model.values.BYTES_PER_ELEMENT;

--- a/Sources/Common/Core/Points/index.d.ts
+++ b/Sources/Common/Core/Points/index.d.ts
@@ -17,10 +17,20 @@ export interface vtkPoints extends vtkDataArray {
   computeBounds(): Bounds;
 
   /**
-   * Get the bounds for this mapper as [xmin, xmax, ymin, ymax,zmin, zmax].
+   * Get a copy of the bounds of the array.
+   * Bounds are [xmin, xmax, ymin, ymax,zmin, zmax].
+   * Will recompute the bounds if necessary.
    * @return {Bounds} The bounds for the mapper.
    */
   getBounds(): Bounds;
+
+  /**
+   * Get a reference to the model bounds of the array.
+   * Bounds are [xmin, xmax, ymin, ymax,zmin, zmax].
+   * Will recompute the bounds if necessary.
+   * @return {Bounds} The bounds for the mapper.
+   */
+  getBoundsByReference(): Bounds;
 
   /**
    * Get the coordinate of a point.

--- a/Sources/Common/Core/Points/index.js
+++ b/Sources/Common/Core/Points/index.js
@@ -1,16 +1,17 @@
 import macro from 'vtk.js/Sources/macros';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
+import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
 const { vtkErrorMacro } = macro;
-
-const INVALID_BOUNDS = [1, -1, 1, -1, 1, -1];
-
 // ----------------------------------------------------------------------------
 // vtkPoints methods
 // ----------------------------------------------------------------------------
 
 function vtkPoints(publicAPI, model) {
+  // Keep track of modified time for bounds computation
+  let boundMTime = 0;
+
   // Set our className
   model.classHierarchy.push('vtkPoints');
 
@@ -37,7 +38,24 @@ function vtkPoints(publicAPI, model) {
 
   publicAPI.insertPoint = (ptId, point) => publicAPI.insertTuple(ptId, point);
 
+  const superGetBounds = publicAPI.getBounds;
   publicAPI.getBounds = () => {
+    if (boundMTime < model.mtime) {
+      publicAPI.computeBounds();
+    }
+    return superGetBounds();
+  };
+
+  const superGetBoundsByReference = publicAPI.getBoundsByReference;
+  publicAPI.getBoundsByReference = () => {
+    if (boundMTime < model.mtime) {
+      publicAPI.computeBounds();
+    }
+    return superGetBoundsByReference();
+  };
+
+  // Trigger the computation of bounds
+  publicAPI.computeBounds = () => {
     if (publicAPI.getNumberOfComponents() === 3) {
       const xRange = publicAPI.getRange(0);
       model.bounds[0] = xRange[0];
@@ -48,30 +66,23 @@ function vtkPoints(publicAPI, model) {
       const zRange = publicAPI.getRange(2);
       model.bounds[4] = zRange[0];
       model.bounds[5] = zRange[1];
-      return model.bounds;
-    }
-
-    if (publicAPI.getNumberOfComponents() !== 2) {
+    } else if (publicAPI.getNumberOfComponents() === 2) {
+      const xRange = publicAPI.getRange(0);
+      model.bounds[0] = xRange[0];
+      model.bounds[1] = xRange[1];
+      const yRange = publicAPI.getRange(1);
+      model.bounds[2] = yRange[0];
+      model.bounds[3] = yRange[1];
+      model.bounds[4] = 0;
+      model.bounds[5] = 0;
+    } else {
       vtkErrorMacro(
         `getBounds called on an array with components of ${publicAPI.getNumberOfComponents()}`
       );
-      return INVALID_BOUNDS;
+      vtkMath.uninitializeBounds(model.bounds);
     }
-
-    const xRange = publicAPI.getRange(0);
-    model.bounds[0] = xRange[0];
-    model.bounds[1] = xRange[1];
-    const yRange = publicAPI.getRange(1);
-    model.bounds[2] = yRange[0];
-    model.bounds[3] = yRange[1];
-    model.bounds[4] = 0;
-    model.bounds[5] = 0;
-
-    return model.bounds;
+    boundMTime = macro.getCurrentGlobalMTime();
   };
-
-  // Trigger the computation of bounds
-  publicAPI.computeBounds = publicAPI.getBounds;
 
   // Initialize
   publicAPI.setNumberOfComponents(
@@ -96,6 +107,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   vtkDataArray.extend(publicAPI, model, initialValues);
+
+  macro.getArray(publicAPI, model, ['bounds'], 6);
   vtkPoints(publicAPI, model);
 }
 

--- a/Sources/Common/DataModel/BoundingBox/api.md
+++ b/Sources/Common/DataModel/BoundingBox/api.md
@@ -93,6 +93,10 @@ Return the Max Length of the box
 
 Return the length of the diagonal or null if not valid.
 
+### getDiagonalLength2(bounds[6]) : Number
+
+Return the squared length of the diagonal or null if not valid.
+
 ### inflate(bounds[6], delta)
 
 Expand the Box by delta on each side, the box will grow by

--- a/Sources/Common/DataModel/BoundingBox/index.d.ts
+++ b/Sources/Common/DataModel/BoundingBox/index.d.ts
@@ -1,6 +1,7 @@
 import { mat4 } from 'gl-matrix';
 import { Bounds, Vector2, Vector3 } from '../../../types';
 import vtkPoints from '../../Core/Points';
+import { Nullable } from '../../../types';
 
 /**
  * Tests whether two bounds equal.
@@ -176,10 +177,16 @@ export function getZRange(bounds: Bounds): Vector2;
 export function getMaxLength(bounds: Bounds): number;
 
 /**
- * Gets the diagonal of the bounding box.
+ * Gets the diagonal length of the bounding box.
  * @param {Bounds} bounds
  */
-export function getDiagonalLength(bounds: Bounds): number;
+export function getDiagonalLength(bounds: Bounds): Nullable<number>;
+
+/**
+ * Gets the squared diagonal length of the bounding box.
+ * @param {Bounds} bounds
+ */
+export function getDiagonalLength2(bounds: Bounds): Nullable<number>;
 
 /**
  * Gets the min point.
@@ -506,10 +513,16 @@ declare class BoundingBox {
   getMaxLength(bounds: Bounds): number;
 
   /**
-   * Gets the diagonal of the bounding box.
+   * Gets the diagonal length of the bounding box.
    * @param {Bounds} bounds
    */
-  getDiagonalLength(bounds: Bounds): number;
+  getDiagonalLength(bounds: Bounds): Nullable<number>;
+
+  /**
+   * Gets the squared diagonal length of the bounding box.
+   * @param {Bounds} bounds
+   */
+  getDiagonalLength2(bounds: Bounds): Nullable<number>;
 
   /**
    * Gets the min point.
@@ -674,6 +687,7 @@ declare const vtkBoundingBox: {
   getLengths: typeof getLengths;
   getMaxLength: typeof getMaxLength;
   getDiagonalLength: typeof getDiagonalLength;
+  getDiagonalLength2: typeof getDiagonalLength2;
   getMinPoint: typeof getMinPoint;
   getMaxPoint: typeof getMaxPoint;
   getXRange: typeof getXRange;

--- a/Sources/Common/DataModel/BoundingBox/index.js
+++ b/Sources/Common/DataModel/BoundingBox/index.js
@@ -259,12 +259,17 @@ export function getMaxLength(bounds) {
   return l[2];
 }
 
-export function getDiagonalLength(bounds) {
+export function getDiagonalLength2(bounds) {
   if (isValid(bounds)) {
     const l = getLengths(bounds);
-    return Math.sqrt(l[0] * l[0] + l[1] * l[1] + l[2] * l[2]);
+    return l[0] * l[0] + l[1] * l[1] + l[2] * l[2];
   }
   return null;
+}
+
+export function getDiagonalLength(bounds) {
+  const lenght2 = getDiagonalLength2(bounds);
+  return lenght2 !== null ? Math.sqrt(lenght2) : null;
 }
 
 export function getMinPoint(bounds) {
@@ -878,6 +883,10 @@ class BoundingBox {
 
   getDiagonalLength() {
     return getDiagonalLength(this.bounds);
+  }
+
+  getDiagonalLength2() {
+    return getDiagonalLength2(this.bounds);
   }
 
   getMinPoint() {

--- a/Sources/Common/DataModel/Cell/index.js
+++ b/Sources/Common/DataModel/Cell/index.js
@@ -1,5 +1,5 @@
 import macro from 'vtk.js/Sources/macros';
-import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
+import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 
 // ----------------------------------------------------------------------------
@@ -40,42 +40,15 @@ function vtkCell(publicAPI, model) {
     }
   };
 
-  publicAPI.getBounds = () => {
-    const nbPoints = model.points.getNumberOfPoints();
-    const x = [];
-    if (nbPoints) {
-      model.points.getPoint(0, x);
-      model.bounds[0] = x[0];
-      model.bounds[1] = x[0];
-      model.bounds[2] = x[1];
-      model.bounds[3] = x[1];
-      model.bounds[4] = x[2];
-      model.bounds[5] = x[2];
-
-      for (let i = 1; i < nbPoints; i++) {
-        model.points.getPoint(i, x);
-        model.bounds[0] = x[0] < model.bounds[0] ? x[0] : model.bounds[0];
-        model.bounds[1] = x[0] > model.bounds[1] ? x[0] : model.bounds[1];
-        model.bounds[2] = x[1] < model.bounds[2] ? x[1] : model.bounds[2];
-        model.bounds[3] = x[1] > model.bounds[3] ? x[1] : model.bounds[3];
-        model.bounds[4] = x[2] < model.bounds[4] ? x[2] : model.bounds[4];
-        model.bounds[5] = x[2] > model.bounds[5] ? x[2] : model.bounds[5];
-      }
-    } else {
-      vtkMath.uninitializeBounds(model.bounds);
-    }
-    return model.bounds;
-  };
+  publicAPI.getBounds = () => model.points.getBounds();
 
   publicAPI.getLength2 = () => {
-    publicAPI.getBounds();
-    let length = 0.0;
-    let diff = 0;
-    for (let i = 0; i < 3; i++) {
-      diff = model.bounds[2 * i + 1] - model.bounds[2 * i];
-      length += diff * diff;
-    }
-    return length;
+    const lengths = vtkBoundingBox.getLengths(publicAPI.getBounds());
+    return (
+      lengths[0] * lengths[0] +
+      lengths[1] * lengths[1] +
+      lengths[2] * lengths[2]
+    );
   };
 
   publicAPI.getParametricDistance = (pcoords) => {

--- a/Sources/Common/DataModel/DataSet/index.d.ts
+++ b/Sources/Common/DataModel/DataSet/index.d.ts
@@ -9,6 +9,13 @@ export interface IDataSetInitialValues {}
 
 export interface vtkDataSet extends vtkObject {
   /**
+   * Initialize the field, cell and point data.
+   * @see vtkDataSetAttributes::initialize()
+   * @see vtkFieldData::initialize()
+   */
+  initialize(): void;
+
+  /**
    * Get dataset's cell data
    */
   getCellData(): vtkDataSetAttributes;

--- a/Sources/Common/DataModel/DataSet/index.js
+++ b/Sources/Common/DataModel/DataSet/index.js
@@ -73,6 +73,11 @@ function vtkDataSet(publicAPI, model) {
         Math.max(mTime, model[fieldName]?.getMTime() ?? mTime),
       superGetMTime()
     );
+
+  publicAPI.initialize = () => {
+    DATASET_FIELDS.forEach((fieldName) => model[fieldName]?.initialize());
+    return publicAPI;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/DataSet/index.js
+++ b/Sources/Common/DataModel/DataSet/index.js
@@ -65,6 +65,14 @@ function vtkDataSet(publicAPI, model) {
       model[fieldName].shallowCopy(other.getReferenceByName(fieldName));
     });
   };
+
+  const superGetMTime = publicAPI.getMTime;
+  publicAPI.getMTime = () =>
+    DATASET_FIELDS.reduce(
+      (mTime, fieldName) =>
+        Math.max(mTime, model[fieldName]?.getMTime() ?? mTime),
+      superGetMTime()
+    );
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.d.ts
@@ -22,12 +22,16 @@ interface IArrayWithIndex {
 
 export interface vtkFieldData extends vtkObject {
   /**
-   *
+   * Initialize fields, clear flags and restore copy beahvior.
+   * @see initializeFields
+   * @see clearFieldFlags
+   * @see copyAllOn
    */
   initialize(): void;
 
   /**
-   *
+   * Delete all arrays and clear flags.
+   * @see initialize
    */
   initializeFields(): void;
 

--- a/Sources/Common/DataModel/DataSetAttributes/index.d.ts
+++ b/Sources/Common/DataModel/DataSetAttributes/index.d.ts
@@ -229,7 +229,8 @@ export interface vtkDataSetAttributes extends vtkFieldData {
   removeArrayByIndex(arrayIdx: number): void;
 
   /**
-   *
+   * Called when initialize() is called.
+   * @see initialize
    */
   initializeAttributeCopyFlags(): void;
 

--- a/Sources/Common/DataModel/ImageData/index.d.ts
+++ b/Sources/Common/DataModel/ImageData/index.d.ts
@@ -21,6 +21,13 @@ interface IComputeHistogram {
 
 export interface vtkImageData extends vtkDataSet {
   /**
+   * Reinitialize the state (direction, spacing, origin, extent, etc.)
+   * and the data set.
+   * @see vtkDataSet::initialize()
+   */
+  initialize(): void;
+
+  /**
    * Returns an object with `{ minimum, maximum, average, variance, sigma, count }`
    * of the imageData points found within the provided `worldBounds`.
    *

--- a/Sources/Common/DataModel/ImageData/index.js
+++ b/Sources/Common/DataModel/ImageData/index.js
@@ -393,6 +393,18 @@ function vtkImageData(publicAPI, model) {
       .getScalars()
       .getComponent(offsetIndex, comp);
   };
+
+  const superInitialize = publicAPI.initialize;
+  publicAPI.initialize = () => {
+    publicAPI.set({
+      direction: mat3.identity(model.direction),
+      spacing: [1.0, 1.0, 1.0],
+      origin: [0.0, 0.0, 0.0],
+      extent: [0, -1, 0, -1, 0, -1],
+      dataDescription: StructuredType.EMPTY,
+    });
+    return superInitialize();
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/PointSet/index.d.ts
+++ b/Sources/Common/DataModel/PointSet/index.d.ts
@@ -9,6 +9,12 @@ export interface IPointSetInitialValues extends IDataSetInitialValues {}
 
 export interface vtkPointSet extends vtkDataSet {
   /**
+   * Empty the points and initialize the data set and .
+   * @see vtkDataSet::initialize()
+   */
+  initialize(): void;
+
+  /**
    * Compute the (X, Y, Z) bounds of the data.
    */
   computeBounds(): void;

--- a/Sources/Common/DataModel/PointSet/index.js
+++ b/Sources/Common/DataModel/PointSet/index.js
@@ -42,6 +42,12 @@ function vtkPointSet(publicAPI, model) {
     const mTime = superGetMTime();
     return Math.max(mTime, model.points?.getMTime() ?? mTime);
   };
+
+  const superInitialize = publicAPI.initialize;
+  publicAPI.initialize = () => {
+    model.points?.initialize();
+    return superInitialize();
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/PointSet/index.js
+++ b/Sources/Common/DataModel/PointSet/index.js
@@ -36,6 +36,12 @@ function vtkPointSet(publicAPI, model) {
     model.points = vtkPoints.newInstance();
     model.points.shallowCopy(other.getPoints());
   };
+
+  const superGetMTime = publicAPI.getMTime;
+  publicAPI.getMTime = () => {
+    const mTime = superGetMTime();
+    return Math.max(mTime, model.points?.getMTime() ?? mTime);
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Common/DataModel/PolyData/index.d.ts
+++ b/Sources/Common/DataModel/PolyData/index.d.ts
@@ -9,6 +9,12 @@ export interface IPolyDataInitialValues extends IPointSetInitialValues {}
 
 export interface vtkPolyData extends vtkPointSet {
   /**
+   * Empty the cells and initialize the point set.
+   * @see vtkPointSet::initialize()
+   */
+  initialize(): void;
+
+  /**
    * Create data structure that allows random access of cells.
    */
   buildCells(): void;

--- a/Sources/Common/DataModel/PolyData/index.js
+++ b/Sources/Common/DataModel/PolyData/index.js
@@ -65,6 +65,12 @@ function vtkPolyData(publicAPI, model) {
       superGetMTime()
     );
 
+  const superInitialize = publicAPI.initialize;
+  publicAPI.initialize = () => {
+    POLYDATA_FIELDS.forEach((type) => model[type]?.initialize());
+    return superInitialize();
+  };
+
   publicAPI.buildCells = () => {
     // here are the number of cells we have
     const nVerts = publicAPI.getNumberOfVerts();

--- a/Sources/Common/DataModel/PolyData/index.js
+++ b/Sources/Common/DataModel/PolyData/index.js
@@ -58,6 +58,13 @@ function vtkPolyData(publicAPI, model) {
     });
   };
 
+  const superGetMTime = publicAPI.getMTime;
+  publicAPI.getMTime = () =>
+    POLYDATA_FIELDS.reduce(
+      (mTime, type) => Math.max(mTime, model[type]?.getMTime() ?? mTime),
+      superGetMTime()
+    );
+
   publicAPI.buildCells = () => {
     // here are the number of cells we have
     const nVerts = publicAPI.getNumberOfVerts();

--- a/Sources/Filters/Core/Cutter/index.js
+++ b/Sources/Filters/Core/Cutter/index.js
@@ -314,7 +314,7 @@ function vtkCutter(publicAPI, model) {
       return;
     }
 
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
 
     dataSetCutter(input, output);
 

--- a/Sources/Filters/Core/Cutter/index.js
+++ b/Sources/Filters/Core/Cutter/index.js
@@ -314,7 +314,7 @@ function vtkCutter(publicAPI, model) {
       return;
     }
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     dataSetCutter(input, output);
 

--- a/Sources/Filters/Core/PolyDataNormals/index.js
+++ b/Sources/Filters/Core/PolyDataNormals/index.js
@@ -98,7 +98,7 @@ function vtkPolyDataNormals(publicAPI, model) {
       return;
     }
 
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
 
     output.setPoints(input.getPoints());
     output.setVerts(input.getVerts());

--- a/Sources/Filters/Core/PolyDataNormals/index.js
+++ b/Sources/Filters/Core/PolyDataNormals/index.js
@@ -98,7 +98,7 @@ function vtkPolyDataNormals(publicAPI, model) {
       return;
     }
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     output.setPoints(input.getPoints());
     output.setVerts(input.getVerts());

--- a/Sources/Filters/Core/ThresholdPoints/index.js
+++ b/Sources/Filters/Core/ThresholdPoints/index.js
@@ -51,7 +51,7 @@ function vtkThresholdPoints(publicAPI, model) {
 
   publicAPI.requestData = (inData, outData) => {
     const input = inData[0];
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     outData[0] = output;
 
     if (model.criterias.length === 0) {
@@ -210,8 +210,6 @@ function vtkThresholdPoints(publicAPI, model) {
         })
       );
     });
-
-    outData[0] = output;
   };
 }
 

--- a/Sources/Filters/Core/ThresholdPoints/index.js
+++ b/Sources/Filters/Core/ThresholdPoints/index.js
@@ -51,7 +51,7 @@ function vtkThresholdPoints(publicAPI, model) {
 
   publicAPI.requestData = (inData, outData) => {
     const input = inData[0];
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     outData[0] = output;
 
     if (model.criterias.length === 0) {

--- a/Sources/Filters/General/AppendPolyData/index.js
+++ b/Sources/Filters/General/AppendPolyData/index.js
@@ -46,7 +46,10 @@ function vtkAppendPolyData(publicAPI, model) {
     }
 
     // Allocate output
-    const output = vtkPolyData.newInstance();
+    const output =
+      outData[0] && inData[0] !== outData[0]
+        ? outData[0]
+        : vtkPolyData.newInstance();
 
     let numPts = 0;
     let pointType = 0;

--- a/Sources/Filters/General/AppendPolyData/index.js
+++ b/Sources/Filters/General/AppendPolyData/index.js
@@ -48,7 +48,7 @@ function vtkAppendPolyData(publicAPI, model) {
     // Allocate output
     const output =
       outData[0] && inData[0] !== outData[0]
-        ? outData[0]
+        ? outData[0].initialize()
         : vtkPolyData.newInstance();
 
     let numPts = 0;

--- a/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
+++ b/Sources/Filters/General/AppendPolyData/test/testAppendPolyData.js
@@ -135,7 +135,6 @@ test.onlyIfWebGL('Test vtkAppendPolyData rendering', (t) => {
 
   const plane = vtkPlaneSource.newInstance({ xResolution: 5, yResolution: 10 });
   calc.setInputConnection(plane.getOutputPort());
-  const planeData = calc.getOutputData();
   const plane2 = vtkPlaneSource.newInstance({
     xResolution: 10,
     yResolution: 5,
@@ -143,11 +142,13 @@ test.onlyIfWebGL('Test vtkAppendPolyData rendering', (t) => {
   plane2.setOrigin(0.5, 0, -0.5);
   plane2.setPoint1(0.5, 0, 0.5);
   plane2.setPoint2(0.5, 1, -0.5);
-  calc.setInputConnection(plane2.getOutputPort());
+  const calc2 = vtkCalculator.newInstance();
+  calc2.setFormula(calc.getFormula());
+  calc2.setInputConnection(plane2.getOutputPort());
 
   const filter = vtkAppendPolyData.newInstance();
-  filter.setInputConnection(calc.getOutputPort());
-  filter.addInputData(planeData);
+  filter.setInputConnection(calc2.getOutputPort());
+  filter.addInputConnection(calc.getOutputPort());
   mapper.setInputConnection(filter.getOutputPort());
 
   // now create something to view it, in this case webgl

--- a/Sources/Filters/General/Calculator/index.js
+++ b/Sources/Filters/General/Calculator/index.js
@@ -265,7 +265,7 @@ function vtkCalculator(publicAPI, model) {
     const arraySpec = model.formula.getArrays(inData);
 
     const newDataSet =
-      outData[0] || vtk({ vtkClass: inData[0].getClassName() });
+      outData[0]?.initialize() || vtk({ vtkClass: inData[0].getClassName() });
     newDataSet.shallowCopy(inData[0]);
     outData[0] = newDataSet;
 

--- a/Sources/Filters/General/Calculator/index.js
+++ b/Sources/Filters/General/Calculator/index.js
@@ -264,7 +264,8 @@ function vtkCalculator(publicAPI, model) {
 
     const arraySpec = model.formula.getArrays(inData);
 
-    const newDataSet = vtk({ vtkClass: inData[0].getClassName() });
+    const newDataSet =
+      outData[0] || vtk({ vtkClass: inData[0].getClassName() });
     newDataSet.shallowCopy(inData[0]);
     outData[0] = newDataSet;
 

--- a/Sources/Filters/General/ClipClosedSurface/index.js
+++ b/Sources/Filters/General/ClipClosedSurface/index.js
@@ -622,7 +622,7 @@ function vtkClipClosedSurface(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     // implement requestData
     const input = inData[0];
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     outData[0] = output;
 
     if (!input) {
@@ -1054,7 +1054,6 @@ function vtkClipClosedSurface(publicAPI, model) {
     squeezeOutputPoints(output, points, pointData, inputPointsType);
     // TODO: Check
     // output.squeeze();
-    outData[0] = output;
   };
 
   Object.keys(ScalarMode).forEach((key) => {

--- a/Sources/Filters/General/ClipClosedSurface/index.js
+++ b/Sources/Filters/General/ClipClosedSurface/index.js
@@ -622,7 +622,7 @@ function vtkClipClosedSurface(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     // implement requestData
     const input = inData[0];
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     outData[0] = output;
 
     if (!input) {

--- a/Sources/Filters/General/ClosedPolyLineToSurfaceFilter/index.js
+++ b/Sources/Filters/General/ClosedPolyLineToSurfaceFilter/index.js
@@ -130,7 +130,7 @@ function vtkClosedPolyLineToSurfaceFilter(publicAPI, model) {
       return;
     }
 
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     output.shallowCopy(input);
 
     // Extract faces

--- a/Sources/Filters/General/ClosedPolyLineToSurfaceFilter/index.js
+++ b/Sources/Filters/General/ClosedPolyLineToSurfaceFilter/index.js
@@ -130,7 +130,7 @@ function vtkClosedPolyLineToSurfaceFilter(publicAPI, model) {
       return;
     }
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     output.shallowCopy(input);
 
     // Extract faces

--- a/Sources/Filters/General/ContourLoopExtraction/index.js
+++ b/Sources/Filters/General/ContourLoopExtraction/index.js
@@ -12,10 +12,8 @@ function vtkContourLoopExtraction(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     const [input] = inData;
 
-    if (!outData[0]) {
-      outData[0] = vtkPolyData.newInstance();
-    }
-    const [output] = outData;
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
+    outData[0] = output;
     publicAPI.extractContours(input, output);
     output.modified();
   };

--- a/Sources/Filters/General/ContourTriangulator/index.js
+++ b/Sources/Filters/General/ContourTriangulator/index.js
@@ -210,8 +210,8 @@ function vtkContourTriangulator(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     // implement requestData
     const input = inData[0];
-    // FIXME: do not instantiate a new polydata each time the filter is executed.
-    const output = outData[0] || vtkPolyData.newInstance();
+
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     outData[0] = output;
 
     if (!input) {

--- a/Sources/Filters/General/ContourTriangulator/index.js
+++ b/Sources/Filters/General/ContourTriangulator/index.js
@@ -211,7 +211,7 @@ function vtkContourTriangulator(publicAPI, model) {
     // implement requestData
     const input = inData[0];
     // FIXME: do not instantiate a new polydata each time the filter is executed.
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     outData[0] = output;
 
     if (!input) {

--- a/Sources/Filters/General/ImageCropFilter/index.js
+++ b/Sources/Filters/General/ImageCropFilter/index.js
@@ -31,6 +31,8 @@ function vtkImageCropFilter(publicAPI, model) {
       vtkErrorMacro('Invalid or missing input');
       return;
     }
+    const outImage = outData[0]?.initialize() || vtkImageData.newInstance();
+    outData[0] = outImage;
 
     const scalars = input.getPointData().getScalars();
 
@@ -60,9 +62,7 @@ function vtkImageCropFilter(publicAPI, model) {
       cropped[4] === extent[4] &&
       cropped[5] === extent[5]
     ) {
-      const sameAsInput = vtkImageData.newInstance();
-      sameAsInput.shallowCopy(input); // Force new mtime
-      outData[0] = sameAsInput;
+      outImage.shallowCopy(input); // Force new mtime
       return;
     }
 
@@ -111,7 +111,6 @@ function vtkImageCropFilter(publicAPI, model) {
         index += slice.length;
       }
     }
-    const outImage = outData[0] || vtkImageData.newInstance();
     outImage.setExtent(cropped);
     outImage.setOrigin(input.getOrigin());
     outImage.setSpacing(input.getSpacing());
@@ -124,8 +123,6 @@ function vtkImageCropFilter(publicAPI, model) {
     });
 
     outImage.getPointData().setScalars(croppedScalars);
-
-    outData[0] = outImage;
   };
 
   publicAPI.isResetAvailable = () => {

--- a/Sources/Filters/General/ImageCropFilter/index.js
+++ b/Sources/Filters/General/ImageCropFilter/index.js
@@ -111,12 +111,11 @@ function vtkImageCropFilter(publicAPI, model) {
         index += slice.length;
       }
     }
-    const outImage = vtkImageData.newInstance({
-      extent: cropped,
-      origin: input.getOrigin(),
-      direction: input.getDirection(),
-      spacing: input.getSpacing(),
-    });
+    const outImage = outData[0] || vtkImageData.newInstance();
+    outImage.setExtent(cropped);
+    outImage.setOrigin(input.getOrigin());
+    outImage.setSpacing(input.getSpacing());
+    outImage.setDirection(input.getDirection());
 
     const croppedScalars = vtkDataArray.newInstance({
       name: scalars.getName(),

--- a/Sources/Filters/General/ImageMarchingCubes/index.js
+++ b/Sources/Filters/General/ImageMarchingCubes/index.js
@@ -341,7 +341,7 @@ function vtkImageMarchingCubes(publicAPI, model) {
     edgeLocator.initialize();
 
     // Update output
-    const polydata = vtkPolyData.newInstance();
+    const polydata = outData[0] || vtkPolyData.newInstance();
     polydata.getPoints().setData(new Float32Array(pBuffer), 3);
     polydata.getPolys().setData(new Uint32Array(tBuffer));
     if (model.computeNormals) {

--- a/Sources/Filters/General/ImageMarchingCubes/index.js
+++ b/Sources/Filters/General/ImageMarchingCubes/index.js
@@ -341,7 +341,7 @@ function vtkImageMarchingCubes(publicAPI, model) {
     edgeLocator.initialize();
 
     // Update output
-    const polydata = outData[0] || vtkPolyData.newInstance();
+    const polydata = outData[0]?.initialize() || vtkPolyData.newInstance();
     polydata.getPoints().setData(new Float32Array(pBuffer), 3);
     polydata.getPolys().setData(new Uint32Array(tBuffer));
     if (model.computeNormals) {

--- a/Sources/Filters/General/ImageMarchingSquares/index.js
+++ b/Sources/Filters/General/ImageMarchingSquares/index.js
@@ -260,7 +260,7 @@ function vtkImageMarchingSquares(publicAPI, model) {
     }
 
     // Update output
-    const polydata = outData[0] || vtkPolyData.newInstance();
+    const polydata = outData[0]?.initialize() || vtkPolyData.newInstance();
     polydata.getPoints().setData(new Float32Array(points), 3);
     polydata.getLines().setData(new Uint32Array(lines));
     outData[0] = polydata;

--- a/Sources/Filters/General/ImageMarchingSquares/index.js
+++ b/Sources/Filters/General/ImageMarchingSquares/index.js
@@ -260,7 +260,7 @@ function vtkImageMarchingSquares(publicAPI, model) {
     }
 
     // Update output
-    const polydata = vtkPolyData.newInstance();
+    const polydata = outData[0] || vtkPolyData.newInstance();
     polydata.getPoints().setData(new Float32Array(points), 3);
     polydata.getLines().setData(new Uint32Array(lines));
     outData[0] = polydata;

--- a/Sources/Filters/General/ImageOutlineFilter/index.js
+++ b/Sources/Filters/General/ImageOutlineFilter/index.js
@@ -19,7 +19,7 @@ function vtkImageOutlineFilter(publicAPI, model) {
       return;
     }
 
-    const output = outData[0] || vtkImageData.newInstance();
+    const output = outData[0]?.initialize() || vtkImageData.newInstance();
     output.set(input.get('spacing', 'origin', 'direction'));
 
     const getIndex = (point, dims) =>

--- a/Sources/Filters/General/ImageOutlineFilter/index.js
+++ b/Sources/Filters/General/ImageOutlineFilter/index.js
@@ -19,9 +19,8 @@ function vtkImageOutlineFilter(publicAPI, model) {
       return;
     }
 
-    const output = vtkImageData.newInstance(
-      input.get('spacing', 'origin', 'direction')
-    );
+    const output = outData[0] || vtkImageData.newInstance();
+    output.set(input.get('spacing', 'origin', 'direction'));
 
     const getIndex = (point, dims) =>
       point[0] + point[1] * dims[0] + point[2] * dims[0] * dims[1];

--- a/Sources/Filters/General/ImageSliceFilter/index.js
+++ b/Sources/Filters/General/ImageSliceFilter/index.js
@@ -45,7 +45,8 @@ function vtkImageSliceFilter(publicAPI, model) {
       values: sliceRawArray,
     });
 
-    const output = vtkImageData.newInstance(datasetDefinition);
+    const output = outData[0] || vtkImageData.newInstance();
+    output.set(datasetDefinition);
     output.getPointData().setScalars(sliceArray);
 
     outData[0] = output;

--- a/Sources/Filters/General/ImageSliceFilter/index.js
+++ b/Sources/Filters/General/ImageSliceFilter/index.js
@@ -45,7 +45,7 @@ function vtkImageSliceFilter(publicAPI, model) {
       values: sliceRawArray,
     });
 
-    const output = outData[0] || vtkImageData.newInstance();
+    const output = outData[0]?.initialize() || vtkImageData.newInstance();
     output.set(datasetDefinition);
     output.getPointData().setScalars(sliceArray);
 

--- a/Sources/Filters/General/ImageStreamline/example/index.js
+++ b/Sources/Filters/General/ImageStreamline/example/index.js
@@ -49,39 +49,36 @@ const vecSource = macro.newInstance((publicAPI, model) => {
   macro.obj(publicAPI, model); // make it an object
   macro.algo(publicAPI, model, 0, 1); // mixin algorithm code 1 in, 1 out
   publicAPI.requestData = (inData, outData) => {
-    // implement requestData
-    if (!outData[0]) {
-      const id = vtkImageData.newInstance();
-      id.setSpacing(0.1, 0.1, 0.1);
-      id.setExtent(0, 9, 0, 9, 0, 9);
-      const dims = [10, 10, 10];
+    const id = outData[0]?.initialize() || vtkImageData.newInstance();
+    id.setSpacing(0.1, 0.1, 0.1);
+    id.setExtent(0, 9, 0, 9, 0, 9);
+    const dims = [10, 10, 10];
 
-      const newArray = new Float32Array(3 * dims[0] * dims[1] * dims[2]);
+    const newArray = new Float32Array(3 * dims[0] * dims[1] * dims[2]);
 
-      let i = 0;
-      for (let z = 0; z <= 9; z++) {
-        for (let y = 0; y <= 9; y++) {
-          for (let x = 0; x <= 9; x++) {
-            newArray[i++] = 0.1 * x;
-            const v = 0.1 * y;
-            newArray[i++] = v * v;
-            newArray[i++] = 0;
-          }
+    let i = 0;
+    for (let z = 0; z <= 9; z++) {
+      for (let y = 0; y <= 9; y++) {
+        for (let x = 0; x <= 9; x++) {
+          newArray[i++] = 0.1 * x;
+          const v = 0.1 * y;
+          newArray[i++] = v * v;
+          newArray[i++] = 0;
         }
       }
-
-      const da = vtkDataArray.newInstance({
-        numberOfComponents: 3,
-        values: newArray,
-      });
-      da.setName('vectors');
-
-      const cpd = id.getPointData();
-      cpd.setVectors(da);
-
-      // Update output
-      outData[0] = id;
     }
+
+    const da = vtkDataArray.newInstance({
+      numberOfComponents: 3,
+      values: newArray,
+    });
+    da.setName('vectors');
+
+    const cpd = id.getPointData();
+    cpd.setVectors(da);
+
+    // Update output
+    outData[0] = id;
   };
 })();
 

--- a/Sources/Filters/General/ImageStreamline/index.js
+++ b/Sources/Filters/General/ImageStreamline/index.js
@@ -262,7 +262,7 @@ function vtkImageStreamline(publicAPI, model) {
       offset2 += data[0].length;
     });
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     output.getPoints().setData(pointArray, 3);
     output.getLines().setData(cellArray);
 

--- a/Sources/Filters/General/ImageStreamline/index.js
+++ b/Sources/Filters/General/ImageStreamline/index.js
@@ -262,7 +262,7 @@ function vtkImageStreamline(publicAPI, model) {
       offset2 += data[0].length;
     });
 
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     output.getPoints().setData(pointArray, 3);
     output.getLines().setData(cellArray);
 

--- a/Sources/Filters/General/ImageStreamline/test/testStreamline.js
+++ b/Sources/Filters/General/ImageStreamline/test/testStreamline.js
@@ -10,39 +10,36 @@ const vecSource = macro.newInstance((publicAPI, model) => {
   macro.obj(publicAPI, model); // make it an object
   macro.algo(publicAPI, model, 0, 1); // mixin algorithm code 1 in, 1 out
   publicAPI.requestData = (inData, outData) => {
-    // implement requestData
-    if (!outData[0]) {
-      const id = vtkImageData.newInstance();
-      id.setSpacing(0.1, 0.1, 0.1);
-      id.setExtent(0, 9, 0, 9, 0, 9);
-      const dims = [10, 10, 10];
+    const id = outData[0]?.initialize() || vtkImageData.newInstance();
+    id.setSpacing(0.1, 0.1, 0.1);
+    id.setExtent(0, 9, 0, 9, 0, 9);
+    const dims = [10, 10, 10];
 
-      const newArray = new Float32Array(3 * dims[0] * dims[1] * dims[2]);
+    const newArray = new Float32Array(3 * dims[0] * dims[1] * dims[2]);
 
-      let i = 0;
-      for (let z = 0; z <= 9; z++) {
-        for (let y = 0; y <= 9; y++) {
-          for (let x = 0; x <= 9; x++) {
-            newArray[i++] = 0.1 * x;
-            const v = 0.1 * y;
-            newArray[i++] = v * v;
-            newArray[i++] = 0;
-          }
+    let i = 0;
+    for (let z = 0; z <= 9; z++) {
+      for (let y = 0; y <= 9; y++) {
+        for (let x = 0; x <= 9; x++) {
+          newArray[i++] = 0.1 * x;
+          const v = 0.1 * y;
+          newArray[i++] = v * v;
+          newArray[i++] = 0;
         }
       }
-
-      const da = vtkDataArray.newInstance({
-        numberOfComponents: 3,
-        values: newArray,
-      });
-      da.setName('vectors');
-
-      const cpd = id.getPointData();
-      cpd.setVectors(da);
-
-      // Update output
-      outData[0] = id;
     }
+
+    const da = vtkDataArray.newInstance({
+      numberOfComponents: 3,
+      values: newArray,
+    });
+    da.setName('vectors');
+
+    const cpd = id.getPointData();
+    cpd.setVectors(da);
+
+    // Update output
+    outData[0] = id;
   };
 })();
 

--- a/Sources/Filters/General/LineFilter/index.js
+++ b/Sources/Filters/General/LineFilter/index.js
@@ -10,7 +10,7 @@ function vtkLineFilter(publicAPI, model) {
   model.classHierarchy.push('vtkLineFilter');
 
   publicAPI.requestData = (inData, outData) => {
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     dataset.getPoints().setData(inData[0].getPoints().getData());
     dataset.getLines().setData(inData[0].getLines().getData());

--- a/Sources/Filters/General/LineFilter/index.js
+++ b/Sources/Filters/General/LineFilter/index.js
@@ -10,7 +10,7 @@ function vtkLineFilter(publicAPI, model) {
   model.classHierarchy.push('vtkLineFilter');
 
   publicAPI.requestData = (inData, outData) => {
-    const dataset = vtkPolyData.newInstance();
+    const dataset = outData[0] || vtkPolyData.newInstance();
 
     dataset.getPoints().setData(inData[0].getPoints().getData());
     dataset.getLines().setData(inData[0].getLines().getData());

--- a/Sources/Filters/General/MoleculeToRepresentation/index.js
+++ b/Sources/Filters/General/MoleculeToRepresentation/index.js
@@ -62,8 +62,8 @@ function vtkMoleculeToRepresentation(publicAPI, model) {
     }
 
     // output
-    const SphereData = outData[0] || vtkPolyData.newInstance();
-    const StickData = outData[1] || vtkPolyData.newInstance();
+    const SphereData = outData[0]?.initialize() || vtkPolyData.newInstance();
+    const StickData = outData[1]?.initialize() || vtkPolyData.newInstance();
 
     // Fetch from input molecule data
     let numPts = 0;

--- a/Sources/Filters/General/MoleculeToRepresentation/index.js
+++ b/Sources/Filters/General/MoleculeToRepresentation/index.js
@@ -62,8 +62,8 @@ function vtkMoleculeToRepresentation(publicAPI, model) {
     }
 
     // output
-    const SphereData = vtkPolyData.newInstance();
-    const StickData = vtkPolyData.newInstance();
+    const SphereData = outData[0] || vtkPolyData.newInstance();
+    const StickData = outData[1] || vtkPolyData.newInstance();
 
     // Fetch from input molecule data
     let numPts = 0;

--- a/Sources/Filters/General/OutlineFilter/index.js
+++ b/Sources/Filters/General/OutlineFilter/index.js
@@ -49,7 +49,7 @@ function vtkOutlineFilter(publicAPI, model) {
     }
 
     const bounds = input.getBounds();
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
 
     output
       .getPoints()

--- a/Sources/Filters/General/OutlineFilter/index.js
+++ b/Sources/Filters/General/OutlineFilter/index.js
@@ -49,7 +49,7 @@ function vtkOutlineFilter(publicAPI, model) {
     }
 
     const bounds = input.getBounds();
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     output
       .getPoints()

--- a/Sources/Filters/General/ScalarToRGBA/index.js
+++ b/Sources/Filters/General/ScalarToRGBA/index.js
@@ -63,7 +63,8 @@ function vtkScalarToRGBA(publicAPI, model) {
       'origin',
       'direction'
     );
-    const output = vtkImageData.newInstance(datasetDefinition);
+    const output = outData[0] || vtkImageData.newInstance();
+    output.set(datasetDefinition);
     output.getPointData().setScalars(colorArray);
 
     outData[0] = output;

--- a/Sources/Filters/General/ScalarToRGBA/index.js
+++ b/Sources/Filters/General/ScalarToRGBA/index.js
@@ -63,7 +63,7 @@ function vtkScalarToRGBA(publicAPI, model) {
       'origin',
       'direction'
     );
-    const output = outData[0] || vtkImageData.newInstance();
+    const output = outData[0]?.initialize() || vtkImageData.newInstance();
     output.set(datasetDefinition);
     output.getPointData().setScalars(colorArray);
 

--- a/Sources/Filters/General/ShrinkPolyData/index.js
+++ b/Sources/Filters/General/ShrinkPolyData/index.js
@@ -325,7 +325,7 @@ function vtkShrinkPolyData(publicAPI, model) {
 
   publicAPI.requestData = (inData, outData) => {
     const input = inData[0];
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     if (!input) {
       vtkErrorMacro('No input!');

--- a/Sources/Filters/General/TransformPolyDataFilter/index.js
+++ b/Sources/Filters/General/TransformPolyDataFilter/index.js
@@ -155,7 +155,7 @@ function vtkTransformPolyDataFilter(publicAPI, model) {
 
   publicAPI.requestData = (inData, outData) => {
     const input = inData[0];
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     if (transformPolyData(input, output)) {
       outData[0] = output;

--- a/Sources/Filters/General/TriangleFilter/index.js
+++ b/Sources/Filters/General/TriangleFilter/index.js
@@ -80,7 +80,7 @@ function vtkTriangleFilter(publicAPI, model) {
       }
     }
 
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
     dataset
       .getPoints()
       .setData(macro.newTypedArrayFrom(pointsDataType, newPoints));

--- a/Sources/Filters/General/TriangleFilter/index.js
+++ b/Sources/Filters/General/TriangleFilter/index.js
@@ -80,7 +80,7 @@ function vtkTriangleFilter(publicAPI, model) {
       }
     }
 
-    const dataset = vtkPolyData.newInstance();
+    const dataset = outData[0] || vtkPolyData.newInstance();
     dataset
       .getPoints()
       .setData(macro.newTypedArrayFrom(pointsDataType, newPoints));

--- a/Sources/Filters/General/TubeFilter/index.js
+++ b/Sources/Filters/General/TubeFilter/index.js
@@ -605,7 +605,7 @@ function vtkTubeFilter(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     // implement requestData
     // pass through for now
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     outData[0] = output;
 
     const input = inData[0];
@@ -849,7 +849,6 @@ function vtkTubeFilter(publicAPI, model) {
     output.setStrips(newStrips);
     output.setPointData(outPD);
     outPD.setNormals(newNormals);
-    outData[0] = output;
   };
 }
 

--- a/Sources/Filters/General/TubeFilter/index.js
+++ b/Sources/Filters/General/TubeFilter/index.js
@@ -605,7 +605,7 @@ function vtkTubeFilter(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
     // implement requestData
     // pass through for now
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     outData[0] = output;
 
     const input = inData[0];

--- a/Sources/Filters/General/WarpScalar/example/index.js
+++ b/Sources/Filters/General/WarpScalar/example/index.js
@@ -55,21 +55,19 @@ const randFilter = macro.newInstance((publicAPI, model) => {
   macro.obj(publicAPI, model); // make it an object
   macro.algo(publicAPI, model, 1, 1); // mixin algorithm code 1 in, 1 out
   publicAPI.requestData = (inData, outData) => {
-    // implement requestData
-    if (!outData[0] || inData[0].getMTime() > outData[0].getMTime()) {
-      const newArray = new Float32Array(
-        inData[0].getPoints().getNumberOfPoints()
-      );
-      for (let i = 0; i < newArray.length; i++) {
-        newArray[i] = i % 2 ? 1 : 0;
-      }
-
-      const da = vtkDataArray.newInstance({ name: 'spike', values: newArray });
-      const newDataSet = vtk({ vtkClass: inData[0].getClassName() });
-      newDataSet.shallowCopy(inData[0]);
-      newDataSet.getPointData().setScalars(da);
-      outData[0] = newDataSet;
+    const newArray = new Float32Array(
+      inData[0].getPoints().getNumberOfPoints()
+    );
+    for (let i = 0; i < newArray.length; i++) {
+      newArray[i] = i % 2 ? 1 : 0;
     }
+
+    const da = vtkDataArray.newInstance({ name: 'spike', values: newArray });
+    const newDataSet =
+      outData[0]?.initialize() || vtk({ vtkClass: inData[0].getClassName() });
+    newDataSet.shallowCopy(inData[0]);
+    newDataSet.getPointData().setScalars(da);
+    outData[0] = newDataSet;
   };
 })();
 

--- a/Sources/Filters/General/WarpScalar/index.js
+++ b/Sources/Filters/General/WarpScalar/index.js
@@ -82,7 +82,10 @@ function vtkWarpScalar(publicAPI, model) {
         inPoints[ptOffset + 2] + model.scaleFactor * s * n[2];
     }
 
-    const newDataSet = outData[0] || vtk({ vtkClass: input.getClassName() });
+    const newDataSet =
+      outData[0] && outData[0] !== inData[0]
+        ? outData[0].initialize()
+        : vtk({ vtkClass: input.getClassName() });
     newDataSet.shallowCopy(input);
     const points = vtkPoints.newInstance();
     points.setData(newPtsData, 3);

--- a/Sources/Filters/General/WarpScalar/index.js
+++ b/Sources/Filters/General/WarpScalar/index.js
@@ -82,7 +82,7 @@ function vtkWarpScalar(publicAPI, model) {
         inPoints[ptOffset + 2] + model.scaleFactor * s * n[2];
     }
 
-    const newDataSet = vtk({ vtkClass: input.getClassName() });
+    const newDataSet = outData[0] || vtk({ vtkClass: input.getClassName() });
     newDataSet.shallowCopy(input);
     const points = vtkPoints.newInstance();
     points.setData(newPtsData, 3);

--- a/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
+++ b/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
@@ -624,7 +624,7 @@ function vtkWindowedSincPolyDataFilter(publicAPI, model) {
     if (!input) {
       return;
     }
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
 
     const outputPoints = publicAPI.vtkWindowedSincPolyDataFilterExecute(
       input.getPoints(),

--- a/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
+++ b/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
@@ -624,7 +624,7 @@ function vtkWindowedSincPolyDataFilter(publicAPI, model) {
     if (!input) {
       return;
     }
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     const outputPoints = publicAPI.vtkWindowedSincPolyDataFilterExecute(
       input.getPoints(),

--- a/Sources/Filters/Sources/ArcSource/index.js
+++ b/Sources/Filters/Sources/ArcSource/index.js
@@ -21,7 +21,7 @@ function vtkArcSource(publicAPI, model) {
     const numPts = model.resolution + 1;
     const tc = [0.0, 0.0];
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     let angle = 0.0;
     let radius = 0.5;

--- a/Sources/Filters/Sources/Arrow2DSource/index.js
+++ b/Sources/Filters/Sources/Arrow2DSource/index.js
@@ -9,9 +9,7 @@ const { ShapeType } = Constants;
 // vtkArrow2DSource methods
 // ----------------------------------------------------------------------------
 
-function vtkStarSource(publicAPI, model) {
-  const dataset = vtkPolyData.newInstance();
-
+function vtkStarSource(publicAPI, model, dataset) {
   const points = macro.newTypedArray(model.pointType, 10 * 3);
   const edges = new Uint32Array(11);
   edges[0] = 10;
@@ -30,9 +28,7 @@ function vtkStarSource(publicAPI, model) {
   return dataset;
 }
 
-function vtk6PointsArrow(publicAPI, model) {
-  const dataset = vtkPolyData.newInstance();
-
+function vtk6PointsArrow(publicAPI, model, dataset) {
   const points = macro.newTypedArray(model.pointType, 6 * 3);
 
   const thickOp = model.height * 0.5 * model.thickness;
@@ -84,9 +80,7 @@ function vtk6PointsArrow(publicAPI, model) {
   return dataset;
 }
 
-function vtk4PointsArrow(publicAPI, model) {
-  const dataset = vtkPolyData.newInstance();
-
+function vtk4PointsArrow(publicAPI, model, dataset) {
   const points = macro.newTypedArray(model.pointType, 4 * 3);
 
   const thickOp = (model.height / 3) * model.thickness;
@@ -121,9 +115,7 @@ function vtk4PointsArrow(publicAPI, model) {
   return dataset;
 }
 
-function vtkTriangleSource(publicAPI, model) {
-  const dataset = vtkPolyData.newInstance();
-
+function vtkTriangleSource(publicAPI, model, dataset) {
   const points = macro.newTypedArray(model.pointType, 3 * 3);
 
   const baseOffsetOp = model.height * (1 - model.base);
@@ -157,7 +149,8 @@ function vtkArrow2DSource(publicAPI, model) {
   };
 
   publicAPI.requestData = (inData, outData) => {
-    outData[0] = shapeToSource[model.shape](publicAPI, model);
+    const dataset = outData[0] || vtkPolyData.newInstance();
+    outData[0] = shapeToSource[model.shape](publicAPI, model, dataset);
 
     vtkMatrixBuilder
       .buildFromRadian()

--- a/Sources/Filters/Sources/Arrow2DSource/index.js
+++ b/Sources/Filters/Sources/Arrow2DSource/index.js
@@ -149,7 +149,7 @@ function vtkArrow2DSource(publicAPI, model) {
   };
 
   publicAPI.requestData = (inData, outData) => {
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
     outData[0] = shapeToSource[model.shape](publicAPI, model, dataset);
 
     vtkMatrixBuilder

--- a/Sources/Filters/Sources/ArrowSource/index.js
+++ b/Sources/Filters/Sources/ArrowSource/index.js
@@ -12,11 +12,7 @@ function vtkArrowSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkArrowSource');
 
-  function requestData(inData, outData) {
-    if (model.deleted) {
-      return;
-    }
-
+  publicAPI.requestData = (inData, outData) => {
     const cylinder = vtkCylinderSource.newInstance({ capping: true });
     cylinder.setResolution(model.shaftResolution);
     cylinder.setRadius(model.shaftRadius);
@@ -80,10 +76,7 @@ function vtkArrowSource(publicAPI, model) {
       // Update output
       outData[0] = append.getOutputData();
     }
-  }
-
-  // Expose methods
-  publicAPI.requestData = requestData;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/CircleSource/index.js
+++ b/Sources/Filters/Sources/CircleSource/index.js
@@ -16,7 +16,7 @@ function vtkCircleSource(publicAPI, model) {
       return;
     }
 
-    let dataset = outData[0];
+    const dataset = outData[0] || vtkPolyData.newInstance();
 
     // Points
     const points = macro.newTypedArray(model.pointType, model.resolution * 3);
@@ -39,7 +39,6 @@ function vtkCircleSource(publicAPI, model) {
     // connect endpoints
     edges[edges.length - 1] = edges[1];
 
-    dataset = vtkPolyData.newInstance();
     dataset.getPoints().setData(points, 3);
     if (model.lines) {
       dataset.getLines().setData(edges, 1);

--- a/Sources/Filters/Sources/CircleSource/index.js
+++ b/Sources/Filters/Sources/CircleSource/index.js
@@ -11,11 +11,7 @@ function vtkCircleSource(publicAPI, model) {
   // Set our classname
   model.classHierarchy.push('vtkCircleSource');
 
-  function requestData(inData, outData) {
-    if (model.deleted) {
-      return;
-    }
-
+  publicAPI.requestData = (inData, outData) => {
     const dataset = outData[0] || vtkPolyData.newInstance();
 
     // Points
@@ -57,10 +53,7 @@ function vtkCircleSource(publicAPI, model) {
 
     // Update output
     outData[0] = dataset;
-  }
-
-  // Expose methods
-  publicAPI.requestData = requestData;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/CircleSource/index.js
+++ b/Sources/Filters/Sources/CircleSource/index.js
@@ -12,7 +12,7 @@ function vtkCircleSource(publicAPI, model) {
   model.classHierarchy.push('vtkCircleSource');
 
   publicAPI.requestData = (inData, outData) => {
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     // Points
     const points = macro.newTypedArray(model.pointType, model.resolution * 3);

--- a/Sources/Filters/Sources/ConcentricCylinderSource/index.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/index.js
@@ -72,8 +72,9 @@ function vtkConcentricCylinderSource(publicAPI, model) {
   publicAPI.getMaskLayer = (index) =>
     index === undefined ? model.mask : model.mask[index];
 
-  function requestData(inData, outData) {
-    if (model.deleted || !model.radius.length) {
+  publicAPI.requestData = (inData, outData) => {
+    if (!model.radius.length) {
+      macro.vtkErrorMacro('No radius defined');
       return;
     }
 
@@ -391,10 +392,7 @@ function vtkConcentricCylinderSource(publicAPI, model) {
 
     // Update output
     outData[0] = dataset;
-  }
-
-  // Expose methods
-  publicAPI.requestData = requestData;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/ConcentricCylinderSource/index.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/index.js
@@ -383,7 +383,7 @@ function vtkConcentricCylinderSource(publicAPI, model) {
       .rotateFromDirections([0, 0, 1], model.direction)
       .apply(points);
 
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
     dataset.getPoints().setData(points, 3);
     dataset.getPolys().setData(polys, 1);
     dataset

--- a/Sources/Filters/Sources/ConcentricCylinderSource/index.js
+++ b/Sources/Filters/Sources/ConcentricCylinderSource/index.js
@@ -80,8 +80,6 @@ function vtkConcentricCylinderSource(publicAPI, model) {
     // Make sure we have consistency
     validateCellFields();
 
-    let dataset = outData[0];
-
     const numLayers = model.radius.length;
     const zRef = model.height / 2.0;
 
@@ -384,7 +382,7 @@ function vtkConcentricCylinderSource(publicAPI, model) {
       .rotateFromDirections([0, 0, 1], model.direction)
       .apply(points);
 
-    dataset = vtkPolyData.newInstance();
+    const dataset = outData[0] || vtkPolyData.newInstance();
     dataset.getPoints().setData(points, 3);
     dataset.getPolys().setData(polys, 1);
     dataset

--- a/Sources/Filters/Sources/ConeSource/example/index.js
+++ b/Sources/Filters/Sources/ConeSource/example/index.js
@@ -5,6 +5,7 @@ import '@kitware/vtk.js/Rendering/Profiles/Geometry';
 
 import vtkFullScreenRenderWindow from '@kitware/vtk.js/Rendering/Misc/FullScreenRenderWindow';
 import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
+// import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
 import vtkConeSource from '@kitware/vtk.js/Filters/Sources/ConeSource';
 import vtkMapper from '@kitware/vtk.js/Rendering/Core/Mapper';
 
@@ -33,6 +34,23 @@ function createConePipeline() {
   mapper.setInputConnection(coneSource.getOutputPort());
 
   renderer.addActor(actor);
+
+  // const polyData = vtkPolyData.newInstance();
+  // const pointCount = Math.round(10000000 / 5);
+  // const points = new Float32Array(3 * pointCount);
+  // points.fill(1);
+  // polyData.getPoints().setData(points);
+  // polyData.getPoints().setRange({ min: 1, max: 1 }, 0);
+  // polyData.getPoints().setRange({ min: 1, max: 1 }, 1);
+  // polyData.getPoints().setRange({ min: 1, max: 1 }, 2);
+  // const polys = new Uint32Array(1000);
+  // polys.fill(1);
+  // polyData.getPolys().setData(polys);
+  // const mapper2 = vtkMapper.newInstance();
+  // mapper2.setInputData(polyData);
+  // const actor2 = vtkActor.newInstance();
+  // actor2.setMapper(mapper2);
+  // renderer.addActor(actor2);
   return { coneSource, mapper, actor };
 }
 
@@ -54,7 +72,7 @@ fullScreenRenderer.addController(controlPanel);
 ['height', 'radius', 'resolution'].forEach((propertyName) => {
   document.querySelector(`.${propertyName}`).addEventListener('input', (e) => {
     const value = Number(e.target.value);
-    pipelines[0].coneSource.set({ [propertyName]: value });
+    // pipelines[0].coneSource.set({ [propertyName]: value });
     pipelines[1].coneSource.set({ [propertyName]: value });
     renderWindow.render();
   });

--- a/Sources/Filters/Sources/ConeSource/index.js
+++ b/Sources/Filters/Sources/ConeSource/index.js
@@ -62,7 +62,7 @@ function vtkConeSource(publicAPI, model) {
       .rotateFromDirections([1, 0, 0], model.direction)
       .apply(points);
 
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
     dataset.getPoints().setData(points, 3);
     dataset.getPolys().setData(polys, 1);
 

--- a/Sources/Filters/Sources/ConeSource/index.js
+++ b/Sources/Filters/Sources/ConeSource/index.js
@@ -15,8 +15,6 @@ function vtkConeSource(publicAPI, model) {
       return;
     }
 
-    let dataset = outData[0];
-
     const angle = (2 * Math.PI) / model.resolution;
     const xbot = -model.height / 2.0;
     const numberOfPoints = model.resolution + 1;
@@ -68,7 +66,7 @@ function vtkConeSource(publicAPI, model) {
       .rotateFromDirections([1, 0, 0], model.direction)
       .apply(points);
 
-    dataset = vtkPolyData.newInstance();
+    const dataset = outData[0] || vtkPolyData.newInstance();
     dataset.getPoints().setData(points, 3);
     dataset.getPolys().setData(polys, 1);
 

--- a/Sources/Filters/Sources/ConeSource/index.js
+++ b/Sources/Filters/Sources/ConeSource/index.js
@@ -10,11 +10,7 @@ function vtkConeSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkConeSource');
 
-  function requestData(inData, outData) {
-    if (model.deleted) {
-      return;
-    }
-
+  publicAPI.requestData = (inData, outData) => {
     const angle = (2 * Math.PI) / model.resolution;
     const xbot = -model.height / 2.0;
     const numberOfPoints = model.resolution + 1;
@@ -72,10 +68,7 @@ function vtkConeSource(publicAPI, model) {
 
     // Update output
     outData[0] = dataset;
-  }
-
-  // Expose methods
-  publicAPI.requestData = requestData;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/CubeSource/index.js
+++ b/Sources/Filters/Sources/CubeSource/index.js
@@ -43,7 +43,7 @@ function vtkCubeSource(publicAPI, model) {
       return;
     }
 
-    const polyData = vtkPolyData.newInstance();
+    const polyData = outData[0] || vtkPolyData.newInstance();
     outData[0] = polyData;
 
     const numberOfPoints = 24;

--- a/Sources/Filters/Sources/CubeSource/index.js
+++ b/Sources/Filters/Sources/CubeSource/index.js
@@ -39,7 +39,7 @@ function vtkCubeSource(publicAPI, model) {
   model.classHierarchy.push('vtkCubeSource');
 
   publicAPI.requestData = (inData, outData) => {
-    const polyData = outData[0] || vtkPolyData.newInstance();
+    const polyData = outData[0]?.initialize() || vtkPolyData.newInstance();
     outData[0] = polyData;
 
     const numberOfPoints = 24;

--- a/Sources/Filters/Sources/CubeSource/index.js
+++ b/Sources/Filters/Sources/CubeSource/index.js
@@ -38,11 +38,7 @@ function vtkCubeSource(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkCubeSource');
 
-  function requestData(inData, outData) {
-    if (model.deleted) {
-      return;
-    }
-
+  publicAPI.requestData = (inData, outData) => {
     const polyData = outData[0] || vtkPolyData.newInstance();
     outData[0] = polyData;
 
@@ -249,7 +245,7 @@ function vtkCubeSource(publicAPI, model) {
       polyData.getLines().initialize();
     }
     polyData.modified();
-  }
+  };
 
   publicAPI.setBounds = (...bounds) => {
     let boundsArray = [];
@@ -275,9 +271,6 @@ function vtkCubeSource(publicAPI, model) {
       (boundsArray[4] + boundsArray[5]) / 2.0,
     ]);
   };
-
-  // Expose methods
-  publicAPI.requestData = requestData;
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/Cursor3D/index.js
+++ b/Sources/Filters/Sources/Cursor3D/index.js
@@ -148,7 +148,7 @@ function vtkCursor3D(publicAPI, model) {
     if (numPts === 0) {
       return;
     }
-    const polyData = vtkPolyData.newInstance();
+    const polyData = outData[0] || vtkPolyData.newInstance();
     const newPts = vtkPoints.newInstance({ size: numPts * 3 });
     //  vtkCellArray is a supporting object that explicitly represents cell
     //  connectivity. The cell array structure is a raw integer list

--- a/Sources/Filters/Sources/Cursor3D/index.js
+++ b/Sources/Filters/Sources/Cursor3D/index.js
@@ -94,9 +94,6 @@ function vtkCursor3D(publicAPI, model) {
   };
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
     let numPts = 0;
     let numLines = 0;
     // Check bounding box and origin

--- a/Sources/Filters/Sources/Cursor3D/index.js
+++ b/Sources/Filters/Sources/Cursor3D/index.js
@@ -145,7 +145,7 @@ function vtkCursor3D(publicAPI, model) {
     if (numPts === 0) {
       return;
     }
-    const polyData = outData[0] || vtkPolyData.newInstance();
+    const polyData = outData[0]?.initialize() || vtkPolyData.newInstance();
     const newPts = vtkPoints.newInstance({ size: numPts * 3 });
     //  vtkCellArray is a supporting object that explicitly represents cell
     //  connectivity. The cell array structure is a raw integer list

--- a/Sources/Filters/Sources/CylinderSource/index.js
+++ b/Sources/Filters/Sources/CylinderSource/index.js
@@ -154,7 +154,7 @@ function vtkCylinderSource(publicAPI, model) {
       .translate(...model.center.map((c) => c * -1))
       .apply(points);
 
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
     dataset.getPoints().setData(points, 3);
     dataset.getPolys().setData(polys, 1);
     dataset.getPointData().setNormals(normals);

--- a/Sources/Filters/Sources/CylinderSource/index.js
+++ b/Sources/Filters/Sources/CylinderSource/index.js
@@ -16,8 +16,6 @@ function vtkCylinderSource(publicAPI, model) {
       return;
     }
 
-    let dataset = outData[0];
-
     const angle = (2.0 * Math.PI) / model.resolution;
     let numberOfPoints = 2 * model.resolution;
     let numberOfPolys = 5 * model.resolution;
@@ -160,7 +158,7 @@ function vtkCylinderSource(publicAPI, model) {
       .translate(...model.center.map((c) => c * -1))
       .apply(points);
 
-    dataset = vtkPolyData.newInstance();
+    const dataset = outData[0] || vtkPolyData.newInstance();
     dataset.getPoints().setData(points, 3);
     dataset.getPolys().setData(polys, 1);
     dataset.getPointData().setNormals(normals);

--- a/Sources/Filters/Sources/CylinderSource/index.js
+++ b/Sources/Filters/Sources/CylinderSource/index.js
@@ -11,11 +11,7 @@ function vtkCylinderSource(publicAPI, model) {
   // Set our classname
   model.classHierarchy.push('vtkCylinderSource');
 
-  function requestData(inData, outData) {
-    if (model.deleted) {
-      return;
-    }
-
+  publicAPI.requestData = (inData, outData) => {
     const angle = (2.0 * Math.PI) / model.resolution;
     let numberOfPoints = 2 * model.resolution;
     let numberOfPolys = 5 * model.resolution;
@@ -166,10 +162,7 @@ function vtkCylinderSource(publicAPI, model) {
 
     // Update output
     outData[0] = dataset;
-  }
-
-  // Expose methods
-  publicAPI.requestData = requestData;
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/Sources/Filters/Sources/DiskSource/index.js
+++ b/Sources/Filters/Sources/DiskSource/index.js
@@ -108,7 +108,7 @@ function vtkDiskSource(publicAPI, model) {
     }
     polys.setData(cellData, cellCount, 1);
 
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
     dataset.setPoints(points);
     dataset.setPolys(polys);
 

--- a/Sources/Filters/Sources/DiskSource/index.js
+++ b/Sources/Filters/Sources/DiskSource/index.js
@@ -25,12 +25,6 @@ function vtkDiskSource(publicAPI, model) {
       pointType,
     } = model;
 
-    if (model.deleted) {
-      return;
-    }
-
-    let dataset = outData[0];
-
     // Points
     const points = vtkPoints.newInstance({
       dataType: pointType,
@@ -114,7 +108,7 @@ function vtkDiskSource(publicAPI, model) {
     }
     polys.setData(cellData, cellCount, 1);
 
-    dataset = vtkPolyData.newInstance();
+    const dataset = outData[0] || vtkPolyData.newInstance();
     dataset.setPoints(points);
     dataset.setPolys(polys);
 

--- a/Sources/Filters/Sources/EllipseArcSource/index.js
+++ b/Sources/Filters/Sources/EllipseArcSource/index.js
@@ -26,7 +26,7 @@ function vtkEllipseArcSource(publicAPI, model) {
     const numPts = resolution + 1;
     const tc = [0.0, 0.0];
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     // Make sure the normal vector is normalized
     const normal = [...model.normal];

--- a/Sources/Filters/Sources/ImageGridSource/index.js
+++ b/Sources/Filters/Sources/ImageGridSource/index.js
@@ -11,10 +11,6 @@ function vtkImageGridSource(publicAPI, model) {
   model.classHierarchy.push('vtkImageGridSource');
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const state = {};
     const dataset = {
       type: 'vtkImageData',

--- a/Sources/Filters/Sources/LineSource/index.js
+++ b/Sources/Filters/Sources/LineSource/index.js
@@ -13,10 +13,6 @@ function vtkLineSource(publicAPI, model) {
   model.classHierarchy.push('vtkLineSource');
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const dataset = outData[0];
 
     // Check input

--- a/Sources/Filters/Sources/LineSource/index.js
+++ b/Sources/Filters/Sources/LineSource/index.js
@@ -19,7 +19,7 @@ function vtkLineSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    const pd = dataset || vtkPolyData.newInstance();
+    const pd = dataset?.initialize() || vtkPolyData.newInstance();
     const v21 = [];
     vtkMath.subtract(model.point2, model.point1, v21);
     if (vtkMath.norm(v21) <= 0.0) {

--- a/Sources/Filters/Sources/LineSource/index.js
+++ b/Sources/Filters/Sources/LineSource/index.js
@@ -23,7 +23,7 @@ function vtkLineSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    const pd = vtkPolyData.newInstance();
+    const pd = dataset || vtkPolyData.newInstance();
     const v21 = [];
     vtkMath.subtract(model.point2, model.point1, v21);
     if (vtkMath.norm(v21) <= 0.0) {

--- a/Sources/Filters/Sources/PlaneSource/index.js
+++ b/Sources/Filters/Sources/PlaneSource/index.js
@@ -19,10 +19,6 @@ function vtkPlaneSource(publicAPI, model) {
   model.classHierarchy.push('vtkPlaneSource');
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const dataset = outData[0];
 
     // Check input

--- a/Sources/Filters/Sources/PlaneSource/index.js
+++ b/Sources/Filters/Sources/PlaneSource/index.js
@@ -29,7 +29,7 @@ function vtkPlaneSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    const pd = vtkPolyData.newInstance();
+    const pd = dataset || vtkPolyData.newInstance();
     const v10 = [];
     const v20 = [];
     vtkMath.subtract(model.point1, model.origin, v10);

--- a/Sources/Filters/Sources/PlaneSource/index.js
+++ b/Sources/Filters/Sources/PlaneSource/index.js
@@ -25,7 +25,7 @@ function vtkPlaneSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    const pd = dataset || vtkPolyData.newInstance();
+    const pd = dataset?.initialize() || vtkPolyData.newInstance();
     const v10 = [];
     const v20 = [];
     vtkMath.subtract(model.point1, model.origin, v10);

--- a/Sources/Filters/Sources/PlatonicSolidSource/index.js
+++ b/Sources/Filters/Sources/PlatonicSolidSource/index.js
@@ -182,7 +182,7 @@ function vtkPlatonicSolidSource(publicAPI, model) {
   model.classHierarchy.push('vtkPlatonicSolidSource');
 
   publicAPI.requestData = (inData, outData) => {
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     let solidData;
     switch (model.solidType) {

--- a/Sources/Filters/Sources/PointSource/index.js
+++ b/Sources/Filters/Sources/PointSource/index.js
@@ -21,7 +21,7 @@ function vtkPointSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    const pd = vtkPolyData.newInstance();
+    const pd = dataset || vtkPolyData.newInstance();
 
     // hand create a point cloud
     const numPts = model.numberOfPoints;

--- a/Sources/Filters/Sources/PointSource/index.js
+++ b/Sources/Filters/Sources/PointSource/index.js
@@ -17,7 +17,7 @@ function vtkPointSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    const pd = dataset || vtkPolyData.newInstance();
+    const pd = dataset?.initialize() || vtkPolyData.newInstance();
 
     // hand create a point cloud
     const numPts = model.numberOfPoints;

--- a/Sources/Filters/Sources/PointSource/index.js
+++ b/Sources/Filters/Sources/PointSource/index.js
@@ -11,10 +11,6 @@ function vtkPointSource(publicAPI, model) {
   model.classHierarchy.push('vtkPointSource');
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const dataset = outData[0];
 
     // Check input

--- a/Sources/Filters/Sources/RTAnalyticSource/index.js
+++ b/Sources/Filters/Sources/RTAnalyticSource/index.js
@@ -9,10 +9,6 @@ function vtkRTAnalyticSource(publicAPI, model) {
   model.classHierarchy.push('vtkRTAnalyticSource');
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const state = {};
     const dataset = {
       type: 'vtkImageData',

--- a/Sources/Filters/Sources/SLICSource/index.js
+++ b/Sources/Filters/Sources/SLICSource/index.js
@@ -98,7 +98,7 @@ function vtkSLICSource(publicAPI, model) {
     const dataSize =
       model.dimensions[0] * model.dimensions[1] * model.dimensions[2];
 
-    const imageData = outData[0] || vtkImageData.newInstance();
+    const imageData = outData[0]?.initialize() || vtkImageData.newInstance();
     imageData.setSpacing(...model.spacing);
     imageData.setExtent(
       0,

--- a/Sources/Filters/Sources/SLICSource/index.js
+++ b/Sources/Filters/Sources/SLICSource/index.js
@@ -95,10 +95,6 @@ function vtkSLICSource(publicAPI, model) {
   publicAPI.getNumberOfClusters = () => model.clusters.length;
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const dataSize =
       model.dimensions[0] * model.dimensions[1] * model.dimensions[2];
 

--- a/Sources/Filters/Sources/SLICSource/index.js
+++ b/Sources/Filters/Sources/SLICSource/index.js
@@ -102,7 +102,7 @@ function vtkSLICSource(publicAPI, model) {
     const dataSize =
       model.dimensions[0] * model.dimensions[1] * model.dimensions[2];
 
-    const imageData = vtkImageData.newInstance();
+    const imageData = outData[0] || vtkImageData.newInstance();
     imageData.setSpacing(...model.spacing);
     imageData.setExtent(
       0,

--- a/Sources/Filters/Sources/SphereSource/index.js
+++ b/Sources/Filters/Sources/SphereSource/index.js
@@ -19,7 +19,7 @@ function vtkSphereSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    dataset = vtkPolyData.newInstance();
+    dataset = dataset || vtkPolyData.newInstance();
 
     // ----------------------------------------------------------------------
     let numPoles = 0;

--- a/Sources/Filters/Sources/SphereSource/index.js
+++ b/Sources/Filters/Sources/SphereSource/index.js
@@ -11,10 +11,6 @@ function vtkSphereSource(publicAPI, model) {
   model.classHierarchy.push('vtkSphereSource');
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     let dataset = outData[0];
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()

--- a/Sources/Filters/Sources/SphereSource/index.js
+++ b/Sources/Filters/Sources/SphereSource/index.js
@@ -15,7 +15,7 @@ function vtkSphereSource(publicAPI, model) {
     const pointDataType = dataset
       ? dataset.getPoints().getDataType()
       : model.pointType;
-    dataset = dataset || vtkPolyData.newInstance();
+    dataset = dataset?.initialize() || vtkPolyData.newInstance();
 
     // ----------------------------------------------------------------------
     let numPoles = 0;

--- a/Sources/Filters/Sources/ViewFinderSource/index.js
+++ b/Sources/Filters/Sources/ViewFinderSource/index.js
@@ -4,7 +4,7 @@ import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 
 function vtkViewFinderSource(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
-    const dataset = vtkPolyData.newInstance();
+    const dataset = outData[0] || vtkPolyData.newInstance();
 
     const points = macro.newTypedArray(model.pointType, 3 * 16);
 

--- a/Sources/Filters/Sources/ViewFinderSource/index.js
+++ b/Sources/Filters/Sources/ViewFinderSource/index.js
@@ -4,7 +4,7 @@ import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 
 function vtkViewFinderSource(publicAPI, model) {
   publicAPI.requestData = (inData, outData) => {
-    const dataset = outData[0] || vtkPolyData.newInstance();
+    const dataset = outData[0]?.initialize() || vtkPolyData.newInstance();
 
     const points = macro.newTypedArray(model.pointType, 3 * 16);
 

--- a/Sources/Filters/Texture/TextureMapToPlane/index.js
+++ b/Sources/Filters/Texture/TextureMapToPlane/index.js
@@ -108,7 +108,7 @@ function vtkTextureMapToPlane(publicAPI, model) {
       return;
     }
 
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     output
       .getPoints()
       .setData(new Float32Array(input.getPoints().getData()), 3);

--- a/Sources/Filters/Texture/TextureMapToPlane/index.js
+++ b/Sources/Filters/Texture/TextureMapToPlane/index.js
@@ -105,7 +105,7 @@ function vtkTextureMapToPlane(publicAPI, model) {
       return;
     }
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     output
       .getPoints()
       .setData(new Float32Array(input.getPoints().getData()), 3);

--- a/Sources/Filters/Texture/TextureMapToPlane/index.js
+++ b/Sources/Filters/Texture/TextureMapToPlane/index.js
@@ -98,9 +98,6 @@ function vtkTextureMapToPlane(publicAPI, model) {
   }
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
     const input = inData[0];
     const nbPoints = input.getPoints().getNumberOfPoints();
     if (nbPoints < 3 && model.automaticPlaneGeneration) {

--- a/Sources/Filters/Texture/TextureMapToSphere/index.js
+++ b/Sources/Filters/Texture/TextureMapToSphere/index.js
@@ -115,7 +115,7 @@ function vtkTextureMapToSphere(publicAPI, model) {
       values: tcoordsData,
     });
 
-    const output = vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
     output
       .getPoints()
       .setData(new Float32Array(input.getPoints().getData()), 3);

--- a/Sources/Filters/Texture/TextureMapToSphere/index.js
+++ b/Sources/Filters/Texture/TextureMapToSphere/index.js
@@ -112,7 +112,7 @@ function vtkTextureMapToSphere(publicAPI, model) {
       values: tcoordsData,
     });
 
-    const output = outData[0] || vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     output
       .getPoints()
       .setData(new Float32Array(input.getPoints().getData()), 3);

--- a/Sources/Filters/Texture/TextureMapToSphere/index.js
+++ b/Sources/Filters/Texture/TextureMapToSphere/index.js
@@ -14,9 +14,6 @@ function vtkTextureMapToSphere(publicAPI, model) {
   model.classHierarchy.push('vtkTextureMapToSphere');
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
     const input = inData[0];
 
     const nbPoints = input.getPoints().getNumberOfPoints();

--- a/Sources/Imaging/Core/ImageReslice/index.js
+++ b/Sources/Imaging/Core/ImageReslice/index.js
@@ -255,7 +255,7 @@ function vtkImageReslice(publicAPI, model) {
     });
 
     // Update output
-    const output = vtkImageData.newInstance();
+    const output = outData[0]?.initialize() || vtkImageData.newInstance();
     output.setDimensions(outDims);
     output.setOrigin(outOrigin);
     output.setSpacing(outSpacing);

--- a/Sources/Imaging/Hybrid/SampleFunction/index.js
+++ b/Sources/Imaging/Hybrid/SampleFunction/index.js
@@ -41,7 +41,7 @@ function vtkSampleFunction(publicAPI, model) {
       vtkErrorMacro('Bad volume dimensions');
       return;
     }
-    const volume = vtkImageData.newInstance();
+    const volume = outData[0]?.initialize() || vtkImageData.newInstance();
     const origin = [
       model.modelBounds[0],
       model.modelBounds[2],

--- a/Sources/Rendering/Core/VectorText/index.js
+++ b/Sources/Rendering/Core/VectorText/index.js
@@ -307,11 +307,10 @@ function vtkVectorText(publicAPI, model) {
    * Creates a vtkPolyData from the processed shapes
    * @returns {Object} vtkPolyData instance
    */
-  function buildPolyData() {
+  function buildPolyData(polyData) {
     model.verticesArray = [];
     model.uvArray = [];
     model.colorArray = [];
-    const polyData = vtkPolyData.newInstance();
     const cells = vtkCellArray.newInstance();
     const pointData = polyData.getPointData();
 
@@ -404,7 +403,9 @@ function vtkVectorText(publicAPI, model) {
     }
 
     buildShape();
-    outData[0] = buildPolyData();
+    const polyData = outData[0]?.initialize() || vtkPolyData.newInstance();
+    buildPolyData(polyData);
+    outData[0] = polyData;
   };
 }
 

--- a/Sources/Testing/Examples/PipelineExecution/example/index.js
+++ b/Sources/Testing/Examples/PipelineExecution/example/index.js
@@ -94,7 +94,6 @@ const randFilter = macro.newInstance((publicAPI, model) => {
   macro.obj(publicAPI, model); // make it an object
   macro.algo(publicAPI, model, 1, 1); // mixin algorithm code 1 in, 1 out
   publicAPI.requestData = (inData, outData) => {
-    // implement requestData
     updateExecution(2);
     const newArray = new Float32Array(
       inData[0].getPoints().getNumberOfPoints()
@@ -104,7 +103,8 @@ const randFilter = macro.newInstance((publicAPI, model) => {
     }
 
     const da = vtkDataArray.newInstance({ name: 'spike', values: newArray });
-    const newDataSet = vtk({ vtkClass: inData[0].getClassName() });
+    const newDataSet =
+      outData[0]?.initialize() || vtk({ vtkClass: inData[0].getClassName() });
     newDataSet.shallowCopy(inData[0]);
     newDataSet.getPointData().setScalars(da);
     outData[0] = newDataSet;

--- a/Sources/Testing/testAlgorithm.js
+++ b/Sources/Testing/testAlgorithm.js
@@ -33,6 +33,7 @@ publicAPI.requestData = (inData, outData) => {
 };
 
 test('Macro methods algo tests', (t) => {
+  macro.obj(publicAPI, model);
   macro.algo(publicAPI, model, numInputs, numOutputs);
 
   // Override shouldUpdate to prevent the need of getMTime()

--- a/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
+++ b/Sources/Widgets/Representations/ImplicitPlaneRepresentation/index.js
@@ -237,7 +237,7 @@ function vtkImplicitPlaneRepresentation(publicAPI, model) {
       state.getActive() && state.getActiveHandle()
     );
 
-    const output = vtkPolyData.newInstance();
+    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
     output.shallowCopy(model._pipelines.plane.filter.getOutputData());
     outData[0] = output;
   };

--- a/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/RectangleContextRepresentation/index.js
@@ -39,10 +39,6 @@ function vtkRectangleContextRepresentation(publicAPI, model) {
   // --------------------------------------------------------------------------
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const list = publicAPI.getRepresentationStates(inData[0]);
     // FIXME: support list > 1.
     const state = list[0];

--- a/Sources/Widgets/Representations/SplineContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/SplineContextRepresentation/index.js
@@ -58,10 +58,6 @@ function vtkSplineContextRepresentation(publicAPI, model) {
     );
 
   publicAPI.requestData = (inData, outData) => {
-    if (model.deleted) {
-      return;
-    }
-
     const widgetState = inData[0];
     const closed = widgetState.getSplineClosed();
 

--- a/Sources/Widgets/Representations/SplineContextRepresentation/index.js
+++ b/Sources/Widgets/Representations/SplineContextRepresentation/index.js
@@ -59,12 +59,12 @@ function vtkSplineContextRepresentation(publicAPI, model) {
 
   publicAPI.requestData = (inData, outData) => {
     const widgetState = inData[0];
+    outData[0] = model.internalPolyData;
     const closed = widgetState.getSplineClosed();
 
     const list = publicAPI.getRepresentationStates(widgetState);
     const inPoints = list.map((state) => state.getOrigin());
     if (inPoints.length <= 1) {
-      outData[0] = model.internalPolyData;
       return;
     }
 
@@ -128,7 +128,6 @@ function vtkSplineContextRepresentation(publicAPI, model) {
       .setData(model.outputBorder ? outCells : []);
 
     model.internalPolyData.modified();
-    outData[0] = model.internalPolyData;
 
     model._pipelines.area.filter.update();
     model._pipelines.border.actor

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -916,7 +916,11 @@ export function algo(publicAPI, model, numberOfInputs, numberOfOutputs) {
         count++;
       }
     }
-    if (publicAPI.requestData && publicAPI.shouldUpdate()) {
+    if (
+      publicAPI.requestData &&
+      !publicAPI.isDeleted() &&
+      publicAPI.shouldUpdate()
+    ) {
       publicAPI.requestData(ins, model.output);
     }
   };


### PR DESCRIPTION
### Context
Make vtkPolyData and requestData() behavior consistent across VTK.js and VTK C++.

### Results
Reuse previous output data whenever possible.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome
