### PR TITLE
fix: remove commit lint rule for dependabot

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Lint commits
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && github.actor != 'dependabot[bot]'
         run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
       - name: Tests must not use test.only
         run: bash .github/workflows/test-only-check.sh


### PR DESCRIPTION
### Context
dependabot PRs sometimes fail due to commit line length not respecting the body-max-line-length rule.

### Results
PRs won't fail due to this anymore

### Changes
Added a rule to ignore Lint commits step in pr-checks for dependabot commits

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
