### PR TITLE
Refactor ICaptureOptions.resetCamera to support function type

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -37,7 +37,7 @@ export interface IOpenGLRenderWindowInitialValues {
 }
 
 export interface ICaptureOptions {
-  resetCamera?: boolean;
+  resetCamera?: boolean | (({ renderer: vtkRenderer }) => void);
   size?: Size;
   scale?: number;
 }


### PR DESCRIPTION
This updates the type of ICaptureOptions.resetCamera to support a function as implemented in [PR#2290](https://github.com/Kitware/vtk-js/pull/2290)