### PR TITLE
chore(RemoteView): add dependencies to example readme

### DIFF
--- a/Sources/Rendering/Misc/RemoteView/example/index.md
+++ b/Sources/Rendering/Misc/RemoteView/example/index.md
@@ -3,6 +3,8 @@
 The RemoteView can be used with either the VTK-Web or ParaView-Web servers.
 The current example will not work until you start one of the servers below on
 your local machine.
+Both vtk and pv servers require wslink==1.12.4 installed in your python environment.
+For the vtk server, you need to install vtk[web] as well.
 
 ## Using VTK as server
 


### PR DESCRIPTION
### Context
RemoteView's example fails due to a wslink version mismatch between js and Python. I added a specification of the necessary version in the README of the example.

### Results
The example works locally. But it still does not on the example page since there's no remote view running. We should probably remove it from the page.

### Changes
Added dependencies list in the example's README file

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code