### PR TITLE
Fix get slice range

### DIFF
--- a/Sources/Common/DataModel/BoundingBox/index.js
+++ b/Sources/Common/DataModel/BoundingBox/index.js
@@ -285,14 +285,14 @@ function oppositeSign(a, b) {
 }
 
 export function getCorners(bounds, corners) {
-  let count = 0;
-  for (let ix = 0; ix < 2; ix++) {
-    for (let iy = 2; iy < 4; iy++) {
-      for (let iz = 4; iz < 6; iz++) {
-        corners[count++] = [bounds[ix], bounds[iy], bounds[iz]];
-      }
-    }
-  }
+  corners[0] = [bounds[0], bounds[2], bounds[4]];
+  corners[1] = [bounds[0], bounds[2], bounds[5]];
+  corners[2] = [bounds[0], bounds[3], bounds[4]];
+  corners[3] = [bounds[0], bounds[3], bounds[5]];
+  corners[4] = [bounds[1], bounds[2], bounds[4]];
+  corners[5] = [bounds[1], bounds[2], bounds[5]];
+  corners[6] = [bounds[1], bounds[3], bounds[4]];
+  corners[7] = [bounds[1], bounds[3], bounds[5]];
   return corners;
 }
 

--- a/Sources/Rendering/Core/Prop3D/index.js
+++ b/Sources/Rendering/Core/Prop3D/index.js
@@ -238,6 +238,13 @@ function vtkProp3D(publicAPI, model) {
     return model.properties[mapperInputPort];
   };
 
+  publicAPI.getProperties = () => {
+    if (model.properties.length === 0) {
+      model.properties[0] = publicAPI.makeProperty?.();
+    }
+    return model.properties;
+  };
+
   publicAPI.setProperty = (firstArg, secondArg) => {
     // Two options for argument layout:
     // - (mapperInputPort, property)


### PR DESCRIPTION

### Context
When a vtkImageData had a rotation/direction matrix, getSliceRange was "too wide".

### Results
getSliceRange is now better fitting the image data bounds.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome
