### PR TITLE
fix(RenderWindowInteractor): add option to disable preventDefault on wheel

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -798,7 +798,9 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   };
 
   publicAPI.handleWheel = (event) => {
-    preventDefault(event);
+    if (model.preventDefaultOnWheel) {
+      preventDefault(event);
+    }
 
     /**
      * wheel event values can vary significantly across browsers, platforms
@@ -1326,6 +1328,7 @@ const DEFAULT_VALUES = {
   wheelTimeoutID: 0,
   moveTimeoutID: 0,
   lastGamepadValues: {},
+  preventDefaultOnWheel: true, // to prevent scrolling
   preventDefaultOnPointerDown: false,
   preventDefaultOnPointerUp: false,
   mouseScrollDebounceByPass: false,
@@ -1366,6 +1369,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'desiredUpdateRate',
     'stillUpdateRate',
     'picker',
+    'preventDefaultOnWheel',
     'preventDefaultOnPointerDown',
     'preventDefaultOnPointerUp',
     'mouseScrollDebounceByPass',


### PR DESCRIPTION
Even if we don't plan to consume the wheel event, we consume it and prevent the user to be able to scroll through the page.