### PR TITLE
fix(PaintWidget): fix widget deactivation when not painting

### DIFF
--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -76,7 +76,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.activeState.get('origin', 'up', 'right', 'direction', 'scale1')
       );
     } else {
-      return macro.VOID;
+      return macro.EVENT_ABORT;
     }
 
     publicAPI.invokeInteractionEvent();


### PR DESCRIPTION
### Context
It was impossible to use paint mode in PaintWidget example.

### Results
The problem is fixed.

### Changes
Replaced macro.VOID return by macro.EVENT_ABORT return in handleEvent to avoid call to deactivateAllWidgets in macros invoke

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
