### PR TITLE
fix(Mapper): fix canUseTextureMapForColoring for cell data with indexed LUT

### DIFF
--- a/Sources/Rendering/Core/Mapper/index.js
+++ b/Sources/Rendering/Core/Mapper/index.js
@@ -614,17 +614,17 @@ function vtkMapper(publicAPI, model) {
   };
 
   publicAPI.canUseTextureMapForColoring = (scalars, cellFlag) => {
+    // index color does not use textures
+    if (model.lookupTable && model.lookupTable.getIndexedLookup()) {
+      return false;
+    }
+
     if (cellFlag && !(model.colorMode === ColorMode.DIRECT_SCALARS)) {
       return true; // cell data always use textures.
     }
 
     if (!model.interpolateScalarsBeforeMapping) {
       return false; // user doesn't want us to use texture maps at all.
-    }
-
-    // index color does not use textures
-    if (model.lookupTable && model.lookupTable.getIndexedLookup()) {
-      return false;
     }
 
     if (!scalars) {

--- a/Sources/Rendering/Core/Mapper/test/testIndexedLookupCellData.js
+++ b/Sources/Rendering/Core/Mapper/test/testIndexedLookupCellData.js
@@ -1,0 +1,121 @@
+import test from 'tape';
+
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkLookupTable from 'vtk.js/Sources/Common/Core/LookupTable';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkPolyData from 'vtk.js/Sources/Common/DataModel/PolyData';
+
+import {
+  ColorMode,
+  ScalarMode,
+} from 'vtk.js/Sources/Rendering/Core/Mapper/Constants';
+
+// Bug: https://github.com/Kitware/vtk-js/issues/3509
+// canUseTextureMapForColoring returns true for cell data + indexed LUT.
+// The indexed lookup check was placed after the cell data shortcut, so cell
+// data with an indexed LUT incorrectly took the texture path, which produces
+// NaN (red) colors because the texture samples continuous float values that
+// don't match any annotations.
+test('Test canUseTextureMapForColoring returns false for indexed LUT with cell data', (t) => {
+  const numCells = 16;
+  const numPoints = 25;
+
+  const points = new Float32Array(3 * numPoints);
+  const polys = new Uint32Array(5 * numCells);
+  const cellCategories = new Uint8Array(numCells);
+
+  for (let i = 0; i < numPoints; i++) {
+    points[i * 3] = i % 5;
+    points[i * 3 + 1] = Math.floor(i / 5);
+  }
+  let idx = 0;
+  for (let j = 0; j < 4; j++) {
+    for (let i = 0; i < 4; i++) {
+      const p0 = j * 5 + i;
+      polys[idx++] = 4;
+      polys[idx++] = p0;
+      polys[idx++] = p0 + 1;
+      polys[idx++] = p0 + 6;
+      polys[idx++] = p0 + 5;
+      cellCategories[j * 4 + i] = (i + j) % 4;
+    }
+  }
+
+  const polydata = vtkPolyData.newInstance();
+  polydata.getPoints().setData(points, 3);
+  polydata.getPolys().setData(polys, 1);
+
+  polydata.getCellData().setScalars(
+    vtkDataArray.newInstance({
+      name: 'CellCategories',
+      numberOfComponents: 1,
+      values: cellCategories,
+    })
+  );
+
+  const lut = vtkLookupTable.newInstance();
+  lut.setNumberOfColors(4);
+  lut.setHueRange(0.0, 0.66);
+  lut.build();
+  lut.setIndexedLookup(true);
+  lut.setAnnotations(['0', '1', '2', '3'], ['Cat0', 'Cat1', 'Cat2', 'Cat3']);
+
+  const mapper = vtkMapper.newInstance({
+    scalarVisibility: true,
+    colorMode: ColorMode.MAP_SCALARS,
+    scalarMode: ScalarMode.USE_CELL_DATA,
+    interpolateScalarsBeforeMapping: false,
+  });
+  mapper.setInputData(polydata);
+  mapper.setLookupTable(lut);
+
+  const scalars = polydata.getCellData().getScalars();
+
+  const canUseTexture = mapper.canUseTextureMapForColoring(scalars, true);
+  t.notOk(
+    canUseTexture,
+    'canUseTextureMapForColoring should return false for cell data + indexed LUT'
+  );
+
+  // Verify mapScalars produces correct colorMapColors (not null from texture path)
+  mapper.mapScalars(polydata, 1.0);
+  const colorMapColors = mapper.getColorMapColors();
+  t.ok(colorMapColors, 'colorMapColors should not be null for indexed LUT');
+  if (!colorMapColors) {
+    t.end();
+    return;
+  }
+  t.equal(
+    colorMapColors.getNumberOfTuples(),
+    numCells,
+    'colorMapColors should have one tuple per cell'
+  );
+
+  // Verify no NaN colors (the red [128,0,0,255] pattern)
+  const cdata = colorMapColors.getData();
+
+  let hasNanColor = false;
+  for (let i = 0; i < numCells; i++) {
+    const r = cdata[i * 4];
+    const g = cdata[i * 4 + 1];
+    const b = cdata[i * 4 + 2];
+    // NaN color is exactly [128, 0, 0, 255] (nanColor = [0.5, 0, 0, 1])
+    if (r === 128 && g === 0 && b === 0) {
+      hasNanColor = true;
+      break;
+    }
+  }
+  t.notOk(
+    hasNanColor,
+    'No cells should have NaN color - all categories have valid annotations'
+  );
+
+  // Also verify colorTextureMap is null (texture path was not taken)
+  const textureMap = mapper.getColorTextureMap();
+  t.notOk(
+    textureMap,
+    'colorTextureMap should be null when indexed LUT is used'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
fixes #3509

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
