### PR TITLE
chore(DepthTest): fix example initial render

### DIFF
--- a/Examples/Geometry/DepthTest/index.js
+++ b/Examples/Geometry/DepthTest/index.js
@@ -335,3 +335,6 @@ bodyElement.addEventListener('keypress', (e) => {
     resetCameraPosition(true);
   }
 });
+
+renderer.resetCamera();
+renderWindow.render();


### PR DESCRIPTION
### Context
The initial render of the DepthTest example is wrong, the first interaction with the camera makes the plane appear

Initial render

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/9e38128c-c930-4e06-9e28-555e57bcb8b3" />

After first interaction

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/7de19510-46c2-4116-802c-7ee4f4c1ddc1" />

### Results

The first render is correct and moving the camera modifies it in a coherent way.

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/25b19d53-8d3b-4d54-8a98-a197f88583a7" />

### Changes
Added resetCamera and render calls.

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
