### PR TITLE
chore(PaintWidget): restore previous options and fix erase

### DIFF
--- a/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/example/index.js
@@ -339,7 +339,13 @@ gui
   });
 
 gui
-  .add(guiParams, 'widget', ['paintWidget', 'splineWidget', 'polygonWidget'])
+  .add(guiParams, 'widget', [
+    'paintWidget',
+    'splineWidget',
+    'polygonWidget',
+    'ellipseWidget',
+    'circleWidget',
+  ])
   .name('Widget')
   .onChange((value) => {
     activeWidget = value;
@@ -355,14 +361,25 @@ gui
     scene.polygonHandle.reset();
     scene.polygonHandle.setVisibility(activeWidget === 'polygonWidget');
     scene.polygonHandle.updateRepresentationForRender();
+
+    scene.ellipseHandle.reset();
+    scene.ellipseHandle.setVisibility(activeWidget === 'ellipseWidget');
+    scene.ellipseHandle.updateRepresentationForRender();
+
+    scene.circleHandle.reset();
+    scene.circleHandle.setVisibility(activeWidget === 'circleWidget');
+    scene.circleHandle.updateRepresentationForRender();
   });
 
 gui
   .add(guiParams, 'operation', ['draw', 'erase'])
   .name('Operation')
   .onChange((mode) => {
-    painter.setDrawStencil(mode === 'draw');
-    painter.setErase(mode === 'erase');
+    if (mode === 'draw') {
+      painter.setLabel(1);
+    } else {
+      painter.setLabel(0);
+    }
   });
 
 gui


### PR DESCRIPTION
### Context
Some of the options of the PaintWidget examples were removed when passing to lil-gui, and erase mode does not work.

### Results
Added back Ellipse and Circle mode
Fixed the erase mode

### Changes
Added the missing modes to the UI selector
Replaced the non-existing method calls for erase by a label change.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
