### PR TITLE
chore(LineSource): prevent negative resolution in example

### DIFF
--- a/Sources/Filters/Sources/LineSource/example/index.js
+++ b/Sources/Filters/Sources/LineSource/example/index.js
@@ -66,6 +66,7 @@ function updateLine() {
 gui
   .add(params, 'resolution')
   .name('Resolution')
+  .min(0)
   .onChange((value) => {
     params.resolution = Number(value);
     updateLine();


### PR DESCRIPTION
### Context
LineSource example allows setting the line resolution as a negative number.

### Results
The minimum resolution now is 0.

### Changes
Added `.min(0)` to the lil-gui widget creation.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code