### PR TITLE
fix(ObjectManager): add instance existence check

### DIFF
--- a/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
+++ b/Sources/Rendering/Misc/SynchronizableRenderWindow/ObjectManager/index.js
@@ -370,7 +370,7 @@ function rendererUpdater(instance, state, context) {
         extractInstanceIds(call[1]).forEach((vpId) => {
           const deps = context
             .getInstance(vpId)
-            .get('flattenedDepIds').flattenedDepIds;
+            ?.get('flattenedDepIds').flattenedDepIds;
           if (deps) {
             // Consider each dependency for un-registering
             deps.forEach((depId) => unregisterCandidates.add(depId));


### PR DESCRIPTION
Add existance check on getInstance call to avoid errors when undefined

### Context
An error occurs on the getInstance(vpId).get('flattenedDepIds') call when said instance is undefined.

### Results
This leads to an error in trame-vtk. It was discovered in [this issue](https://github.com/Kitware/trame/discussions/868#discussioncomment-16958025).

### Changes
Added an existance check on the getInstance output.

### PR and Code Checklist
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
