### PR TITLE
fix(vtkWebGPUImageCPRMapper): projection direction should use vtkImag…

### DIFF
--- a/Sources/Rendering/WebGPU/ImageCPRMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageCPRMapper/index.js
@@ -110,8 +110,8 @@ fn sampleOpacityRow(value: f32, row: f32) -> f32
 
 fn getProjectedValue(volumePosTC: vec3<f32>, projectionDirection: vec3<f32>) -> vec4<f32>
 {
-  let volumeSize = max(mapperUBO.VolumeSizeMC.xyz, vec3<f32>(0.000001));
-  let scaledDirection = projectionDirection / volumeSize;
+  let scaledDirection =
+    (mapperUBO.MCTCMatrix * vec4<f32>(projectionDirection, 0.0)).xyz;
   let projectionStep = mapperUBO.ProjectionParams.z * scaledDirection;
   let projectionStart = volumePosTC + mapperUBO.ProjectionParams.y * scaledDirection;
 
@@ -627,14 +627,6 @@ function vtkWebGPUImageCPRMapper(publicAPI, model) {
     mat4.multiply(tmpMat4, tmp2Mat4, modelToIndex);
     model.UBO.setArray('MCTCMatrix', tmpMat4);
 
-    const spacing = image.getSpacing();
-    model.UBO.setArray('VolumeSizeMC', [
-      spacing[0] * dims[0],
-      spacing[1] * dims[1],
-      spacing[2] * dims[2],
-      1.0,
-    ]);
-
     const centerPoint = model.renderable.getCenterPoint();
     model.UBO.setArray('GlobalCenterPoint', [
       ...(centerPoint ?? [0.0, 0.0, 0.0]),
@@ -939,7 +931,6 @@ export function extend(publicAPI, model, initialValues = {}) {
   model.UBO.addEntry('BCSCMatrix', 'mat4x4<f32>');
   model.UBO.addEntry('MCTCMatrix', 'mat4x4<f32>');
   model.UBO.addEntry('BackgroundColor', 'vec4<f32>');
-  model.UBO.addEntry('VolumeSizeMC', 'vec4<f32>');
   model.UBO.addEntry('GlobalCenterPoint', 'vec4<f32>');
   model.UBO.addEntry('UniformOrientation', 'vec4<f32>');
   model.UBO.addEntry('TangentDirection', 'vec4<f32>');


### PR DESCRIPTION
### Context

`vtkWebGPUImageCPRMapper` already uses `MCTCMatrix` to transform CPR sample positions from model coordinates to texture coordinates. That matrix is built from `image.getWorldToIndex()`, so it includes the `vtkImageData` direction matrix.

This is the same class of issue as the one addressed for `vtkOpenGLImageCPRMapper` in #3508. The WebGPU implementation had the same size-only projection direction conversion path.

However, the projection slab direction was still converted to texture space by dividing by `VolumeSizeMC`:

```wgsl
let volumeSize = max(mapperUBO.VolumeSizeMC.xyz, vec3<f32>(0.000001));
let scaledDirection = projectionDirection / volumeSize;
```

That only accounts for volume size. It does not account for image direction, so CPR projection sampling can follow the wrong texture-space direction for oriented images, including flipped or rotated `vtkImageData`.

### Results

Before this change, the CPR sample position used `MCTCMatrix`, but the projection direction used a separate size-only conversion. This could make the projection slab sample along the wrong axis or sign when `vtkImageData` direction is not identity.

After this change, both the CPR sample position and the projection slab direction are transformed through `MCTCMatrix`. Positions use `w = 1.0`, while direction vectors use `w = 0.0` so the image orientation and spacing are applied without applying translation.

### Changes

Transform the projection slab direction with `MCTCMatrix` using `w = 0.0` so image orientation is applied to direction vectors without applying translation.

Replace the size-only `projectionDirection / VolumeSizeMC` conversion with:

```wgsl
(mapperUBO.MCTCMatrix * vec4<f32>(projectionDirection, 0.0)).xyz
```

so projection sampling follows the correct direction for oriented `vtkImageData`.

Remove the `VolumeSizeMC` UBO entry and its CPU-side setup because the projection direction conversion now comes directly from `MCTCMatrix`.

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**:  master
  - **OS**:  Window 11 25H2 26200.8457
  - **Browser**:   148.0.3967.70