### PR TITLE
fix(types): correct defaultViewAPI typing

### DIFF
--- a/Sources/Rendering/Core/RenderWindow/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindow/index.d.ts
@@ -29,10 +29,7 @@ interface IStatistics {
   str: string;
 }
 
-export const enum DEFAULT_VIEW_API {
-  'WebGL',
-  'WebGPU',
-}
+export type DEFAULT_VIEW_API = 'WebGL' | 'WebGPU';
 
 export interface vtkRenderWindow extends vtkObject {
   /**

--- a/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
+++ b/Sources/Rendering/Misc/FullScreenRenderWindow/index.d.ts
@@ -1,7 +1,7 @@
 import { vtkObject } from '../../../interfaces';
 import { RGBAColor, RGBColor } from '../../../types';
 import vtkRenderer from '../../Core/Renderer';
-import vtkRenderWindow from '../../Core/RenderWindow';
+import vtkRenderWindow, { DEFAULT_VIEW_API } from '../../Core/RenderWindow';
 import vtkRenderWindowInteractor from '../../Core/RenderWindowInteractor';
 
 // import vtkOpenGLRenderWindow from "../../../OpenGL/RenderWindow";
@@ -16,7 +16,7 @@ export interface IFullScreenRenderWindowInitialValues {
   containerStyle?: object;
   controlPanelStyle?: object;
   controllerVisibility?: boolean;
-  defaultViewAPI?: boolean;
+  defaultViewAPI?: DEFAULT_VIEW_API;
   listenWindowResize?: boolean;
   resizeCallback?: any;
 }
@@ -41,7 +41,7 @@ export interface vtkFullScreenRenderWindow extends vtkObject {
 
   /**
    * Returns vtkWebGPURenderWindow if ?viewAPI='WebGPU' is in URL, or if
-   * vtkFullScreenRenderWindow has been created with "defaultViewAPI: 'WebGPU",
+   * vtkFullScreenRenderWindow has been created with "defaultViewAPI: 'WebGPU'",
    * otherwise vtkOpenGLRenderWindow is returned.
    */
   getApiSpecificRenderWindow(): any; // vtkOpenGLRenderWindow || vtkWebGPURenderWindow


### PR DESCRIPTION
`defaultViewAPI` is a string at runtime ('WebGL' / 'WebGPU'), but the types
disagreed:

- `DEFAULT_VIEW_API` was a `const enum` with numeric values, so
  `setDefaultViewAPI(DEFAULT_VIEW_API.WebGPU)` would pass `1` and silently
  fall back to WebGL.
- `IFullScreenRenderWindowInitialValues.defaultViewAPI` was typed `boolean`.

Switch `DEFAULT_VIEW_API` to a string union (same exported name) and reuse it.
No runtime changes. Related: #3216, #3139.