### PR TITLE
fix(RemoteView): bump wslink from 1.12.4 to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,12 +59,12 @@
         "vitepress-plugin-google-analytics": "1.0.2",
         "vitepress-plugin-llms": "1.12.2",
         "vitest": "4.1.7",
-        "wslink": "1.12.4",
+        "wslink": "2.5.0",
         "xml2js": "0.6.2"
       },
       "peerDependencies": {
         "autoprefixer": "^10.4.7",
-        "wslink": ">=1.1.0 || ^2.0.0"
+        "wslink": ">=2.0.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1003,6 +1003,16 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -6994,19 +7004,6 @@
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
@@ -14517,13 +14514,13 @@
       }
     },
     "node_modules/wslink": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/wslink/-/wslink-1.12.4.tgz",
-      "integrity": "sha512-4AJtHZ0qtBa7zOp0e3R5OJxQ6HY9eo+jDPcjms6E2ChXgQ5D4hlMynFF8mEFXx54+PmLo8f2DMiM9bxN6QTAjg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/wslink/-/wslink-2.5.0.tgz",
+      "integrity": "sha512-+m7GWH9G3Y2iAN9CP8M5z/Re2u/Q1KEXvUZ2ISGle7CF6T07z2jS8sWfgp4Y8ZRUbUCHp6IJnEL1xkbzeNn18Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "json5": "2.2.3"
+        "@msgpack/msgpack": "^2.8.0"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -76,12 +76,12 @@
     "vitepress-plugin-google-analytics": "1.0.2",
     "vitepress-plugin-llms": "1.12.2",
     "vitest": "4.1.7",
-    "wslink": "1.12.4",
+    "wslink": "2.5.0",
     "xml2js": "0.6.2"
   },
   "peerDependencies": {
     "autoprefixer": "^10.4.7",
-    "wslink": ">=1.1.0 || ^2.0.0"
+    "wslink": ">=2.0.0"
   },
   "scripts": {
     "validate": "oxfmt --check \"Sources/**/*.[tj]s\" \"Examples/**/*.[tj]s\"",


### PR DESCRIPTION
### Context
The project is still using <2.0.0 wslink, resulting in errors when using a naive install for a python server

### Results
Bumped the version to >2.0.0

### Changes
Bumped wslink from 1.12.4 to 2.5.0

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
