### PR TITLE
fix(Convolution2DPass): fix default kernel size

### DIFF
--- a/Sources/Rendering/OpenGL/Convolution2DPass/index.js
+++ b/Sources/Rendering/OpenGL/Convolution2DPass/index.js
@@ -15,7 +15,7 @@ function vtkConvolution2DPass(publicAPI, model) {
   model.classHierarchy.push('vtkConvolution2DPass');
 
   publicAPI.computeKernelWeight = function computeKernelWeight(kernel) {
-    const weight = kernel.reduce((prev, curr) => prev + curr);
+    const weight = kernel.reduce((prev, curr) => prev + curr, 0);
     return weight <= 0 ? 1 : weight;
   };
 
@@ -34,12 +34,11 @@ function vtkConvolution2DPass(publicAPI, model) {
     }
 
     // if no kernel is set, use the default kernel (no post-processing)
-    if (model.kernel === null) {
-      model.kernel = new Float32Array(model.kernelDimension);
-      model.kernel[Math.floor(model.kernelDimension / 2)] = 1;
-    }
-
     const kernelLength = model.kernelDimension * model.kernelDimension;
+    if (model.kernel === null) {
+      model.kernel = new Float32Array(kernelLength);
+      model.kernel[Math.floor(kernelLength / 2)] = 1;
+    }
     if (model.kernel.length !== kernelLength) {
       vtkErrorMacro(
         `The given kernel is invalid. 2D convolution kernels have to be 1D arrays with ${kernelLength} components representing the ${model.kernelDimension}x${model.kernelDimension} kernel in row-major form.`


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
