### PR TITLE
chore(README): fix broken and outdated badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 ## [VTK.js - The Visualization Toolkit for JavaScript](http://kitware.github.io/vtk-js/)
 
-[![Build Status](https://github.com/Kitware/vtk-js/workflows/Build%20and%20Test/badge.svg)](https://github.com/Kitware/vtk-js/workflows/Build%20and%20Test/badge.svg)
-[![Build Status](https://travis-ci.org/Kitware/vtk-js.svg)](https://travis-ci.org/Kitware/vtk-js)
-[![Dependency Status](https://david-dm.org/kitware/vtk-js.svg)](https://david-dm.org/kitware/vtk-js)
+[![Build and Test](https://github.com/Kitware/vtk-js/actions/workflows/build-test.yml/badge.svg)](https://github.com/Kitware/vtk-js/actions/workflows/build-test.yml)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 ![npm-download](https://img.shields.io/npm/dm/vtk.js.svg)
-![npm-version-requirement](https://img.shields.io/badge/npm->=5.0.0-brightgreen.svg)
-![node-version-requirement](https://img.shields.io/badge/node->=8.0.0-brightgreen.svg)
+![npm-version-requirement](https://img.shields.io/badge/npm->=10.0.0-brightgreen.svg)
+![node-version-requirement](https://img.shields.io/badge/node->=22.0.0-brightgreen.svg)
 [![DOI](https://zenodo.org/badge/57900965.svg)](https://zenodo.org/badge/latestdoi/57900965)
 
 ### Introduction


### PR DESCRIPTION
Remove the dead Travis CI and David-DM badges, switch the build status badge to the current GitHub Actions URL, and bump the npm/node version badges to match the documented requirements (npm >=10, node >=22).
