### PR TITLE
Model transform view matrix fix

### DIFF
--- a/Sources/Rendering/Core/Camera/index.d.ts
+++ b/Sources/Rendering/Core/Camera/index.d.ts
@@ -688,7 +688,7 @@ export interface vtkCamera extends vtkObject {
    * This matrix could be used for model related transformations such as scale, shear, rotations and translations.
    * @param {mat4} mat The value of the model transform matrix.
    */
-  setModelTransformMatrixMatrix(mat: mat4): void;
+  setModelTransformMatrix(mat: mat4): void;
 
   /**
    * Set the view up direction for the camera.

--- a/Sources/Rendering/Core/Camera/index.d.ts
+++ b/Sources/Rendering/Core/Camera/index.d.ts
@@ -303,7 +303,7 @@ export interface vtkCamera extends vtkObject {
   /**
    * Get the view transform
    */
-  getViewMatrix(): mat4;
+  getViewMatrix(out?: mat4): mat4;
 
   /**
    * Get the model transform matrix for the camera.

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -498,28 +498,24 @@ function vtkCamera(publicAPI, model) {
     publicAPI.computeViewParametersFromViewMatrix(tmpMatrix);
   };
 
-  publicAPI.setModelTransformMatrix = (mat) => {
-    model.modelTransformMatrix = mat;
-  };
-
-  publicAPI.getModelTransformMatrix = () => model.modelTransformMatrix;
-
   publicAPI.setViewMatrix = (mat) => {
     model.viewMatrix = mat;
     if (model.viewMatrix) {
-      mat4.copy(tmpMatrix, model.viewMatrix);
-      publicAPI.computeViewParametersFromViewMatrix(tmpMatrix);
+      publicAPI.computeViewParametersFromViewMatrix(model.viewMatrix);
       mat4.transpose(model.viewMatrix, model.viewMatrix);
     }
   };
 
   publicAPI.getViewMatrix = () => {
+    const result = new Float64Array(16);
+
     if (model.viewMatrix) {
       if (model.modelTransformMatrix) {
-        mat4.multiply(tmpMatrix, model.viewMatrix, model.modelTransformMatrix);
-        return tmpMatrix;
+        mat4.multiply(result, model.modelTransformMatrix, model.viewMatrix);
+      } else {
+        mat4.copy(result, model.viewMatrix);
       }
-      return model.viewMatrix;
+      return result;
     }
 
     mat4.lookAt(
@@ -531,9 +527,8 @@ function vtkCamera(publicAPI, model) {
 
     mat4.transpose(tmpMatrix, tmpMatrix);
 
-    const result = new Float64Array(16);
     if (model.modelTransformMatrix) {
-      mat4.multiply(result, tmpMatrix, model.modelTransformMatrix);
+      mat4.multiply(result, model.modelTransformMatrix, tmpMatrix);
     } else {
       mat4.copy(result, tmpMatrix);
     }
@@ -809,6 +804,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'useOffAxisProjection',
     'freezeFocalPoint',
     'physicalScale',
+    'modelTransformMatrix',
   ]);
 
   macro.getArray(publicAPI, model, [

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -506,8 +506,8 @@ function vtkCamera(publicAPI, model) {
     }
   };
 
-  publicAPI.getViewMatrix = () => {
-    const result = new Float64Array(16);
+  publicAPI.getViewMatrix = (out = undefined) => {
+    const result = out ?? new Float64Array(16);
 
     if (model.viewMatrix) {
       if (model.modelTransformMatrix) {

--- a/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
+++ b/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
@@ -109,5 +109,14 @@ describe('Camera Model Transform Matrix', () => {
 
       expect(camera.getViewMatrix()[0]).toBe(1);
     });
+
+    it('writes the view matrix into a caller-provided output buffer', () => {
+      const out = new Float64Array(16);
+
+      const view = camera.getViewMatrix(out);
+
+      expect(view).toBe(out);
+      expect(areEquals(view, camera.getViewMatrix())).toBe(true);
+    });
   });
 });

--- a/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
+++ b/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mat4 } from 'gl-matrix';
+import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
+import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
+import vtkTransform from 'vtk.js/Sources/Common/Transform/Transform';
+
+let camera;
+
+describe('Camera Model Transform Matrix', () => {
+  beforeEach(() => {
+    camera = vtkCamera.newInstance();
+  });
+
+  describe('getViewMatrix composition', () => {
+    it('applies the model transform in world space (modelTransform * viewMatrix), not camera space (viewMatrix * modelTransform)', () => {
+      camera.setPosition(5, 5, 5);
+      camera.setFocalPoint(0, 0, 0);
+      camera.setViewUp(0, 1, 0);
+
+      // A translation does not commute with the view rotation/translation, so
+      // this genuinely distinguishes the two multiplication orders.
+      const transform = vtkTransform.newInstance();
+      transform.translate(1, 0, 0);
+      const modelTransform = transform.getMatrix();
+
+      camera.setModelTransformMatrix(null);
+      const viewMatrix = camera.getViewMatrix();
+
+      camera.setModelTransformMatrix(modelTransform);
+      const composed = camera.getViewMatrix();
+
+      const worldSpace = mat4.multiply(
+        mat4.create(),
+        modelTransform,
+        viewMatrix
+      );
+      const cameraSpace = mat4.multiply(
+        mat4.create(),
+        viewMatrix,
+        modelTransform
+      );
+
+      expect(areEquals(composed, worldSpace)).toBe(true);
+      expect(areEquals(composed, cameraSpace)).toBe(false);
+
+      transform.delete();
+    });
+
+    it('keeps the world-space transform consistent across camera orientations (vertical exaggeration)', () => {
+      // 2x vertical exaggeration: a non-uniform world-space Z scale.
+      const transform = vtkTransform.newInstance();
+      transform.scale(1, 1, 2);
+      const modelTransform = transform.getMatrix();
+
+      camera.setPosition(0, 0, 10);
+      camera.setFocalPoint(0, 0, 0);
+      camera.setViewUp(0, 1, 0);
+
+      // The exaggeration must stay world-space (pre-multiplied), so model
+      // transforms must be applied before the view matrix for every orientation.
+      [() => {}, () => camera.azimuth(37), () => camera.elevation(50)].forEach(
+        (rotate) => {
+          rotate();
+
+          camera.setModelTransformMatrix(null);
+          const viewMatrix = camera.getViewMatrix();
+
+          camera.setModelTransformMatrix(modelTransform);
+          const composed = camera.getViewMatrix();
+
+          const worldSpace = mat4.multiply(
+            mat4.create(),
+            modelTransform,
+            viewMatrix
+          );
+          expect(areEquals(composed, worldSpace)).toBe(true);
+        }
+      );
+
+      transform.delete();
+    });
+  });
+
+  describe('getViewMatrix buffer isolation', () => {
+    it('getCompositeProjectionMatrix does not let getProjectionMatrix clobber the view matrix', () => {
+      camera.setPosition(3, 4, 5);
+      camera.setFocalPoint(0, 0, 0);
+      camera.setViewUp(0, 1, 0);
+      camera.setClippingRange(0.1, 100);
+
+      const aspect = 1.5;
+
+      // Capture the two factors independently. Both APIs return matrices the
+      // caller can keep while later camera calls reuse internal scratch buffers.
+      const view = camera.getViewMatrix();
+      const projection = camera.getProjectionMatrix(aspect, -1, 1);
+      const expected = mat4.multiply(mat4.create(), view, projection);
+
+      const composite = camera.getCompositeProjectionMatrix(aspect, -1, 1);
+
+      expect(areEquals(composite, expected)).toBe(true);
+    });
+
+    it('returns a reusable copy when an explicit view matrix is set', () => {
+      camera.setViewMatrix(mat4.create());
+
+      const view = camera.getViewMatrix();
+      view[0] = 2;
+
+      expect(camera.getViewMatrix()[0]).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
When applying the model transform matrix, it was observed that the matrix was being applied in the view space leading to unintended orientation specific artifacts. This change fixes the order of matrix multiplication for the transform and adds testing to ensure that the transform is applied camera-orientation-agnostically in the world space.

Supersedes https://github.com/Kitware/vtk-js/pull/3538

Review comments here https://github.com/PaulHax/vtk-js/pull/30