### PR TITLE
perf(camera): use getViewMatrix output parameter to avoid copy

### DIFF
--- a/Sources/Interaction/Manipulators/MouseCameraTrackballPanManipulatorAutoCenter/index.js
+++ b/Sources/Interaction/Manipulators/MouseCameraTrackballPanManipulatorAutoCenter/index.js
@@ -71,8 +71,7 @@ function computeNewCenterOfRotation(
 function getCameraMatrix(renderer, tempMatrix) {
   const cam = renderer.getActiveCamera();
   if (cam) {
-    mat4.copy(tempMatrix, cam.getViewMatrix());
-    return tempMatrix;
+    return cam.getViewMatrix(tempMatrix);
   }
   return null;
 }

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -49,10 +49,10 @@ function vtkCamera(publicAPI, model) {
   }
 
   publicAPI.orthogonalizeViewUp = () => {
-    const vt = publicAPI.getViewMatrix();
-    model.viewUp[0] = vt[4];
-    model.viewUp[1] = vt[5];
-    model.viewUp[2] = vt[6];
+    publicAPI.getViewMatrix(tmpMatrix);
+    model.viewUp[0] = tmpMatrix[4];
+    model.viewUp[1] = tmpMatrix[5];
+    model.viewUp[2] = tmpMatrix[6];
 
     publicAPI.modified();
   };
@@ -231,8 +231,8 @@ function vtkCamera(publicAPI, model) {
     const fp = model.focalPoint;
 
     // get the eye / camera position from the viewMatrix
-    const vt = publicAPI.getViewMatrix();
-    const axis = [-vt[0], -vt[1], -vt[2]];
+    publicAPI.getViewMatrix(tmpMatrix);
+    const axis = [-tmpMatrix[0], -tmpMatrix[1], -tmpMatrix[2]];
 
     mat4.identity(trans);
 
@@ -251,8 +251,8 @@ function vtkCamera(publicAPI, model) {
   publicAPI.pitch = (angle) => {
     const position = model.position;
 
-    const vt = publicAPI.getViewMatrix();
-    const axis = [vt[0], vt[1], vt[2]];
+    publicAPI.getViewMatrix(tmpMatrix);
+    const axis = [tmpMatrix[0], tmpMatrix[1], tmpMatrix[2]];
 
     mat4.identity(trans);
 
@@ -388,7 +388,7 @@ function vtkCamera(publicAPI, model) {
 
   publicAPI.computeCameraLightTransform = () => {
     // not sure if this is the correct transformation, based on the same funciton in VTK
-    mat4.copy(tmpMatrix, publicAPI.getViewMatrix());
+    publicAPI.getViewMatrix(tmpMatrix);
     mat4.invert(tmpMatrix, tmpMatrix);
 
     mat4.fromScaling(tmpMatrix2, [
@@ -507,6 +507,7 @@ function vtkCamera(publicAPI, model) {
   };
 
   publicAPI.getViewMatrix = (out = undefined) => {
+    // Note that out can be tmpMatrix
     const result = out ?? new Float64Array(16);
 
     if (model.viewMatrix) {
@@ -529,7 +530,7 @@ function vtkCamera(publicAPI, model) {
 
     if (model.modelTransformMatrix) {
       mat4.multiply(result, model.modelTransformMatrix, tmpMatrix);
-    } else {
+    } else if (result != tmpMatrix) {
       mat4.copy(result, tmpMatrix);
     }
     return result;

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -506,34 +506,29 @@ function vtkCamera(publicAPI, model) {
     }
   };
 
-  publicAPI.getViewMatrix = (out = undefined) => {
-    // Note that out can be tmpMatrix
-    const result = out ?? new Float64Array(16);
-
+  publicAPI.getViewMatrix = (out = new Float64Array(16)) => {
     if (model.viewMatrix) {
       if (model.modelTransformMatrix) {
-        mat4.multiply(result, model.modelTransformMatrix, model.viewMatrix);
+        mat4.multiply(out, model.modelTransformMatrix, model.viewMatrix);
       } else {
-        mat4.copy(result, model.viewMatrix);
+        mat4.copy(out, model.viewMatrix);
       }
-      return result;
+      return out;
     }
 
     mat4.lookAt(
-      tmpMatrix,
+      out,
       model.position, // eye
       model.focalPoint, // at
       model.viewUp // up
     );
 
-    mat4.transpose(tmpMatrix, tmpMatrix);
+    mat4.transpose(out, out);
 
     if (model.modelTransformMatrix) {
-      mat4.multiply(result, model.modelTransformMatrix, tmpMatrix);
-    } else if (result != tmpMatrix) {
-      mat4.copy(result, tmpMatrix);
+      mat4.multiply(out, model.modelTransformMatrix, out);
     }
-    return result;
+    return out;
   };
 
   publicAPI.setProjectionMatrix = (mat) => {

--- a/Sources/Rendering/OpenGL/Camera/index.js
+++ b/Sources/Rendering/OpenGL/Camera/index.js
@@ -54,7 +54,7 @@ function vtkOpenGLCamera(publicAPI, model) {
       ren.getMTime() > model.keyMatrixTime.getMTime() ||
       model.renderable.getMTime() > model.keyMatrixTime.getMTime()
     ) {
-      mat4.copy(model.keyMatrices.wcvc, model.renderable.getViewMatrix());
+      model.renderable.getViewMatrix(model.keyMatrices.wcvc);
 
       mat3.fromMat4(model.keyMatrices.normalMatrix, model.keyMatrices.wcvc);
       mat3.invert(

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -130,12 +130,8 @@ export default function widgetBehavior(publicAPI, model) {
   };
 
   publicAPI.rotateHandlesToFaceCamera = () => {
-    model.representations[0].setViewMatrix(
-      model._camera.getViewMatrix()
-    );
-    model.representations[1].setViewMatrix(
-      model._camera.getViewMatrix()
-    );
+    model.representations[0].setViewMatrix(model._camera.getViewMatrix());
+    model.representations[1].setViewMatrix(model._camera.getViewMatrix());
   };
 
   // Handles visibility ---------------------------------------------------------

--- a/Sources/Widgets/Widgets3D/LineWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/LineWidget/behavior.js
@@ -131,10 +131,10 @@ export default function widgetBehavior(publicAPI, model) {
 
   publicAPI.rotateHandlesToFaceCamera = () => {
     model.representations[0].setViewMatrix(
-      Array.from(model._camera.getViewMatrix())
+      model._camera.getViewMatrix()
     );
     model.representations[1].setViewMatrix(
-      Array.from(model._camera.getViewMatrix())
+      model._camera.getViewMatrix()
     );
   };
 


### PR DESCRIPTION
By providing the expected output array, one can avoid an array copy

### Context
Following #3544, we can improve the usage of getViewMatrix

### Results
Some functions will get faster.

### Changes
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Firefox
