### PR TITLE
Avoid GL readbacks for perf 

### DIFF
--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -14,6 +14,16 @@ function vtkFramebuffer(publicAPI, model) {
   // publicAPI.getDrawMode = () => model.context.DRAW_FRAMEBUFFER;
   // publicAPI.getReadMode = () => model.context.READ_FRAMEBUFFER;
 
+  // Keep the render window's JS-side binding mirror in step with binds made
+  // through this class. Inert until someone seeds the tracker (see
+  // OpenGLRenderWindow.setFramebufferBinding).
+  function syncTrackedBinding(binding) {
+    const renderWindow = model._openGLRenderWindow;
+    if (renderWindow && renderWindow.getFramebufferBinding() !== undefined) {
+      renderWindow.setFramebufferBinding(binding);
+    }
+  }
+
   publicAPI.saveCurrentBindingsAndBuffers = (modeIn) => {
     const mode =
       typeof modeIn !== 'undefined' ? modeIn : publicAPI.getBothMode();
@@ -29,10 +39,12 @@ function vtkFramebuffer(publicAPI, model) {
       return;
     }
 
+    // gl.getParameter(FRAMEBUFFER_BINDING) is a synchronous CPU/GPU sync
+    // point; prefer the render window's JS-side mirror when it is seeded.
     const gl = model.context;
-    model.previousDrawBinding = gl.getParameter(
-      model.context.FRAMEBUFFER_BINDING
-    );
+    const tracked = model._openGLRenderWindow.getFramebufferBinding();
+    model.previousDrawBinding =
+      tracked !== undefined ? tracked : gl.getParameter(gl.FRAMEBUFFER_BINDING);
     model.previousActiveFramebuffer =
       model._openGLRenderWindow.getActiveFramebuffer();
   };
@@ -58,6 +70,7 @@ function vtkFramebuffer(publicAPI, model) {
 
     const gl = model.context;
     gl.bindFramebuffer(gl.FRAMEBUFFER, model.previousDrawBinding);
+    syncTrackedBinding(model.previousDrawBinding);
     model._openGLRenderWindow.setActiveFramebuffer(
       model.previousActiveFramebuffer
     );
@@ -73,6 +86,10 @@ function vtkFramebuffer(publicAPI, model) {
       mode = model.context.FRAMEBUFFER;
     }
     model.context.bindFramebuffer(mode, model.glFramebuffer);
+    if (mode !== model.context.READ_FRAMEBUFFER) {
+      // READ_FRAMEBUFFER binds do not change FRAMEBUFFER_BINDING.
+      syncTrackedBinding(model.glFramebuffer);
+    }
     for (let i = 0; i < model.colorBuffers.length; i++) {
       model.colorBuffers[i].bind();
     }

--- a/Sources/Rendering/OpenGL/Framebuffer/index.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/index.js
@@ -14,6 +14,16 @@ function vtkFramebuffer(publicAPI, model) {
   // publicAPI.getDrawMode = () => model.context.DRAW_FRAMEBUFFER;
   // publicAPI.getReadMode = () => model.context.READ_FRAMEBUFFER;
 
+  // Keep the render window's JS-side binding mirror in step with binds made
+  // through this class. Inert until someone seeds the tracker (see
+  // OpenGLRenderWindow.setFramebufferBinding).
+  function syncTrackedBinding(binding) {
+    const renderWindow = model._openGLRenderWindow;
+    if (renderWindow && renderWindow.getFramebufferBindingKnown()) {
+      renderWindow.setFramebufferBinding(binding);
+    }
+  }
+
   publicAPI.saveCurrentBindingsAndBuffers = (modeIn) => {
     const mode =
       typeof modeIn !== 'undefined' ? modeIn : publicAPI.getBothMode();
@@ -29,10 +39,13 @@ function vtkFramebuffer(publicAPI, model) {
       return;
     }
 
+    // gl.getParameter(FRAMEBUFFER_BINDING) is a synchronous CPU/GPU sync
+    // point; prefer the render window's JS-side mirror when it is seeded.
     const gl = model.context;
-    model.previousDrawBinding = gl.getParameter(
-      model.context.FRAMEBUFFER_BINDING
-    );
+    const renderWindow = model._openGLRenderWindow;
+    model.previousDrawBinding = renderWindow.getFramebufferBindingKnown()
+      ? renderWindow.getFramebufferBinding()
+      : gl.getParameter(gl.FRAMEBUFFER_BINDING);
     model.previousActiveFramebuffer =
       model._openGLRenderWindow.getActiveFramebuffer();
   };
@@ -58,6 +71,7 @@ function vtkFramebuffer(publicAPI, model) {
 
     const gl = model.context;
     gl.bindFramebuffer(gl.FRAMEBUFFER, model.previousDrawBinding);
+    syncTrackedBinding(model.previousDrawBinding);
     model._openGLRenderWindow.setActiveFramebuffer(
       model.previousActiveFramebuffer
     );
@@ -73,6 +87,10 @@ function vtkFramebuffer(publicAPI, model) {
       mode = model.context.FRAMEBUFFER;
     }
     model.context.bindFramebuffer(mode, model.glFramebuffer);
+    if (mode !== model.context.READ_FRAMEBUFFER) {
+      // READ_FRAMEBUFFER binds do not change FRAMEBUFFER_BINDING.
+      syncTrackedBinding(model.glFramebuffer);
+    }
     for (let i = 0; i < model.colorBuffers.length; i++) {
       model.colorBuffers[i].bind();
     }

--- a/Sources/Rendering/OpenGL/Framebuffer/test/testFramebufferBindingTracking.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/test/testFramebufferBindingTracking.js
@@ -1,0 +1,95 @@
+import { it, expect } from 'vitest';
+
+import vtkFramebuffer from 'vtk.js/Sources/Rendering/OpenGL/Framebuffer';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
+
+function createContextHarness() {
+  const renderWindow = vtkRenderWindow.newInstance();
+  const view = renderWindow.newAPISpecificView('WebGL');
+  renderWindow.addView(view);
+  view.initialize();
+  const gl = view.getContext();
+
+  // Count FRAMEBUFFER_BINDING readbacks while keeping getParameter working.
+  const rawGetParameter = gl.getParameter.bind(gl);
+  const counter = { bindingQueries: 0 };
+  gl.getParameter = (pname) => {
+    if (pname === gl.FRAMEBUFFER_BINDING) {
+      counter.bindingQueries += 1;
+    }
+    return rawGetParameter(pname);
+  };
+
+  const makeFramebuffer = () => {
+    const framebuffer = vtkFramebuffer.newInstance();
+    framebuffer.setOpenGLRenderWindow(view);
+    framebuffer.create(4, 4);
+    return framebuffer;
+  };
+
+  const currentBinding = () => rawGetParameter(gl.FRAMEBUFFER_BINDING);
+
+  // Deleting the own property restores the prototype method.
+  const removeSpy = () => delete gl.getParameter;
+
+  return { view, counter, makeFramebuffer, currentBinding, removeSpy };
+}
+
+it.skipIf(__VTK_TEST_NO_WEBGL__)(
+  'save/restore reads the binding back from GL when tracking is not seeded',
+  () => {
+    const { view, counter, makeFramebuffer, currentBinding, removeSpy } =
+      createContextHarness();
+    const framebuffer = makeFramebuffer();
+
+    expect(view.getFramebufferBinding()).toBeUndefined();
+
+    framebuffer.saveCurrentBindingsAndBuffers();
+    expect(counter.bindingQueries).toBe(1);
+
+    framebuffer.bind();
+    // Binds do not seed tracking on their own.
+    expect(view.getFramebufferBinding()).toBeUndefined();
+
+    framebuffer.restorePreviousBindingsAndBuffers();
+    expect(currentBinding()).toBe(null);
+
+    framebuffer.saveCurrentBindingsAndBuffers();
+    expect(counter.bindingQueries).toBe(2);
+    removeSpy();
+  }
+);
+
+it.skipIf(__VTK_TEST_NO_WEBGL__)(
+  'seeded binding tracking avoids getParameter and follows bind/restore',
+  () => {
+    const { view, counter, makeFramebuffer, currentBinding, removeSpy } =
+      createContextHarness();
+    const outer = makeFramebuffer();
+    const inner = makeFramebuffer();
+
+    // The caller (e.g. a host embedding vtk.js) declares what is bound.
+    view.setFramebufferBinding(null);
+
+    outer.saveCurrentBindingsAndBuffers();
+    outer.bind();
+    expect(view.getFramebufferBinding()).toBe(outer.getGLFramebuffer());
+
+    // Nested save/restore (a mapper capturing state inside a render pass)
+    // must see the outer binding through the mirror.
+    inner.saveCurrentBindingsAndBuffers();
+    inner.bind();
+    expect(view.getFramebufferBinding()).toBe(inner.getGLFramebuffer());
+    inner.restorePreviousBindingsAndBuffers();
+    expect(currentBinding()).toBe(outer.getGLFramebuffer());
+    expect(view.getFramebufferBinding()).toBe(outer.getGLFramebuffer());
+
+    outer.restorePreviousBindingsAndBuffers();
+    expect(currentBinding()).toBe(null);
+    expect(view.getFramebufferBinding()).toBe(null);
+
+    expect(counter.bindingQueries).toBe(0);
+    removeSpy();
+  }
+);

--- a/Sources/Rendering/OpenGL/Framebuffer/test/testFramebufferBindingTracking.js
+++ b/Sources/Rendering/OpenGL/Framebuffer/test/testFramebufferBindingTracking.js
@@ -1,0 +1,96 @@
+import { it, expect } from 'vitest';
+
+import vtkFramebuffer from 'vtk.js/Sources/Rendering/OpenGL/Framebuffer';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
+
+function createContextHarness() {
+  const renderWindow = vtkRenderWindow.newInstance();
+  const view = renderWindow.newAPISpecificView('WebGL');
+  renderWindow.addView(view);
+  view.initialize();
+  const gl = view.getContext();
+
+  // Count FRAMEBUFFER_BINDING readbacks while keeping getParameter working.
+  const rawGetParameter = gl.getParameter.bind(gl);
+  const counter = { bindingQueries: 0 };
+  gl.getParameter = (pname) => {
+    if (pname === gl.FRAMEBUFFER_BINDING) {
+      counter.bindingQueries += 1;
+    }
+    return rawGetParameter(pname);
+  };
+
+  const makeFramebuffer = () => {
+    const framebuffer = vtkFramebuffer.newInstance();
+    framebuffer.setOpenGLRenderWindow(view);
+    framebuffer.create(4, 4);
+    return framebuffer;
+  };
+
+  const currentBinding = () => rawGetParameter(gl.FRAMEBUFFER_BINDING);
+
+  // Deleting the own property restores the prototype method.
+  const removeSpy = () => delete gl.getParameter;
+
+  return { view, counter, makeFramebuffer, currentBinding, removeSpy };
+}
+
+it.skipIf(__VTK_TEST_NO_WEBGL__)(
+  'save/restore reads the binding back from GL when tracking is not seeded',
+  () => {
+    const { view, counter, makeFramebuffer, currentBinding, removeSpy } =
+      createContextHarness();
+    const framebuffer = makeFramebuffer();
+
+    expect(view.getFramebufferBindingKnown()).toBe(false);
+
+    framebuffer.saveCurrentBindingsAndBuffers();
+    expect(counter.bindingQueries).toBe(1);
+
+    framebuffer.bind();
+    // Binds do not seed tracking on their own.
+    expect(view.getFramebufferBindingKnown()).toBe(false);
+
+    framebuffer.restorePreviousBindingsAndBuffers();
+    expect(currentBinding()).toBe(null);
+
+    framebuffer.saveCurrentBindingsAndBuffers();
+    expect(counter.bindingQueries).toBe(2);
+    removeSpy();
+  }
+);
+
+it.skipIf(__VTK_TEST_NO_WEBGL__)(
+  'seeded binding tracking avoids getParameter and follows bind/restore',
+  () => {
+    const { view, counter, makeFramebuffer, currentBinding, removeSpy } =
+      createContextHarness();
+    const outer = makeFramebuffer();
+    const inner = makeFramebuffer();
+
+    // The caller (e.g. a host embedding vtk.js) declares what is bound.
+    view.setFramebufferBinding(null);
+    expect(view.getFramebufferBindingKnown()).toBe(true);
+
+    outer.saveCurrentBindingsAndBuffers();
+    outer.bind();
+    expect(view.getFramebufferBinding()).toBe(outer.getGLFramebuffer());
+
+    // Nested save/restore (a mapper capturing state inside a render pass)
+    // must see the outer binding through the mirror.
+    inner.saveCurrentBindingsAndBuffers();
+    inner.bind();
+    expect(view.getFramebufferBinding()).toBe(inner.getGLFramebuffer());
+    inner.restorePreviousBindingsAndBuffers();
+    expect(currentBinding()).toBe(outer.getGLFramebuffer());
+    expect(view.getFramebufferBinding()).toBe(outer.getGLFramebuffer());
+
+    outer.restorePreviousBindingsAndBuffers();
+    expect(currentBinding()).toBe(null);
+    expect(view.getFramebufferBinding()).toBe(null);
+
+    expect(counter.bindingQueries).toBe(0);
+    removeSpy();
+  }
+);

--- a/Sources/Rendering/OpenGL/Helper/index.js
+++ b/Sources/Rendering/OpenGL/Helper/index.js
@@ -44,8 +44,12 @@ function vtkOpenGLHelper(publicAPI, model) {
       const mode = publicAPI.getOpenGLMode(rep);
       const wideLines = publicAPI.haveWideLines(ren, actor);
       const gl = model.context;
-      const depthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
+      // Only the point-picking pass alters the depth mask, and reading it
+      // back with gl.getParameter can stall, so scope the save/restore to
+      // the pointPicking path instead of paying it on every draw call.
+      let depthMask;
       if (model.pointPicking) {
+        depthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
         gl.depthMask(false);
       }
       const drawingLines = mode === gl.LINES;

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -252,6 +252,22 @@ export interface vtkOpenGLRenderWindow extends vtkViewNode {
   ): Nullable<WebGLRenderingContext>;
 
   /**
+   * Seed/update the JS-side mirror of the raw WebGLFramebuffer binding
+   * (null = default framebuffer) so framebuffer save/restore can avoid
+   * gl.getParameter(FRAMEBUFFER_BINDING) readbacks. Tracking is inert until
+   * first seeded; once seeded, callers binding framebuffers directly on the
+   * context must keep it in sync.
+   * @param binding
+   */
+  setFramebufferBinding(binding: Nullable<WebGLFramebuffer>): void;
+
+  /**
+   * The tracked raw framebuffer binding, or undefined when tracking has not
+   * been seeded.
+   */
+  getFramebufferBinding(): Nullable<WebGLFramebuffer> | undefined;
+
+  /**
    *
    * @param {CanvasRenderingContext2DSettings} options
    */

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -264,6 +264,29 @@ export interface vtkOpenGLRenderWindow extends vtkViewNode {
   ): Nullable<WebGL2RenderingContext>;
 
   /**
+   * Seed/update the JS-side mirror of the raw WebGLFramebuffer binding
+   * (null = default framebuffer) so framebuffer save/restore can avoid
+   * gl.getParameter(FRAMEBUFFER_BINDING) readbacks. Tracking is inert until
+   * first seeded; once seeded, callers binding framebuffers directly on the
+   * context must keep it in sync.
+   * @param binding
+   */
+  setFramebufferBinding(binding: Nullable<WebGLFramebuffer>): void;
+
+  /**
+   * The mirrored raw framebuffer binding (null = default framebuffer). Only
+   * meaningful while getFramebufferBindingKnown() returns true.
+   */
+  getFramebufferBinding(): Nullable<WebGLFramebuffer>;
+
+  /**
+   * Whether the framebuffer-binding mirror has been seeded with
+   * setFramebufferBinding. False on a fresh render window: saves fall back
+   * to querying GL.
+   */
+  getFramebufferBindingKnown(): boolean;
+
+  /**
    *
    * @param {CanvasRenderingContext2DSettings} options
    */

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1212,6 +1212,17 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     model.activeFramebuffer = newActiveFramebuffer;
   };
 
+  // JS-side mirror of the raw WebGLFramebuffer binding (null = default
+  // framebuffer), so FBO save/restore can avoid the CPU/GPU sync stall of a
+  // gl.getParameter(FRAMEBUFFER_BINDING) readback. Tracking is inert
+  // (undefined = unknown, readback fallback) until a caller seeds it; once
+  // seeded, vtkFramebuffer keeps it in sync, and callers binding framebuffers
+  // directly on the context must do the same.
+  publicAPI.setFramebufferBinding = (binding) => {
+    model.framebufferBinding = binding;
+  };
+  publicAPI.getFramebufferBinding = () => model.framebufferBinding;
+
   const superSetSize = publicAPI.setSize;
   publicAPI.setSize = (width, height) => {
     const modified = superSetSize(width, height);

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -1159,6 +1159,17 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     model.activeFramebuffer = newActiveFramebuffer;
   };
 
+  // JS-side mirror of the raw WebGLFramebuffer binding (null = default
+  // framebuffer), so FBO save/restore can avoid the CPU/GPU sync stall of a
+  // gl.getParameter(FRAMEBUFFER_BINDING) readback. Inert while
+  // framebufferBindingKnown is false (the readback fallback); once a caller
+  // seeds it, vtkFramebuffer keeps it in sync, and callers binding
+  // framebuffers directly on the context must do the same.
+  publicAPI.setFramebufferBinding = (binding) => {
+    model.framebufferBinding = binding;
+    model.framebufferBindingKnown = true;
+  };
+
   const superSetSize = publicAPI.setSize;
   publicAPI.setSize = (...args) => {
     const modified = superSetSize(...args);
@@ -1275,6 +1286,8 @@ const DEFAULT_VALUES = {
   renderPasses: [],
   notifyStartCaptureImage: false,
   activeFramebuffer: null,
+  framebufferBinding: null,
+  framebufferBindingKnown: false,
   imageFormat: 'image/png',
   useOffScreen: false,
   useBackgroundImage: false,
@@ -1326,6 +1339,8 @@ export function extend(publicAPI, model, initialValues = {}) {
     'textureUnitManager',
     'useBackgroundImage',
     'activeFramebuffer',
+    'framebufferBinding',
+    'framebufferBindingKnown',
     'rootOpenGLRenderWindow',
   ]);
 


### PR DESCRIPTION
Two hot-path `gl.getParameter` readbacks of dynamic GL state removed.

### Context

Reading dynamic state back is a synchronization point with the GPU process. On an uncontended context browsers answer from CPU-side state and the query is nearly free; standalone vtk.js scenes show no measurable change from this PR. But when vtk.js shares a context with a busy host (e.g. rendering inside a MapLibre custom layer), Chromium answers each query with a GPU-process round-trip (~0.2 ms), and the first query of the frame additionally blocks until the host's queued GPU work drains (20-45 ms measured mid-frame over a terrain-heavy map, spikes past 100 ms). A per-draw query keeps re-paying smaller stalls as each draw refills the queue.

Demo, no vtk.js involved ([`gl-readback-stall-demo` branch](https://github.com/PaulHax/vtk-js/blob/gl-readback-stall-demo/getparameter-stall-demo.html), one self-contained HTML file; serve it and open): a MapLibre terrain page whose custom layer just issues N × `getParameter(DEPTH_WRITEMASK)` per frame, the pattern vtk.js's draw path had. On Chromium (ANGLE D3D12): N=0 → 30 fps; N=200, i.e. a 200-actor scene before this PR → 12 fps, with the first query of each frame costing 43 ms p50 / 137 ms max.

### Changes


- **Helper:** `drawArrays` read `DEPTH_WRITEMASK` unconditionally on every draw call, but only the point-picking pass uses the value. The readback (and restore) is now scoped to `pointPicking`; ordinary rendering issues no query.
- **Framebuffer:** `saveCurrentBindings` queried `FRAMEBUFFER_BINDING` on every save (e.g. each ForwardPass zbuffer capture). `vtkOpenGLRenderWindow` now carries a JS-side mirror (`set`/`getFramebufferBinding`, gated by an explicit `getFramebufferBindingKnown()` flag). The mirror is inert until first seeded, so stock behavior is byte-identical. Once a caller seeds it (e.g. an embedding host that knows what it bound), saves use the mirror and `vtkFramebuffer` bind/restore keep it in sync. A unit test covers both modes, including nested save/bind/restore through the mirror.

### Results

A/B benchmark (200-actor scene in a MapLibre terrain custom layer, continuous camera motion, Chromium/ANGLE D3D12; harness pairs this branch with the external-context render window follow-up): mean vtk render time **79 ms → 14 ms** per frame, whole-frame **91 ms → 35 ms** (11 → 29 fps). The measured win is dominated by the per-draw Helper readback; the Framebuffer mirror removes the queries that remain once an embedding host declares its framebuffer (any single remaining query inherits the whole stall), so the steady-state render path can issue zero readbacks.