### PR TITLE
fix(examples): remove unused vtk-root element

### DIFF
--- a/Documentation/scripts/build-examples.mjs
+++ b/Documentation/scripts/build-examples.mjs
@@ -63,7 +63,6 @@ function buildHtml(
     </style>
   </head>
   <body>
-    <div id="vtk-root" style="height:100%; width:100%;"></div>
     <script>
       window.global = window.global || {};
     </script>

--- a/Examples/Applications/OfflineLocalView/index.js
+++ b/Examples/Applications/OfflineLocalView/index.js
@@ -139,8 +139,7 @@ export function load(container, options) {
 
 export function initLocalFileLoader(container) {
   autoInit = false;
-  const exampleContainer =
-    document.querySelector('.content') || document.querySelector('#vtk-root');
+  const exampleContainer = document.querySelector('.content');
   const rootBody = document.querySelector('body');
   const myContainer = container || exampleContainer || rootBody;
 
@@ -179,8 +178,7 @@ export function initLocalFileLoader(container) {
 const userParams = vtkURLExtract.extractURLParameters();
 
 if (userParams.url || userParams.fileURL) {
-  const exampleContainer =
-    document.querySelector('.content') || document.querySelector('#vtk-root');
+  const exampleContainer = document.querySelector('.content');
   const rootBody = document.querySelector('body');
   const myContainer = exampleContainer || rootBody;
   if (myContainer) {


### PR DESCRIPTION
### Context
Some examples have been broken since the switch to lil-gui, the example of ResliceCursorWidget is one of them. The widgets were displayed below a white div.

### Results
The example is now correctly displayed.

### Changes
Added a container element, by taking inspiration from DepthTest example.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [ ] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

Tested with

```
npm run build
npm run docs:generate
npm run docs:build
npm run docs:build-examples
npm run docs:serve 
```