### PR TITLE
fix(examples): replace failing esm.sh links by jsdeliver links

### DIFF
--- a/Examples/Applications/SkyboxViewer/index.js
+++ b/Examples/Applications/SkyboxViewer/index.js
@@ -27,7 +27,9 @@ import style from './SkyboxViewer.module.css';
 // Dynamically load WebXR polyfill from CDN for WebVR and Cardboard API backwards compatibility
 if (navigator.xr === undefined) {
   vtkResourceLoader
-    .loadScript('https://esm.sh/webxr-polyfill@latest/build/webxr-polyfill.js')
+    .loadScript(
+      'https://cdn.jsdelivr.net/npm/webxr-polyfill@latest/build/webxr-polyfill.js'
+    )
     .then(() => {
       // eslint-disable-next-line no-new, no-undef
       new WebXRPolyfill();

--- a/Examples/Geometry/ItkWasmGeometry/index.js
+++ b/Examples/Geometry/ItkWasmGeometry/index.js
@@ -60,7 +60,9 @@ async function update() {
 
 // After the itk-wasm UMD script has been loaded, `window.itk` provides the itk-wasm API.
 vtkResourceLoader
-  .loadScript('https://esm.sh/itk-wasm@1.0.0-b.70/dist/umd/itk-wasm.min.js')
+  .loadScript(
+    'https://cdn.jsdelivr.net/npm/itk-wasm@1.0.0-b.8/dist/umd/itk-wasm.js'
+  )
   .then(update);
 
 global.mapper = mapper;

--- a/Examples/Geometry/VR/index.js
+++ b/Examples/Geometry/VR/index.js
@@ -29,9 +29,10 @@ import GUI from 'lil-gui';
 // Dynamically load WebXR polyfill from CDN for WebVR and Cardboard API backwards compatibility
 if (navigator.xr === undefined) {
   vtkResourceLoader
-    .loadScript('https://esm.sh/webxr-polyfill@latest/build/webxr-polyfill.js')
+    .loadScript(
+      'https://cdn.jsdelivr.net/npm/webxr-polyfill@latest/build/webxr-polyfill.js'
+    )
     .then(() => {
-      // eslint-disable-next-line no-new, no-undef
       new WebXRPolyfill();
     });
 }

--- a/Examples/Volume/Scrolling2DMixedImages/index.js
+++ b/Examples/Volume/Scrolling2DMixedImages/index.js
@@ -246,7 +246,9 @@ async function update() {
 
 // After the itk-wasm UMD script has been loaded, `window.itk` provides the itk-wasm API.
 vtkResourceLoader
-  .loadScript('https://esm.sh/itk-wasm@1.0.0-b.8/dist/umd/itk-wasm.js')
+  .loadScript(
+    'https://cdn.jsdelivr.net/npm/itk-wasm@1.0.0-b.8/dist/umd/itk-wasm.js'
+  )
   .then(update);
 
 // -----------------------------------------------------------


### PR DESCRIPTION
### Context
Several examples (SkyBoxViewer, ItkWasmGeometry, VR and Scrolling2DMixedImages) do not work due to 

### Results
This PR fixes the problem.

### Changes
URLs changed.

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
