### PR TITLE
fix(vtkVolumeFS): fix Radon transform

### DIFF
--- a/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
+++ b/Sources/Rendering/OpenGL/glsl/vtkVolumeFS.glsl
@@ -309,6 +309,30 @@ vec3 getColorFromTexture(float scalar, int component, float height) {
   return texture2D(colorTexture, vec2(scaledScalar, height)).rgb;
 }
 
+float getRadonOpacity(vec4 tValue) {
+  #ifdef EnabledIndependentComponents
+    return getOpacityFromTexture(tValue.r, 0, 0.5);
+  #else
+    #if vtkNumberOfComponents == 1
+      return getOpacityFromTexture(tValue.r, 0, 0.5);
+    #endif
+    #if vtkNumberOfComponents == 2
+      return getOpacityFromTexture(tValue.a, 1, 0.5);
+    #endif
+    #if vtkNumberOfComponents == 3
+      return getOpacityFromTexture(tValue.a, 0, 0.5);
+    #endif
+    #if vtkNumberOfComponents == 4
+      return getOpacityFromTexture(tValue.a, 3, 0.5);
+    #endif
+  #endif
+}
+
+vec3 getRadonColor(float normalizedRayIntensity) {
+  float colorCoord = clamp(normalizedRayIntensity, 0.0, 1.0);
+  return texture2D(colorTexture, vec2(colorCoord, 0.5)).rgb;
+}
+
 //=======================================================================
 // transformation between VC and IS space
 
@@ -1554,7 +1578,8 @@ void applyBlend(vec3 rayOriginVC, vec3 rayDirVC, float minDistance,
 
   #if vtkBlendMode == RADON_TRANSFORM_BLEND
     float normalizedRayIntensity = 1.0;
-    vec3 posVC = rayOriginVC + minDistance * rayDirVC;
+    vec3 firstPosVC = rayOriginVC + minDistance * rayDirVC;
+    vec3 posVC = firstPosVC;
     float stepsTraveled = 0.0;
 
     // handle very thin volumes
@@ -1562,11 +1587,16 @@ void applyBlend(vec3 rayOriginVC, vec3 rayDirVC, float minDistance,
       vec3 posIS = posVCtoIS(posVC);
       vec4 tValue = getTextureValue(posIS);
       normalizedRayIntensity -= raySteps * sampleDistance *
-                                getOpacityFromTexture(tValue.r, 0, 0.5);
+                                getRadonOpacity(tValue);
       gl_FragData[0] =
-          vec4(getColorFromTexture(normalizedRayIntensity, 0, 0.5), 1.0);
+          vec4(getRadonColor(normalizedRayIntensity), 1.0);
       return;
     }
+
+    vec3 firstPosIS = posVCtoIS(firstPosVC);
+    vec4 firstValue = getTextureValue(firstPosIS);
+    normalizedRayIntensity -=
+        jitter * sampleDistance * getRadonOpacity(firstValue);
 
     posVC += jitter * stepVC;
     stepsTraveled += jitter;
@@ -1581,15 +1611,24 @@ void applyBlend(vec3 rayOriginVC, vec3 rayDirVC, float minDistance,
       // Convert scalar value to normalizedRayIntensity coefficient and
       // accumulate normalizedRayIntensity
       normalizedRayIntensity -=
-          sampleDistance * getOpacityFromTexture(value.r, 0, 0.5);
+          sampleDistance * getRadonOpacity(value);
 
       posVC += stepVC;
       stepsTraveled++;
     }
 
+    if ((raySteps - stepsTraveled) > 0.0) {
+      vec3 endPosIS = clamp(
+        posVCtoIS(rayOriginVC + maxDistance * rayDirVC),
+        vec3(0.0), vec3(1.0));
+      vec4 endValue = getTextureValue(endPosIS);
+      normalizedRayIntensity -=
+          (raySteps - stepsTraveled) * sampleDistance * getRadonOpacity(endValue);
+    }
+
     // map normalizedRayIntensity to color
     gl_FragData[0] =
-        vec4(getColorFromTexture(normalizedRayIntensity, 0, 0.5), 1.0);
+        vec4(getRadonColor(normalizedRayIntensity), 1.0);
   #endif
 
   #if vtkBlendMode == LABELMAP_EDGE_PROJECTION_BLEND


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

Open VolumeMapperBlendModes with Radon, see volume is white https://kitware.github.io/vtk-js/examples/VolumeMapperBlendModes/index.html

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->
Restore the Radon lookup fixed in #2699.
Sample the color texture with normalized intensity.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
