### PR TITLE
fix(WebGPU): apply projection once in ImageMapper and refresh imageData textures

### DIFF
--- a/Sources/Rendering/WebGPU/ImageMapper/index.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/index.js
@@ -665,12 +665,14 @@ function vtkWebGPUImageMapper(publicAPI, model) {
       lines.push('var tcoord : vec3<f32> = (mapperUBO.SCTCMatrix * pos).xyz;');
     }
     lines.push(
+      // Clip planes are evaluated in stabilized coordinates, so capture the
+      // position before it is projected.
+      'output.vertexSC = pos;',
       'pos = rendererUBO.SCPCMatrix * pos;',
       // Match the OpenGL coincident topology constant offset scale (~1 / 2^16 = 0.000016)
       'pos.z = clamp(pos.z - 0.000016 * mapperUBO.CoincidentOffset * pos.w, 0.0, pos.w);',
       'output.tcoordVS = tcoord;',
-      'output.vertexSC = pos;',
-      'output.Position = rendererUBO.SCPCMatrix * pos;'
+      'output.Position = pos;'
     );
     code = vtkWebGPUShaderCache.substitute(
       code,

--- a/Sources/Rendering/WebGPU/ImageMapper/test/testImageMapperCameraProjection.js
+++ b/Sources/Rendering/WebGPU/ImageMapper/test/testImageMapperCameraProjection.js
@@ -1,0 +1,106 @@
+import { it, expect } from 'vitest';
+
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
+import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
+
+// Fraction of pixels in a captured data URL brighter than the given cutoff.
+async function computeBrightFraction(dataURL, cutoff = 100) {
+  const image = new Image();
+  image.src = dataURL;
+  await image.decode();
+
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const context = canvas.getContext('2d');
+  context.drawImage(image, 0, 0);
+
+  const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
+  let bright = 0;
+  const pixelCount = data.length / 4;
+  for (let i = 0; i < data.length; i += 4) {
+    if ((data[i] + data[i + 1] + data[i + 2]) / 3 > cutoff) {
+      bright++;
+    }
+  }
+  return bright / pixelCount;
+}
+
+it.skipIf(!__VTK_TEST_WEBGPU__)(
+  'Test WebGPU ImageMapper applies the view-projection matrix exactly once',
+  async () => {
+    const gc = testUtils.createGarbageCollector();
+
+    const container = document.querySelector('body');
+    const renderWindowContainer = gc.registerDOMElement(
+      document.createElement('div')
+    );
+    container.appendChild(renderWindowContainer);
+
+    const renderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+    const renderer = gc.registerResource(vtkRenderer.newInstance());
+    renderWindow.addRenderer(renderer);
+    renderer.setBackground(0, 0, 0);
+
+    // A constant bright slice positioned away from the world origin, the way
+    // medical viewers place slices in patient space.
+    const dims = 64;
+    const sliceZ = 50;
+    const values = new Uint8Array(dims * dims).fill(255);
+    const scalars = vtkDataArray.newInstance({
+      name: 'Scalars',
+      values,
+      numberOfComponents: 1,
+    });
+    const imageData = gc.registerResource(vtkImageData.newInstance());
+    imageData.setDimensions(dims, dims, 1);
+    imageData.setOrigin(0, 0, sliceZ);
+    imageData.getPointData().setScalars(scalars);
+
+    const mapper = gc.registerResource(vtkImageMapper.newInstance());
+    mapper.setInputData(imageData);
+
+    const actor = gc.registerResource(vtkImageSlice.newInstance());
+    actor.getProperty().setColorWindow(255);
+    actor.getProperty().setColorLevel(127);
+    actor.setMapper(mapper);
+    renderer.addActor(actor);
+
+    // Parallel camera one unit in front of the slice, looking down +z. If
+    // the vertex shader applies the SCPC (view-projection) matrix more than
+    // once, the doubly-projected quad falls outside the clip volume and the
+    // slice silently disappears; applied once, it fills the viewport.
+    const center = (dims - 1) / 2;
+    const camera = renderer.getActiveCamera();
+    camera.setParallelProjection(true);
+    camera.setFocalPoint(center, center, sliceZ);
+    camera.setPosition(center, center, sliceZ - 1);
+    camera.setViewUp(0, -1, 0);
+    camera.setParallelScale(dims / 2);
+    camera.setClippingRange(0.01, 1000.01);
+
+    const view = gc.registerResource(renderWindow.newAPISpecificView('WebGPU'));
+    view.setContainer(renderWindowContainer);
+    renderWindow.addView(view);
+    view.setSize(128, 128);
+
+    const promise = view
+      .captureNextImage()
+      .then(async (image) => {
+        const brightFraction = await computeBrightFraction(image);
+        expect(
+          brightFraction,
+          'the slice must cover the viewport (a doubly-projected quad is clipped away and renders nothing)'
+        ).toBeGreaterThan(0.5);
+      })
+      .finally(gc.releaseResources);
+    renderWindow.render();
+    return promise;
+  }
+);

--- a/Sources/Rendering/WebGPU/TextureManager/index.js
+++ b/Sources/Rendering/WebGPU/TextureManager/index.js
@@ -171,6 +171,11 @@ function vtkWebGPUTextureManager(publicAPI, model) {
     treq.imageData = imgData;
     // fill out the req time and format based on imageData/image
     _fillRequest(treq);
+    // _fillRequest keys the request time on the scalar array mtime alone.
+    // Consumers that write scalars in place and only call
+    // imageData.modified() must still invalidate the cached texture, so key
+    // on the newest of the imageData and scalar array mtimes.
+    treq.time = Math.max(treq.time, imgData.getMTime());
     treq.hash = treq.time + treq.format + treq.mipLevel;
     return model.device.getTextureManager().getTexture(treq);
   };

--- a/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
+++ b/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
@@ -1,0 +1,55 @@
+import { it, expect } from 'vitest';
+
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
+
+it.skipIf(!__VTK_TEST_WEBGPU__)(
+  'Test vtkWebGPUTextureManager invalidates cached imageData textures',
+  async () => {
+    const device = await testUtils.createWebGPUTestDevice();
+
+    try {
+      const values = new Uint8Array(4 * 4).fill(10);
+      const scalars = vtkDataArray.newInstance({
+        name: 'Scalars',
+        values,
+        numberOfComponents: 1,
+      });
+      const imageData = vtkImageData.newInstance();
+      imageData.setDimensions(4, 4, 1);
+      imageData.getPointData().setScalars(scalars);
+
+      const textureManager = device.getTextureManager();
+
+      const texture = textureManager.getTextureForImageData(imageData);
+      expect(
+        textureManager.getTextureForImageData(imageData),
+        'an unchanged imageData reuses the cached texture'
+      ).toBe(texture);
+
+      // Write the scalars in place and signal the change through
+      // imageData.modified() alone — the pattern used by consumers that
+      // stream new frames into an existing array (the OpenGL backend keys
+      // its texture rebuilds on the imageData mtime, so this must also
+      // refresh the WebGPU texture cache).
+      values.fill(200);
+      imageData.modified();
+      const textureAfterImageDataModified =
+        textureManager.getTextureForImageData(imageData);
+      expect(
+        textureAfterImageDataModified,
+        'imageData.modified() alone must invalidate the cached texture'
+      ).not.toBe(texture);
+
+      // Direct scalar-array modification keeps invalidating as before.
+      scalars.modified();
+      expect(
+        textureManager.getTextureForImageData(imageData),
+        'scalars.modified() must invalidate the cached texture'
+      ).not.toBe(textureAfterImageDataModified);
+    } finally {
+      device.getHandle().destroy();
+    }
+  }
+);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -19,6 +19,15 @@ const chromiumArgs = ci
   ? ['--no-sandbox', '--enable-unsafe-swiftshader', '--use-angle=swiftshader']
   : [];
 
+if (webGPU) {
+  // Headless Chromium does not expose a WebGPU adapter by default.
+  chromiumArgs.push('--enable-unsafe-webgpu');
+  if (ci) {
+    // No real GPU on CI: use Dawn's software (SwiftShader) WebGPU adapter.
+    chromiumArgs.push('--use-webgpu-adapter=swiftshader');
+  }
+}
+
 const firefox = {
   browser: 'firefox',
   headless: false, // supported Vitest Browser option; xvfb-run supplies the display on CI


### PR DESCRIPTION
### Context
The WebGPU `ImageMapper` vertex shader applies `rendererUBO.SCPCMatrix` twice (regression from 7fbc87a98). With close-in cameras — e.g. a parallel camera one unit in front of the slice, as medical viewers set up — the doubly-projected quad falls outside the clip volume and the slice silently renders nothing. The same commit also stores a clip-space position in `vertexSC`, which the clip-plane code expects in stabilized coordinates.

Separately, `TextureManager.getTextureForImageData` keys its texture cache on the scalar array mtime alone, so writing scalars in place and signaling with `imageData.modified()` (the invalidation the OpenGL backend keys texture rebuilds on) keeps returning the stale texture.

Both were found while rendering image stacks on the WebGPU view API from Cornerstone3D.

### Results
- Image slices render again with offset parallel cameras (before: nothing drawn; reproducible with the `ImageMapper` example and `?viewAPI=WebGPU`).
- Clip planes on `ImageMapper` are evaluated in stabilized coordinates again.
- Textures refresh when scalars are updated in place and only `imageData.modified()` is called.

### Changes
- `WebGPU/ImageMapper`: capture `vertexSC` before projecting, apply `SCPCMatrix` once (matches `ImageResliceMapper`/`ImageCPRMapper`).
- `WebGPU/TextureManager`: key the `getTextureForImageData` cache on the newest of the imageData and scalar array mtimes.
- `vitest.config.js`: pass `--enable-unsafe-webgpu` to headless Chromium for `WEBGPU=1` runs (plus the SwiftShader WebGPU adapter on CI) so the WebGPU tests can acquire an adapter.
- No public API changes.
- [x] Documentation and TypeScript definitions were updated to match those changes (none needed — no API changes)

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
Two regression tests, one per fix; both fail without the fixes:

```
WEBGPU=1 NO_WEBGL=1 npx vitest run \
  Sources/Rendering/WebGPU/ImageMapper/test/testImageMapperCameraProjection.js \
  Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
```

- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: master (07c3e9a5e)
  - **OS**: macOS 15
  - **Browser**: Chromium (Playwright, headless) and Chrome, Apple Metal adapter
