### PR TITLE
fix(SplineWidget): fix bug where SplineWidget handles cannot be dragged after creation

### DIFF
--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -346,6 +346,7 @@ export default function widgetBehavior(publicAPI, model) {
       if (model.freeHand && model.activeState === model.moveHandle) {
         addPoint();
       }
+      return macro.EVENT_ABORT;
     }
 
     return model.hasFocus ? macro.EVENT_ABORT : macro.VOID;


### PR DESCRIPTION

<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

1. Execute command: Run `npm run example SplineWidget`.
2. Open the example in your browser, click "Place Widget" in the top-right corner, and add several points. Press Enter to confirm and create the SplineWidget.
3. Hover the mouse over any handle (control point) of the SplineWidget and attempt to drag it using the left mouse button.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

The handles are unresponsive; the control points cannot be dragged or moved.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->

Root Cause Analysis: The issue occurs because the handleMouseMove method in SplineWidget does not return macro.EVENT_ABORT when isHandleMoving is true. Even though the widget is currently in a dragging state, the mouse event continues to propagate to other subscribers. Consequently, the WidgetManager captures the event and triggers the w.deactivateAllHandles() method, which deactivates the currently selected handle and interrupts the drag operation.

Proposed Fix: To resolve this, we must return macro.EVENT_ABORT within the handleMouseMove logic whenever isHandleMoving is true. This ensures that the event is consumed by the active widget and prevented from propagating to the WidgetManager or other listeners.


### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) --> latest master
  - **OS**: <!-- ex: Windows 10, iOS 13.6 --> Windows 11
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 --> Chrome: 144.0.7559.112

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
