### PR TITLE
docs(hardwareselector.getpixelinformation): use vtkDebugMacro instead…

### DIFF
--- a/Sources/Rendering/OpenGL/HardwareSelector/index.js
+++ b/Sources/Rendering/OpenGL/HardwareSelector/index.js
@@ -8,7 +8,7 @@ import vtkDataSet from 'vtk.js/Sources/Common/DataModel/DataSet';
 const { PassTypes } = Constants;
 const { SelectionContent, SelectionField } = vtkSelectionNode;
 const { FieldAssociations } = vtkDataSet;
-const { vtkErrorMacro } = macro;
+const { vtkErrorMacro, vtkDebugMacro } = macro;
 
 const idOffset = 1;
 
@@ -682,7 +682,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
   ) => {
     // Base case
     const maxDist = maxDistance < 0 ? 0 : maxDistance;
-    console.log('getPixelInformation called', maxDist);
+    vtkDebugMacro('getPixelInformation called', maxDist);
     if (maxDist === 0) {
       outSelectedPosition[0] = inDisplayPosition[0];
       outSelectedPosition[1] = inDisplayPosition[1];
@@ -695,15 +695,15 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
         return null;
       }
 
-      console.log(inDisplayPosition);
-      console.log(model.area);
+      vtkDebugMacro(inDisplayPosition);
+      vtkDebugMacro(model.area);
       // offset inDisplayPosition based on the lower-left-corner of the Area.
       const displayPosition = [
         inDisplayPosition[0] - model.area[0],
         inDisplayPosition[1] - model.area[1],
       ];
 
-      console.log('adjusted displayPosition', displayPosition);
+      vtkDebugMacro('adjusted displayPosition', displayPosition);
 
       const actorid = convert(
         displayPosition[0],
@@ -713,7 +713,7 @@ function vtkOpenGLHardwareSelector(publicAPI, model) {
         'getPixelInformation'
       );
 
-      console.log('actorid', actorid);
+      vtkDebugMacro('actorid', actorid);
       if (actorid <= 0 || actorid - idOffset >= model.props.length) {
         // the pixel did not hit any actor.
         return null;


### PR DESCRIPTION
… of console.log

fix #3398

### Context
Currently, getPixelInformation always logs debug information to the console.
This can be noisy in production and makes debugging other parts harder.
This PR replaces console.log statements with vtkDebugMacro.
Related feature request: fix #3398

### Results
- Replaced console.log with vtkDebugMacro.
- No functional changes; existing behavior is preserved by default.
- Reduces console noise while allowing detailed debugging when needed.

### Changes
- Updated internal logging to use vtkDebugMacro instead of console.log.
- No breaking changes introduced.
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [X] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [X] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests
- [X] Tested environment:
  - **vtk.js**: 34.16.3
  - **OS**: Windows 11
  - **Browser**: Chrome 144.0.0.0 (Windows 10)


