### PR TITLE
fix(OpenGLTexture): fix regression causing RGB DICOM not to display

### DIFF
--- a/Sources/Rendering/OpenGL/Texture/index.js
+++ b/Sources/Rendering/OpenGL/Texture/index.js
@@ -1625,7 +1625,7 @@ function vtkOpenGLTexture(publicAPI, model) {
       width,
       height,
       dataArray: vtkDataArray.newInstance({
-        numComps,
+        numberOfComponents: numComps,
         dataType,
         values: data,
         ranges,
@@ -1897,7 +1897,7 @@ function vtkOpenGLTexture(publicAPI, model) {
       height,
       depth,
       dataArray: vtkDataArray.newInstance({
-        numComps,
+        numberOfComponents: numComps,
         dataType,
         values: data,
         ranges,


### PR DESCRIPTION


<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
A regression was introduced during the transition to named parameters, where numComps was passed instead of numberOfComponents set to 1 by default. This caused RGB DICOM images to display incorrectly, as only one component was used instead of the intended three.

Ref: https://github.com/kitware/vtk-js/commit/7fbbaa83b697f7fb7b09fe03a05fbca397271496

Fixes #3344

### Results

Check the example in the issue

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
