### PR TITLE
fix(SplineWidget): lastHandle may not show after loseFocus

### DIFF
--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -414,7 +414,7 @@ export default function widgetBehavior(publicAPI, model) {
     if (model.hasFocus) {
       model._interactor.cancelAnimation(publicAPI);
     }
-
+    model.lastHandle?.setVisible(true);
     model.widgetState.deactivate();
     model.moveHandle.deactivate();
     model.moveHandle.setVisible(false);


### PR DESCRIPTION
### Context
SplineWidget adds new points through left mouse button clicks and confirms all points by pressing the Enter key on the keyboard.
The bug reproduction steps are as follows:

1. Run npm run example SplineWidget to execute the SplineWidget example
2. Click the placeWidget button on the screen to start adding SplineWidget points
3. Left-click on the screen to add the first point
4. Left-click on the screen to add the second point
5. Left-click on the screen to add the third point, then without moving the mouse, directly press the Enter key on the keyboard to confirm adding the points
6. Result: only two points are added to the splineWidget on the screen, the third point disappears

The expected result is that the third point should also be added to the SplineWidget. The cause of this phenomenon is that after the last added point, as long as the mouse hasn't moved, the visible property of model.lastHandle won't be updated to true, causing vtkSplineContextRepresentation to not render the last point.

### Results

After the modification, the last point can now be correctly rendered in the above situation.

### Changes

The fix is simply to add one line in the SplineWidget's loseFocus function: if lastHandle exists, set its visible property to true.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests 
- [x] Tested environment:
  - **vtk.js**:  
  - **OS**: Windows11
  - **Browser**: Chrome 143.0.7499.193
