### PR TITLE
fix(Testing): match webpack define name to JS global for VTKJS_TEST_PATTERN

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = function init(config) {
         new ESLintPlugin(),
         new webpack.DefinePlugin({
           __BASE_PATH__: "'/base'",
-          __TEST_PATTERN__: JSON.stringify(process.env.VTKJS_TEST_PATTERN || ''),
+          __VTKJS_TEST_PATTERN__: JSON.stringify(process.env.VTKJS_TEST_PATTERN || ''),
         }),
         new webpack.ProvidePlugin({ process: ['process/browser'] }),
       ],


### PR DESCRIPTION
The webpack DefinePlugin used __TEST_PATTERN__ but Sources/Testing/index.js reads __VTKJS_TEST_PATTERN__, so the filter was never applied.

Sorry.