### PR TITLE
chore(ConeSource): add initial resetCamera and render

### DIFF
--- a/Sources/Filters/Sources/ConeSource/example/index.js
+++ b/Sources/Filters/Sources/ConeSource/example/index.js
@@ -158,6 +158,8 @@ gui
 
 updateDimensions();
 updateTransformedCone();
+renderer.resetCamera();
+renderWindow.render();
 
 // -----------------------------------------------------------
 // Make some variables global so that you can inspect and


### PR DESCRIPTION
### Context
On initial loading, the cone of SimpleCone example clips into the camera plane.

<img width="1000" height="450" alt="image" src="https://github.com/user-attachments/assets/b1e689a3-114f-4f02-b52b-f8537a1f0015" />

### Results
The cone is properly displayed away from the camera.

<img width="1000" height="450" alt="image" src="https://github.com/user-attachments/assets/12c18579-fded-4f12-b0b6-aef5cfa6232c" />

### Changes
Added a `resetCamera` and `render` call after loading the scene.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
