### PR TITLE
fix(xmlreader): use \s to split plain-text data-arrays on any white-spcae character  fix #2642

### DIFF
--- a/Sources/IO/XML/XMLReader/index.js
+++ b/Sources/IO/XML/XMLReader/index.js
@@ -270,7 +270,7 @@ function processDataArray(
   if (format === 'ascii') {
     values = new TYPED_ARRAY[dataType](size * numberOfComponents);
     let offset = 0;
-    dataArrayElem.firstChild.nodeValue.split(/[\\t \\n]+/).forEach((token) => {
+    dataArrayElem.firstChild.nodeValue.split(/[\s]+/).forEach((token) => {
       if (token.trim().length) {
         values[offset++] = Number(token);
       }


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
Fixes #2642: In ascii XML polyData files (.vtp), Paraview splits data on newline and/or white-space, whereas due to the mistyped regex vtk.js does not

### Results
Now, vtk.js splits on any white-space character.

### Changes
a single regex dealing with splitting a string.
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [ x] Run `npm run reformat` to have correctly formatted code
I only changed a single regex in one line - this is not necessary. I just "checked" it to get past a possible bot.

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x ] Tested environment:
  - **vtk.js**: 32.14.0
  - **OS**: LINUX
  - **Browser**: Chrome 136.0.7103.177

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
