### PR TITLE
Add JSDoc comment for WIDGET_PRIORITY constant

### DIFF
--- a/Sources/Widgets/Core/AbstractWidget/Constants.js
+++ b/Sources/Widgets/Core/AbstractWidget/Constants.js
@@ -1,4 +1,6 @@
-/** @type {number} The priority used for widget interaction in VTK.js. */
+/** @type {number} The priority used for widget interaction in VTK.js.
+ * High value for high priority (default priority is 0.0)
+ */
 export const WIDGET_PRIORITY = 0.5;
 
 export default { WIDGET_PRIORITY };

--- a/Sources/Widgets/Core/AbstractWidget/Constants.js
+++ b/Sources/Widgets/Core/AbstractWidget/Constants.js
@@ -1,3 +1,4 @@
+/** @type {number} The priority used for widget interaction in VTK.js. */
 export const WIDGET_PRIORITY = 0.5;
 
 export default { WIDGET_PRIORITY };


### PR DESCRIPTION
## Problem
The public constant `WIDGET_PRIORITY` in `Sources/Widgets/Core/AbstractWidget/Constants.js` lacks documentation, which may lead to confusion for users regarding its purpose and type information. Improving documentation enhances code readability and usability in the VTK.js ecosystem.

## Changes
Added a JSDoc comment to `WIDGET_PRIORITY` to specify its type (`number`) and describe its role as the priority used for widget interaction in VTK.js.

## Verification
- Review the added comment for accuracy and consistency with existing documentation style.
- Run the repository's test suite to ensure no functional regressions, as this change only adds documentation.