### PR TITLE
BREAKING CHANGE: feat(macros)!: remove getStateArrayMapFunc

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,8 @@
+## From 35.x to 36
+
+- **macros**: `getStateArrayMapFunc` has been removed. Inline the equivalent where needed, e.g. `arr.map((item) => (item && item.isA ? item.getState() : item))`.
+
+
 ## From 34.x to 35
 
 - **vtkMapper**: mappers should overwrite `computeBounds()` instead of `getBounds` that now calls `computeBounds()` before returning a copy of the mapper bounds.

--- a/Sources/macros.d.ts
+++ b/Sources/macros.d.ts
@@ -141,13 +141,6 @@ declare function safeArrays(model: object): void;
 declare function enumToString(e: object, value: any): string;
 
 /**
- * If item is a VtkObject, return its getState() otherwise return itself.
- *
- * @param item object to extract its state from
- */
-declare function getStateArrayMapFunc(item: any): any;
-
-/**
  * Call provided function on the next EDT pass
  *
  * @param fn function to execute
@@ -725,7 +718,6 @@ declare const Macro: {
   get: typeof get;
   getArray: typeof getArray;
   getCurrentGlobalMTime(): Number;
-  getStateArrayMapFunc: typeof getStateArrayMapFunc;
   isVtkObject: typeof isVtkObject;
   keystore: typeof keystore;
   measurePromiseExecution: typeof measurePromiseExecution;

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -212,13 +212,6 @@ function enumToString(e, value) {
   return Object.keys(e).find((key) => e[key] === value);
 }
 
-function getStateArrayMapFunc(item) {
-  if (item && item.isA) {
-    return item.getState();
-  }
-  return item;
-}
-
 // ----------------------------------------------------------------------------
 // setImmediate
 // ----------------------------------------------------------------------------
@@ -1797,7 +1790,6 @@ export default {
   get,
   getArray,
   getCurrentGlobalMTime,
-  getStateArrayMapFunc,
   isVtkObject,
   keystore,
   measurePromiseExecution,


### PR DESCRIPTION
BREAKING CHANGE: getStateArrayMapFunc has been removed from macros.

Follow up to https://github.com/Kitware/vtk-js/pull/3472