### PR TITLE
feat(WebGPU): implement subimage texture upload

### DIFF
--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -4,6 +4,8 @@ import vtkWebGPUTextureView from 'vtk.js/Sources/Rendering/WebGPU/TextureView';
 import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
 import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
 
+const { vtkErrorMacro } = macro;
+
 // ----------------------------------------------------------------------------
 // Global methods
 // ----------------------------------------------------------------------------
@@ -15,6 +17,142 @@ import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
 function vtkWebGPUTexture(publicAPI, model) {
   // Set our className
   model.classHierarchy.push('vtkWebGPUTexture');
+
+  const getUploadArrayType = (tDetails, fallbackType) => {
+    if (tDetails.elementSize === 2 && tDetails.sampleType === 'float') {
+      return 'Uint16Array';
+    }
+
+    if (tDetails.sampleType === 'sint') {
+      if (tDetails.elementSize === 1) return 'Int8Array';
+      if (tDetails.elementSize === 2) return 'Int16Array';
+      if (tDetails.elementSize === 4) return 'Int32Array';
+    } else if (tDetails.sampleType === 'unfilterable-float') {
+      if (tDetails.elementSize === 4) return 'Float32Array';
+    } else {
+      if (tDetails.elementSize === 1) return 'Uint8Array';
+      if (tDetails.elementSize === 2) return 'Uint16Array';
+      if (tDetails.elementSize === 4) return 'Uint32Array';
+    }
+
+    return fallbackType;
+  };
+
+  const prepareTextureUploadData = (arr, width, height, depth) => {
+    const tDetails = vtkWebGPUTypes.getDetailsFromTextureFormat(model.format);
+    const expectedRowElements = width * tDetails.numComponents;
+    const expectedElementCount = expectedRowElements * height * depth;
+    const halfFloat =
+      tDetails.elementSize === 2 && tDetails.sampleType === 'float';
+
+    if (!arr?.length && expectedElementCount > 0) {
+      vtkErrorMacro('Texture upload failed: missing nativeArray data.');
+      return null;
+    }
+
+    if (arr.length < expectedElementCount) {
+      vtkErrorMacro(
+        `Texture upload failed: expected ${expectedElementCount} values but received ${arr.length}.`
+      );
+      return null;
+    }
+
+    const inputArray =
+      arr.length > expectedElementCount
+        ? arr.subarray(0, expectedElementCount)
+        : arr;
+
+    const sourceBytesPerElement =
+      inputArray.BYTES_PER_ELEMENT || tDetails.elementSize;
+    const expectedBytesPerRow = width * tDetails.stride;
+    const alignedBytesPerRow =
+      256 * Math.floor((expectedBytesPerRow + 255) / 256);
+    const outputArrayType = getUploadArrayType(
+      tDetails,
+      inputArray.constructor.name
+    );
+    const outputBytesPerElement = halfFloat
+      ? 2
+      : macro.newTypedArray(outputArrayType, 0).BYTES_PER_ELEMENT;
+    const alignedRowElements = alignedBytesPerRow / outputBytesPerElement;
+    const inputRowBytes = expectedRowElements * sourceBytesPerElement;
+    const requiresRepack =
+      halfFloat ||
+      inputArray.constructor.name !== outputArrayType ||
+      inputRowBytes !== alignedBytesPerRow;
+
+    // No changes needed if not half float and already aligned
+    if (!requiresRepack) {
+      return {
+        data: inputArray,
+        bytesPerRow: alignedBytesPerRow,
+      };
+    }
+
+    // Create the output array
+    const totalRows = height * depth;
+    const outArray = macro.newTypedArray(
+      outputArrayType,
+      alignedRowElements * totalRows
+    );
+
+    // Copy and convert data when needed
+    if (halfFloat) {
+      for (let row = 0; row < totalRows; row++) {
+        const inOffset = row * expectedRowElements;
+        const outOffset = row * alignedRowElements;
+        for (let i = 0; i < expectedRowElements; i++) {
+          outArray[outOffset + i] = HalfFloat.toHalf(inputArray[inOffset + i]);
+        }
+      }
+    } else if (alignedRowElements === expectedRowElements) {
+      // If the output width is the same as input, just copy
+      outArray.set(inputArray);
+    } else {
+      for (let row = 0; row < totalRows; row++) {
+        outArray.set(
+          inputArray.subarray(
+            row * expectedRowElements,
+            (row + 1) * expectedRowElements
+          ),
+          row * alignedRowElements
+        );
+      }
+    }
+
+    return {
+      data: outArray,
+      bytesPerRow: alignedBytesPerRow,
+    };
+  };
+
+  const validateTextureWriteBounds = (x, y, z, width, height, depth) => {
+    if (x < 0 || y < 0 || z < 0 || width <= 0 || height <= 0 || depth <= 0) {
+      vtkErrorMacro(
+        `Texture upload failed: invalid write region ` +
+          `origin=(${x}, ${y}, ${z}) ` +
+          `size=(${width}, ${height}, ${depth}).`
+      );
+      return false;
+    }
+
+    if (
+      x + width > model.width ||
+      y + height > model.height ||
+      z + depth > model.depth
+    ) {
+      vtkErrorMacro(
+        `Texture upload failed: write region ` +
+          `origin=(${x}, ${y}, ${z}) ` +
+          `size=(${width}, ${height}, ${depth}) ` +
+          `exceeds texture extent=(${model.width}, ` +
+          `${model.height}, ${model.depth}).`
+      );
+      return false;
+    }
+
+    return true;
+  };
 
   publicAPI.create = (device, options) => {
     model.device = device;
@@ -121,84 +259,21 @@ function vtkWebGPUTexture(publicAPI, model) {
       return;
     }
 
-    const tDetails = vtkWebGPUTypes.getDetailsFromTextureFormat(model.format);
-    let bufferBytesPerRow = model.width * tDetails.stride;
-
-    /**
-     * Align texture data to ensure bytesPerRow is a multiple of 256.
-     * This is necessary for WebGPU texture uploads, especially for half-float formats.
-     * It also handles half-float conversion if the texture format requires it.
-     * @param {*} arr - The input array containing texture data.
-     * @param {*} height - The height of the texture.
-     * @param {*} depth - The depth of the texture (1 for 2D textures).
-     * @returns
-     */
-    const alignTextureData = (arr, height, depth) => {
-      // bytesPerRow must be a multiple of 256 so we might need to rebuild
-      // the data here before passing to the buffer. e.g. if it is unorm8x4 then
-      // we need to have width be a multiple of 64
-      // Check if the texture is half float
-      const halfFloat =
-        tDetails.elementSize === 2 && tDetails.sampleType === 'float';
-
-      const bytesPerElement = arr.BYTES_PER_ELEMENT;
-      const inWidthInBytes = (arr.length / (height * depth)) * bytesPerElement;
-
-      // No changes needed if not half float and already aligned
-      if (!halfFloat && inWidthInBytes % 256 === 0) {
-        return [arr, inWidthInBytes];
-      }
-
-      // Calculate dimensions for the new buffer
-      const inWidth = inWidthInBytes / bytesPerElement;
-      const outBytesPerElement = tDetails.elementSize;
-      const outWidthInBytes =
-        256 * Math.floor((inWidth * outBytesPerElement + 255) / 256);
-      const outWidth = outWidthInBytes / outBytesPerElement;
-
-      // Create the output array
-      const outArray = macro.newTypedArray(
-        halfFloat ? 'Uint16Array' : arr.constructor.name,
-        outWidth * height * depth
-      );
-
-      // Copy and convert data when needed
-      const totalRows = height * depth;
-      if (halfFloat) {
-        for (let v = 0; v < totalRows; v++) {
-          const inOffset = v * inWidth;
-          const outOffset = v * outWidth;
-          for (let i = 0; i < inWidth; i++) {
-            outArray[outOffset + i] = HalfFloat.toHalf(arr[inOffset + i]);
-          }
-        }
-      } else if (outWidth === inWidth) {
-        // If the output width is the same as input, just copy
-        outArray.set(arr);
-      } else {
-        for (let v = 0; v < totalRows; v++) {
-          outArray.set(
-            arr.subarray(v * inWidth, (v + 1) * inWidth),
-            v * outWidth
-          );
-        }
-      }
-
-      return [outArray, outWidthInBytes];
-    };
-
     if (req.nativeArray) {
       nativeArray = req.nativeArray;
     }
 
     const is3D = publicAPI.getDimensionality() === 3;
-    const alignedTextureData = alignTextureData(
+    const preparedData = prepareTextureUploadData(
       nativeArray,
+      model.width,
       model.height,
       is3D ? model.depth : 1
     );
-    bufferBytesPerRow = alignedTextureData[1];
-    const data = alignedTextureData[0];
+    if (!preparedData) {
+      return;
+    }
+    const data = preparedData.data;
 
     model.device.getHandle().queue.writeTexture(
       {
@@ -209,7 +284,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       data,
       {
         offset: 0,
-        bytesPerRow: bufferBytesPerRow,
+        bytesPerRow: preparedData.bytesPerRow,
         rowsPerImage: model.height,
       },
       {
@@ -226,6 +301,61 @@ function vtkWebGPUTexture(publicAPI, model) {
         model.mipLevel + 1
       );
     }
+    model.ready = true;
+  };
+
+  publicAPI.writeSubImageData = (req) => {
+    const x = req.x ?? 0;
+    const y = req.y ?? 0;
+    const z = req.z ?? 0;
+    const width = req.width ?? model.width - x;
+    const height = req.height ?? model.height - y;
+    const depth = req.depth ?? model.depth - z;
+    const nativeArray = req.nativeArray || [];
+    if (!validateTextureWriteBounds(x, y, z, width, height, depth)) {
+      return;
+    }
+    const preparedData = prepareTextureUploadData(
+      nativeArray,
+      width,
+      height,
+      depth
+    );
+    if (!preparedData) {
+      return;
+    }
+
+    model.device.getHandle().queue.writeTexture(
+      {
+        texture: model.handle,
+        mipLevel: 0,
+        origin: {
+          x,
+          y,
+          z,
+        },
+      },
+      preparedData.data,
+      {
+        offset: 0,
+        bytesPerRow: preparedData.bytesPerRow,
+        rowsPerImage: height,
+      },
+      {
+        width,
+        height,
+        depthOrArrayLayers: depth,
+      }
+    );
+
+    if (publicAPI.getDimensionality() !== 3 && model.mipLevel > 0) {
+      vtkTexture.generateMipmaps(
+        model.device.getHandle(),
+        model.handle,
+        model.mipLevel + 1
+      );
+    }
+
     model.ready = true;
   };
 

--- a/Sources/Rendering/WebGPU/Texture/test/testWriteSubImageData.js
+++ b/Sources/Rendering/WebGPU/Texture/test/testWriteSubImageData.js
@@ -1,0 +1,140 @@
+import test from 'tape';
+
+import macro from 'vtk.js/Sources/macros';
+import vtkWebGPUTexture from 'vtk.js/Sources/Rendering/WebGPU/Texture';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+test.onlyIfWebGPU('Test vtkWebGPUTexture.writeSubImageData', async (t) => {
+  const device = await testUtils.createWebGPUTestDevice();
+  const texture = vtkWebGPUTexture.newInstance({ label: 'subImageTexture' });
+
+  try {
+    texture.create(device, {
+      width: 4,
+      height: 4,
+      format: 'rgba8unorm',
+      usage:
+        /* eslint-disable no-undef */
+        /* eslint-disable no-bitwise */
+        GPUTextureUsage.TEXTURE_BINDING |
+        /* eslint-disable no-undef */
+        /* eslint-disable no-bitwise */
+        GPUTextureUsage.COPY_DST |
+        /* eslint-disable no-undef */
+        /* eslint-disable no-bitwise */
+        GPUTextureUsage.COPY_SRC,
+    });
+
+    const basePixels = new Uint8Array(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      basePixels[i * 4 + 3] = 255;
+    }
+    texture.writeImageData({ nativeArray: basePixels });
+
+    const patch = new Uint8Array([
+      255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
+    ]);
+    texture.writeSubImageData({
+      x: 1,
+      y: 1,
+      width: 2,
+      height: 2,
+      nativeArray: patch,
+    });
+
+    const actual = await testUtils.readWebGPUTexture2D(device, texture, 4, 4);
+
+    const expected = new Uint8Array(basePixels);
+    const setPixel = (x, y, rgba) => {
+      expected.set(rgba, (y * 4 + x) * 4);
+    };
+    setPixel(1, 1, [255, 0, 0, 255]);
+    setPixel(2, 1, [0, 255, 0, 255]);
+    setPixel(1, 2, [0, 0, 255, 255]);
+    setPixel(2, 2, [255, 255, 0, 255]);
+
+    t.equal(
+      actual.length,
+      expected.length,
+      'readback size matches texture size'
+    );
+
+    for (let i = 0; i < expected.length; i++) {
+      t.equal(actual[i], expected[i], `byte ${i} matches expected value`);
+    }
+  } finally {
+    texture.getHandle().destroy();
+    device.getHandle().destroy();
+  }
+  t.end();
+});
+
+test.onlyIfWebGPU(
+  'Test vtkWebGPUTexture.writeSubImageData rejects out-of-bounds writes',
+  async (t) => {
+    const device = await testUtils.createWebGPUTestDevice();
+    const texture = vtkWebGPUTexture.newInstance({
+      label: 'subImageTextureOutOfBounds',
+    });
+    const errors = [];
+    const previousErrorLogger = console.error;
+
+    macro.setLoggerFunction('error', (...args) => {
+      errors.push(args.join(' '));
+    });
+
+    try {
+      texture.create(device, {
+        width: 4,
+        height: 4,
+        format: 'rgba8unorm',
+        usage:
+          /* eslint-disable no-undef */
+          /* eslint-disable no-bitwise */
+          GPUTextureUsage.TEXTURE_BINDING |
+          /* eslint-disable no-undef */
+          /* eslint-disable no-bitwise */
+          GPUTextureUsage.COPY_DST |
+          /* eslint-disable no-undef */
+          /* eslint-disable no-bitwise */
+          GPUTextureUsage.COPY_SRC,
+      });
+
+      const basePixels = new Uint8Array(4 * 4 * 4);
+      for (let i = 0; i < 16; i++) {
+        basePixels[i * 4 + 3] = 255;
+      }
+      texture.writeImageData({ nativeArray: basePixels });
+
+      const patch = new Uint8Array([
+        255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
+      ]);
+      texture.writeSubImageData({
+        x: 3,
+        y: 3,
+        width: 2,
+        height: 2,
+        nativeArray: patch,
+      });
+
+      const actual = await testUtils.readWebGPUTexture2D(device, texture, 4, 4);
+
+      t.equal(errors.length, 1, 'out-of-bounds write logs one error');
+      console.log(errors);
+      t.ok(
+        errors[0].includes('exceeds texture extent'),
+        'error explains that the write region is out of bounds'
+      );
+      t.deepEqual(
+        Array.from(actual),
+        Array.from(basePixels),
+        'texture contents remain unchanged after rejected write'
+      );
+    } finally {
+      macro.setLoggerFunction('error', previousErrorLogger);
+      texture.getHandle().destroy();
+      device.getHandle().destroy();
+    }
+    t.end();
+  }
+);

--- a/Sources/Testing/testUtils.js
+++ b/Sources/Testing/testUtils.js
@@ -1,5 +1,6 @@
 import pixelmatch from 'pixelmatch';
 import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
+import vtkWebGPUDevice from 'vtk.js/Sources/Rendering/WebGPU/Device';
 
 let REMOVE_DOM_ELEMENTS = true;
 
@@ -204,11 +205,84 @@ function objEquals(a, b) {
   return true;
 }
 
+function alignTo256(value) {
+  return Math.ceil(value / 256) * 256;
+}
+
+async function createWebGPUTestDevice() {
+  const adapter = await navigator.gpu.requestAdapter({
+    powerPreference: 'high-performance',
+  });
+  if (!adapter) {
+    throw new Error('Failed to acquire a WebGPU adapter.');
+  }
+
+  const handle = await adapter.requestDevice();
+  const device = vtkWebGPUDevice.newInstance();
+  device.initialize(handle);
+  return device;
+}
+
+async function readWebGPUTexture2D(device, texture, width, height) {
+  const bytesPerPixel = 4;
+  const unpaddedBytesPerRow = width * bytesPerPixel;
+  const bytesPerRow = alignTo256(unpaddedBytesPerRow);
+  const bufferSize = bytesPerRow * height;
+
+  const readBuffer = device.getHandle().createBuffer({
+    size: bufferSize,
+    /* eslint-disable no-undef */
+    /* eslint-disable no-bitwise */
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const commandEncoder = device.getHandle().createCommandEncoder();
+  commandEncoder.copyTextureToBuffer(
+    {
+      texture: texture.getHandle(),
+      mipLevel: 0,
+      origin: { x: 0, y: 0, z: 0 },
+    },
+    {
+      buffer: readBuffer,
+      bytesPerRow,
+      rowsPerImage: height,
+    },
+    {
+      width,
+      height,
+      depthOrArrayLayers: 1,
+    }
+  );
+  device.getHandle().queue.submit([commandEncoder.finish()]);
+  await device.getHandle().queue.onSubmittedWorkDone();
+
+  /* eslint-disable no-undef */
+  await readBuffer.mapAsync(GPUMapMode.READ);
+  const mapped = new Uint8Array(readBuffer.getMappedRange());
+  const result = new Uint8Array(unpaddedBytesPerRow * height);
+
+  for (let row = 0; row < height; row++) {
+    const srcStart = row * bytesPerRow;
+    const dstStart = row * unpaddedBytesPerRow;
+    result.set(
+      mapped.subarray(srcStart, srcStart + unpaddedBytesPerRow),
+      dstStart
+    );
+  }
+
+  readBuffer.unmap();
+  readBuffer.destroy();
+  return result;
+}
+
 export default {
   arrayEquals,
   compareImages,
   createGarbageCollector,
   createImage,
+  createWebGPUTestDevice,
+  readWebGPUTexture2D,
   keepDOM,
   objEquals,
   removeDOM,


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
