### PR TITLE
chore(Testing): add VTKJS_TEST_PATTERN env var for filtering tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,11 @@ To create and debug a test:
 - Run `npm run test:debug`
 - In the opened window, click the Debug button and place breakpoints in browser debugger.
 
+To run a subset of tests matching a pattern:
+```sh
+$ VTKJS_TEST_PATTERN=ConeSource npm test
+```
+
 ## Updating Documentation
 
 The vtk.js documentation is part of the code repository and is entirely written in

--- a/Sources/Testing/index.js
+++ b/Sources/Testing/index.js
@@ -3,11 +3,26 @@
  * entrypoints into one chunk. This cuts down on extraneous
  * code generation and addresses a race issue with the
  * timer task queue.
+ *
+ * Optional filtering:
+ *   VTKJS_TEST_PATTERN=ConeSource npm test
+ *   VTKJS_TEST_PATTERN=Filters/Sources/ConeSource/test npm test
  */
+
+/* global __VTKJS_TEST_PATTERN__ */
 
 import './setupTestEnv';
 
 // webpack will include files that match the regex
 // '..' refers to the Sources/ dir
 const testsContext = require.context('..', true, /test[^/]+\.js$/);
-testsContext.keys().forEach(testsContext);
+
+const testPattern =
+  typeof __VTKJS_TEST_PATTERN__ !== 'undefined' ? __VTKJS_TEST_PATTERN__ : '';
+const testKeys = testsContext.keys();
+
+if (testPattern) {
+  testKeys.filter((key) => key.includes(testPattern)).forEach(testsContext);
+} else {
+  testKeys.forEach(testsContext);
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,6 +58,7 @@ module.exports = function init(config) {
         new ESLintPlugin(),
         new webpack.DefinePlugin({
           __BASE_PATH__: "'/base'",
+          __TEST_PATTERN__: JSON.stringify(process.env.VTKJS_TEST_PATTERN || ''),
         }),
         new webpack.ProvidePlugin({ process: ['process/browser'] }),
       ],


### PR DESCRIPTION
Just a little convence to run only one test without `test.only` by setting VTKJS_TEST_PATTERN:
`VTKJS_TEST_PATTERN=ConeSource npm test`
