### PR TITLE
ci(tests): fix running tests on Chrome 144

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
           npx tsc -p tsconfig.esm-check.json
           npx tsc -p tsconfig.umd-check.json
       - name: Chrome and Firefox tests
-        run: xvfb-run --auto-servernum npm run test -- --browsers Chrome,Firefox
+        run: xvfb-run --auto-servernum npm run test -- --browsers ChromeSwiftShader,Firefox
       - name: Archive test results
         if: github.event_name != 'merge_group' && (success() || failure())
         uses: actions/upload-artifact@v4

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -323,6 +323,9 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
         model.canvas.getContext('webgl', options) ||
         model.canvas.getContext('experimental-webgl', options);
     }
+    if (!result) {
+      vtkErrorMacro('no webgl context');
+    }
 
     return new Proxy(result, getCachingContextHandler());
   };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -84,6 +84,10 @@ module.exports = function init(config) {
     },
 
     customLaunchers: {
+      ChromeSwiftShader: {
+        base: 'ChromeHeadless',
+        flags: ['--enable-unsafe-swiftshader'],
+      },
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox', '--ignore-gpu-blacklist'],


### PR DESCRIPTION
Since Chrome 144, tests were failing to instantiate a webgl context. See https://groups.google.com/a/chromium.org/g/chromium-dev/c/CXVQSpBCjWQ

### Context
Some PR were failing due to their Chrome tests failure. This happened since Chrome 144 was used instead of 143.

### Results

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Ubuntu on WSL
  - **Browser**: Chrome 144
