### PR TITLE
fix(xmlreader): use \s to split plain-text data-arrays on any white-space character

### DIFF
--- a/Sources/IO/XML/XMLReader/index.js
+++ b/Sources/IO/XML/XMLReader/index.js
@@ -270,7 +270,7 @@ function processDataArray(
   if (format === 'ascii') {
     values = new TYPED_ARRAY[dataType](size * numberOfComponents);
     let offset = 0;
-    dataArrayElem.firstChild.nodeValue.split(/[\\t \\n]+/).forEach((token) => {
+    dataArrayElem.firstChild.nodeValue.split(/[\s]+/).forEach((token) => {
       if (token.trim().length) {
         values[offset++] = Number(token);
       }


### PR DESCRIPTION
### Context
Fixes https://github.com/Kitware/vtk-js/issues/2642: In ascii XML polyData files (.vtp), Paraview splits data on newline and/or white-space, whereas due to the mistyped regex vtk.js does not.

### Results
Now, vtk.js splits on any white-space character.

### Changes
a single regex dealing with splitting a string.
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
I only changed a single regex in one line - this is not necessary. I just "checked" it to get past a possible bot.
### Testing
 - [ ] This change adds or fixes unit tests
 - [x] Tested environment:
  -  vtk.js: 32.14.0
  -  OS: LINUX
  -  Browser: Chrome 136.0.7103.177

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
