### PR TITLE
chore(ClipClosedSurface): fix surface colors not showing

### DIFF
--- a/Sources/Filters/General/ClipClosedSurface/example/index.js
+++ b/Sources/Filters/General/ClipClosedSurface/example/index.js
@@ -35,6 +35,7 @@ const actor = vtkActor.newInstance();
 renderer.addActor(actor);
 
 const mapper = vtkMapper.newInstance({ interpolateScalarBeforeMapping: true });
+mapper.setColorModeToDirectScalars();
 actor.setMapper(mapper);
 
 const cam = vtkCamera.newInstance();


### PR DESCRIPTION
### Context
Surface colors are incorrect in ClipClosedSurface example

<img width="365" height="300" alt="image" src="https://github.com/user-attachments/assets/7ec379cc-69a2-49e0-98fd-918e9bee2b1e" />


### Results
The sphere and plane colors are now correct.

<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/6e3c5b0e-4c74-4e09-916f-69b5c2af7050" />

### Changes
Added `mapper.setColorModeToDirectScalars();` in the example to use the scalars set by the filter.

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code