### PR TITLE
feat(WebGPU): add clipping plane support for polydata, volume and image

### DIFF
--- a/Sources/Rendering/Core/AbstractMapper/index.d.ts
+++ b/Sources/Rendering/Core/AbstractMapper/index.d.ts
@@ -1,6 +1,7 @@
+import { mat4 } from 'gl-matrix';
 import { vtkAlgorithm, vtkObject } from '../../../interfaces';
 import vtkPlane from '../../../Common/DataModel/Plane';
-import { mat4 } from 'gl-matrix';
+import { Vector4 } from '../../../types';
 
 /**
  *
@@ -32,6 +33,12 @@ export interface vtkAbstractMapper extends vtkAbstractMapperBase {
   getClippingPlanes(): vtkPlane[];
 
   /**
+   * Get the modified time of the clipping planes list.
+   * @return {Number} The modified time.
+   */
+  getClippingPlanesMTime(): number;
+
+  /**
    * Remove all clipping planes.
    * @return true if there were planes, false otherwise.
    */
@@ -51,8 +58,24 @@ export interface vtkAbstractMapper extends vtkAbstractMapperBase {
   setClippingPlanes(planes: vtkPlane[]): void;
 
   /**
+   * Get the ith clipping plane transformed from world coordinates into the
+   * target coordinate system defined by the provided world-to-coordinates
+   * matrix.
+   * @param {mat4} worldToCoords
+   * @param {Number} i
+   * @param {Number[]} [hnormal]
+   */
+  getClippingPlaneInCoords(
+    worldToCoords: mat4,
+    i: number,
+    hnormal?: Vector4 | Float64Array
+  ): Vector4 | Float64Array | undefined;
+
+  /**
    * Get the ith clipping plane as a homogeneous plane equation.
    * Use getNumberOfClippingPlanes() to get the number of planes.
+   * This API expects a coordinates-to-world matrix and preserves the legacy
+   * behavior used by existing data-coordinate callers.
    * @param {mat4} propMatrix
    * @param {Number} i
    * @param {Number[]} hnormal

--- a/Sources/Rendering/Core/AbstractMapper/index.js
+++ b/Sources/Rendering/Core/AbstractMapper/index.js
@@ -1,8 +1,30 @@
+import { mat4, vec4 } from 'gl-matrix';
 import macro from 'vtk.js/Sources/macros';
+
+const { vtkErrorMacro } = macro;
 
 // ----------------------------------------------------------------------------
 // vtkAbstractMapper methods
 // ----------------------------------------------------------------------------
+
+const tmpClipMatrix = new Float64Array(16);
+const tmpClipWorldPlane = new Float64Array(4);
+
+function getClipPlaneEquation(plane, out) {
+  const normal = plane.getNormalByReference();
+  const origin = plane.getOriginByReference();
+
+  out[0] = normal[0];
+  out[1] = normal[1];
+  out[2] = normal[2];
+  out[3] = -(
+    normal[0] * origin[0] +
+    normal[1] * origin[1] +
+    normal[2] * origin[2]
+  );
+
+  return out;
+}
 
 function vtkAbstractMapper(publicAPI, model) {
   model.classHierarchy.push('vtkAbstractMapper');
@@ -45,6 +67,14 @@ function vtkAbstractMapper(publicAPI, model) {
 
   publicAPI.getClippingPlanes = () => model.clippingPlanes;
 
+  publicAPI.getClippingPlanesMTime = () => {
+    let mtime = 0;
+    for (let i = 0; i < model.clippingPlanes.length; i++) {
+      mtime = Math.max(mtime, model.clippingPlanes[i].getMTime());
+    }
+    return mtime;
+  };
+
   publicAPI.setClippingPlanes = (planes) => {
     if (!planes) {
       return;
@@ -59,34 +89,32 @@ function vtkAbstractMapper(publicAPI, model) {
     }
   };
 
-  publicAPI.getClippingPlaneInDataCoords = (propMatrix, i, hnormal) => {
+  publicAPI.getClippingPlaneInCoords = (worldToCoords, i, hnormal) => {
+    if (i < 0 || i >= model.clippingPlanes?.length) {
+      vtkErrorMacro(`Clipping plane index ${i} is out of range.`);
+      return undefined;
+    }
+    const outHNormal = hnormal || new Float64Array(4);
+    getClipPlaneEquation(model.clippingPlanes[i], tmpClipWorldPlane);
+    mat4.invert(tmpClipMatrix, worldToCoords);
+    mat4.transpose(tmpClipMatrix, tmpClipMatrix);
+    vec4.transformMat4(outHNormal, tmpClipWorldPlane, tmpClipMatrix);
+    return outHNormal;
+  };
+
+  publicAPI.getClippingPlaneInDataCoords = (coordsToWorld, i, hnormal) => {
     const clipPlanes = model.clippingPlanes;
-    const mat = propMatrix;
 
     if (clipPlanes) {
       const n = clipPlanes.length;
       if (i >= 0 && i < n) {
-        // Get the plane
-        const plane = clipPlanes[i];
-        const normal = plane.getNormal();
-        const origin = plane.getOrigin();
-
-        // Compute the plane equation
-        const v1 = normal[0];
-        const v2 = normal[1];
-        const v3 = normal[2];
-        const v4 = -(v1 * origin[0] + v2 * origin[1] + v3 * origin[2]);
-
-        // Transform normal from world to data coords
-        hnormal[0] = v1 * mat[0] + v2 * mat[4] + v3 * mat[8] + v4 * mat[12];
-        hnormal[1] = v1 * mat[1] + v2 * mat[5] + v3 * mat[9] + v4 * mat[13];
-        hnormal[2] = v1 * mat[2] + v2 * mat[6] + v3 * mat[10] + v4 * mat[14];
-        hnormal[3] = v1 * mat[3] + v2 * mat[7] + v3 * mat[11] + v4 * mat[15];
+        getClipPlaneEquation(clipPlanes[i], tmpClipWorldPlane);
+        vec4.transformMat4(hnormal, tmpClipWorldPlane, coordsToWorld);
 
         return;
       }
     }
-    macro.vtkErrorMacro(`Clipping plane index ${i} is out of range.`);
+    vtkErrorMacro(`Clipping plane index ${i} is out of range.`);
   };
 }
 

--- a/Sources/Rendering/WebGPU/CellArrayMapper/index.js
+++ b/Sources/Rendering/WebGPU/CellArrayMapper/index.js
@@ -13,6 +13,12 @@ import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
 import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
 import vtkWebGPUSimpleMapper from 'vtk.js/Sources/Rendering/WebGPU/SimpleMapper';
 import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
+import {
+  addClipPlaneEntries,
+  getClippingPlaneEquationsInCoords,
+  getClipPlaneShaderChecks,
+  MAX_CLIPPING_PLANES,
+} from 'vtk.js/Sources/Rendering/WebGPU/Helpers/ClippingPlanes';
 
 const { Resolve } = CoincidentTopologyHelper;
 const { FieldAssociations } = vtkDataSet;
@@ -21,7 +27,6 @@ const { Representation } = vtkProperty;
 const { ScalarMode } = vtkMapper;
 const { CoordinateSystem } = vtkProp;
 const { DisplayLocation } = vtkProperty2D;
-
 const vtkWebGPUPolyDataVS = `
 //VTK::Renderer::Dec
 
@@ -384,6 +389,8 @@ fn main(
 }
 `;
 
+const tmp2Mat4 = new Float64Array(16);
+
 function isEdges(hash) {
   // edge pipelines have "edge" in them
   return hash.indexOf('edge') >= 0;
@@ -436,13 +443,15 @@ function vtkWebGPUCellArrayMapper(publicAPI, model) {
   publicAPI.updateUBO = () => {
     const actor = model.WebGPUActor.getRenderable();
     const ppty = actor.getProperty();
+    const clippingPlanesMTime = model.renderable.getClippingPlanesMTime();
     const backfaceProperty = actor.getBackfaceProperty?.() ?? ppty;
     const utime = model.UBO.getSendTime();
     if (
       publicAPI.getMTime() <= utime &&
       ppty.getMTime() <= utime &&
       backfaceProperty.getMTime() <= utime &&
-      model.renderable.getMTime() <= utime
+      model.renderable.getMTime() <= utime &&
+      clippingPlanesMTime <= utime
     ) {
       return;
     }
@@ -548,6 +557,24 @@ function vtkWebGPUCellArrayMapper(publicAPI, model) {
     const cp = publicAPI.getCoincidentParameters();
     model.UBO.setValue('CoincidentFactor', cp.factor);
     model.UBO.setValue('CoincidentOffset', cp.offset);
+    model.UBO.setValue('NumClipPlanes', 0);
+
+    if (!model.is2D && model.useRendererMatrix) {
+      const center = model.WebGPURenderer.getStabilizedCenterByReference();
+      mat4.fromTranslation(tmp2Mat4, [-center[0], -center[1], -center[2]]);
+      const numClipPlanes = getClippingPlaneEquationsInCoords(
+        model.renderable,
+        tmp2Mat4,
+        model.clipPlanes
+      );
+      model.UBO.setValue('NumClipPlanes', numClipPlanes);
+
+      if (numClipPlanes > 0) {
+        for (let i = 0; i < numClipPlanes; i++) {
+          model.UBO.setArray(`ClipPlane${i}`, model.clipPlanes[i]);
+        }
+      }
+    }
 
     // Only send if needed
     model.UBO.sendIfNeeded(model.WebGPURenderWindow.getDevice());
@@ -654,9 +681,11 @@ function vtkWebGPUCellArrayMapper(publicAPI, model) {
     const vDesc = pipeline.getShaderDescription('vertex');
     vDesc.addBuiltinOutput('vec4<f32>', '@builtin(position) Position');
     if (!vDesc.hasOutput('vertexVC')) vDesc.addOutput('vec4<f32>', 'vertexVC');
+    if (!vDesc.hasOutput('vertexSC')) vDesc.addOutput('vec4<f32>', 'vertexSC');
     let code = vDesc.getCode();
     if (model.useRendererMatrix) {
       code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+        '    output.vertexSC = mapperUBO.BCSCMatrix * vec4<f32>(vertexBC.xyz, 1.0);',
         '    var pCoord: vec4<f32> = rendererUBO.SCPCMatrix*mapperUBO.BCSCMatrix*vertexBC;',
         '    output.vertexVC = rendererUBO.SCVCMatrix * mapperUBO.BCSCMatrix * vec4<f32>(vertexBC.xyz, 1.0);',
         '//VTK::Position::Impl',
@@ -704,6 +733,19 @@ function vtkWebGPUCellArrayMapper(publicAPI, model) {
       '    output.Position = pCoord;',
     ]).result;
     vDesc.setCode(code);
+
+    const fDesc = pipeline.getShaderDescription('fragment');
+    code = fDesc.getCode();
+    const clipPlaneChecks = getClipPlaneShaderChecks({
+      countName: 'mapperUBO.NumClipPlanes',
+      planePrefix: 'mapperUBO.ClipPlane',
+      positionName: 'input.vertexSC',
+    });
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+      ...clipPlaneChecks,
+      '//VTK::Position::Impl',
+    ]).result;
+    fDesc.setCode(code);
   };
   model.shaderReplacements.set(
     'replaceShaderPosition',
@@ -1545,7 +1587,6 @@ export function extend(publicAPI, model, initiaLalues = {}) {
   model.vertexShaderTemplate = vtkWebGPUPolyDataVS;
 
   model._tmpMat3 = mat3.identity(new Float64Array(9));
-  model._tmpMat4 = mat4.identity(new Float64Array(16));
 
   // UBO
   model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
@@ -1587,6 +1628,8 @@ export function extend(publicAPI, model, initiaLalues = {}) {
   model.UBO.addEntry('ClipNear', 'f32');
   model.UBO.addEntry('ClipFar', 'f32');
   model.UBO.addEntry('Time', 'u32');
+  addClipPlaneEntries(model.UBO, 'ClipPlane');
+  model.UBO.addEntry('NumClipPlanes', 'u32');
 
   // Build VTK API
   macro.setGet(publicAPI, model, [
@@ -1599,6 +1642,9 @@ export function extend(publicAPI, model, initiaLalues = {}) {
   ]);
 
   model.textures = [];
+  model.clipPlanes = Array.from({ length: MAX_CLIPPING_PLANES }, () => [
+    0.0, 0.0, 0.0, 0.0,
+  ]);
 
   // Object methods
   vtkWebGPUCellArrayMapper(publicAPI, model);

--- a/Sources/Rendering/WebGPU/Helpers/ClippingPlanes.js
+++ b/Sources/Rendering/WebGPU/Helpers/ClippingPlanes.js
@@ -1,0 +1,34 @@
+export const MAX_CLIPPING_PLANES = 6;
+
+export function addClipPlaneEntries(buffer, prefix) {
+  for (let i = 0; i < MAX_CLIPPING_PLANES; i++) {
+    buffer.addEntry(`${prefix}${i}`, 'vec4<f32>');
+  }
+}
+
+export function getClipPlaneShaderChecks({
+  countName,
+  planePrefix,
+  positionName,
+  returnValue = 'discard',
+}) {
+  const checks = [];
+  for (let i = 0; i < MAX_CLIPPING_PLANES; i++) {
+    checks.push(
+      `  if (${countName} > ${i}u && dot(${planePrefix}${i}, ${positionName}) < 0.0) { ${returnValue}; }`
+    );
+  }
+  return checks;
+}
+
+export function getClippingPlaneEquationsInCoords(
+  mapper,
+  worldToCoords,
+  outPlanes
+) {
+  const count = mapper.getClippingPlanes().length;
+  for (let i = 0; i < count; i++) {
+    mapper.getClippingPlaneInCoords(worldToCoords, i, outPlanes[i]);
+  }
+  return count;
+}

--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -4,6 +4,12 @@ import * as macro from 'vtk.js/Sources/macros';
 import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
 import vtkWebGPUFullScreenQuad from 'vtk.js/Sources/Rendering/WebGPU/FullScreenQuad';
 import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
+import {
+  addClipPlaneEntries,
+  getClippingPlaneEquationsInCoords,
+  getClipPlaneShaderChecks,
+  MAX_CLIPPING_PLANES,
+} from 'vtk.js/Sources/Rendering/WebGPU/Helpers/ClippingPlanes';
 
 import { Resolve } from 'vtk.js/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper';
 import { InterpolationType } from 'vtk.js/Sources/Rendering/Core/ImageProperty/Constants';
@@ -13,9 +19,8 @@ import {
 } from 'vtk.js/Sources/Rendering/WebGPU/ImageMapper/Constants';
 import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
 
-// const { vtkErrorMacro } = macro;
+const { vtkErrorMacro } = macro;
 const { SlicingMode } = Constants;
-
 const imgFragTemplate = `
 //VTK::Renderer::Dec
 
@@ -24,6 +29,8 @@ const imgFragTemplate = `
 //VTK::TCoord::Dec
 
 //VTK::Image::Dec
+
+//VTK::Clip::Dec
 
 //VTK::RenderEncoder::Dec
 
@@ -36,6 +43,8 @@ fn main(
 //VTK::IOStructs::Output
 {
   var output: fragmentOutput;
+
+  //VTK::Clip::Impl
 
   //VTK::Image::Sample
 
@@ -215,7 +224,11 @@ function vtkWebGPUImageMapper(publicAPI, model) {
   publicAPI.render = () => {
     model.renderable.update();
 
-    model.currentInput = model.renderable.getInputData();
+    model.currentInput = model.renderable.getCurrentImage();
+    if (!model.currentInput) {
+      vtkErrorMacro('No input!');
+      return;
+    }
 
     publicAPI.prepareToDraw(model.WebGPURenderer.getRenderEncoder());
     model.renderEncoder.registerDrawCallback(model.pipeline, publicAPI.draw);
@@ -257,13 +270,15 @@ function vtkWebGPUImageMapper(publicAPI, model) {
     const utime = model.UBO.getSendTime();
     const actor = model.WebGPUImageSlice.getRenderable();
     const volMapr = actor.getMapper();
+    const clippingPlanesMTime = model.renderable.getClippingPlanesMTime();
     if (
       publicAPI.getMTime() > utime ||
       model.renderable.getMTime() > utime ||
-      actor.getProperty().getMTime() > utime
+      actor.getProperty().getMTime() > utime ||
+      clippingPlanesMTime > utime
     ) {
       // compute the SCTCMatrix
-      const image = volMapr.getInputData();
+      const image = volMapr.getCurrentImage();
       const center = model.WebGPURenderer.getStabilizedCenterByReference();
 
       mat4.identity(tmpMat4);
@@ -422,6 +437,23 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       const cp = publicAPI.getCoincidentParameters();
       model.UBO.setValue('CoincidentFactor', cp.factor);
       model.UBO.setValue('CoincidentOffset', cp.offset);
+      model.UBO.setValue('NumClipPlanes', 0);
+
+      const numClipPlanes = model.renderable.getClippingPlanes().length;
+      model.UBO.setValue('NumClipPlanes', numClipPlanes);
+
+      if (numClipPlanes > 0) {
+        mat4.fromTranslation(tmp2Mat4, [-center[0], -center[1], -center[2]]);
+        getClippingPlaneEquationsInCoords(
+          model.renderable,
+          tmp2Mat4,
+          model.clipPlanes
+        );
+        for (let i = 0; i < numClipPlanes; i++) {
+          model.UBO.setArray(`ClipPlane${i}`, model.clipPlanes[i]);
+        }
+      }
+
       model.UBO.sendIfNeeded(model.device);
     }
   };
@@ -686,6 +718,7 @@ function vtkWebGPUImageMapper(publicAPI, model) {
   publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
     const vDesc = pipeline.getShaderDescription('vertex');
     vDesc.addBuiltinOutput('vec4<f32>', '@builtin(position) Position');
+    vDesc.addOutput('vec4<f32>', 'vertexSC');
     let code = vDesc.getCode();
     const lines = [
       'var pos: vec4<f32> = mapperUBO.Origin +',
@@ -702,7 +735,8 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       // Match the OpenGL coincident topology constant offset scale (~1 / 2^16 = 0.000016)
       'pos.z = clamp(pos.z - 0.000016 * mapperUBO.CoincidentOffset * pos.w, 0.0, pos.w);',
       'output.tcoordVS = tcoord;',
-      'output.Position = pos;'
+      'output.vertexSC = pos;',
+      'output.Position = rendererUBO.SCPCMatrix * pos;'
     );
     code = vtkWebGPUShaderCache.substitute(
       code,
@@ -1059,6 +1093,24 @@ function vtkWebGPUImageMapper(publicAPI, model) {
   };
   sr.set('replaceShaderImage', publicAPI.replaceShaderImage);
 
+  publicAPI.replaceShaderClip = (hash, pipeline, vertexInput) => {
+    const fDesc = pipeline.getShaderDescription('fragment');
+    let code = fDesc.getCode();
+    const clipPlaneChecks = getClipPlaneShaderChecks({
+      countName: 'mapperUBO.NumClipPlanes',
+      planePrefix: 'mapperUBO.ClipPlane',
+      positionName: 'input.vertexSC',
+    });
+
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Clip::Impl', [
+      ...clipPlaneChecks,
+      '//VTK::Clip::Impl',
+    ]).result;
+
+    fDesc.setCode(code);
+  };
+  sr.set('replaceShaderClip', publicAPI.replaceShaderClip);
+
   publicAPI.replaceShaderCoincidentOffset = (hash, pipeline, vertexInput) => {
     const fDesc = pipeline.getShaderDescription('fragment');
     if (!fDesc) {
@@ -1117,6 +1169,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.UBO.addEntry('Opacity', 'f32');
   model.UBO.addEntry('CoincidentFactor', 'f32');
   model.UBO.addEntry('CoincidentOffset', 'f32');
+  addClipPlaneEntries(model.UBO, 'ClipPlane');
+  model.UBO.addEntry('NumClipPlanes', 'u32');
 
   model.lutBuildTime = {};
   macro.obj(model.lutBuildTime, { mtime: 0 });
@@ -1132,6 +1186,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.opacityTmpTable = new Float32Array(model.rowLength);
   model.colorLUTArray = null;
   model.opacityLUTArray = null;
+  model.clipPlanes = Array.from({ length: MAX_CLIPPING_PLANES }, () => [
+    0.0, 0.0, 0.0, 0.0,
+  ]);
 
   model.VBOBuildTime = {};
   macro.obj(model.VBOBuildTime);
@@ -1149,4 +1206,4 @@ export const newInstance = macro.newInstance(extend, 'vtkWebGPUImageMapper');
 export default { newInstance, extend };
 
 // Register ourself to WebGPU backend if imported
-registerOverride('vtkImageMapper', newInstance);
+registerOverride('vtkAbstractImageMapper', newInstance);

--- a/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
+++ b/Sources/Rendering/WebGPU/VolumePassFSQ/index.js
@@ -6,6 +6,11 @@ import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
 import vtkWebGPUStorageBuffer from 'vtk.js/Sources/Rendering/WebGPU/StorageBuffer';
 import vtkWebGPUSampler from 'vtk.js/Sources/Rendering/WebGPU/Sampler';
 import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
+import {
+  addClipPlaneEntries,
+  getClippingPlaneEquationsInCoords,
+  MAX_CLIPPING_PLANES,
+} from 'vtk.js/Sources/Rendering/WebGPU/Helpers/ClippingPlanes';
 
 import { BlendMode } from 'vtk.js/Sources/Rendering/Core/VolumeMapper/Constants';
 
@@ -26,6 +31,46 @@ fn getTextureValue(vTex: texture_3d<f32>, tpos: vec4<f32>) -> f32
 {
   // todo multicomponent support
   return textureSampleLevel(vTex, clampSampler, tpos.xyz, 0.0).r;
+}
+
+fn intersectRayBoundsWithClipPlanes(vNum: i32, minPosSC: vec4<f32>, rayStepSC: vec4<f32>, rayBounds: vec2<f32>) -> vec2<f32>
+{
+  var result: vec2<f32> = rayBounds;
+  let clipCount: i32 = i32(volumeSSBO.values[vNum].clipPlaneStates.x);
+  if (clipCount <= 0)
+  {
+    return result;
+  }
+
+  ${Array.from(
+    { length: MAX_CLIPPING_PLANES },
+    (_, idx) => `
+  if (clipCount > ${idx})
+  {
+    let clipPlane${idx}: vec4<f32> = volumeSSBO.values[vNum].clipPlane${idx};
+    let rayDirRatio${idx}: f32 = dot(rayStepSC, clipPlane${idx});
+    let equationResult${idx}: f32 = dot(minPosSC, clipPlane${idx});
+
+    let absRayDirRatio${idx}: f32 = abs(rayDirRatio${idx});
+    if (absRayDirRatio${idx} > 1e-6)
+    {
+      let intersection${idx}: f32 = -equationResult${idx} / rayDirRatio${idx};
+      result.x = select(result.x, max(result.x, intersection${idx}), rayDirRatio${idx} > 0.0);
+      result.y = select(result.y, min(result.y, intersection${idx}), rayDirRatio${idx} < 0.0);
+    }
+    else if (equationResult${idx} < 0.0)
+    {
+      result.x = result.y;
+    }
+
+    if (result.x >= result.y)
+    {
+      return result;
+    }
+  }`
+  ).join('\n')}
+
+  return result;
 }
 
 fn getGradient(vTex: texture_3d<f32>, tpos: vec4<f32>, vNum: i32, scalar: f32) -> vec4<f32>
@@ -159,7 +204,11 @@ fn traverseMax(vTex: texture_3d<f32>, vNum: i32, cNum: i32, rayLengthSC: f32, mi
   var tpos2: vec4<f32> = volumeSSBO.values[vNum].SCTCMatrix*(minPosSC + rayStepSC);
   var tstep: vec4<f32> = tpos2 - tpos;
 
-  var rayBounds: vec2<f32> = adjustBounds(tpos, tstep, numSteps);
+  var rayBounds: vec2<f32> = intersectRayBoundsWithClipPlanes(
+    vNum,
+    minPosSC,
+    rayStepSC,
+    adjustBounds(tpos, tstep, numSteps));
 
   // did we hit anything
   if (rayBounds.x >= rayBounds.y)
@@ -199,7 +248,11 @@ fn traverseMin(vTex: texture_3d<f32>, vNum: i32, cNum: i32, rayLengthSC: f32, mi
   var tpos2: vec4<f32> = volumeSSBO.values[vNum].SCTCMatrix*(minPosSC + rayStepSC);
   var tstep: vec4<f32> = tpos2 - tpos;
 
-  var rayBounds: vec2<f32> = adjustBounds(tpos, tstep, numSteps);
+  var rayBounds: vec2<f32> = intersectRayBoundsWithClipPlanes(
+    vNum,
+    minPosSC,
+    rayStepSC,
+    adjustBounds(tpos, tstep, numSteps));
 
   // did we hit anything
   if (rayBounds.x >= rayBounds.y)
@@ -239,7 +292,11 @@ fn traverseAverage(vTex: texture_3d<f32>, vNum: i32, cNum: i32, rayLengthSC: f32
   var tpos2: vec4<f32> = volumeSSBO.values[vNum].SCTCMatrix*(minPosSC + rayStepSC);
   var tstep: vec4<f32> = tpos2 - tpos;
 
-  var rayBounds: vec2<f32> = adjustBounds(tpos, tstep, numSteps);
+  var rayBounds: vec2<f32> = intersectRayBoundsWithClipPlanes(
+    vNum,
+    minPosSC,
+    rayStepSC,
+    adjustBounds(tpos, tstep, numSteps));
 
   // did we hit anything
   if (rayBounds.x >= rayBounds.y)
@@ -274,6 +331,7 @@ fn traverseAverage(vTex: texture_3d<f32>, vNum: i32, cNum: i32, rayLengthSC: f32
   if (sampleCount <= 0.0)
   {
     traverseVals[vNum] = vec4<f32>(0.0,0.0,0.0,0.0);
+    return;
   }
 
   // process to get the color and opacity
@@ -288,7 +346,11 @@ fn traverseAdditive(vTex: texture_3d<f32>, vNum: i32, cNum: i32, rayLengthSC: f3
   var tpos2: vec4<f32> = volumeSSBO.values[vNum].SCTCMatrix*(minPosSC + rayStepSC);
   var tstep: vec4<f32> = tpos2 - tpos;
 
-  var rayBounds: vec2<f32> = adjustBounds(tpos, tstep, numSteps);
+  var rayBounds: vec2<f32> = intersectRayBoundsWithClipPlanes(
+    vNum,
+    minPosSC,
+    rayStepSC,
+    adjustBounds(tpos, tstep, numSteps));
 
   // did we hit anything
   if (rayBounds.x >= rayBounds.y)
@@ -309,7 +371,6 @@ fn traverseAdditive(vTex: texture_3d<f32>, vNum: i32, cNum: i32, rayLengthSC: f3
     // {
       sumVal = sumVal + sample;
     // }
-
     // increment position
     curDist = curDist + 1.0;
     tpos = tpos + tstep;
@@ -333,7 +394,9 @@ fn composite(rayLengthSC: f32, minPosSC: vec4<f32>, rayStepSC: vec4<f32>) -> vec
   var curDist: f32 = 0.0;
   var computedColor: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
   var sampleColor: vec4<f32>;
+  var numSteps: f32 = rayLengthSC/mapperUBO.SampleDistance;
 //VTK::Volume::TraverseCalls
+//VTK::Volume::TraverseInit
 
   loop
   {
@@ -389,7 +452,6 @@ fn main(
 
 const tmpMat4 = new Float64Array(16);
 const tmp2Mat4 = new Float64Array(16);
-
 // ----------------------------------------------------------------------------
 // vtkWebGPUVolumePassFSQ methods
 // ----------------------------------------------------------------------------
@@ -419,6 +481,7 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
     const fDesc = pipeline.getShaderDescription('fragment');
     let code = fDesc.getCode();
     const compositeCalls = [];
+    const clipInit = [];
     const traverseCalls = [];
     for (let i = 0; i < model.volumes.length; i++) {
       // todo pass rowPos
@@ -427,12 +490,26 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
         .getMapper()
         .getBlendMode();
       if (blendMode === BlendMode.COMPOSITE_BLEND) {
+        clipInit.push(
+          `  var tpos${i}: vec4<f32> = volumeSSBO.values[${i}].SCTCMatrix*minPosSC;`
+        );
+        clipInit.push(
+          `  var tpos2_${i}: vec4<f32> = volumeSSBO.values[${i}].SCTCMatrix*(minPosSC + rayStepSC);`
+        );
+        clipInit.push(`  var tstep${i}: vec4<f32> = tpos2_${i} - tpos${i};`);
+        clipInit.push(
+          `  var rayBounds${i}: vec2<f32> = intersectRayBoundsWithClipPlanes(${i}, minPosSC, rayStepSC, adjustBounds(tpos${i}, tstep${i}, numSteps));`
+        );
         compositeCalls.push(
-          `    sampleColor = processVolume(volTexture${i}, ${i}, ${model.rowStarts[i]}, rayPosSC, tfunRows);`
+          `    if (curDist >= rayBounds${i}.x * mapperUBO.SampleDistance && curDist <= rayBounds${i}.y * mapperUBO.SampleDistance) {`
+        );
+        compositeCalls.push(
+          `      sampleColor = processVolume(volTexture${i}, ${i}, ${model.rowStarts[i]}, rayPosSC, tfunRows);`
         );
         compositeCalls.push(`    computedColor = vec4<f32>(
           sampleColor.a * sampleColor.rgb * (1.0 - computedColor.a) + computedColor.rgb,
           (1.0 - computedColor.a)*sampleColor.a + computedColor.a);`);
+        compositeCalls.push('    }');
       } else {
         traverseCalls.push(`  sampleColor = traverseVals[${i}];`);
         traverseCalls.push(`  computedColor = vec4<f32>(
@@ -449,6 +526,11 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
       code,
       '//VTK::Volume::TraverseCalls',
       traverseCalls
+    ).result;
+    code = vtkWebGPUShaderCache.substitute(
+      code,
+      '//VTK::Volume::TraverseInit',
+      clipInit
     ).result;
     code = vtkWebGPUShaderCache.substitute(code, '//VTK::Volume::TraverseDec', [
       `var<private> traverseVals: array<vec4<f32>,${model.volumes.length}>;`,
@@ -637,7 +719,8 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
         mtime,
         vol.getMTime(),
         image.getMTime(),
-        volMapr.getMTime()
+        volMapr.getMTime(),
+        volMapr.getClippingPlanesMTime()
       );
     }
     if (mtime < model.SSBO.getSendTime()) {
@@ -656,6 +739,11 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
     //
     const marray = new Float64Array(model.volumes.length * 16);
     const vPlaneArray = new Float64Array(model.volumes.length * 16);
+    const clipPlaneArrays = Array.from(
+      { length: MAX_CLIPPING_PLANES },
+      () => new Float64Array(model.volumes.length * 4)
+    );
+    const clipPlaneStates = new Float64Array(model.volumes.length * 4);
     const tstepArray = new Float64Array(model.volumes.length * 4);
     const shadeArray = new Float64Array(model.volumes.length * 4);
     const spacingArray = new Float64Array(model.volumes.length * 4);
@@ -727,6 +815,21 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
       ipScalarRangeArray[vidx * 4] = ipScalarRange[0] / tScale;
       ipScalarRangeArray[vidx * 4 + 1] = ipScalarRange[1] / tScale;
       ipScalarRangeArray[vidx * 4 + 2] = actor.getProperty().getFilterMode();
+
+      mat4.fromTranslation(tmp2Mat4, [-center[0], -center[1], -center[2]]);
+      const clipPlaneCount = getClippingPlaneEquationsInCoords(
+        volMapr,
+        tmp2Mat4,
+        model.clipPlanes
+      );
+      clipPlaneStates[vidx * 4] = clipPlaneCount;
+      for (let i = 0; i < clipPlaneCount; i++) {
+        const clipOffset = vidx * 4;
+        clipPlaneArrays[i][clipOffset] = model.clipPlanes[i][0];
+        clipPlaneArrays[i][clipOffset + 1] = model.clipPlanes[i][1];
+        clipPlaneArrays[i][clipOffset + 2] = model.clipPlanes[i][2];
+        clipPlaneArrays[i][clipOffset + 3] = model.clipPlanes[i][3];
+      }
     }
     model.SSBO.addEntry('SCTCMatrix', 'mat4x4<f32>');
     model.SSBO.addEntry('planeNormals', 'mat4x4<f32>');
@@ -734,12 +837,18 @@ function vtkWebGPUVolumePassFSQ(publicAPI, model) {
     model.SSBO.addEntry('tstep', 'vec4<f32>');
     model.SSBO.addEntry('spacing', 'vec4<f32>');
     model.SSBO.addEntry('ipScalarRange', 'vec4<f32>');
+    addClipPlaneEntries(model.SSBO, 'clipPlane');
+    model.SSBO.addEntry('clipPlaneStates', 'vec4<f32>');
     model.SSBO.setAllInstancesFromArray('SCTCMatrix', marray);
     model.SSBO.setAllInstancesFromArray('planeNormals', vPlaneArray);
     model.SSBO.setAllInstancesFromArray('shade', shadeArray);
     model.SSBO.setAllInstancesFromArray('tstep', tstepArray);
     model.SSBO.setAllInstancesFromArray('spacing', spacingArray);
     model.SSBO.setAllInstancesFromArray('ipScalarRange', ipScalarRangeArray);
+    for (let i = 0; i < MAX_CLIPPING_PLANES; i++) {
+      model.SSBO.setAllInstancesFromArray(`clipPlane${i}`, clipPlaneArrays[i]);
+    }
+    model.SSBO.setAllInstancesFromArray('clipPlaneStates', clipPlaneStates);
     model.SSBO.send(device);
 
     // now create the componentSSBO
@@ -975,6 +1084,9 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.lutBuildTime = {};
   macro.obj(model.lutBuildTime, { mtime: 0 });
+  model.clipPlanes = Array.from({ length: MAX_CLIPPING_PLANES }, () => [
+    0.0, 0.0, 0.0, 0.0,
+  ]);
 
   // Object methods
   vtkWebGPUVolumePassFSQ(publicAPI, model);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
fixes : #2061
fixes : #2293
fixes : #2227
fixes : #1966

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Implement WebGPU clipping planes for polydata, image and volume rendering,

Use VolumeRenderingWithPolyData example for testing.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
