### PR TITLE
fix(examples): fix EventEmitter heritage error in examples

### DIFF
--- a/Utilities/ExampleRunner/vite.example.config.mjs
+++ b/Utilities/ExampleRunner/vite.example.config.mjs
@@ -1,10 +1,10 @@
 import path from 'path';
+import nodePolyfills from '@rolldown/plugin-node-polyfills';
 import {
   glslPlugin,
   svgRawPlugin,
   cjsonPlugin,
   workerInlinePlugin,
-  ignorePlugin,
   serveStaticDataPlugin,
 } from '../build/plugins.mjs';
 
@@ -44,6 +44,11 @@ export function createExampleConfig({
       __BASE_PATH__: JSON.stringify(''),
       global: 'globalThis',
     },
+    optimizeDeps: {
+      rolldownOptions: {
+        plugins: [nodePolyfills()],
+      },
+    },
     css: {
       modules: {
         localsConvention: 'camelCaseOnly',
@@ -63,7 +68,6 @@ export function createExampleConfig({
       glslPlugin(),
       svgRawPlugin(),
       cjsonPlugin(),
-      ignorePlugin(['crypto']),
       serveStaticDataPlugin(repoRoot),
       {
         name: 'vtk-example-runner-entry',


### PR DESCRIPTION
### Context
Some examples (XMLImageDataWriter, XMLPolyDataWriter, SurfaceLICMapper, GeometryViewer, ImageViewer, OctreeViewer, TubesViewer, VolumeViewer, TimeSeries, VolumeMapperLightAndShadow, WebXRChestCTBlendedCVR, WebXRHeadFullVolumeCVR, WebXRHeadGradientCVR and WebXRVolume) fail due to a `class heritage events_1.EventEmitter is not an object or null` error.

### Results
This PR fixes this issue in these examples, though other errors remain in some of the examples cited.

### Changes
Added "vite-plugin-node-polyfills" dependency

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
