### PR TITLE
feat(RenderWindow): add manageCanvas for externally owned canvases

### DIFF
--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -22,6 +22,7 @@ export interface IOpenGLRenderWindowInitialValues {
   context?: WebGLRenderingContext | WebGL2RenderingContext;
   context2D?: CanvasRenderingContext2D;
   canvas?: HTMLCanvasElement;
+  manageCanvas?: boolean;
   cursorVisibility?: boolean;
   cursor?: string;
   textureUnitManager?: null;
@@ -93,6 +94,19 @@ export interface vtkOpenGLRenderWindow extends vtkViewNode {
    * Set the webgl canvas.
    */
   setCanvas(canvas: Nullable<HTMLCanvasElement>): boolean;
+
+  /**
+   * When true (default), vtk.js owns the canvas: it resizes and styles it and
+   * installs webglcontextlost/webglcontextrestored handlers. Set false when
+   * the canvas belongs to another library (see vtkSharedRenderWindow).
+   */
+  getManageCanvas(): boolean;
+
+  /**
+   * Set whether vtk.js owns the canvas and may resize, style, and install
+   * webglcontextlost/webglcontextrestored handlers on it.
+   */
+  setManageCanvas(manageCanvas: boolean): boolean;
 
   /**
    * Check if a point is in the viewport.
@@ -348,7 +362,10 @@ export interface vtkOpenGLRenderWindow extends vtkViewNode {
    * be multiplied by the current renderwindow size to compute the screenshot
    * size.  If no `size` or `scale` are provided, the current renderwindow
    * size is assumed.  The default format is "image/png". Returns a promise
-   * that resolves to the captured screenshot.
+   * that resolves to the captured screenshot. When an explicit `size` or
+   * `scale` is given while `manageCanvas` is false, it is ignored with a
+   * warning and the capture happens at the current size, since honoring it
+   * would resize the canvas.
    * @param {String} format
    * @param {ICaptureOptions} options
    */

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -12,7 +12,7 @@ import vtkRenderPass from 'vtk.js/Sources/Rendering/SceneGraph/RenderPass';
 import vtkRenderWindowViewNode from 'vtk.js/Sources/Rendering/SceneGraph/RenderWindowViewNode';
 import { createContextProxyHandler } from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow/ContextProxy';
 
-const { vtkDebugMacro, vtkErrorMacro } = macro;
+const { vtkDebugMacro, vtkErrorMacro, vtkWarningMacro } = macro;
 
 const SCREENSHOT_PLACEHOLDER = {
   position: 'absolute',
@@ -129,20 +129,23 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
   publicAPI.getViewNodeFactory = () => model.myFactory;
 
-  // prevent default context lost handler
-  model.canvas.addEventListener('webglcontextlost', _preventDefault, false);
+  // prevent default context lost handler; an externally owned canvas
+  // (manageCanvas=false) keeps its host's context-loss handling
+  if (model.manageCanvas) {
+    model.canvas.addEventListener('webglcontextlost', _preventDefault, false);
 
-  model.canvas.addEventListener(
-    'webglcontextrestored',
-    publicAPI.restoreContext,
-    false
-  );
+    model.canvas.addEventListener(
+      'webglcontextrestored',
+      publicAPI.restoreContext,
+      false
+    );
+  }
 
   // Auto update style
   const previousSize = [0, 0];
   function updateWindow() {
     // Canvas size
-    if (model.renderable) {
+    if (model.renderable && model.manageCanvas) {
       if (
         model.size[0] !== previousSize[0] ||
         model.size[1] !== previousSize[1]
@@ -161,7 +164,9 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     }
 
     // Offscreen ?
-    model.canvas.style.display = model.useOffScreen ? 'none' : 'block';
+    if (model.manageCanvas) {
+      model.canvas.style.display = model.useOffScreen ? 'none' : 'block';
+    }
 
     // Cursor type
     if (model.el) {
@@ -550,15 +555,26 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     if (model.deleted) {
       return null;
     }
+    // Captures with an explicit size or scale take the two-pass path below
+    // (placeholder image + canvas resize), which needs vtk.js to own the
+    // canvas. Fall back to a current-size capture otherwise.
+    let screenshotSize =
+      !!size || scale !== 1
+        ? size || model.size.map((val) => val * scale)
+        : null;
+    if (screenshotSize !== null && !model.manageCanvas) {
+      vtkWarningMacro(
+        'Ignoring the requested screenshot size/scale: resizing the canvas requires manageCanvas=true on vtkOpenGLRenderWindow. Capturing at the current size instead.'
+      );
+      screenshotSize = null;
+    }
+
     model.imageFormat = format;
     const previous = model.notifyStartCaptureImage;
     model.notifyStartCaptureImage = true;
 
     model._screenshot = {
-      size:
-        !!size || scale !== 1
-          ? size || model.size.map((val) => val * scale)
-          : null,
+      size: screenshotSize,
     };
 
     return new Promise((resolve, reject) => {
@@ -1316,6 +1332,7 @@ const DEFAULT_VALUES = {
   context: null,
   context2D: null,
   canvas: null,
+  manageCanvas: true,
   cursorVisibility: true,
   cursor: 'pointer',
   textureUnitManager: null,
@@ -1386,6 +1403,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'context',
     'context2D',
     'canvas',
+    'manageCanvas',
     'renderPasses',
     'notifyStartCaptureImage',
     'defaultToWebgl2',

--- a/Sources/Rendering/OpenGL/RenderWindow/test/testManageCanvas.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/test/testManageCanvas.js
@@ -1,0 +1,49 @@
+import { it, expect, vi } from 'vitest';
+
+import vtkOpenGLRenderWindow from 'vtk.js/Sources/Rendering/OpenGL/RenderWindow';
+
+it('does not manage externally owned canvases', () => {
+  const canvas = document.createElement('canvas');
+  canvas.style.display = 'inline';
+  const addEventListener = vi.spyOn(canvas, 'addEventListener');
+  const glWindow = vtkOpenGLRenderWindow.newInstance({
+    canvas,
+    manageCanvas: false,
+  });
+
+  expect(glWindow.getManageCanvas()).toBe(false);
+  expect(addEventListener).not.toHaveBeenCalledWith(
+    'webglcontextlost',
+    expect.any(Function),
+    false
+  );
+  expect(addEventListener).not.toHaveBeenCalledWith(
+    'webglcontextrestored',
+    expect.any(Function),
+    false
+  );
+
+  glWindow.setRenderable({});
+  glWindow.setUseOffScreen(true);
+  glWindow.setSize(640, 480);
+
+  expect(canvas.getAttribute('width')).toBe(null);
+  expect(canvas.getAttribute('height')).toBe(null);
+  expect(canvas.style.display).toBe('inline');
+});
+
+it('captures at the current size when a resize would be needed', async () => {
+  const glWindow = vtkOpenGLRenderWindow.newInstance({ manageCanvas: false });
+
+  // the size/scale request is dropped, so the capture takes the single-pass
+  // path and resolves on the next imageReady without a canvas resize
+  const sizedCapture = glWindow.captureNextImage('image/png', {
+    size: [320, 300],
+  });
+  glWindow.invokeImageReady('data:sized');
+  await expect(sizedCapture).resolves.toBe('data:sized');
+
+  const scaledCapture = glWindow.captureNextImage('image/png', { scale: 2 });
+  glWindow.invokeImageReady('data:scaled');
+  await expect(scaledCapture).resolves.toBe('data:scaled');
+});


### PR DESCRIPTION
When the canvas belongs to another library (MapLibre, three.js, a plain app canvas), vtk.js must not resize or restyle it or take over webglcontextlost/webglcontextrestored handling. manageCanvas (default true, no behavior change) opts out of canvas DOM management.

For example, a vtk.js custom layer sharing MapLibre's canvas syncs its size from the drawing buffer inside MapLibre's frame, so a managed canvas would get its width/height attributes rewritten mid-frame, resetting the drawing buffer and wiping the just-drawn basemap on every resize.

Screenshot captures with an explicit size or scale go through the two-pass resize path, so with manageCanvas=false the requested size is ignored with a warning and the capture happens at the current size instead of corrupting the host canvas.

Supersedes https://github.com/Kitware/vtk-js/pull/3453