### PR TITLE
feat(property2d): add explicit culling API to vtkProperty2D

### DIFF
--- a/Sources/Rendering/Core/Property2D/index.d.ts
+++ b/Sources/Rendering/Core/Property2D/index.d.ts
@@ -8,6 +8,8 @@ export interface IProperty2DInitialValues {
   pointSize?: number;
   lineWidth?: number;
   displayLocation?: DisplayLocation;
+  backfaceCulling?: boolean;
+  frontfaceCulling?: boolean;
 }
 
 export interface vtkProperty2D extends vtkObject {
@@ -20,6 +22,16 @@ export interface vtkProperty2D extends vtkObject {
    * Get the color of the object.
    */
   getColorByReference(): RGBColor;
+
+  /**
+   * Get the status of backface culling.
+   */
+  getBackfaceCulling(): boolean;
+
+  /**
+   * Get the status of frontface culling.
+   */
+  getFrontfaceCulling(): boolean;
 
   /**
    * Get the display location of the object.
@@ -81,6 +93,22 @@ export interface vtkProperty2D extends vtkObject {
   setColorFrom(color: RGBColor): boolean;
 
   /**
+   * Turn on/off fast culling of polygons based on orientation of normal
+   * with respect to camera. If backface culling is on, polygons facing
+   * away from camera are not drawn.
+   * @param {Boolean} backfaceCulling
+   */
+  setBackfaceCulling(backfaceCulling: boolean): boolean;
+
+  /**
+   * Turn on/off fast culling of polygons based on orientation of normal
+   * with respect to camera. If frontface culling is on, polygons facing
+   * towards camera are not drawn.
+   * @param {Boolean} frontfaceCulling
+   */
+  setFrontfaceCulling(frontfaceCulling: boolean): boolean;
+
+  /**
    * Set the display location of the object.
    * @param {String} displayLocation
    */
@@ -127,7 +155,7 @@ export function extend(
  * Method use to create a new instance of vtkProperty2D with object color, ambient color, diffuse color,
  * specular color, and edge color white; ambient coefficient=0; diffuse
  * coefficient=0; specular coefficient=0; specular power=1; Gouraud shading;
- * and surface representation. Backface and frontface culling are off.
+ * and surface representation. Backface culling is on and frontface culling is off.
  * @param {IProperty2DInitialValues} [initialValues] for pre-setting some of its content
  */
 export function newInstance(

--- a/Sources/Rendering/Core/Property2D/index.js
+++ b/Sources/Rendering/Core/Property2D/index.js
@@ -38,6 +38,8 @@ const DEFAULT_VALUES = {
   lineWidth: 1,
   representation: Representation.SURFACE,
   displayLocation: DisplayLocation.FOREGROUND,
+  backfaceCulling: true,
+  frontfaceCulling: false,
 };
 
 // ----------------------------------------------------------------------------
@@ -53,6 +55,8 @@ export function extend(publicAPI, model, initialValues = {}) {
     'pointSize',
     'displayLocation',
     'representation',
+    'backfaceCulling',
+    'frontfaceCulling',
   ]);
   macro.setGetArray(publicAPI, model, ['color'], 3);
 

--- a/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
@@ -93,10 +93,20 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
       return;
     }
 
-    // cull back face to avoid double drawing
     const gl = model.context;
-    model._openGLRenderWindow.enableCullFace();
-    model._openGLRenderWindow.setCullFaceMode(gl.BACK);
+    const prop = actor.getProperty();
+    if (prop.getBackfaceCulling() || prop.getFrontfaceCulling()) {
+      model._openGLRenderWindow.enableCullFace();
+      if (prop.getBackfaceCulling() && prop.getFrontfaceCulling()) {
+        model._openGLRenderWindow.setCullFaceMode(gl.FRONT_AND_BACK);
+      } else if (prop.getBackfaceCulling()) {
+        model._openGLRenderWindow.setCullFaceMode(gl.BACK);
+      } else {
+        model._openGLRenderWindow.setCullFaceMode(gl.FRONT);
+      }
+    } else {
+      model._openGLRenderWindow.disableCullFace();
+    }
 
     publicAPI.renderPieceStart(ren, actor);
     publicAPI.renderPieceDraw(ren, actor);


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

Support frontface and backface culling with vtkActor2D/vtkProperty2D/vtkPolyDataMapper2D.

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
