### PR TITLE
fix(vtkOpenGLImageCPRMapper): projectionScaledDirection should have vtkImageData direction matrix

### DIFF
--- a/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
+++ b/Sources/Rendering/OpenGL/ImageCPRMapper/index.js
@@ -773,7 +773,6 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
     ];
     if (useProjection) {
       tcoordFSDec.push(
-        'uniform vec3 volumeSizeMC;',
         'uniform int projectionSlabNumberOfSamples;',
         'uniform float projectionConstantOffset;',
         'uniform float projectionStepLength;'
@@ -930,7 +929,7 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
 
       // Loop on all the samples of the projection
       tcoordFSImpl.push(
-        'vec3 projectionScaledDirection = projectionDirection / volumeSizeMC;',
+        'vec3 projectionScaledDirection = (MCTCMatrix * vec4(projectionDirection, 0.0)).xyz;',
         'vec3 projectionStep = projectionStepLength * projectionScaledDirection;',
         'vec3 projectionStartPosition = volumePosTC + projectionConstantOffset * projectionScaledDirection;',
         'vec4 tvalue = initialProjectionTextureValue;',
@@ -1199,16 +1198,11 @@ function vtkOpenGLImageCPRMapper(publicAPI, model) {
     }
     // Projection uniforms
     if (model.renderable.isProjectionEnabled()) {
-      const image = model.currentImageDataInput;
-      const spacing = image.getSpacing();
-      const dimensions = image.getDimensions();
       const projectionSlabThickness =
         model.renderable.getProjectionSlabThickness();
       const projectionSlabNumberOfSamples =
         model.renderable.getProjectionSlabNumberOfSamples();
 
-      const volumeSize = vec3.mul([], spacing, dimensions);
-      program.setUniform3fArray('volumeSizeMC', volumeSize);
       program.setUniformi(
         'projectionSlabNumberOfSamples',
         projectionSlabNumberOfSamples


### PR DESCRIPTION
### Context

`vtkOpenGLImageCPRMapper` already uses `MCTCMatrix` to transform CPR sample
positions from model coordinates to texture coordinates. That matrix is built
from `image.getWorldToIndex()`, so it includes the `vtkImageData` direction
matrix.

However, the projection slab direction was still converted to texture space by
dividing by `volumeSizeMC`:

```glsl
vec3 projectionScaledDirection = projectionDirection / volumeSizeMC;
```

That only accounts for volume size. It does not account for image direction,
so CPR projection sampling can follow the wrong texture-space direction for
oriented images, including flipped or rotated `vtkImageData`.

### Results

Before this change, the CPR sample position used `MCTCMatrix`, but the
projection direction used a separate size-only conversion. This could make the
projection slab sample along the wrong axis or sign when `vtkImageData`
direction is not identity.

After this change, both the CPR sample position and the projection slab
direction are transformed through `MCTCMatrix`. Positions use `w = 1.0`, while
direction vectors use `w = 0.0` so the image orientation and spacing are
applied without applying translation.

### Changes

- Transform the projection slab direction with `MCTCMatrix` using `w = 0.0`
  so image orientation is applied to direction vectors without applying
  translation.
- Replace the size-only `projectionDirection / volumeSizeMC` conversion with
  `(MCTCMatrix * vec4(projectionDirection, 0.0)).xyz` so projection sampling
  follows the correct direction for oriented `vtkImageData`.
- Remove the `volumeSizeMC` shader uniform and its CPU-side setup because the
  projection direction conversion now comes directly from `MCTCMatrix`.

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

You can run `npm run example ImageCPRMapper` and you can see the result is the same as modified.

Both commands completed without errors.

- [ ] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Microsoft Edge 148.0.3967.54
