### PR TITLE
Fix interactor style trackball camera mouse wheel event

### DIFF
--- a/Sources/Filters/Sources/LineSource/example/index.js
+++ b/Sources/Filters/Sources/LineSource/example/index.js
@@ -66,6 +66,7 @@ function updateLine() {
 gui
   .add(params, 'resolution')
   .name('Resolution')
+  .min(0)
   .onChange((value) => {
     params.resolution = Number(value);
     updateLine();

--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/index.js
@@ -421,7 +421,7 @@ function vtkInteractorStyleTrackballCamera(publicAPI, model) {
 
   //----------------------------------------------------------------------------
   publicAPI.handleMouseWheel = (callData) => {
-    const dyf = 1 - callData.spinY / model.zoomFactor;
+    const dyf = Math.exp(-callData.spinY / model.zoomFactor);
     publicAPI.dollyByFactor(model.getRenderer(callData), dyf);
   };
 

--- a/Sources/Interaction/Style/InteractorStyleTrackballCamera/test/testMouseWheel.js
+++ b/Sources/Interaction/Style/InteractorStyleTrackballCamera/test/testMouseWheel.js
@@ -1,0 +1,53 @@
+import { it, expect } from 'vitest';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkConeSource from 'vtk.js/Sources/Filters/Sources/ConeSource';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkFullScreenRenderWindow from 'vtk.js/Sources/Rendering/Misc/FullScreenRenderWindow';
+import vtkInteractorStyleTrackballCamera from 'vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera';
+
+function setup() {
+  const fullScreenRenderer = vtkFullScreenRenderWindow.newInstance({
+    background: [0.2, 0.3, 0.4],
+  });
+  const renderWindow = fullScreenRenderer.getRenderWindow();
+  const renderer = fullScreenRenderer.getRenderer();
+  renderWindow.addRenderer(renderer);
+  const interactor = fullScreenRenderer.getInteractor();
+  const trackballCamera = vtkInteractorStyleTrackballCamera.newInstance();
+  interactor.setInteractorStyle(trackballCamera);
+  const interactorStyle = interactor.getInteractorStyle();
+  const coneSource = vtkConeSource.newInstance({ height: 1.0 });
+  const mapper = vtkMapper.newInstance();
+  mapper.setInputConnection(coneSource.getOutputPort());
+  const actor = vtkActor.newInstance();
+  actor.setMapper(mapper);
+  renderer.addActor(actor);
+  renderer.resetCamera();
+  renderWindow.render();
+  return { renderer, interactorStyle };
+}
+
+it('Test vtkInteractorStyleTrackballCamera mouse wheel event symetry', () => {
+  const { renderer, interactorStyle } = setup();
+  renderer.resetCamera();
+  const camera = renderer.getActiveCamera();
+  const sequences = [
+    [-1, 1],
+    [0.5, -0.5],
+    [0.2, 0.3, -0.3, -0.2],
+    [-2, 3, 2, -3],
+  ];
+  for (const sequence of sequences) {
+    const position = camera.getPosition();
+    for (const diff of sequence) {
+      interactorStyle.handleMouseWheel({
+        spinY: diff,
+        pokedRenderer: renderer,
+      });
+    }
+    expect(
+      camera.getPosition(),
+      'Make sure chaining 2 mouse wheel events of opposite values is equivalent to a no-op.'
+    ).toEqual(position);
+  }
+});


### PR DESCRIPTION
### Context

InteractorStyleTrackballCamera's mouseWheel to dolly factor formula has 2 issues:
1) It's not symetrical (f(x) != 1/f(-x)) which makes a chain of zoom + dezoom different from a no-op.
2) It prevents dezooming at zoomFactor === 1 (the current formula is 1 - spin / zoomFactor, which returns 0 0 for zoomFactor = 1 and x = 1, which is the value of a mouseWheel dezoom event by default)

### Results
The new formula is symetrical and never reaches 0 to always allow zooming and dezooming.

### Changes
Replaced the formula `dollyFactor = 1 - spin / zoomFactor` by `dollyFactor = exp(- spin / zoomFactor)`

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code