### PR TITLE
chore(Calculator): fix scalar range widget reactivity

### DIFF
--- a/Sources/Filters/General/Calculator/example/index.js
+++ b/Sources/Filters/General/Calculator/example/index.js
@@ -221,11 +221,13 @@ const rangeFolder = gui.addFolder('Scalar range');
 rangeFolder
   .add(params, 'min')
   .name('Min')
-  .onFinishChange(() => updateScalarRange());
+  .onFinishChange(() => updateScalarRange())
+  .listen();
 rangeFolder
   .add(params, 'max')
   .name('Max')
-  .onFinishChange(() => updateScalarRange());
+  .onFinishChange(() => updateScalarRange())
+  .listen();
 
 gui
   .add(
@@ -242,7 +244,7 @@ gui
   )
   .name('Next formula');
 
-// Eecompute scalar range
+// Recompute scalar range
 applyFormula();
 
 // -----------------------------------------------------------


### PR DESCRIPTION
### Context
Calculator example's Scalar Range widgets are not updated automatically on formula change.

### Results
The min and max of scalar range are now updated automatically on formula change.

### Changes
Added a missing `.listen()` call.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code