### PR TITLE
chore(InteractorStyleMPRSlice): fix recursion error in example

### DIFF
--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
@@ -27,35 +27,6 @@ global.fullScreen = fullScreenRenderWindow;
 global.renderWindow = renderWindow;
 
 // ----------------------------------------------------------------------------
-// Volume rendering
-// ----------------------------------------------------------------------------
-
-const actor = vtkVolume.newInstance();
-const mapper = vtkVolumeMapper.newInstance();
-actor.setMapper(mapper);
-
-const reader = vtkHttpDataSetReader.newInstance({
-  fetchGzip: true,
-});
-reader
-  .setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`, { loadData: true })
-  .then(() => {
-    const data = reader.getOutputData();
-
-    mapper.setInputData(data);
-
-    // set interactor style volume mapper after mapper sets input data
-    istyle.setVolumeMapper(mapper);
-    istyle.setSliceNormal(0, 0, 1);
-
-    const range = istyle.getSliceRange();
-    istyle.setSlice((range[0] + range[1]) / 2);
-
-    renderer.addVolume(actor);
-    renderWindow.render();
-  });
-
-// ----------------------------------------------------------------------------
 // UI (lil-gui)
 // ----------------------------------------------------------------------------
 
@@ -95,5 +66,33 @@ function updateUI() {
   sliceCtrl.updateDisplay?.();
 }
 
-istyle.onModified(updateUI);
-updateUI();
+// ----------------------------------------------------------------------------
+// Volume rendering
+// ----------------------------------------------------------------------------
+
+const actor = vtkVolume.newInstance();
+const mapper = vtkVolumeMapper.newInstance();
+actor.setMapper(mapper);
+
+const reader = vtkHttpDataSetReader.newInstance({
+  fetchGzip: true,
+});
+reader
+  .setUrl(`${__BASE_PATH__}/data/volume/headsq.vti`, { loadData: true })
+  .then(() => {
+    const data = reader.getOutputData();
+
+    mapper.setInputData(data);
+
+    // set interactor style volume mapper after mapper sets input data
+    istyle.setVolumeMapper(mapper);
+    istyle.setSliceNormal(0, 0, 1);
+
+    const range = istyle.getSliceRange();
+    istyle.setSlice((range[0] + range[1]) / 2);
+
+    renderer.addVolume(actor);
+    renderWindow.render();
+    istyle.onModified(updateUI);
+    updateUI();
+  });

--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/example/index.js
@@ -84,6 +84,7 @@ function updateUI() {
 
   sliceCtrl.min(range[0]);
   sliceCtrl.max(range[1]);
+  sliceCtrl.step((range[1] - range[0]) / 1000);
   sliceCtrl.setValue(slice);
 
   function toFixed(n) {

--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
@@ -137,6 +137,9 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   };
 
   publicAPI.setSlice = (slice) => {
+    if (publicAPI.getSlice() === slice) {
+      return false;
+    }
     const renderer = model._interactor.getCurrentRenderer();
     const camera = renderer.getActiveCamera();
 
@@ -171,6 +174,7 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
       camera.setPosition(...newPos);
       camera.setFocalPoint(...slicePoint);
     }
+    return true;
   };
 
   publicAPI.getSliceRange = () => {

--- a/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
+++ b/Sources/Interaction/Style/InteractorStyleMPRSlice/index.js
@@ -137,40 +137,44 @@ function vtkInteractorStyleMPRSlice(publicAPI, model) {
   };
 
   publicAPI.setSlice = (slice) => {
+    if (publicAPI.getSlice() === slice) {
+      return false;
+    }
+
+    if (!model.volumeMapper) {
+      return false;
+    }
+
+    const range = publicAPI.getSliceRange();
+
+    const clampedSlice = clamp(slice, ...range);
+    const center = model.volumeMapper.getCenter();
+
     const renderer = model._interactor.getCurrentRenderer();
     const camera = renderer.getActiveCamera();
+    const distance = camera.getDistance();
+    const dop = camera.getDirectionOfProjection();
+    vtkMath.normalize(dop);
 
-    if (model.volumeMapper) {
-      const range = publicAPI.getSliceRange();
+    const midPoint = (range[1] + range[0]) / 2.0;
+    const zeroPoint = [
+      center[0] - dop[0] * midPoint,
+      center[1] - dop[1] * midPoint,
+      center[2] - dop[2] * midPoint,
+    ];
+    const slicePoint = [
+      zeroPoint[0] + dop[0] * clampedSlice,
+      zeroPoint[1] + dop[1] * clampedSlice,
+      zeroPoint[2] + dop[2] * clampedSlice,
+    ];
 
-      const clampedSlice = clamp(slice, ...range);
-      const center = model.volumeMapper.getCenter();
+    const newPos = [
+      slicePoint[0] - dop[0] * distance,
+      slicePoint[1] - dop[1] * distance,
+      slicePoint[2] - dop[2] * distance,
+    ];
 
-      const distance = camera.getDistance();
-      const dop = camera.getDirectionOfProjection();
-      vtkMath.normalize(dop);
-
-      const midPoint = (range[1] + range[0]) / 2.0;
-      const zeroPoint = [
-        center[0] - dop[0] * midPoint,
-        center[1] - dop[1] * midPoint,
-        center[2] - dop[2] * midPoint,
-      ];
-      const slicePoint = [
-        zeroPoint[0] + dop[0] * clampedSlice,
-        zeroPoint[1] + dop[1] * clampedSlice,
-        zeroPoint[2] + dop[2] * clampedSlice,
-      ];
-
-      const newPos = [
-        slicePoint[0] - dop[0] * distance,
-        slicePoint[1] - dop[1] * distance,
-        slicePoint[2] - dop[2] * distance,
-      ];
-
-      camera.setPosition(...newPos);
-      camera.setFocalPoint(...slicePoint);
-    }
+    return camera.setPositionAndFocalPoint(newPos, slicePoint);
   };
 
   publicAPI.getSliceRange = () => {

--- a/Sources/Rendering/Core/Camera/index.d.ts
+++ b/Sources/Rendering/Core/Camera/index.d.ts
@@ -559,6 +559,13 @@ export interface vtkCamera extends vtkObject {
   setPosition(x: number, y: number, z: number): boolean;
 
   /**
+   * Set the camera's position and focal point in world coordinates.
+   * @param {Number[]} position The position.
+   * @param {Number[]} focalPoint The focal point.
+   */
+  setPositionAndFocalPoint(position: number[], focalPoint: number[]): boolean;
+
+  /**
    *
    * @param {mat4} mat
    */

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -57,40 +57,64 @@ function vtkCamera(publicAPI, model) {
     publicAPI.modified();
   };
 
-  publicAPI.setPosition = (x, y, z) => {
+  const setPosition = (x, y, z) => {
     if (
       x === model.position[0] &&
       y === model.position[1] &&
       z === model.position[2]
     ) {
-      return;
+      return false;
     }
 
     model.position[0] = x;
     model.position[1] = y;
     model.position[2] = z;
-
-    // recompute the focal distance
-    publicAPI.computeDistance();
-    publicAPI.modified();
+    return true;
   };
 
-  publicAPI.setFocalPoint = (x, y, z) => {
+  publicAPI.setPosition = (x, y, z) => {
+    if (setPosition(x, y, z)) {
+      // recompute the focal distance
+      publicAPI.computeDistance();
+      publicAPI.modified();
+      return true;
+    }
+    return false;
+  };
+
+  const setFocalPoint = (x, y, z) => {
     if (
       x === model.focalPoint[0] &&
       y === model.focalPoint[1] &&
       z === model.focalPoint[2]
     ) {
-      return;
+      return false;
     }
 
     model.focalPoint[0] = x;
     model.focalPoint[1] = y;
     model.focalPoint[2] = z;
+    return true;
+  };
 
-    // recompute the focal distance
-    publicAPI.computeDistance();
-    publicAPI.modified();
+  publicAPI.setFocalPoint = (x, y, z) => {
+    if (setFocalPoint(x, y, z)) {
+      // recompute the focal distance
+      publicAPI.computeDistance();
+      publicAPI.modified();
+      return true;
+    }
+    return false;
+  };
+
+  publicAPI.setPositionAndFocalPoint = (position, focalPoint) => {
+    if (setPosition(...position) || setFocalPoint(...focalPoint)) {
+      // recompute the focal distance
+      publicAPI.computeDistance();
+      publicAPI.modified();
+      return true;
+    }
+    return false;
   };
 
   publicAPI.setDistance = (d) => {


### PR DESCRIPTION
### Context
InteractorStyleMPRSlice example fails due to a recursion error.

### Results
The error is fixed so the example works.

### Changes
Added a difference threshold on the interactor Stume slice update to avoid recursion error

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code