### PR TITLE
Fix webgpu vtktexture cache invalidation

### DIFF
--- a/Sources/Rendering/WebGPU/Texture/index.js
+++ b/Sources/Rendering/WebGPU/Texture/index.js
@@ -155,7 +155,7 @@ function vtkWebGPUTexture(publicAPI, model) {
   };
 
   publicAPI.create = (device, options) => {
-    model.device = device;
+    model._device = device;
     model.width = options.width;
     model.height = options.height;
     model.depth = options.depth ? options.depth : 1;
@@ -173,7 +173,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       : GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST;
     /* eslint-enable no-undef */
     /* eslint-enable no-bitwise */
-    model.handle = model.device.getHandle().createTexture({
+    model.handle = model._device.getHandle().createTexture({
       size: [model.width, model.height, model.depth],
       format: model.format, // 'rgba8unorm',
       usage: model.usage,
@@ -184,7 +184,7 @@ function vtkWebGPUTexture(publicAPI, model) {
   };
 
   publicAPI.assignFromHandle = (device, handle, options) => {
-    model.device = device;
+    model._device = device;
     model.handle = handle;
     model.width = options.width;
     model.height = options.height;
@@ -209,7 +209,7 @@ function vtkWebGPUTexture(publicAPI, model) {
     const _copyImageToTexture = (source) => {
       const originZ = req.originZ ?? 0;
       const depth = req.depth ?? 1;
-      model.device.getHandle().queue.copyExternalImageToTexture(
+      model._device.getHandle().queue.copyExternalImageToTexture(
         {
           source,
           flipY: req.flip,
@@ -226,7 +226,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       // Generate mipmaps on GPU if needed
       if (model.dimension === '2d' && depth === 1 && model.mipLevel > 0) {
         vtkTexture.generateMipmaps(
-          model.device.getHandle(),
+          model._device.getHandle(),
           model.handle,
           model.mipLevel + 1
         );
@@ -288,7 +288,7 @@ function vtkWebGPUTexture(publicAPI, model) {
     }
     const data = preparedData.data;
 
-    model.device.getHandle().queue.writeTexture(
+    model._device.getHandle().queue.writeTexture(
       {
         texture: model.handle,
         mipLevel: 0,
@@ -309,7 +309,7 @@ function vtkWebGPUTexture(publicAPI, model) {
 
     if (model.dimension === '2d' && depth === 1 && model.mipLevel > 0) {
       vtkTexture.generateMipmaps(
-        model.device.getHandle(),
+        model._device.getHandle(),
         model.handle,
         model.mipLevel + 1
       );
@@ -338,7 +338,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       return;
     }
 
-    model.device.getHandle().queue.writeTexture(
+    model._device.getHandle().queue.writeTexture(
       {
         texture: model.handle,
         mipLevel: 0,
@@ -363,7 +363,7 @@ function vtkWebGPUTexture(publicAPI, model) {
 
     if (publicAPI.getDimensionality() !== 3 && model.mipLevel > 0) {
       vtkTexture.generateMipmaps(
-        model.device.getHandle(),
+        model._device.getHandle(),
         model.handle,
         model.mipLevel + 1
       );
@@ -404,7 +404,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       model.width = tex.getWidth();
       model.height = tex.getHeight();
       model.depth = tex.getDepth();
-      model.handle = model.device.getHandle().createTexture({
+      model.handle = model._device.getHandle().createTexture({
         size: [model.width, model.height, model.depth],
         dimension: model.dimension,
         format: model.format,
@@ -423,7 +423,7 @@ function vtkWebGPUTexture(publicAPI, model) {
       model.width = width;
       model.height = height;
       model.depth = depth;
-      model.handle = model.device.getHandle().createTexture({
+      model.handle = model._device.getHandle().createTexture({
         size: [model.width, model.height, model.depth],
         dimension: model.dimension,
         format: model.format,
@@ -455,7 +455,7 @@ function vtkWebGPUTexture(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  device: null,
+  _device: null,
   dimension: '2d',
   handle: null,
   buffer: null,
@@ -481,7 +481,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'format',
     'usage',
   ]);
-  macro.setGet(publicAPI, model, ['device', 'label']);
+  macro.setGet(publicAPI, model, ['_device', 'label']);
 
   vtkWebGPUTexture(publicAPI, model);
 }

--- a/Sources/Rendering/WebGPU/Texture/test/testWriteSubImageData.js
+++ b/Sources/Rendering/WebGPU/Texture/test/testWriteSubImageData.js
@@ -10,61 +10,56 @@ it.skipIf(!__VTK_TEST_WEBGPU__)(
     const device = await testUtils.createWebGPUTestDevice();
     const texture = vtkWebGPUTexture.newInstance({ label: 'subImageTexture' });
 
-    try {
-      texture.create(device, {
-        width: 4,
-        height: 4,
-        format: 'rgba8unorm',
-        usage:
-          /* eslint-disable no-undef */
-          /* eslint-disable no-bitwise */
-          GPUTextureUsage.TEXTURE_BINDING |
-          /* eslint-disable no-undef */
-          /* eslint-disable no-bitwise */
-          GPUTextureUsage.COPY_DST |
-          /* eslint-disable no-undef */
-          /* eslint-disable no-bitwise */
-          GPUTextureUsage.COPY_SRC,
-      });
+    texture.create(device, {
+      width: 4,
+      height: 4,
+      format: 'rgba8unorm',
+      usage:
+        /* eslint-disable no-undef */
+        /* eslint-disable no-bitwise */
+        GPUTextureUsage.TEXTURE_BINDING |
+        /* eslint-disable no-undef */
+        /* eslint-disable no-bitwise */
+        GPUTextureUsage.COPY_DST |
+        /* eslint-disable no-undef */
+        /* eslint-disable no-bitwise */
+        GPUTextureUsage.COPY_SRC,
+    });
 
-      const basePixels = new Uint8Array(4 * 4 * 4);
-      for (let i = 0; i < 16; i++) {
-        basePixels[i * 4 + 3] = 255;
-      }
-      texture.writeImageData({ nativeArray: basePixels });
+    const basePixels = new Uint8Array(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      basePixels[i * 4 + 3] = 255;
+    }
+    texture.writeImageData({ nativeArray: basePixels });
 
-      const patch = new Uint8Array([
-        255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
-      ]);
-      texture.writeSubImageData({
-        x: 1,
-        y: 1,
-        width: 2,
-        height: 2,
-        nativeArray: patch,
-      });
+    const patch = new Uint8Array([
+      255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
+    ]);
+    texture.writeSubImageData({
+      x: 1,
+      y: 1,
+      width: 2,
+      height: 2,
+      nativeArray: patch,
+    });
 
-      const actual = await testUtils.readWebGPUTexture2D(device, texture, 4, 4);
+    const actual = await testUtils.readWebGPUTexture2D(device, texture, 4, 4);
 
-      const expected = new Uint8Array(basePixels);
-      const setPixel = (x, y, rgba) => {
-        expected.set(rgba, (y * 4 + x) * 4);
-      };
-      setPixel(1, 1, [255, 0, 0, 255]);
-      setPixel(2, 1, [0, 255, 0, 255]);
-      setPixel(1, 2, [0, 0, 255, 255]);
-      setPixel(2, 2, [255, 255, 0, 255]);
+    const expected = new Uint8Array(basePixels);
+    const setPixel = (x, y, rgba) => {
+      expected.set(rgba, (y * 4 + x) * 4);
+    };
+    setPixel(1, 1, [255, 0, 0, 255]);
+    setPixel(2, 1, [0, 255, 0, 255]);
+    setPixel(1, 2, [0, 0, 255, 255]);
+    setPixel(2, 2, [255, 255, 0, 255]);
 
-      expect(actual.length, 'readback size matches texture size').toBe(
-        expected.length
-      );
+    expect(actual.length, 'readback size matches texture size').toBe(
+      expected.length
+    );
 
-      for (let i = 0; i < expected.length; i++) {
-        expect(actual[i], `byte ${i} matches expected value`).toBe(expected[i]);
-      }
-    } finally {
-      texture.getHandle().destroy();
-      device.getHandle().destroy();
+    for (let i = 0; i < expected.length; i++) {
+      expect(actual[i], `byte ${i} matches expected value`).toBe(expected[i]);
     }
   }
 );
@@ -131,8 +126,6 @@ it.skipIf(!__VTK_TEST_WEBGPU__)(
       ).toEqual(Array.from(basePixels));
     } finally {
       macro.setLoggerFunction('error', previousErrorLogger);
-      texture.getHandle().destroy();
-      device.getHandle().destroy();
     }
   }
 );

--- a/Sources/Rendering/WebGPU/TextureManager/index.js
+++ b/Sources/Rendering/WebGPU/TextureManager/index.js
@@ -195,6 +195,14 @@ function vtkWebGPUTextureManager(publicAPI, model) {
     }
     // fill out the req time and format based on imageData/image
     _fillRequest(treq);
+    // _fillRequest derives the cache hash from the scalar array mtime alone,
+    // discarding the texture mtime seeded above. A texture rebuild must also
+    // be triggered by srcTexture.modified() or imageData.modified() alone, so
+    // hash on the newest of the texture, imageData, and scalar array mtimes.
+    treq.time = Math.max(treq.time, srcTexture.getMTime());
+    if (treq.imageData) {
+      treq.time = Math.max(treq.time, treq.imageData.getMTime());
+    }
     treq.mipLevel = srcTexture.getMipLevel();
     treq.hash = treq.time + treq.format + treq.mipLevel;
     return model.device.getTextureManager().getTexture(treq);

--- a/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
+++ b/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
@@ -22,11 +22,15 @@ it.skipIf(!__VTK_TEST_WEBGPU__)(
 
       const textureManager = device.getTextureManager();
 
+      // Identities are compared as booleans: passing the textures themselves
+      // to expect() makes a failure serialize them through
+      // toJSON()/getState(), which recurses the circular device–texture
+      // graph and masks the assertion message with a stack overflow.
       const texture = textureManager.getTextureForImageData(imageData);
       expect(
-        textureManager.getTextureForImageData(imageData),
+        textureManager.getTextureForImageData(imageData) === texture,
         'an unchanged imageData reuses the cached texture'
-      ).toBe(texture);
+      ).toBe(true);
 
       // Write the scalars in place and signal the change through
       // imageData.modified() alone — the pattern used by consumers that
@@ -38,16 +42,17 @@ it.skipIf(!__VTK_TEST_WEBGPU__)(
       const textureAfterImageDataModified =
         textureManager.getTextureForImageData(imageData);
       expect(
-        textureAfterImageDataModified,
+        textureAfterImageDataModified === texture,
         'imageData.modified() alone must invalidate the cached texture'
-      ).not.toBe(texture);
+      ).toBe(false);
 
       // Direct scalar-array modification keeps invalidating as before.
       scalars.modified();
       expect(
-        textureManager.getTextureForImageData(imageData),
+        textureManager.getTextureForImageData(imageData) ===
+          textureAfterImageDataModified,
         'scalars.modified() must invalidate the cached texture'
-      ).not.toBe(textureAfterImageDataModified);
+      ).toBe(false);
     } finally {
       device.getHandle().destroy();
     }

--- a/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
+++ b/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
@@ -9,52 +9,48 @@ it.skipIf(!__VTK_TEST_WEBGPU__)(
   async () => {
     const device = await testUtils.createWebGPUTestDevice();
 
-    try {
-      const values = new Uint8Array(4 * 4).fill(10);
-      const scalars = vtkDataArray.newInstance({
-        name: 'Scalars',
-        values,
-        numberOfComponents: 1,
-      });
-      const imageData = vtkImageData.newInstance();
-      imageData.setDimensions(4, 4, 1);
-      imageData.getPointData().setScalars(scalars);
+    const values = new Uint8Array(4 * 4).fill(10);
+    const scalars = vtkDataArray.newInstance({
+      name: 'Scalars',
+      values,
+      numberOfComponents: 1,
+    });
+    const imageData = vtkImageData.newInstance();
+    imageData.setDimensions(4, 4, 1);
+    imageData.getPointData().setScalars(scalars);
 
-      const textureManager = device.getTextureManager();
+    const textureManager = device.getTextureManager();
 
-      // Identities are compared as booleans: passing the textures themselves
-      // to expect() makes a failure serialize them through
-      // toJSON()/getState(), which recurses the circular device–texture
-      // graph and masks the assertion message with a stack overflow.
-      const texture = textureManager.getTextureForImageData(imageData);
-      expect(
-        textureManager.getTextureForImageData(imageData) === texture,
-        'an unchanged imageData reuses the cached texture'
-      ).toBe(true);
+    // Identities are compared as booleans: passing the textures themselves
+    // to expect() makes a failure serialize them through
+    // toJSON()/getState(), which recurses the circular device–texture
+    // graph and masks the assertion message with a stack overflow.
+    const texture = textureManager.getTextureForImageData(imageData);
+    expect(
+      textureManager.getTextureForImageData(imageData) === texture,
+      'an unchanged imageData reuses the cached texture'
+    ).toBe(true);
 
-      // Write the scalars in place and signal the change through
-      // imageData.modified() alone — the pattern used by consumers that
-      // stream new frames into an existing array (the OpenGL backend keys
-      // its texture rebuilds on the imageData mtime, so this must also
-      // refresh the WebGPU texture cache).
-      values.fill(200);
-      imageData.modified();
-      const textureAfterImageDataModified =
-        textureManager.getTextureForImageData(imageData);
-      expect(
-        textureAfterImageDataModified === texture,
-        'imageData.modified() alone must invalidate the cached texture'
-      ).toBe(false);
+    // Write the scalars in place and signal the change through
+    // imageData.modified() alone — the pattern used by consumers that
+    // stream new frames into an existing array (the OpenGL backend keys
+    // its texture rebuilds on the imageData mtime, so this must also
+    // refresh the WebGPU texture cache).
+    values.fill(200);
+    imageData.modified();
+    const textureAfterImageDataModified =
+      textureManager.getTextureForImageData(imageData);
+    expect(
+      textureAfterImageDataModified === texture,
+      'imageData.modified() alone must invalidate the cached texture'
+    ).toBe(false);
 
-      // Direct scalar-array modification keeps invalidating as before.
-      scalars.modified();
-      expect(
-        textureManager.getTextureForImageData(imageData) ===
-          textureAfterImageDataModified,
-        'scalars.modified() must invalidate the cached texture'
-      ).toBe(false);
-    } finally {
-      device.getHandle().destroy();
-    }
+    // Direct scalar-array modification keeps invalidating as before.
+    scalars.modified();
+    expect(
+      textureManager.getTextureForImageData(imageData) ===
+        textureAfterImageDataModified,
+      'scalars.modified() must invalidate the cached texture'
+    ).toBe(false);
   }
 );

--- a/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
+++ b/Sources/Rendering/WebGPU/TextureManager/test/testImageDataTextureCacheInvalidation.js
@@ -9,47 +9,43 @@ it.skipIf(!__VTK_TEST_WEBGPU__)(
   async () => {
     const device = await testUtils.createWebGPUTestDevice();
 
-    try {
-      const values = new Uint8Array(4 * 4).fill(10);
-      const scalars = vtkDataArray.newInstance({
-        name: 'Scalars',
-        values,
-        numberOfComponents: 1,
-      });
-      const imageData = vtkImageData.newInstance();
-      imageData.setDimensions(4, 4, 1);
-      imageData.getPointData().setScalars(scalars);
+    const values = new Uint8Array(4 * 4).fill(10);
+    const scalars = vtkDataArray.newInstance({
+      name: 'Scalars',
+      values,
+      numberOfComponents: 1,
+    });
+    const imageData = vtkImageData.newInstance();
+    imageData.setDimensions(4, 4, 1);
+    imageData.getPointData().setScalars(scalars);
 
-      const textureManager = device.getTextureManager();
+    const textureManager = device.getTextureManager();
 
-      const texture = textureManager.getTextureForImageData(imageData);
-      expect(
-        textureManager.getTextureForImageData(imageData),
-        'an unchanged imageData reuses the cached texture'
-      ).toBe(texture);
+    const texture = textureManager.getTextureForImageData(imageData);
+    expect(
+      textureManager.getTextureForImageData(imageData),
+      'an unchanged imageData reuses the cached texture'
+    ).toBe(texture);
 
-      // Write the scalars in place and signal the change through
-      // imageData.modified() alone — the pattern used by consumers that
-      // stream new frames into an existing array (the OpenGL backend keys
-      // its texture rebuilds on the imageData mtime, so this must also
-      // refresh the WebGPU texture cache).
-      values.fill(200);
-      imageData.modified();
-      const textureAfterImageDataModified =
-        textureManager.getTextureForImageData(imageData);
-      expect(
-        textureAfterImageDataModified,
-        'imageData.modified() alone must invalidate the cached texture'
-      ).not.toBe(texture);
+    // Write the scalars in place and signal the change through
+    // imageData.modified() alone — the pattern used by consumers that
+    // stream new frames into an existing array (the OpenGL backend keys
+    // its texture rebuilds on the imageData mtime, so this must also
+    // refresh the WebGPU texture cache).
+    values.fill(200);
+    imageData.modified();
+    const textureAfterImageDataModified =
+      textureManager.getTextureForImageData(imageData);
+    expect(
+      textureAfterImageDataModified,
+      'imageData.modified() alone must invalidate the cached texture'
+    ).not.toBe(texture);
 
-      // Direct scalar-array modification keeps invalidating as before.
-      scalars.modified();
-      expect(
-        textureManager.getTextureForImageData(imageData),
-        'scalars.modified() must invalidate the cached texture'
-      ).not.toBe(textureAfterImageDataModified);
-    } finally {
-      device.getHandle().destroy();
-    }
+    // Direct scalar-array modification keeps invalidating as before.
+    scalars.modified();
+    expect(
+      textureManager.getTextureForImageData(imageData),
+      'scalars.modified() must invalidate the cached texture'
+    ).not.toBe(textureAfterImageDataModified);
   }
 );

--- a/Sources/Rendering/WebGPU/TextureManager/test/testVTKTextureCacheInvalidation.js
+++ b/Sources/Rendering/WebGPU/TextureManager/test/testVTKTextureCacheInvalidation.js
@@ -10,59 +10,55 @@ it.skipIf(!__VTK_TEST_WEBGPU__)(
   async () => {
     const device = await testUtils.createWebGPUTestDevice();
 
-    try {
-      const values = new Uint8Array(4 * 4).fill(10);
-      const scalars = vtkDataArray.newInstance({
-        name: 'Scalars',
-        values,
-        numberOfComponents: 1,
-      });
-      const imageData = vtkImageData.newInstance();
-      imageData.setDimensions(4, 4, 1);
-      imageData.getPointData().setScalars(scalars);
+    const values = new Uint8Array(4 * 4).fill(10);
+    const scalars = vtkDataArray.newInstance({
+      name: 'Scalars',
+      values,
+      numberOfComponents: 1,
+    });
+    const imageData = vtkImageData.newInstance();
+    imageData.setDimensions(4, 4, 1);
+    imageData.getPointData().setScalars(scalars);
 
-      const srcTexture = vtkTexture.newInstance();
-      srcTexture.setInputData(imageData);
+    const srcTexture = vtkTexture.newInstance();
+    srcTexture.setInputData(imageData);
 
-      const textureManager = device.getTextureManager();
+    const textureManager = device.getTextureManager();
 
-      const texture = textureManager.getTextureForVTKTexture(srcTexture);
-      expect(
-        textureManager.getTextureForVTKTexture(srcTexture) === texture,
-        'an unchanged vtkTexture reuses the cached texture'
-      ).toBe(true);
+    const texture = textureManager.getTextureForVTKTexture(srcTexture);
+    expect(
+      textureManager.getTextureForVTKTexture(srcTexture) === texture,
+      'an unchanged vtkTexture reuses the cached texture'
+    ).toBe(true);
 
-      // Write the scalars in place and signal the change through
-      // imageData.modified() alone — the pattern used by consumers that
-      // stream new frames into an existing array.
-      values.fill(200);
-      imageData.modified();
-      const afterImageDataModified =
-        textureManager.getTextureForVTKTexture(srcTexture);
-      expect(
-        afterImageDataModified === texture,
-        'imageData.modified() alone must invalidate the cached texture'
-      ).toBe(false);
+    // Write the scalars in place and signal the change through
+    // imageData.modified() alone — the pattern used by consumers that
+    // stream new frames into an existing array.
+    values.fill(200);
+    imageData.modified();
+    const afterImageDataModified =
+      textureManager.getTextureForVTKTexture(srcTexture);
+    expect(
+      afterImageDataModified === texture,
+      'imageData.modified() alone must invalidate the cached texture'
+    ).toBe(false);
 
-      // The mtime seeded from the source texture must also keep counting:
-      // srcTexture.modified() alone refreshes the cache entry.
-      srcTexture.modified();
-      const afterTextureModified =
-        textureManager.getTextureForVTKTexture(srcTexture);
-      expect(
-        afterTextureModified === afterImageDataModified,
-        'srcTexture.modified() alone must invalidate the cached texture'
-      ).toBe(false);
+    // The mtime seeded from the source texture must also keep counting:
+    // srcTexture.modified() alone refreshes the cache entry.
+    srcTexture.modified();
+    const afterTextureModified =
+      textureManager.getTextureForVTKTexture(srcTexture);
+    expect(
+      afterTextureModified === afterImageDataModified,
+      'srcTexture.modified() alone must invalidate the cached texture'
+    ).toBe(false);
 
-      // Direct scalar-array modification keeps invalidating as before.
-      scalars.modified();
-      expect(
-        textureManager.getTextureForVTKTexture(srcTexture) ===
-          afterTextureModified,
-        'scalars.modified() must invalidate the cached texture'
-      ).toBe(false);
-    } finally {
-      device.getHandle().destroy();
-    }
+    // Direct scalar-array modification keeps invalidating as before.
+    scalars.modified();
+    expect(
+      textureManager.getTextureForVTKTexture(srcTexture) ===
+        afterTextureModified,
+      'scalars.modified() must invalidate the cached texture'
+    ).toBe(false);
   }
 );

--- a/Sources/Rendering/WebGPU/TextureManager/test/testVTKTextureCacheInvalidation.js
+++ b/Sources/Rendering/WebGPU/TextureManager/test/testVTKTextureCacheInvalidation.js
@@ -1,0 +1,68 @@
+import { it, expect } from 'vitest';
+
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
+import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+
+it.skipIf(!__VTK_TEST_WEBGPU__)(
+  'Test vtkWebGPUTextureManager invalidates cached vtkTexture textures',
+  async () => {
+    const device = await testUtils.createWebGPUTestDevice();
+
+    try {
+      const values = new Uint8Array(4 * 4).fill(10);
+      const scalars = vtkDataArray.newInstance({
+        name: 'Scalars',
+        values,
+        numberOfComponents: 1,
+      });
+      const imageData = vtkImageData.newInstance();
+      imageData.setDimensions(4, 4, 1);
+      imageData.getPointData().setScalars(scalars);
+
+      const srcTexture = vtkTexture.newInstance();
+      srcTexture.setInputData(imageData);
+
+      const textureManager = device.getTextureManager();
+
+      const texture = textureManager.getTextureForVTKTexture(srcTexture);
+      expect(
+        textureManager.getTextureForVTKTexture(srcTexture) === texture,
+        'an unchanged vtkTexture reuses the cached texture'
+      ).toBe(true);
+
+      // Write the scalars in place and signal the change through
+      // imageData.modified() alone — the pattern used by consumers that
+      // stream new frames into an existing array.
+      values.fill(200);
+      imageData.modified();
+      const afterImageDataModified =
+        textureManager.getTextureForVTKTexture(srcTexture);
+      expect(
+        afterImageDataModified === texture,
+        'imageData.modified() alone must invalidate the cached texture'
+      ).toBe(false);
+
+      // The mtime seeded from the source texture must also keep counting:
+      // srcTexture.modified() alone refreshes the cache entry.
+      srcTexture.modified();
+      const afterTextureModified =
+        textureManager.getTextureForVTKTexture(srcTexture);
+      expect(
+        afterTextureModified === afterImageDataModified,
+        'srcTexture.modified() alone must invalidate the cached texture'
+      ).toBe(false);
+
+      // Direct scalar-array modification keeps invalidating as before.
+      scalars.modified();
+      expect(
+        textureManager.getTextureForVTKTexture(srcTexture) ===
+          afterTextureModified,
+        'scalars.modified() must invalidate the cached texture'
+      ).toBe(false);
+    } finally {
+      device.getHandle().destroy();
+    }
+  }
+);

--- a/Sources/Rendering/WebGPU/TextureManager/test/testVTKTextureCacheInvalidation.js
+++ b/Sources/Rendering/WebGPU/TextureManager/test/testVTKTextureCacheInvalidation.js
@@ -1,0 +1,63 @@
+import { it, expect } from 'vitest';
+
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
+import vtkTexture from 'vtk.js/Sources/Rendering/Core/Texture';
+
+it.skipIf(!__VTK_TEST_WEBGPU__)(
+  'Test vtkWebGPUTextureManager invalidates cached vtkTexture textures',
+  async () => {
+    const device = await testUtils.createWebGPUTestDevice();
+
+    const values = new Uint8Array(4 * 4).fill(10);
+    const scalars = vtkDataArray.newInstance({
+      name: 'Scalars',
+      values,
+      numberOfComponents: 1,
+    });
+    const imageData = vtkImageData.newInstance();
+    imageData.setDimensions(4, 4, 1);
+    imageData.getPointData().setScalars(scalars);
+
+    const srcTexture = vtkTexture.newInstance();
+    srcTexture.setInputData(imageData);
+
+    const textureManager = device.getTextureManager();
+
+    const texture = textureManager.getTextureForVTKTexture(srcTexture);
+    expect(
+      textureManager.getTextureForVTKTexture(srcTexture),
+      'an unchanged vtkTexture reuses the cached texture'
+    ).toBe(texture);
+
+    // Write the scalars in place and signal the change through
+    // imageData.modified() alone — the pattern used by consumers that
+    // stream new frames into an existing array.
+    values.fill(200);
+    imageData.modified();
+    const afterImageDataModified =
+      textureManager.getTextureForVTKTexture(srcTexture);
+    expect(
+      afterImageDataModified,
+      'imageData.modified() alone must invalidate the cached texture'
+    ).not.toBe(texture);
+
+    // The mtime seeded from the source texture must also keep counting:
+    // srcTexture.modified() alone refreshes the cache entry.
+    srcTexture.modified();
+    const afterTextureModified =
+      textureManager.getTextureForVTKTexture(srcTexture);
+    expect(
+      afterTextureModified,
+      'srcTexture.modified() alone must invalidate the cached texture'
+    ).not.toBe(afterImageDataModified);
+
+    // Direct scalar-array modification keeps invalidating as before.
+    scalars.modified();
+    expect(
+      textureManager.getTextureForVTKTexture(srcTexture),
+      'scalars.modified() must invalidate the cached texture'
+    ).not.toBe(afterTextureModified);
+  }
+);

--- a/Sources/Testing/testUtils.js
+++ b/Sources/Testing/testUtils.js
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, onTestFinished } from 'vitest';
 import pixelmatch from 'pixelmatch';
 import vtkRTAnalyticSource from 'vtk.js/Sources/Filters/Sources/RTAnalyticSource';
 import vtkWebGPUDevice from 'vtk.js/Sources/Rendering/WebGPU/Device';
@@ -203,6 +203,7 @@ async function createWebGPUTestDevice() {
   }
 
   const handle = await adapter.requestDevice();
+  onTestFinished(() => handle.destroy());
   const device = vtkWebGPUDevice.newInstance();
   device.initialize(handle);
   return device;


### PR DESCRIPTION
### Context

PR #3547 (e072af2fe1) fixed the stale-texture cache for `getTextureForImageData`: the shared `_fillRequest` helper derives the cache hash from the scalar array mtime alone, so writing scalars in place and signaling with `imageData.modified()` kept returning the stale GPU texture.

The sibling entry point `getTextureForVTKTexture` has the identical clobber: it seeds the hash with the `vtkTexture` mtime, but for imageData-backed textures `_fillRequest` overwrites it. Streaming new pixels into a texture draped over geometry (`actor.addTexture(...)`), a background, or a skybox silently keeps rendering the old image unless `scalars.modified()` is called directly — the OpenGL backend refreshes in all of these cases.

### Results

- imageData-backed `vtkTexture`s refresh when scalars are updated in place and the change is signaled through `imageData.modified()` or `texture.modified()` alone (before: the WebGPU view kept the stale texture until `scalars.modified()`; WebGL updated).
- Non-imageData texture sources (image, jsImageData, imageBitmap, canvas) are unaffected — their hash already used the texture mtime.
- Failing texture-cache assertions now report their message instead of a stack overflow: `expect(...).toBe(vtkTexture)` made the reporter serialize the circular device–texture graph through `toJSON()`/`getState()` until `RangeError: Maximum call stack size exceeded` masked the actual failure.
- Device-level WebGPU tests no longer need `try`/`finally` cleanup: `createWebGPUTestDevice` destroys its device when the test finishes, pass or fail.

### Changes

- `WebGPU/TextureManager`: `getTextureForVTKTexture` hashes cache entries on the newest of the texture, imageData, and scalar array mtimes, mirroring e072af2fe1.
- New regression test `TextureManager/test/testVTKTextureCacheInvalidation.js`.
- `TextureManager/test/testImageDataTextureCacheInvalidation.js`: compare cached texture identities as booleans so assertion failures stay readable.
- `Testing/testUtils.js`: `createWebGPUTestDevice` registers `onTestFinished(() => handle.destroy())`; removed per-test device cleanup from the device-level tests (destroying a device destroys every resource created from it).
- No public API changes.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

```
WEBGPU=1 npx vitest run \
  Sources/Rendering/WebGPU/TextureManager \
  Sources/Rendering/WebGPU/Texture/test/testWriteSubImageData.js
```

The new regression test fails without the fix (`imageData.modified() alone must invalidate the cached texture: expected true to be false`). Note the WebGPU tests are skipped unless `WEBGPU=1` is set, so CI does not exercise them yet.

- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: master (ca498ee75)
  - **OS**: Linux (WSL2 Ubuntu 24.04)
  - **Browser**: Chromium (Playwright, headless)