### PR TITLE
chore(SimpleCone): fix example

### DIFF
--- a/Examples/Geometry/SimpleCone/index.js
+++ b/Examples/Geometry/SimpleCone/index.js
@@ -35,4 +35,4 @@ actor.setMapper(mapper);
 
 renderer.addActor(actor);
 renderer.resetCamera();
-renderWindow.render();
+renderWindow.getRenderWindow().render();


### PR DESCRIPTION
### Context
The initial render call of the SimpleCone example does not work.

### Results
The cone is now displayed correctly.

### Changes
Fixed a wrong render call in the example.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
