### PR TITLE
feat(WebGPU): add coincident topology offsets to CellArrayMapper

### DIFF
--- a/Sources/Rendering/WebGPU/CellArrayMapper/index.js
+++ b/Sources/Rendering/WebGPU/CellArrayMapper/index.js
@@ -1,6 +1,8 @@
 import { mat3, mat4 } from 'gl-matrix';
 
 import * as macro from 'vtk.js/Sources/macros';
+import vtkDataSet from 'vtk.js/Sources/Common/DataModel/DataSet';
+import CoincidentTopologyHelper from 'vtk.js/Sources/Rendering/Core/Mapper/CoincidentTopologyHelper';
 import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
 import vtkProp from 'vtk.js/Sources/Rendering/Core/Prop';
 import vtkProperty from 'vtk.js/Sources/Rendering/Core/Property';
@@ -12,6 +14,8 @@ import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffe
 import vtkWebGPUSimpleMapper from 'vtk.js/Sources/Rendering/WebGPU/SimpleMapper';
 import vtkWebGPUTypes from 'vtk.js/Sources/Rendering/WebGPU/Types';
 
+const { Resolve } = CoincidentTopologyHelper;
+const { FieldAssociations } = vtkDataSet;
 const { BufferUsage, PrimitiveTypes } = vtkWebGPUBufferManager;
 const { Representation } = vtkProperty;
 const { ScalarMode } = vtkMapper;
@@ -541,6 +545,9 @@ function vtkWebGPUCellArrayMapper(publicAPI, model) {
     model.UBO.setValue('LineWidth', ppty.getLineWidth());
     model.UBO.setValue('Opacity', ppty.getOpacity());
     model.UBO.setValue('PropID', model.WebGPUActor.getPropID());
+    const cp = publicAPI.getCoincidentParameters();
+    model.UBO.setValue('CoincidentFactor', cp.factor);
+    model.UBO.setValue('CoincidentOffset', cp.offset);
 
     // Only send if needed
     model.UBO.sendIfNeeded(model.WebGPURenderWindow.getDevice());
@@ -581,6 +588,67 @@ function vtkWebGPUCellArrayMapper(publicAPI, model) {
       cullMode: publicAPI.getCullMode(),
     },
   });
+
+  publicAPI.getCoincidentParameters = () => {
+    let cp = {
+      factor: 0.0,
+      offset: 0.0,
+    };
+
+    const actor = model.WebGPUActor?.getRenderable();
+    const prop = actor?.getProperty?.();
+    if (!prop) {
+      return cp;
+    }
+
+    if (
+      // backwards compat with code that (errorneously) set this to boolean
+      // eslint-disable-next-line eqeqeq
+      model.renderable.getResolveCoincidentTopology() ==
+        Resolve.PolygonOffset ||
+      (prop.getEdgeVisibility() &&
+        prop.getRepresentation() === Representation.SURFACE)
+    ) {
+      const primType = model.primitiveType;
+      if (
+        primType === PrimitiveTypes.Verts ||
+        prop.getRepresentation() === Representation.POINTS
+      ) {
+        cp = model.renderable.getCoincidentTopologyPointOffsetParameter();
+      } else if (
+        primType === PrimitiveTypes.Lines ||
+        prop.getRepresentation() === Representation.WIREFRAME
+      ) {
+        cp = model.renderable.getCoincidentTopologyLineOffsetParameters();
+      } else if (
+        primType === PrimitiveTypes.Triangles ||
+        primType === PrimitiveTypes.TriangleStrips
+      ) {
+        cp = model.renderable.getCoincidentTopologyPolygonOffsetParameters();
+      }
+
+      if (
+        primType === PrimitiveTypes.TriangleEdges ||
+        primType === PrimitiveTypes.TriangleStripEdges
+      ) {
+        cp = model.renderable.getCoincidentTopologyPolygonOffsetParameters();
+        cp.factor /= 2.0;
+        cp.offset /= 2.0;
+      }
+    }
+
+    // Hardware point picking always offsets due to the saved depth buffer.
+    const selector = model.WebGPURenderer?.getSelector?.();
+    if (
+      selector &&
+      selector.getFieldAssociation() ===
+        FieldAssociations.FIELD_ASSOCIATION_POINTS
+    ) {
+      cp.offset -= 2.0;
+    }
+
+    return cp;
+  };
 
   publicAPI.replaceShaderPosition = (hash, pipeline, vertexInput) => {
     const vDesc = pipeline.getShaderDescription('vertex');
@@ -631,14 +699,40 @@ function vtkWebGPUCellArrayMapper(publicAPI, model) {
       ]).result;
     }
     code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+      // Match the OpenGL coincident-topology constant offset scale (~1 / 2^16 = 0.000016)
+      '    pCoord.z = clamp(pCoord.z - 0.000016 * mapperUBO.CoincidentOffset * pCoord.w, 0.0, pCoord.w);',
       '    output.Position = pCoord;',
     ]).result;
-
     vDesc.setCode(code);
   };
   model.shaderReplacements.set(
     'replaceShaderPosition',
     publicAPI.replaceShaderPosition
+  );
+
+  publicAPI.replaceShaderCoincidentOffset = (hash, pipeline, vertexInput) => {
+    const fDesc = pipeline.getShaderDescription('fragment');
+    if (!fDesc) {
+      return;
+    }
+
+    fDesc.addBuiltinInput('vec4<f32>', '@builtin(position) fragPos');
+    fDesc.addBuiltinOutput('f32', '@builtin(frag_depth) fragDepth');
+
+    let code = fDesc.getCode();
+    code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+      '  var coincidentDepth: f32 = input.fragPos.z;',
+      '  if (mapperUBO.CoincidentFactor != 0.0) {',
+      '    let cscale = length(vec2<f32>(dpdx(input.fragPos.z), dpdy(input.fragPos.z)));',
+      '    coincidentDepth = coincidentDepth - mapperUBO.CoincidentFactor * cscale;',
+      '  }',
+      '  output.fragDepth = clamp(coincidentDepth, 0.0, 1.0);',
+    ]).result;
+    fDesc.setCode(code);
+  };
+  model.shaderReplacements.set(
+    'replaceShaderCoincidentOffset',
+    publicAPI.replaceShaderCoincidentOffset
   );
 
   publicAPI.replaceShaderNormal = (hash, pipeline, vertexInput) => {
@@ -1487,6 +1581,8 @@ export function extend(publicAPI, model, initiaLalues = {}) {
   model.UBO.addEntry('Opacity', 'f32');
   model.UBO.addEntry('OpacityBF', 'f32');
   model.UBO.addEntry('ZValue', 'f32');
+  model.UBO.addEntry('CoincidentFactor', 'f32');
+  model.UBO.addEntry('CoincidentOffset', 'f32');
   model.UBO.addEntry('PropID', 'u32');
   model.UBO.addEntry('ClipNear', 'f32');
   model.UBO.addEntry('ClipFar', 'f32');


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
