### PR TITLE
fix(glyph): clear stale source shift scale

### DIFF
--- a/Sources/Rendering/Core/Glyph3DMapper/test/testGlyph3DMapperShiftScale.js
+++ b/Sources/Rendering/Core/Glyph3DMapper/test/testGlyph3DMapperShiftScale.js
@@ -1,0 +1,98 @@
+import test from 'tape';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkCellArray from 'vtk.js/Sources/Common/Core/CellArray';
+import vtkGlyph3DMapper from 'vtk.js/Sources/Rendering/Core/Glyph3DMapper';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+
+function makePolyDataFromPoints(coords) {
+  const polyData = vtkPolyData.newInstance();
+  polyData.getPoints().setData(Float32Array.from(coords), 3);
+  return polyData;
+}
+
+function updatePoints(polyData, coords) {
+  polyData.getPoints().setData(Float32Array.from(coords), 3);
+  polyData.getPoints().modified();
+  polyData.modified();
+}
+
+function makeLineGlyphSource() {
+  const source = makePolyDataFromPoints([-0.5, 0, 0, 0.5, 0, 0]);
+  source.setLines(
+    vtkCellArray.newInstance({
+      values: new Uint32Array([2, 0, 1]),
+    })
+  );
+  return source;
+}
+
+function getActivePrimitiveCABOs(openGLRenderWindow, mapper) {
+  const openGLMapper = openGLRenderWindow.getViewNodeFor(mapper);
+  const primitives = openGLMapper.getReferenceByName('primitives');
+  return primitives
+    .map((primitive) => primitive.getCABO())
+    .filter((cabo) => cabo.getElementCount() > 0);
+}
+
+test.onlyIfWebGL(
+  'Test vtkGlyph3DMapper clears source VBO shift/scale after shifted glyph centers',
+  (t) => {
+    const gc = testUtils.createGarbageCollector(t);
+
+    const container = document.querySelector('body');
+    const renderWindowContainer = gc.registerDOMElement(
+      document.createElement('div')
+    );
+    container.appendChild(renderWindowContainer);
+
+    const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+    const renderer = gc.registerResource(vtkRenderer.newInstance());
+    renderWindow.addRenderer(renderer);
+
+    const centers = gc.registerResource(
+      makePolyDataFromPoints([10000000, 0, 0, 10000001, 0, 0])
+    );
+    const source = gc.registerResource(makeLineGlyphSource());
+    const mapper = gc.registerResource(vtkGlyph3DMapper.newInstance());
+    const actor = gc.registerResource(vtkActor.newInstance());
+
+    mapper.setInputData(centers, 0);
+    mapper.setInputData(source, 1);
+    mapper.setScalarVisibility(false);
+
+    actor.setMapper(mapper);
+    renderer.addActor(actor);
+
+    const openGLRenderWindow = gc.registerResource(
+      renderWindow.newAPISpecificView()
+    );
+    openGLRenderWindow.setContainer(renderWindowContainer);
+    renderWindow.addView(openGLRenderWindow);
+    openGLRenderWindow.setSize(1, 1);
+
+    renderWindow.render();
+
+    const shiftedCABOs = getActivePrimitiveCABOs(openGLRenderWindow, mapper);
+    t.ok(shiftedCABOs.length > 0, 'glyph source VBOs were built');
+    t.ok(
+      shiftedCABOs.some((cabo) => cabo.getCoordShiftAndScaleEnabled()),
+      'far glyph centers enable shift/scale on source VBOs'
+    );
+
+    updatePoints(centers, [-0.5, 0, 0, 0.5, 0, 0]);
+    renderWindow.render();
+
+    const unshiftedCABOs = getActivePrimitiveCABOs(openGLRenderWindow, mapper);
+    t.ok(
+      unshiftedCABOs.every((cabo) => !cabo.getCoordShiftAndScaleEnabled()),
+      'source VBO shift/scale is cleared once glyph centers no longer use it'
+    );
+
+    gc.releaseResources();
+  }
+);

--- a/Sources/Rendering/Core/SphereMapper/test/testSphereMapperShiftScale.js
+++ b/Sources/Rendering/Core/SphereMapper/test/testSphereMapperShiftScale.js
@@ -1,0 +1,85 @@
+import test from 'tape';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkSphereMapper from 'vtk.js/Sources/Rendering/Core/SphereMapper';
+
+function makePolyDataFromPoints(coords) {
+  const polyData = vtkPolyData.newInstance();
+  polyData.getPoints().setData(Float32Array.from(coords), 3);
+  return polyData;
+}
+
+function updatePoints(polyData, coords) {
+  polyData.getPoints().setData(Float32Array.from(coords), 3);
+  polyData.getPoints().modified();
+  polyData.modified();
+}
+
+function getActivePrimitiveCABOs(openGLRenderWindow, mapper) {
+  const openGLMapper = openGLRenderWindow.getViewNodeFor(mapper);
+  const primitives = openGLMapper.getReferenceByName('primitives');
+  return primitives
+    .map((primitive) => primitive.getCABO())
+    .filter((cabo) => cabo.getElementCount() > 0);
+}
+
+test.onlyIfWebGL(
+  'Test vtkSphereMapper clears VBO shift/scale after shifted points',
+  (t) => {
+    const gc = testUtils.createGarbageCollector(t);
+
+    const container = document.querySelector('body');
+    const renderWindowContainer = gc.registerDOMElement(
+      document.createElement('div')
+    );
+    container.appendChild(renderWindowContainer);
+
+    const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+    const renderer = gc.registerResource(vtkRenderer.newInstance());
+    renderWindow.addRenderer(renderer);
+
+    const polyData = gc.registerResource(
+      makePolyDataFromPoints([10000000, 0, 0, 10000001, 0, 0])
+    );
+    const mapper = gc.registerResource(vtkSphereMapper.newInstance());
+    const actor = gc.registerResource(vtkActor.newInstance());
+
+    mapper.setInputData(polyData);
+    mapper.setScalarVisibility(false);
+
+    actor.setMapper(mapper);
+    renderer.addActor(actor);
+
+    const openGLRenderWindow = gc.registerResource(
+      renderWindow.newAPISpecificView()
+    );
+    openGLRenderWindow.setContainer(renderWindowContainer);
+    renderWindow.addView(openGLRenderWindow);
+    openGLRenderWindow.setSize(1, 1);
+
+    renderWindow.render();
+
+    const shiftedCABOs = getActivePrimitiveCABOs(openGLRenderWindow, mapper);
+    t.ok(shiftedCABOs.length > 0, 'sphere VBOs were built');
+    t.ok(
+      shiftedCABOs.some((cabo) => cabo.getCoordShiftAndScaleEnabled()),
+      'far points enable shift/scale on VBOs'
+    );
+
+    updatePoints(polyData, [-0.5, 0, 0, 0.5, 0, 0]);
+    renderWindow.render();
+
+    const unshiftedCABOs = getActivePrimitiveCABOs(openGLRenderWindow, mapper);
+    t.ok(
+      unshiftedCABOs.every((cabo) => !cabo.getCoordShiftAndScaleEnabled()),
+      'VBO shift/scale is cleared once points no longer use it'
+    );
+
+    gc.releaseResources();
+  }
+);

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -756,12 +756,13 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
 
     // apply shift + scale to primitives AFTER vtkOpenGLPolyDataMapper.buildBufferObjects
     // so that the Glyph3DMapper gets the last say in the shift + scale
-    if (useShiftAndScale) {
-      for (let i = primTypes.Start; i < primTypes.End; i++) {
-        model.primitives[i]
-          .getCABO()
-          .setCoordShiftAndScale(coordShift, coordScale);
-      }
+    for (let i = primTypes.Start; i < primTypes.End; i++) {
+      model.primitives[i]
+        .getCABO()
+        .setCoordShiftAndScale(
+          useShiftAndScale ? coordShift : null,
+          useShiftAndScale ? coordScale : null
+        );
     }
   };
 }

--- a/Sources/Rendering/OpenGL/SphereMapper/index.js
+++ b/Sources/Rendering/OpenGL/SphereMapper/index.js
@@ -296,9 +296,10 @@ function vtkOpenGLSphereMapper(publicAPI, model) {
 
     const { useShiftAndScale, coordShift, coordScale } =
       computeCoordShiftAndScale(points);
-    if (useShiftAndScale) {
-      vbo.setCoordShiftAndScale(coordShift, coordScale);
-    }
+    vbo.setCoordShiftAndScale(
+      useShiftAndScale ? coordShift : null,
+      useShiftAndScale ? coordScale : null
+    );
 
     //
     // Generate points and point data for sides


### PR DESCRIPTION
Bug fix.  Clear stale coordinate shift/scale state on glyph source VBOs when `vtkGlyph3DMapper` no longer needs shift/scale normalization for glyph centers.

### Details

`vtkGlyph3DMapper` applies shift/scale normalization to glyph center matrices for large coordinate ranges. It also applies the same transform to glyph source primitives after the base `PolyDataMapper` builds source VBOs.

Previously, when a later frame no longer required center shift/scale, the mapper stopped applying the transform to center matrices but did not clear the previous transform from the source primitive CABOs. That left glyph centers and glyph source geometry using different coordinate transforms.

This updates `Glyph3DMapper` to always set the source primitive shift/scale state: pass the computed shift/scale when active, otherwise pass `null, null` to clear stale state.