### PR TITLE
fix(Property): stop setSpecularPower from overwriting roughness

### DIFF
--- a/Sources/Rendering/Core/Property/index.js
+++ b/Sources/Rendering/Core/Property/index.js
@@ -62,18 +62,6 @@ function vtkProperty(publicAPI, model) {
     return [].concat(model.color);
   };
 
-  publicAPI.setSpecularPower = (specularPower) => {
-    const roughness = 1 / Math.max(1.0, specularPower);
-    if (
-      model.roughness !== roughness ||
-      model.specularPower !== specularPower
-    ) {
-      model.specularPower = specularPower; // Specular power still needs to be set as long as webgl is using it (otherwise testShaderReplacementsClear fails)
-      model.roughness = roughness;
-      publicAPI.modified();
-    }
-  };
-
   publicAPI.addShaderVariable = notImplemented('AddShaderVariable');
 
   publicAPI.setInterpolationToFlat = () =>


### PR DESCRIPTION
Drop the `setSpecularPower` override that also writes `roughness`, leaving
the plain `macro.setGet` setter behind.

I think the override existed to auto-derive a PBR `roughness` for WebGL code
that only set the Phong `specularPower`. But Phong and PBR are parallel
rendering paths, not a migration — so the bridge silently corrupts `roughness`
for any caller that sets both.