### PR TITLE
docs(website): enlarge examples and add link to Kitware Inc

### DIFF
--- a/Documentation/.vitepress/config.mts
+++ b/Documentation/.vitepress/config.mts
@@ -40,7 +40,7 @@ export default defineConfig({
       provider: 'local',
     },
     footer: {
-      copyright: `© ${new Date().getFullYear()} Kitware Inc.`,
+      copyright: `© ${new Date().getFullYear()} <a href="https://www.kitware.com/" target="_blank">Kitware Inc</a>.`,
     },
   },
   markdown: {

--- a/Documentation/scripts/generate-examples.mjs
+++ b/Documentation/scripts/generate-examples.mjs
@@ -90,7 +90,7 @@ title: ${name}
       src="${examplePage}"
       title="${name} example"
       loading="lazy"
-      style="width: 100%; height: 500px; border: none;"
+      style="width: 100%; height: 100%; border: none;"
       allowfullscreen
     ></iframe>
   </div>


### PR DESCRIPTION

### Context
VTK.js examples were too small vertically.

### Results
Take the full verticality for the examples.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment

⚠️ NOT TESTED