### PR TITLE
Fix vtkImageData typescript definitions for initialization values

### DIFF
--- a/Sources/Common/DataModel/ImageData/index.d.ts
+++ b/Sources/Common/DataModel/ImageData/index.d.ts
@@ -9,6 +9,7 @@ export interface IImageDataInitialValues extends IDataSetInitialValues {
   spacing?: number[];
   origin?: number[];
   extent?: number[];
+  direction?: number[];
 }
 
 interface IComputeHistogram {

--- a/Sources/Common/DataModel/ImageData/index.js
+++ b/Sources/Common/DataModel/ImageData/index.js
@@ -232,7 +232,9 @@ function vtkImageData(publicAPI, model) {
     vtkBoundingBox.transformBounds(bin, model.worldToIndex, bout);
 
   // Make sure the transform is correct
-  publicAPI.onModified(publicAPI.computeTransforms);
+  model._onOriginChanged = publicAPI.computeTransforms;
+  model._onDirectionChanged = publicAPI.computeTransforms;
+  model._onSpacingChanged = publicAPI.computeTransforms;
   publicAPI.computeTransforms();
 
   publicAPI.getCenter = () => vtkBoundingBox.getCenter(publicAPI.getBounds());


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Include `direction` as a property of initialization values in the `vtkImageData` constructor. Direction property is already allowed but typescript definition did not include it, causing typescript errors on applications side.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
