### PR TITLE
fix(windowedsincpolydatafilter): filter shall not initialize() when r…

### DIFF
--- a/Sources/Filters/General/WindowedSincPolyDataFilter/example/index.js
+++ b/Sources/Filters/General/WindowedSincPolyDataFilter/example/index.js
@@ -65,9 +65,9 @@ const params = {
   passBand: 0.25,
   featureAngle: 45,
   edgeAngle: 15,
-  nonManifoldSmoothing: 0,
-  featureEdgeSmoothing: 0,
-  boundarySmoothing: 1,
+  nonManifoldSmoothing: false,
+  featureEdgeSmoothing: false,
+  boundarySmoothing: true,
 };
 gui
   .add(params, 'numberOfIterations', 0, 100, 1)

--- a/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
+++ b/Sources/Filters/General/WindowedSincPolyDataFilter/index.js
@@ -3,7 +3,6 @@ import macro from 'vtk.js/Sources/macros';
 import vtkBoundingBox from 'vtk.js/Sources/Common/DataModel/BoundingBox';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import vtkMath from 'vtk.js/Sources/Common/Core/Math/index';
-import { AttributeTypes } from 'vtk.js/Sources/Common/DataModel/DataSetAttributes/Constants';
 import vtkPoints from 'vtk.js/Sources/Common/Core/Points';
 import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
 import vtkTriangle from 'vtk.js/Sources/Common/DataModel/Triangle';
@@ -587,8 +586,7 @@ function vtkWindowedSincPolyDataFilter(publicAPI, model) {
         values: newScalars,
       });
 
-      const idx = output.getPointData().addArray(newScalarsArray);
-      output.getPointData().setActiveAttribute(idx, AttributeTypes.SCALARS);
+      output.getPointData().setScalars(newScalarsArray);
     }
 
     if (model.generateErrorVectors) {
@@ -624,7 +622,7 @@ function vtkWindowedSincPolyDataFilter(publicAPI, model) {
     if (!input) {
       return;
     }
-    const output = outData[0]?.initialize() || vtkPolyData.newInstance();
+    const output = outData[0] || vtkPolyData.newInstance();
 
     const outputPoints = publicAPI.vtkWindowedSincPolyDataFilterExecute(
       input.getPoints(),


### PR DESCRIPTION
…equested

It would otherwise empty the inputs. An alternative could have been to "duplicate" the input arrays into the output.

fix #3429



### Context
Re-executing a filter re-uses the output. In most cases reusing the output requires to clear it first.
Doing so was breaking the WindowedSincPolyDataFilter.

### Results
WindowedSincPolyDataFilter can be called multiple times in a row.

### Changes
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows 11
  - **Browser**: Chrome