### PR TITLE
fix(SplineWidget): Mouse position and moveHandle position are misaligned under specific conditions

### DIFF
--- a/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/SplineWidget/behavior.js
@@ -419,6 +419,7 @@ export default function widgetBehavior(publicAPI, model) {
     model.widgetState.deactivate();
     model.moveHandle.deactivate();
     model.moveHandle.setVisible(false);
+    model.moveHandle.setOrigin(null);
     model.activeState = null;
     model._interactor.render();
 


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Steps to Reproduce

1. Run the example: Execute `npm run example SplineWidget`.
2. Access the demo: Open the example in your browser.
3. Initiate placement: Click the `Place Widget` button in the top-right corner.
4. Draw a spline: Left-click to add the first point, move the mouse to add a second point, and then a third.
5. Complete drawing: Move the mouse to a position not overlapping the existing points and press Enter to finish.
6. Activate a handle: Hover the mouse over the second point until it turns blue (activated).
7. Reset placement: Move the mouse directly to the `Place Widget` button to start a new SplineWidget, then move the mouse back onto the canvas.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

There is a significant offset between the mouse cursor and the moveHandle, rather than the moveHandle being positioned directly under the cursor.

### Reason

1. Stale Coordinates: During Step 6, the `handleMouseMove` function in `SplineWidget's behavior` is triggered. This executes `manipulator.handleEvent`, which calls `_addWorldDeltas` in `AbstractManipulator`. This stores the coordinates of the activated blue point into its `model._prevWorldCoords`.
2. Residual State: When `Place Widget` is clicked again, `model.moveHandle` in `SplineWidget's behavior` is assigned to `model.activeState`. At this point, `moveHandle` still contains the `origin` value from the previous session.
3. Incorrect Delta Calculation: In the handleMouseMove function, `const curOrigin = model.activeState.getOrigin()` returns a `curOrigin` value. Consequently, the logic executes `model.activeState.setOrigin(add(curOrigin, worldDelta, []))`. Because `_prevWorldCoords` was already set to an incorrect/stale value, the calculated delta is wrong, causing the misalignment.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->

The most concise fix is to ensure the moveHandle is reset when the widget loses focus.

By calling `model.moveHandle.setOrigin(null)` within the `loseFocus` function, we ensure the handle returns to its initial empty state. This prevents the `if (curOrigin)` condition in `handleMouseMove` from being met incorrectly, thereby avoiding the offset issue.


### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->  master
  - **OS**: <!-- ex: Windows 10, iOS 13.6 --> Windows 11
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 --> Chrome 144.0.7559.110

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
