### PR TITLE
fix(links): clear Cells and Links arrays when polydata is cleared

### DIFF
--- a/Sources/Common/DataModel/PolyData/index.js
+++ b/Sources/Common/DataModel/PolyData/index.js
@@ -39,6 +39,11 @@ function vtkPolyData(publicAPI, model) {
       .replace(/\s+/g, '');
   }
 
+  function clearCells() {
+    model.cells = undefined;
+    model.links = undefined;
+  }
+
   // build empty cell arrays and set methods
   POLYDATA_FIELDS.forEach((type) => {
     publicAPI[`getNumberOf${camelize(type)}`] = () =>
@@ -48,6 +53,7 @@ function vtkPolyData(publicAPI, model) {
     } else {
       model[type] = vtk(model[type]);
     }
+    model[`_on${camelize(type)}Changed`] = clearCells;
   });
 
   publicAPI.getNumberOfCells = () =>
@@ -75,6 +81,7 @@ function vtkPolyData(publicAPI, model) {
   const superInitialize = publicAPI.initialize;
   publicAPI.initialize = () => {
     POLYDATA_FIELDS.forEach((type) => model[type]?.initialize());
+    clearCells();
     return superInitialize();
   };
 
@@ -180,7 +187,7 @@ function vtkPolyData(publicAPI, model) {
    * topologically complex queries.
    */
   publicAPI.buildLinks = (initialSize = 0) => {
-    if (model.cells === undefined) {
+    if (model.cells == null) {
       publicAPI.buildCells();
     }
 


### PR DESCRIPTION
BuildLinks enforces building cells only if they do not exist. When clearing the polydata, cells and links must be cleared accordingly. Same when verts, lines, polys and strips arrays are changed

fix #3361

### Context
Filters reuse their previous output data, but they now clear them.
A crash was happening when trying to access a cell that does not exist in model.cells.
This is because the model.cells array is outdated.

### Results
Enforce the cells array to be recomputed after clearing a polydata.
The ContourLoopExtraction example now works again.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes an example
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome

