### PR TITLE
feat(WebGPU): add vtkSkybox

### DIFF
--- a/Sources/Rendering/Core/Viewport/index.d.ts
+++ b/Sources/Rendering/Core/Viewport/index.d.ts
@@ -58,6 +58,12 @@ export interface vtkViewport extends vtkObject {
   getBackgroundByReference(): number[];
 
   /**
+   * Get the gradient background flag.
+   * @returns {Boolean}
+   */
+  getGradientBackground(): boolean;
+
+  /**
    *
    */
   getSize(): Size;
@@ -176,6 +182,12 @@ export interface vtkViewport extends vtkObject {
    * @param {Number[]} background
    */
   setBackgroundFrom(background: number[]): boolean;
+
+  /**
+   * Set the gradient background flag.
+   * @param {Boolean} gradientBackground
+   */
+  setGradientBackground(gradientBackground: boolean): boolean;
 
   /**
    * Specify the viewport for the Viewport to draw in the rendering window.

--- a/Sources/Rendering/Core/Viewport/index.d.ts
+++ b/Sources/Rendering/Core/Viewport/index.d.ts
@@ -38,24 +38,28 @@ export interface vtkViewport extends vtkObject {
   getActors2D(): vtkActor2D[];
 
   /**
-   *
+   * Get the viewport background.
+   * @returns {RGBColor}
    */
-  getBackground2(): number[];
+  getBackground2(): RGBColor;
 
   /**
-   *
+   * Get the viewport background.
+   * @returns {RGBColor}
    */
-  getBackground2ByReference(): number[];
+  getBackground2ByReference(): RGBColor;
 
   /**
-   *
+   * Get the viewport background.
+   * @returns {RGBColor}
    */
-  getBackground(): number[];
+  getBackground(): RGBColor;
 
   /**
-   *
+   * Get the viewport background.
+   * @returns {RGBColor}
    */
-  getBackgroundByReference(): number[];
+  getBackgroundByReference(): RGBColor;
 
   /**
    * Get the gradient background flag.
@@ -64,7 +68,7 @@ export interface vtkViewport extends vtkObject {
   getGradientBackground(): boolean;
 
   /**
-   *
+   * Get the size and origin of the viewport in display coordinates.
    */
   getSize(): Size;
 
@@ -158,7 +162,7 @@ export interface vtkViewport extends vtkObject {
   setBackground(background: number[]): boolean;
 
   /**
-   *
+   * Set the viewport secondary background.
    * @param {Number} r Defines the red component (between 0 and 1).
    * @param {Number} g Defines the green component (between 0 and 1).
    * @param {Number} b Defines the blue component (between 0 and 1).
@@ -166,22 +170,22 @@ export interface vtkViewport extends vtkObject {
   setBackground2(r: number, g: number, b: number): boolean;
 
   /**
-   *
-   * @param {Number[]} background
+   * Set the viewport secondary background.
+   * @param {RGBColor} background
    */
-  setBackground2(background: number[]): boolean;
+  setBackground2(background: RGBColor): boolean;
 
   /**
-   *
-   * @param {Number[]} background
+   * Set the viewport secondary background.
+   * @param {RGBColor} background
    */
-  setBackground2From(background: number[]): boolean;
+  setBackground2From(background: RGBColor): boolean;
 
   /**
-   *
-   * @param {Number[]} background
+   * Set the viewport background.
+   * @param {RGBColor} background
    */
-  setBackgroundFrom(background: number[]): boolean;
+  setBackgroundFrom(background: RGBColor): boolean;
 
   /**
    * Set the gradient background flag.

--- a/Sources/Rendering/Core/Viewport/index.js
+++ b/Sources/Rendering/Core/Viewport/index.js
@@ -172,6 +172,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.obj(publicAPI, model);
   macro.event(publicAPI, model, 'event');
 
+  macro.setGet(publicAPI, model, ['gradientBackground']);
   macro.setGetArray(publicAPI, model, ['viewport'], 4);
 
   macro.setGetArray(publicAPI, model, ['background', 'background2'], 3);

--- a/Sources/Rendering/WebGPU/Background/index.js
+++ b/Sources/Rendering/WebGPU/Background/index.js
@@ -159,10 +159,9 @@ function vtkWebGPUBackground(publicAPI, model) {
     }
 
     const isGradientBackground = renderer.getGradientBackground?.();
-    const background = renderer.getBackgroundByReference?.() ?? [0, 0, 0, 1];
+    const background = renderer.getBackgroundByReference?.() ?? [0, 0, 0];
     const background2 = renderer.getBackground2ByReference?.() ?? [0, 0, 0];
-    const background2rgba = [...background2, 1.0];
-    if (isGradientBackground && !areEquals(background, background2rgba)) {
+    if (isGradientBackground && !areEquals(background, background2)) {
       return {
         mode: 'gradient',
         texture: null,
@@ -243,10 +242,20 @@ function vtkWebGPUBackground(publicAPI, model) {
   };
 
   publicAPI.updateUBO = (device, rendererNode, renderer) => {
-    const background = renderer.getBackgroundByReference?.() ?? [0, 0, 0, 1];
+    const background = renderer.getBackgroundByReference?.() ?? [0, 0, 0];
     const background2 = renderer.getBackground2ByReference?.() ?? [0, 0, 0];
-    model.UBO.setArray('BackgroundColor', background);
-    model.UBO.setArray('BackgroundColor2', [...background2, 1.0]);
+    model.UBO.setArray('BackgroundColor', [
+      background[0],
+      background[1],
+      background[2],
+      1.0,
+    ]);
+    model.UBO.setArray('BackgroundColor2', [
+      background2[0],
+      background2[1],
+      background2[2],
+      1.0,
+    ]);
 
     const keyMats = model.webgpuCamera.getKeyMatrices(rendererNode);
     mat4.transpose(_tNormalMat4, keyMats.normalMatrix);

--- a/Sources/Rendering/WebGPU/Background/index.js
+++ b/Sources/Rendering/WebGPU/Background/index.js
@@ -1,0 +1,293 @@
+import { mat4 } from 'gl-matrix';
+
+import macro from 'vtk.js/Sources/macros';
+import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
+import vtkWebGPUFullScreenQuad from 'vtk.js/Sources/Rendering/WebGPU/FullScreenQuad';
+import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
+
+const solidFragTemplate = `
+//VTK::Renderer::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::RenderEncoder::Dec
+
+//VTK::IOStructs::Dec
+
+@fragment
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output: fragmentOutput;
+
+  var computedColor: vec4<f32> = mapperUBO.BackgroundColor;
+
+  //VTK::RenderEncoder::Impl
+  return output;
+}
+`;
+
+const gradientFragTemplate = `
+//VTK::Renderer::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::RenderEncoder::Dec
+
+//VTK::IOStructs::Dec
+
+@fragment
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output: fragmentOutput;
+
+  let t = clamp(input.tcoordVS.y, 0.0, 1.0);
+  var computedColor: vec4<f32> = mix(mapperUBO.BackgroundColor2, mapperUBO.BackgroundColor, t);
+
+  //VTK::RenderEncoder::Impl
+  return output;
+}
+`;
+
+const textureFragTemplate = `
+//VTK::Renderer::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::RenderEncoder::Dec
+
+//VTK::IOStructs::Dec
+
+@fragment
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output: fragmentOutput;
+
+  var computedColor: vec4<f32> = textureSampleLevel(BackgroundTexture, BackgroundTextureSampler, input.tcoordVS, 0.0);
+
+  //VTK::RenderEncoder::Impl
+  return output;
+}
+`;
+
+const environmentFragTemplate = `
+fn vecToRectCoord(dir: vec3<f32>) -> vec2<f32> {
+  var tau: f32 = 6.28318530718;
+  var pi: f32 = 3.14159265359;
+  var out: vec2<f32> = vec2<f32>(0.0);
+
+  out.x = atan2(dir.z, dir.x) / tau;
+  out.x += 0.5;
+
+  var phix: f32 = length(vec2(dir.x, dir.z));
+  out.y = atan2(dir.y, phix) / pi + 0.5;
+
+  return out;
+}
+
+//VTK::Renderer::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::RenderEncoder::Dec
+
+//VTK::IOStructs::Dec
+
+@fragment
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output: fragmentOutput;
+
+  var tcoord: vec4<f32> = vec4<f32>(input.vertexVC.xy, -1, 1);
+  var V: vec4<f32> = normalize(mapperUBO.FSQMatrix * tcoord);
+  var background = textureSampleLevel(EnvironmentTexture, EnvironmentTextureSampler, vecToRectCoord(V.xyz), 0.0);
+  var computedColor: vec4<f32> = vec4<f32>(background.rgb, 1.0);
+
+  //VTK::RenderEncoder::Impl
+  return output;
+}
+`;
+
+const _fsqMat4 = new Float64Array(16);
+const _tNormalMat4 = new Float64Array(16);
+
+function vtkWebGPUBackground(publicAPI, model) {
+  model.classHierarchy.push('vtkWebGPUBackground');
+
+  publicAPI.getMode = (renderer) => {
+    if (
+      renderer.getTexturedBackground?.() &&
+      renderer.getBackgroundTexture?.().getImageLoaded?.()
+    ) {
+      return {
+        mode: 'texture',
+        texture: renderer.getBackgroundTexture(),
+        textureName: 'BackgroundTexture',
+        pipelineHash: 'backgroundTexture',
+      };
+    }
+
+    if (
+      renderer.getUseEnvironmentTextureAsBackground?.() &&
+      renderer.getEnvironmentTexture?.().getImageLoaded?.()
+    ) {
+      return {
+        mode: 'environment',
+        texture: renderer.getEnvironmentTexture(),
+        textureName: 'EnvironmentTexture',
+        pipelineHash: 'backgroundEnvironment',
+      };
+    }
+
+    const isGradientBackground = renderer.getGradientBackground?.();
+    const background = renderer.getBackgroundByReference?.() ?? [0, 0, 0, 1];
+    const background2 = renderer.getBackground2ByReference?.() ?? [0, 0, 0];
+    const background2rgba = [...background2, 1.0];
+    if (isGradientBackground && !areEquals(background, background2rgba)) {
+      return {
+        mode: 'gradient',
+        texture: null,
+        textureName: null,
+        pipelineHash: 'backgroundGradient',
+      };
+    }
+
+    return {
+      mode: 'solid',
+      texture: null,
+      textureName: null,
+      pipelineHash: 'backgroundSolid',
+    };
+  };
+
+  publicAPI.ensureQuad = (device) => {
+    if (model.quad) {
+      return;
+    }
+
+    model.quad = vtkWebGPUFullScreenQuad.newInstance();
+    model.quad.setDevice(device);
+
+    model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
+    model.UBO.addEntry('FSQMatrix', 'mat4x4<f32>');
+    model.UBO.addEntry('BackgroundColor', 'vec4<f32>');
+    model.UBO.addEntry('BackgroundColor2', 'vec4<f32>');
+    model.quad.setUBO(model.UBO);
+  };
+
+  publicAPI.getFragmentTemplate = (mode) => {
+    switch (mode) {
+      case 'gradient':
+        return gradientFragTemplate;
+      case 'texture':
+        return textureFragTemplate;
+      case 'environment':
+        return environmentFragTemplate;
+      case 'solid':
+      default:
+        return solidFragTemplate;
+    }
+  };
+
+  publicAPI.updateTexture = (device, texture, textureName) => {
+    if (!texture || !textureName) {
+      model.quad.setTextureViews([]);
+      return;
+    }
+
+    const webgpuTexture = device
+      .getTextureManager()
+      .getTextureForVTKTexture(texture, textureName);
+    if (!webgpuTexture.getReady()) {
+      model.quad.setTextureViews([]);
+      return;
+    }
+
+    const tview = webgpuTexture.createView(textureName);
+    const interpolate = texture.getInterpolate?.() ? 'linear' : 'nearest';
+    let options = {
+      minFilter: interpolate,
+      magFilter: interpolate,
+    };
+    if (textureName === 'EnvironmentTexture') {
+      options = {
+        addressModeU: 'repeat',
+        addressModeV: 'clamp-to-edge',
+        addressModeW: 'repeat',
+        minFilter: interpolate,
+        magFilter: interpolate,
+        mipmapFilter: 'linear',
+      };
+    }
+    tview.addSampler(device, options);
+    model.quad.setTextureViews([tview]);
+  };
+
+  publicAPI.updateUBO = (device, rendererNode, renderer) => {
+    const background = renderer.getBackgroundByReference?.() ?? [0, 0, 0, 1];
+    const background2 = renderer.getBackground2ByReference?.() ?? [0, 0, 0];
+    model.UBO.setArray('BackgroundColor', background);
+    model.UBO.setArray('BackgroundColor2', [...background2, 1.0]);
+
+    const keyMats = model.webgpuCamera.getKeyMatrices(rendererNode);
+    mat4.transpose(_tNormalMat4, keyMats.normalMatrix);
+    mat4.mul(_fsqMat4, keyMats.scvc, keyMats.pcsc);
+    mat4.mul(_fsqMat4, _tNormalMat4, _fsqMat4);
+    model.UBO.setArray('FSQMatrix', _fsqMat4);
+    model.UBO.sendIfNeeded(device);
+  };
+
+  publicAPI.render = (renderEncoder, rendererNode) => {
+    const renderer = rendererNode.getRenderable();
+    const device = rendererNode.getParent().getDevice();
+    publicAPI.ensureQuad(device);
+
+    model.webgpuCamera = rendererNode.getViewNodeFor(
+      renderer.getActiveCamera(),
+      model.webgpuCamera
+    );
+
+    const { mode, texture, textureName, pipelineHash } =
+      publicAPI.getMode(renderer);
+    model.quad.setPipelineHash(pipelineHash);
+    model.quad.setFragmentShaderTemplate(publicAPI.getFragmentTemplate(mode));
+    publicAPI.updateTexture(device, texture, textureName);
+    publicAPI.updateUBO(device, rendererNode, renderer);
+    model.quad.prepareAndDraw(renderEncoder);
+  };
+}
+
+const DEFAULT_VALUES = {
+  quad: null,
+  UBO: null,
+  webgpuCamera: null,
+};
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+  macro.obj(publicAPI, model);
+  vtkWebGPUBackground(publicAPI, model);
+}
+
+export const newInstance = macro.newInstance(extend, 'vtkWebGPUBackground');
+
+export default { newInstance, extend };

--- a/Sources/Rendering/WebGPU/Profiles/All.js
+++ b/Sources/Rendering/WebGPU/Profiles/All.js
@@ -8,7 +8,7 @@ import 'vtk.js/Sources/Rendering/WebGPU/Actor2D';
 import 'vtk.js/Sources/Rendering/WebGPU/CubeAxesActor';
 import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper';
 import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper2D';
-// import 'vtk.js/Sources/Rendering/WebGPU/Skybox';
+import 'vtk.js/Sources/Rendering/WebGPU/Skybox';
 import 'vtk.js/Sources/Rendering/WebGPU/ScalarBarActor';
 import 'vtk.js/Sources/Rendering/WebGPU/Texture';
 

--- a/Sources/Rendering/WebGPU/Profiles/Geometry.js
+++ b/Sources/Rendering/WebGPU/Profiles/Geometry.js
@@ -8,7 +8,7 @@ import 'vtk.js/Sources/Rendering/WebGPU/Actor2D';
 import 'vtk.js/Sources/Rendering/WebGPU/CubeAxesActor';
 import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper';
 import 'vtk.js/Sources/Rendering/WebGPU/PolyDataMapper2D';
-// import 'vtk.js/Sources/Rendering/WebGPU/Skybox';
+import 'vtk.js/Sources/Rendering/WebGPU/Skybox';
 import 'vtk.js/Sources/Rendering/WebGPU/ScalarBarActor';
 import 'vtk.js/Sources/Rendering/WebGPU/Texture';
 

--- a/Sources/Rendering/WebGPU/Renderer/index.js
+++ b/Sources/Rendering/WebGPU/Renderer/index.js
@@ -2,87 +2,14 @@ import { vec3, mat4 } from 'gl-matrix';
 import * as macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
+import vtkWebGPUBackground from 'vtk.js/Sources/Rendering/WebGPU/Background';
 import vtkWebGPUBindGroup from 'vtk.js/Sources/Rendering/WebGPU/BindGroup';
-import vtkWebGPUFullScreenQuad from 'vtk.js/Sources/Rendering/WebGPU/FullScreenQuad';
 import vtkWebGPUStorageBuffer from 'vtk.js/Sources/Rendering/WebGPU/StorageBuffer';
 import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
 
 import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
 
 const { vtkDebugMacro } = macro;
-
-const clearFragColorTemplate = `
-//VTK::Renderer::Dec
-
-//VTK::Mapper::Dec
-
-//VTK::TCoord::Dec
-
-//VTK::RenderEncoder::Dec
-
-//VTK::IOStructs::Dec
-
-@fragment
-fn main(
-//VTK::IOStructs::Input
-)
-//VTK::IOStructs::Output
-{
-  var output: fragmentOutput;
-
-  var computedColor: vec4<f32> = mapperUBO.BackgroundColor;
-
-  //VTK::RenderEncoder::Impl
-  return output;
-}
-`;
-
-const clearFragTextureTemplate = `
-fn vecToRectCoord(dir: vec3<f32>) -> vec2<f32> {
-  var tau: f32 = 6.28318530718;
-  var pi: f32 = 3.14159265359;
-  var out: vec2<f32> = vec2<f32>(0.0);
-
-  out.x = atan2(dir.z, dir.x) / tau;
-  out.x += 0.5;
-
-  var phix: f32 = length(vec2(dir.x, dir.z));
-  out.y = atan2(dir.y, phix) / pi + 0.5;
-
-  return out;
-}
-
-//VTK::Renderer::Dec
-
-//VTK::Mapper::Dec
-
-//VTK::TCoord::Dec
-
-//VTK::RenderEncoder::Dec
-
-//VTK::IOStructs::Dec
-
-@fragment
-fn main(
-//VTK::IOStructs::Input
-)
-//VTK::IOStructs::Output
-{
-  var output: fragmentOutput;
-
-  var tcoord: vec4<f32> = vec4<f32>(input.vertexVC.xy, -1, 1);
-  var V: vec4<f32> = normalize(mapperUBO.FSQMatrix * tcoord); // vec2<f32>((input.tcoordVS.x - 0.5) * 2, -(input.tcoordVS.y - 0.5) * 2);
-  // textureSampleLevel gets rid of some ugly artifacts
-  var background = textureSampleLevel(EnvironmentTexture, EnvironmentTextureSampler, vecToRectCoord(V.xyz), 0.0);
-  var computedColor: vec4<f32> = vec4<f32>(background.rgb, 1);
-
-  //VTK::RenderEncoder::Impl
-  return output;
-}
-`;
-
-const _fsqClearMat4 = new Float64Array(16);
-const _tNormalMat4 = new Float64Array(16);
 
 // Light type index gives either 0, 1, or 2 which indicates what type of light there is.
 // While technically, there are only spot and directional lights, within the CellArrayMapper
@@ -360,79 +287,7 @@ function vtkWebGPURenderer(publicAPI, model) {
     if (model.renderable.getTransparent() || model.suppressClear) {
       return;
     }
-
-    const device = model._parent.getDevice();
-    // Normal Solid Color
-    if (!model.clearFSQ) {
-      model.clearFSQ = vtkWebGPUFullScreenQuad.newInstance();
-      model.clearFSQ.setDevice(device);
-      model.clearFSQ.setPipelineHash('clearfsq');
-      model.clearFSQ.setFragmentShaderTemplate(clearFragColorTemplate);
-      const ubo = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
-      ubo.addEntry('FSQMatrix', 'mat4x4<f32>');
-      ubo.addEntry('BackgroundColor', 'vec4<f32>');
-      model.clearFSQ.setUBO(ubo);
-
-      model.backgroundTex = model.renderable.getEnvironmentTexture();
-    }
-    // Textured Background
-    if (
-      model.clearFSQ.getPipelineHash() !== 'clearfsqwithtexture' &&
-      model.renderable.getUseEnvironmentTextureAsBackground() &&
-      model.backgroundTex?.getImageLoaded()
-    ) {
-      model.clearFSQ.setFragmentShaderTemplate(clearFragTextureTemplate);
-      const ubo = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
-      ubo.addEntry('FSQMatrix', 'mat4x4<f32>');
-      ubo.addEntry('BackgroundColor', 'vec4<f32>');
-      model.clearFSQ.setUBO(ubo);
-
-      const environmentTextureHash = device
-        .getTextureManager()
-        .getTextureForVTKTexture(model.backgroundTex, 'EnvironmentTexture');
-      if (environmentTextureHash.getReady()) {
-        const tview = environmentTextureHash.createView(`EnvironmentTexture`);
-        model.clearFSQ.setTextureViews([tview]);
-        model.backgroundTexLoaded = true;
-        const interpolate = model.backgroundTex.getInterpolate()
-          ? 'linear'
-          : 'nearest';
-        tview.addSampler(device, {
-          addressModeU: 'repeat',
-          addressModeV: 'clamp-to-edge',
-          addressModeW: 'repeat',
-          minFilter: interpolate,
-          magFilter: interpolate,
-          mipmapFilter: 'linear',
-        });
-      }
-      model.clearFSQ.setPipelineHash('clearfsqwithtexture');
-    } else if (
-      model.clearFSQ.getPipelineHash() === 'clearfsqwithtexture' &&
-      !model.renderable.getUseEnvironmentTextureAsBackground()
-    ) {
-      // In case the mode is changed at runtime
-      model.clearFSQ = vtkWebGPUFullScreenQuad.newInstance();
-      model.clearFSQ.setDevice(device);
-      model.clearFSQ.setPipelineHash('clearfsq');
-      model.clearFSQ.setFragmentShaderTemplate(clearFragColorTemplate);
-      const ubo = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
-      ubo.addEntry('FSQMatrix', 'mat4x4<f32>');
-      ubo.addEntry('BackgroundColor', 'vec4<f32>');
-      model.clearFSQ.setUBO(ubo);
-    }
-
-    const keyMats = model.webgpuCamera.getKeyMatrices(publicAPI);
-    const background = model.renderable.getBackgroundByReference();
-
-    model.clearFSQ.getUBO().setArray('BackgroundColor', background);
-    mat4.transpose(_tNormalMat4, keyMats.normalMatrix);
-    mat4.mul(_fsqClearMat4, keyMats.scvc, keyMats.pcsc);
-    mat4.mul(_fsqClearMat4, _tNormalMat4, _fsqClearMat4);
-    model.clearFSQ.getUBO().setArray('FSQMatrix', _fsqClearMat4);
-
-    model.clearFSQ.getUBO().sendIfNeeded(device);
-    model.clearFSQ.prepareAndDraw(model.renderEncoder);
+    model.background.render(model.renderEncoder, publicAPI);
   };
 
   publicAPI.translucentPass = (prepass) => {
@@ -574,6 +429,7 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   model.bindGroup = vtkWebGPUBindGroup.newInstance({ label: 'rendererBG' });
   model.bindGroup.setBindables([model.UBO, model.SSBO]);
+  model.background = vtkWebGPUBackground.newInstance();
 
   model.tmpMat4 = mat4.identity(new Float64Array(16));
 

--- a/Sources/Rendering/WebGPU/Skybox/index.js
+++ b/Sources/Rendering/WebGPU/Skybox/index.js
@@ -1,0 +1,441 @@
+import { mat4 } from 'gl-matrix';
+
+import macro from 'vtk.js/Sources/macros';
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
+import vtkWebGPUFullScreenQuad from 'vtk.js/Sources/Rendering/WebGPU/FullScreenQuad';
+import vtkWebGPUShaderCache from 'vtk.js/Sources/Rendering/WebGPU/ShaderCache';
+import vtkWebGPUTexture from 'vtk.js/Sources/Rendering/WebGPU/Texture';
+import vtkWebGPUUniformBuffer from 'vtk.js/Sources/Rendering/WebGPU/UniformBuffer';
+
+import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
+
+const { VtkDataTypes } = vtkDataArray;
+const { vtkErrorMacro } = macro;
+
+const backgroundFragTemplate = `
+//VTK::Renderer::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::RenderEncoder::Dec
+
+//VTK::IOStructs::Dec
+
+@fragment
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output: fragmentOutput;
+
+  var computedColor: vec4<f32> = textureSampleLevel(sbtexture, sbtextureSampler, input.tcoordVS, 0.0);
+
+  //VTK::RenderEncoder::Impl
+  return output;
+}
+`;
+
+const boxFragTemplate = `
+fn remapCubeCoord(dir: vec3<f32>) -> vec3<f32> {
+  var tc = normalize(dir);
+  if (abs(tc.z) < max(abs(tc.x), abs(tc.y))) {
+    tc = vec3<f32>(1.0, 1.0, -1.0) * tc;
+  } else {
+    tc = vec3<f32>(-1.0, 1.0, 1.0) * tc;
+  }
+  return tc;
+}
+
+//VTK::Renderer::Dec
+
+//VTK::Mapper::Dec
+
+//VTK::TCoord::Dec
+
+//VTK::RenderEncoder::Dec
+
+//VTK::IOStructs::Dec
+
+@fragment
+fn main(
+//VTK::IOStructs::Input
+)
+//VTK::IOStructs::Output
+{
+  var output: fragmentOutput;
+
+  let clipPos = vec4<f32>(input.vertexVC.xy, 1.0, 1.0);
+  let worldPos = mapperUBO.IMCPCMatrix * clipPos;
+  let direction = remapCubeCoord(worldPos.xyz / worldPos.w - mapperUBO.CameraPosition.xyz);
+  var computedColor: vec4<f32> = textureSampleLevel(sbtexture, sbtextureSampler, direction, 0.0);
+
+  //VTK::RenderEncoder::Impl
+  return output;
+}
+`;
+
+const _imcpc = new Float64Array(16);
+
+function getTextureFormat(dataArray) {
+  const numComp = dataArray.getNumberOfComponents();
+  let format = 'rgba';
+
+  if (numComp === 1) {
+    format = 'r';
+  } else if (numComp === 2) {
+    format = 'rg';
+  }
+
+  switch (dataArray.getDataType()) {
+    case VtkDataTypes.UNSIGNED_CHAR:
+      return `${format}8unorm`;
+    case VtkDataTypes.FLOAT:
+    case VtkDataTypes.UNSIGNED_INT:
+    case VtkDataTypes.INT:
+    case VtkDataTypes.DOUBLE:
+    case VtkDataTypes.UNSIGNED_SHORT:
+    case VtkDataTypes.SHORT:
+    default:
+      return `${format}16float`;
+  }
+}
+
+function flipTextureRowsY(dataArray, width, height, numComponents) {
+  const flipped = macro.newTypedArray(
+    dataArray.constructor.name,
+    dataArray.length
+  );
+  const rowSize = width * numComponents;
+
+  for (let y = 0; y < height; ++y) {
+    const dstOffset = y * rowSize;
+    const srcOffset = (height - y - 1) * rowSize;
+    flipped.set(dataArray.subarray(srcOffset, srcOffset + rowSize), dstOffset);
+  }
+
+  return flipped;
+}
+
+function vtkWebGPUSkybox(publicAPI, model) {
+  model.classHierarchy.push('vtkWebGPUSkybox');
+
+  function getTextureInterpolation(texture) {
+    return texture.getInterpolate?.() ? 'linear' : 'nearest';
+  }
+
+  function getCachedTextureView(device, texture, webgpuTexture, format) {
+    const interpolate = getTextureInterpolation(texture);
+
+    if (format === 'background') {
+      if (
+        model.backgroundTextureView &&
+        model.backgroundWebGPUTexture === webgpuTexture &&
+        model.backgroundInterpolate === interpolate
+      ) {
+        return model.backgroundTextureView;
+      }
+
+      const tview = webgpuTexture.createView('sbtexture');
+      tview.addSampler(device, {
+        minFilter: interpolate,
+        magFilter: interpolate,
+      });
+      model.backgroundWebGPUTexture = webgpuTexture;
+      model.backgroundInterpolate = interpolate;
+      model.backgroundTextureView = tview;
+      return tview;
+    }
+
+    if (
+      model.boxTextureView &&
+      model.boxWebGPUTexture === webgpuTexture &&
+      model.boxInterpolate === interpolate
+    ) {
+      return model.boxTextureView;
+    }
+
+    const tview = webgpuTexture.createView('sbtexture', {
+      dimension: 'cube',
+    });
+    tview.addSampler(device, {
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge',
+      addressModeW: 'clamp-to-edge',
+      minFilter: interpolate,
+      magFilter: interpolate,
+    });
+    model.boxWebGPUTexture = webgpuTexture;
+    model.boxInterpolate = interpolate;
+    model.boxTextureView = tview;
+    return tview;
+  }
+
+  publicAPI.buildPass = (prepass) => {
+    if (prepass) {
+      model.WebGPURenderer =
+        publicAPI.getFirstAncestorOfType('vtkWebGPURenderer');
+      model.WebGPURenderWindow = model.WebGPURenderer?.getFirstAncestorOfType(
+        'vtkWebGPURenderWindow'
+      );
+
+      if (model.WebGPURenderer) {
+        const renderer = model.WebGPURenderer.getRenderable();
+        model.webgpuCamera = model.WebGPURenderer.getViewNodeFor(
+          renderer.getActiveCamera(),
+          model.webgpuCamera
+        );
+      }
+    }
+  };
+
+  publicAPI.queryPass = (prepass, renderPass) => {
+    if (prepass) {
+      if (!model.renderable || !model.renderable.getVisibility()) {
+        return;
+      }
+      renderPass.incrementOpaqueActorCount();
+    }
+  };
+
+  publicAPI.ensureQuad = (device) => {
+    if (model.quad) {
+      return;
+    }
+
+    model.quad = vtkWebGPUFullScreenQuad.newInstance();
+    model.quad.setDevice(device);
+    model.quad.setWebGPURenderer(model.WebGPURenderer);
+
+    model.UBO = vtkWebGPUUniformBuffer.newInstance({ label: 'mapperUBO' });
+    model.UBO.addEntry('IMCPCMatrix', 'mat4x4<f32>');
+    model.UBO.addEntry('CameraPosition', 'vec4<f32>');
+    model.quad.setUBO(model.UBO);
+
+    const replaceSkyboxShaderPosition = (hash, pipeline) => {
+      const vDesc = pipeline.getShaderDescription('vertex');
+      vDesc.addBuiltinOutput('vec4<f32>', '@builtin(position) Position');
+      if (!vDesc.hasOutput('vertexVC')) {
+        vDesc.addOutput('vec4<f32>', 'vertexVC');
+      }
+      if (!vDesc.hasOutput('tcoordVS')) {
+        vDesc.addOutput('vec2<f32>', 'tcoordVS');
+      }
+
+      let code = vDesc.getCode();
+      code = vtkWebGPUShaderCache.substitute(code, '//VTK::Position::Impl', [
+        'output.tcoordVS = vec2<f32>(vertexBC.x * 0.5 + 0.5, vertexBC.y * 0.5 + 0.5);',
+        'output.Position = vec4<f32>(vertexBC.x, vertexBC.y, 1.0, 1.0);',
+        'output.vertexVC = vec4<f32>(vertexBC.x, vertexBC.y, 1.0, 1.0);',
+      ]).result;
+      vDesc.setCode(code);
+    };
+    model.quad
+      .getShaderReplacements()
+      .set('replaceShaderPosition', replaceSkyboxShaderPosition);
+  };
+
+  publicAPI.getTexture = () => model.renderable.getTextures?.()?.[0] ?? null;
+
+  publicAPI.getCubeTextureHash = (texture) => {
+    let hash = `${texture.getMTime()}-skybox-cube`;
+    for (let i = 0; i < 6; i++) {
+      const imageData = texture.getInputData(i);
+      if (!imageData) {
+        return null;
+      }
+
+      hash += `-${imageData.getMTime()}`;
+      const scalars = imageData.getPointData().getScalars();
+      if (scalars) {
+        hash += `-${scalars.getMTime()}`;
+      }
+    }
+    return hash;
+  };
+
+  publicAPI.getCubeTexture = (device, texture) => {
+    const hash = publicAPI.getCubeTextureHash(texture);
+    if (!hash) {
+      return null;
+    }
+
+    return device.getCachedObject(hash, () => {
+      const firstImage = texture.getInputData(0);
+      const firstScalars = firstImage.getPointData().getScalars();
+      const dims = firstImage.getDimensions();
+      const webgpuTexture = vtkWebGPUTexture.newInstance({
+        label: 'sbtexture',
+      });
+      webgpuTexture.create(device, {
+        width: dims[0],
+        height: dims[1],
+        depth: 6,
+        dimension: '2d',
+        format: getTextureFormat(firstScalars),
+      });
+
+      for (let i = 0; i < 6; i++) {
+        const imageData = texture.getInputData(i);
+        const faceDims = imageData.getDimensions();
+        const scalars = imageData.getPointData().getScalars();
+        const faceData = flipTextureRowsY(
+          scalars.getData(),
+          faceDims[0],
+          faceDims[1],
+          scalars.getNumberOfComponents()
+        );
+        webgpuTexture.writeImageData({
+          nativeArray: faceData,
+          width: faceDims[0],
+          height: faceDims[1],
+          depth: 1,
+          originZ: i,
+        });
+      }
+
+      return webgpuTexture;
+    });
+  };
+
+  publicAPI.updateTexture = (device) => {
+    const texture = publicAPI.getTexture();
+    if (!texture) {
+      model.quad.setTextureViews([]);
+      return false;
+    }
+
+    if (model.renderable.getFormat() === 'background') {
+      const webgpuTexture = device
+        .getTextureManager()
+        .getTextureForVTKTexture(texture, 'sbtexture');
+      if (!webgpuTexture.getReady()) {
+        model.quad.setTextureViews([]);
+        return false;
+      }
+
+      const tview = getCachedTextureView(
+        device,
+        texture,
+        webgpuTexture,
+        'background'
+      );
+      model.quad.setTextureViews([tview]);
+      return true;
+    }
+
+    if (model.renderable.getFormat() === 'box') {
+      const webgpuTexture = publicAPI.getCubeTexture(device, texture);
+      if (!webgpuTexture?.getReady()) {
+        model.quad.setTextureViews([]);
+        return false;
+      }
+
+      const tview = getCachedTextureView(device, texture, webgpuTexture, 'box');
+      model.quad.setTextureViews([tview]);
+      return true;
+    }
+
+    vtkErrorMacro(
+      `Unsupported vtkSkybox format ${model.renderable.getFormat()}`
+    );
+    model.quad.setTextureViews([]);
+    return false;
+  };
+
+  publicAPI.updateUBO = (device) => {
+    const camera = model.WebGPURenderer.getRenderable().getActiveCamera();
+    const keyMats = model.webgpuCamera.getKeyMatrices(model.WebGPURenderer);
+    const stabilizedCenter =
+      model.WebGPURenderer.getStabilizedCenterByReference();
+    mat4.copy(_imcpc, keyMats.pcsc);
+    model.UBO.setArray('IMCPCMatrix', _imcpc);
+    model.UBO.setArray('CameraPosition', [
+      camera.getPositionByReference()[0] - stabilizedCenter[0],
+      camera.getPositionByReference()[1] - stabilizedCenter[1],
+      camera.getPositionByReference()[2] - stabilizedCenter[2],
+      1.0,
+    ]);
+    model.UBO.sendIfNeeded(device);
+  };
+
+  publicAPI.releaseGraphicsResources = () => {
+    model.quad?.releaseGraphicsResources?.();
+    model.quad = null;
+    model.UBO = null;
+    model.backgroundTextureView = null;
+    model.backgroundWebGPUTexture = null;
+    model.backgroundInterpolate = null;
+    model.boxTextureView = null;
+    model.boxWebGPUTexture = null;
+    model.boxInterpolate = null;
+    model.lastFormat = null;
+    model.webgpuCamera = null;
+    model.WebGPURenderer = null;
+    model.WebGPURenderWindow = null;
+  };
+
+  publicAPI.opaquePass = (prepass) => {
+    if (
+      !prepass ||
+      !model.renderable ||
+      !model.renderable.getVisibility() ||
+      model.WebGPURenderer?.getSelector()
+    ) {
+      return;
+    }
+
+    const device = model.WebGPURenderWindow.getDevice();
+    publicAPI.ensureQuad(device);
+    model.quad.setWebGPURenderer(model.WebGPURenderer);
+
+    const format = model.renderable.getFormat();
+    if (model.lastFormat !== format) {
+      model.quad.setPipelineHash(`skybox-${format}`);
+      model.quad.setFragmentShaderTemplate(
+        format === 'background' ? backgroundFragTemplate : boxFragTemplate
+      );
+      model.lastFormat = format;
+    }
+
+    if (!publicAPI.updateTexture(device)) {
+      return;
+    }
+
+    publicAPI.updateUBO(device);
+    model.quad.prepareToDraw(model.WebGPURenderer.getRenderEncoder());
+    model.quad.registerDrawCallback(model.WebGPURenderer.getRenderEncoder());
+  };
+}
+
+const DEFAULT_VALUES = {
+  backgroundInterpolate: null,
+  backgroundTextureView: null,
+  backgroundWebGPUTexture: null,
+  boxInterpolate: null,
+  boxTextureView: null,
+  boxWebGPUTexture: null,
+  lastFormat: null,
+  quad: null,
+  UBO: null,
+  webgpuCamera: null,
+  WebGPURenderer: null,
+  WebGPURenderWindow: null,
+};
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  vtkViewNode.extend(publicAPI, model, initialValues);
+
+  vtkWebGPUSkybox(publicAPI, model);
+}
+
+export const newInstance = macro.newInstance(extend, 'vtkWebGPUSkybox');
+
+export default { newInstance, extend };
+
+registerOverride('vtkSkybox', newInstance);

--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -159,7 +159,11 @@ function vtkWebGPUTexture(publicAPI, model) {
     model.width = options.width;
     model.height = options.height;
     model.depth = options.depth ? options.depth : 1;
-    const dimension = model.depth === 1 ? '2d' : '3d';
+    if (options.dimension) {
+      model.dimension = options.dimension;
+    } else {
+      model.dimension = model.depth === 1 ? '2d' : '3d';
+    }
     model.format = options.format ? options.format : 'rgba8unorm';
     model.mipLevel = options.mipLevel ? options.mipLevel : 0;
     /* eslint-disable no-undef */
@@ -174,7 +178,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       format: model.format, // 'rgba8unorm',
       usage: model.usage,
       label: model.label,
-      dimension,
+      dimension: model.dimension,
       mipLevelCount: model.mipLevel + 1,
     });
   };
@@ -185,6 +189,11 @@ function vtkWebGPUTexture(publicAPI, model) {
     model.width = options.width;
     model.height = options.height;
     model.depth = options.depth ? options.depth : 1;
+    if (options.dimension) {
+      model.dimension = options.dimension;
+    } else {
+      model.dimension = model.depth === 1 ? '2d' : '3d';
+    }
     model.format = options.format ? options.format : 'rgba8unorm';
     /* eslint-disable no-undef */
     /* eslint-disable no-bitwise */
@@ -198,6 +207,8 @@ function vtkWebGPUTexture(publicAPI, model) {
   publicAPI.writeImageData = (req) => {
     let nativeArray = [];
     const _copyImageToTexture = (source) => {
+      const originZ = req.originZ ?? 0;
+      const depth = req.depth ?? 1;
       model.device.getHandle().queue.copyExternalImageToTexture(
         {
           source,
@@ -207,13 +218,13 @@ function vtkWebGPUTexture(publicAPI, model) {
           texture: model.handle,
           premultipliedAlpha: true,
           mipLevel: 0,
-          origin: { x: 0, y: 0, z: 0 },
+          origin: { x: 0, y: 0, z: originZ },
         },
-        [source.width, source.height, model.depth]
+        [source.width, source.height, depth]
       );
 
       // Generate mipmaps on GPU if needed
-      if (publicAPI.getDimensionality() !== 3 && model.mipLevel > 0) {
+      if (model.dimension === '2d' && depth === 1 && model.mipLevel > 0) {
         vtkTexture.generateMipmaps(
           model.device.getHandle(),
           model.handle,
@@ -263,12 +274,14 @@ function vtkWebGPUTexture(publicAPI, model) {
       nativeArray = req.nativeArray;
     }
 
-    const is3D = publicAPI.getDimensionality() === 3;
+    const width = req.width ?? model.width;
+    const height = req.height ?? model.height;
+    const depth = req.depth ?? 1;
     const preparedData = prepareTextureUploadData(
       nativeArray,
-      model.width,
-      model.height,
-      is3D ? model.depth : 1
+      width,
+      height,
+      depth
     );
     if (!preparedData) {
       return;
@@ -279,22 +292,22 @@ function vtkWebGPUTexture(publicAPI, model) {
       {
         texture: model.handle,
         mipLevel: 0,
-        origin: { x: 0, y: 0, z: 0 },
+        origin: { x: 0, y: 0, z: req.originZ ?? 0 },
       },
       data,
       {
         offset: 0,
         bytesPerRow: preparedData.bytesPerRow,
-        rowsPerImage: model.height,
+        rowsPerImage: height,
       },
       {
-        width: model.width,
-        height: model.height,
-        depthOrArrayLayers: is3D ? model.depth : 1,
+        width,
+        height,
+        depthOrArrayLayers: depth,
       }
     );
 
-    if (!is3D && model.mipLevel > 0) {
+    if (model.dimension === '2d' && depth === 1 && model.mipLevel > 0) {
       vtkTexture.generateMipmaps(
         model.device.getHandle(),
         model.handle,
@@ -393,6 +406,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       model.depth = tex.getDepth();
       model.handle = model.device.getHandle().createTexture({
         size: [model.width, model.height, model.depth],
+        dimension: model.dimension,
         format: model.format,
         usage: model.usage,
         label: model.label,
@@ -411,6 +425,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       model.depth = depth;
       model.handle = model.device.getHandle().createTexture({
         size: [model.width, model.height, model.depth],
+        dimension: model.dimension,
         format: model.format,
         usage: model.usage,
         label: model.label,
@@ -421,7 +436,13 @@ function vtkWebGPUTexture(publicAPI, model) {
   publicAPI.createView = (label, options = {}) => {
     // if options is missing values try to add them in
     if (!options.dimension) {
-      options.dimension = model.depth === 1 ? '2d' : '3d';
+      if (model.dimension === '3d') {
+        options.dimension = '3d';
+      } else if (model.depth === 1) {
+        options.dimension = '2d';
+      } else {
+        options.dimension = '2d-array';
+      }
     }
     const view = vtkWebGPUTextureView.newInstance({ label });
     view.create(publicAPI, options);
@@ -435,6 +456,7 @@ function vtkWebGPUTexture(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   device: null,
+  dimension: '2d',
   handle: null,
   buffer: null,
   ready: false,
@@ -450,6 +472,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.obj(publicAPI, model);
 
   macro.get(publicAPI, model, [
+    'dimension',
     'handle',
     'ready',
     'width',

--- a/Sources/Rendering/WebGPU/index.js
+++ b/Sources/Rendering/WebGPU/index.js
@@ -13,6 +13,7 @@ import './PolyDataMapper';
 import './PolyDataMapper2D';
 import './Renderer';
 import './ScalarBarActor';
+import './Skybox';
 import './SphereMapper';
 import './StickMapper';
 import './Texture';


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Test with https://kitware.github.io/vtk-js/examples/SkyboxViewer/index.html?fileURL=https://data.kitware.com/api/v1/file/5ae8a89c8d777f0685796bae/download&viewAPI=WebGPU

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
