### PR TITLE
fix: bump xmlbuilder2 version to address security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "spark-md5": "3.0.2",
         "utif": "3.1.0",
         "webworker-promise": "0.5.0",
-        "xmlbuilder2": "3.1.1"
+        "xmlbuilder2": "^4.0.3"
       },
       "bin": {
         "vtkDataConverter": "Utilities/DataGenerator/convert-cli.js",
@@ -1184,51 +1184,51 @@
       }
     },
     "node_modules/@oozcitak/dom": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
-      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-2.0.2.tgz",
+      "integrity": "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==",
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/url": "1.0.4",
-        "@oozcitak/util": "8.3.8"
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/url": "^3.0.0",
+        "@oozcitak/util": "^10.0.0"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@oozcitak/infra": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
-      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-2.0.2.tgz",
+      "integrity": "sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==",
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/util": "8.3.8"
+        "@oozcitak/util": "^10.0.0"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@oozcitak/url": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
-      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-3.0.0.tgz",
+      "integrity": "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==",
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8"
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/util": "^10.0.0"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@oozcitak/util": {
-      "version": "8.3.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
-      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-10.0.0.tgz",
+      "integrity": "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -3809,7 +3809,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/argv-formatter": {
@@ -5568,6 +5567,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7022,7 +7022,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -12954,6 +12953,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
@@ -14613,40 +14613,18 @@
       }
     },
     "node_modules/xmlbuilder2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
-      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-4.0.3.tgz",
+      "integrity": "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==",
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/dom": "1.15.10",
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8",
-        "js-yaml": "3.14.1"
+        "@oozcitak/dom": "^2.0.2",
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/util": "^10.0.0",
+        "js-yaml": "^4.1.1"
       },
       "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/xmlbuilder2/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/xmlbuilder2/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "node": ">=20.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "spark-md5": "3.0.2",
     "utif": "3.1.0",
     "webworker-promise": "0.5.0",
-    "xmlbuilder2": "3.1.1"
+    "xmlbuilder2": "^4.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "19.7.1",


### PR DESCRIPTION
xmlbuilder2 has a dependency on js-yaml. js-yaml versions <3.14.2 has a moderate severity vulnerability (CVE-2025-64718). This patch bumps xmlbuilder2 to a version that depends on the fixed js-yaml.

### Context
fix #3519

### Results
Fix this specific vulnerability.

### Changes

Dependency bump: xmlbuilder2 3.1.1 -> ^4.0.3

- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [ ] This change adds or fixes unit tests
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->