### PR TITLE
docs(BREAKING_CHANGES): note standalone bundles now load as ES modules

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -2,6 +2,7 @@
 
 - **`vtk-lite.js` deprecated.** The UMD build previously produced a slimmed-down companion bundle `dist/umd/vtk-lite.js` (curated ColorMaps subset; `PDBReader`, `MoleculeToRepresentation`, `MobileVR`, and `webvr-polyfill` stubbed out). The Vite build pipeline no longer produces a distinct lite bundle; `vtk-lite.js` now ships as a byte-identical alias of `vtk.js` so existing `<script src=…/vtk-lite.js>` and CDN consumers continue to load. Consumers should migrate to `vtk.js` directly — the alias will be removed in a future major. Note that anything that indexed into the `ColorMaps` array by position will now see the full preset set, not the lite subset.
 - **macros**: `getStateArrayMapFunc` has been removed. Inline the equivalent where needed, e.g. `arr.map((item) => (item && item.isA ? item.getState() : item))`.
+- **Standalone example/viewer bundles now load as ES modules.** The Vite build emits `<script type="module">` for standalone apps (e.g. `OfflineLocalView`, `GeometryViewer`). Module scripts are deferred, so consumers that embed a bundle and synchronously call into the global the app exposes (e.g. `window.OfflineLocalView`) at parse time run before the module executes, when that global is not yet defined. Defer your init (await the module, or wait for `DOMContentLoaded`). See [Kitware/trame-vtk#120](https://github.com/Kitware/trame-vtk/issues/120).
 
 
 ## From 34.x to 35


### PR DESCRIPTION
The Vite migration switched standalone apps (e.g. OfflineLocalView, GeometryViewer) from an IIFE classic <script> to a deferred ESM <script type="module">. These apps expose their API as a global assigned by their own source (e.g. `window.OfflineLocalView = { load }`). Because the module is deferred, a consumer that synchronously calls that global at parse time (as trame-vtk did) runs before the module executes and throws. Mitigation: await the module or wait for DOMContentLoaded. Links Kitware/trame-vtk#120.