### PR TITLE
docs(seedwidget): fix SeedWidget example

### DIFF
--- a/Sources/Widgets/Widgets3D/SeedWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/SeedWidget/example/index.js
@@ -47,9 +47,7 @@ renderer.addActor(actor);
 const widgetManager = vtkWidgetManager.newInstance();
 widgetManager.setRenderer(renderer);
 
-let widget = null;
-let widgetHandle = null;
-
+let previousWidgetHandle = null;
 renderer.resetCamera();
 
 // -----------------------------------------------------------
@@ -59,10 +57,10 @@ renderer.resetCamera();
 const gui = new GUI();
 const params = {
   AddWidget: (eventOrCenter = null) => {
-    if (widgetHandle) {
-      widgetHandle.endInteract();
+    if (previousWidgetHandle) {
+      previousWidgetHandle.endInteract();
     }
-    widget = vtkSeedWidget.newInstance();
+    const widget = vtkSeedWidget.newInstance();
 
     // Important: set the manipulator of the widget to constrain movement to the actor
     widget.setManipulator(manipulator);
@@ -78,17 +76,24 @@ const params = {
 
     // Start placement interaction
     widget.placeWidget(cone.getOutputData().getBounds());
-    widgetHandle = widgetManager.addWidget(widget);
+    const widgetHandle = widgetManager.addWidget(widget);
     if (Array.isArray(eventOrCenter)) {
       widgetHandle.setCenter(eventOrCenter);
     } else {
       widgetHandle.startInteract();
     }
+    global.widget = widget;
+    global.widgetHandle = widgetHandle;
+    previousWidgetHandle = widgetHandle;
   },
   RemoveWidget: () => {
+    if (previousWidgetHandle) {
+      previousWidgetHandle.endInteract();
+    }
     const widgets = widgetManager.getWidgets();
     if (!widgets.length) return;
     widgetManager.removeWidget(widgets[widgets.length - 1]);
+    previousWidgetHandle = null;
     renderWindow.render();
   },
 };
@@ -102,9 +107,7 @@ params.AddWidget([0.5, 0, 0]);
 // globals
 // -----------------------------------------------------------
 
-global.widget = widget;
 global.renderer = renderer;
 global.fullScreenRenderer = fullScreenRenderer;
 global.renderWindow = renderWindow;
 global.widgetManager = widgetManager;
-global.widgetHandle = widgetHandle;


### PR DESCRIPTION
Crash after removing a widget and adding a new widget. widgetHandle was accessed despite having been previously deleted.

### Context
https://discourse.vtk.org/t/how-to-programmatically-add-the-vtkseedwidget-or-vtkspherewidget/16130/15

### Results
No more crash after removing and adding a widget.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Chrome
