### PR TITLE
Fix camera model transform bounds

### DIFF
--- a/Sources/Rendering/Core/Camera/index.d.ts
+++ b/Sources/Rendering/Core/Camera/index.d.ts
@@ -711,6 +711,17 @@ export interface vtkCamera extends vtkObject {
   /**
    * Set the model transform matrix for the camera.
    * This matrix could be used for model related transformations such as scale, shear, rotations and translations.
+   * It is applied to world coordinates before the camera transform, so the
+   * resulting view matrix is `view * modelTransform`. A common use is a global
+   * vertical exaggeration, e.g. a scale of (1, 1, 10) on world Z.
+   *
+   * The matrix is in gl-matrix column-major order, like `userMatrix` on
+   * vtkProp3D, so a matrix from vtkTransform or vtkMatrixBuilder can be passed
+   * directly.
+   *
+   * Note the camera pose (position, focalPoint, viewUp, clippingRange) is
+   * interpreted after this transform is applied, so it is expressed in
+   * transformed space rather than world space.
    * @param {mat4} mat The value of the model transform matrix.
    */
   setModelTransformMatrix(mat: mat4): void;

--- a/Sources/Rendering/Core/Camera/index.d.ts
+++ b/Sources/Rendering/Core/Camera/index.d.ts
@@ -686,6 +686,17 @@ export interface vtkCamera extends vtkObject {
   /**
    * Set the model transform matrix for the camera.
    * This matrix could be used for model related transformations such as scale, shear, rotations and translations.
+   * It is applied to world coordinates before the camera transform, so the
+   * resulting view matrix is `view * modelTransform`. A common use is a global
+   * vertical exaggeration, e.g. a scale of (1, 1, 10) on world Z.
+   *
+   * The matrix is in gl-matrix column-major order, like `userMatrix` on
+   * vtkProp3D, so a matrix from vtkTransform or vtkMatrixBuilder can be passed
+   * directly.
+   *
+   * Note the camera pose (position, focalPoint, viewUp, clippingRange) is
+   * interpreted after this transform is applied, so it is expressed in
+   * transformed space rather than world space.
    * @param {mat4} mat The value of the model transform matrix.
    */
   setModelTransformMatrix(mat: mat4): void;

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -31,6 +31,7 @@ function vtkCamera(publicAPI, model) {
   const upbasis = new Float64Array([0.0, 1.0, 0.0]);
   const tmpMatrix = mat4.identity(new Float64Array(16));
   const tmpMatrix2 = mat4.identity(new Float64Array(16));
+  const tmpModelTransform = mat4.identity(new Float64Array(16));
   const tmpvec1 = new Float64Array(3);
   const tmpvec2 = new Float64Array(3);
   const tmpvec3 = new Float64Array(3);
@@ -506,14 +507,24 @@ function vtkCamera(publicAPI, model) {
     }
   };
 
+  // Compose the model transform into a row-major view matrix so that the
+  // resulting transform is view * modelTransform, i.e. the model transform is
+  // applied to world coordinates before the camera transform.
+  // modelTransformMatrix is supplied by the caller in gl-matrix column-major
+  // order (like userMatrix on vtkProp3D), while `out` is in vtk's row-major
+  // order, so the model transform has to be transposed before multiplying.
+  const applyModelTransform = (out) => {
+    if (model.modelTransformMatrix) {
+      mat4.transpose(tmpModelTransform, model.modelTransformMatrix);
+      mat4.multiply(out, tmpModelTransform, out);
+    }
+    return out;
+  };
+
   publicAPI.getViewMatrix = (out = new Float64Array(16)) => {
     if (model.viewMatrix) {
-      if (model.modelTransformMatrix) {
-        mat4.multiply(out, model.modelTransformMatrix, model.viewMatrix);
-      } else {
-        mat4.copy(out, model.viewMatrix);
-      }
-      return out;
+      mat4.copy(out, model.viewMatrix);
+      return applyModelTransform(out);
     }
 
     mat4.lookAt(
@@ -525,10 +536,7 @@ function vtkCamera(publicAPI, model) {
 
     mat4.transpose(out, out);
 
-    if (model.modelTransformMatrix) {
-      mat4.multiply(out, model.modelTransformMatrix, out);
-    }
-    return out;
+    return applyModelTransform(out);
   };
 
   publicAPI.setProjectionMatrix = (mat) => {

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -35,6 +35,7 @@ function vtkCamera(publicAPI, model) {
   const upbasis = new Float64Array([0.0, 1.0, 0.0]);
   const tmpMatrix = mat4.identity(new Float64Array(16));
   const tmpMatrix2 = mat4.identity(new Float64Array(16));
+  const tmpModelTransform = mat4.identity(new Float64Array(16));
   const tmpvec1 = new Float64Array(3);
   const tmpvec2 = new Float64Array(3);
   const tmpvec3 = new Float64Array(3);
@@ -535,14 +536,24 @@ function vtkCamera(publicAPI, model) {
     }
   };
 
+  // Compose the model transform into a row-major view matrix so that the
+  // resulting transform is view * modelTransform, i.e. the model transform is
+  // applied to world coordinates before the camera transform.
+  // modelTransformMatrix is supplied by the caller in gl-matrix column-major
+  // order (like userMatrix on vtkProp3D), while `out` is in vtk's row-major
+  // order, so the model transform has to be transposed before multiplying.
+  const applyModelTransform = (out) => {
+    if (model.modelTransformMatrix) {
+      mat4.transpose(tmpModelTransform, model.modelTransformMatrix);
+      mat4.multiply(out, tmpModelTransform, out);
+    }
+    return out;
+  };
+
   publicAPI.getViewMatrix = (out = new Float64Array(16)) => {
     if (model.viewMatrix) {
-      if (model.modelTransformMatrix) {
-        mat4.multiply(out, model.modelTransformMatrix, model.viewMatrix);
-      } else {
-        mat4.copy(out, model.viewMatrix);
-      }
-      return out;
+      mat4.copy(out, model.viewMatrix);
+      return applyModelTransform(out);
     }
 
     mat4.lookAt(
@@ -554,10 +565,7 @@ function vtkCamera(publicAPI, model) {
 
     mat4.transpose(out, out);
 
-    if (model.modelTransformMatrix) {
-      mat4.multiply(out, model.modelTransformMatrix, out);
-    }
-    return out;
+    return applyModelTransform(out);
   };
 
   publicAPI.setProjectionMatrix = (mat) => {

--- a/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
+++ b/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
@@ -1,10 +1,25 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mat4 } from 'gl-matrix';
+import { mat4, vec3 } from 'gl-matrix';
 import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
 import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
 import vtkTransform from 'vtk.js/Sources/Common/Transform/Transform';
 
 let camera;
+
+// getViewMatrix returns vtk's row-major order; transpose to get a matrix that
+// can be applied to points with gl-matrix.
+function asPointTransform(rowMajor) {
+  return mat4.transpose(mat4.create(), rowMajor);
+}
+
+// Where does world point p land in eye coordinates?
+function toEye(cam, p) {
+  return vec3.transformMat4(
+    vec3.create(),
+    p,
+    asPointTransform(cam.getViewMatrix())
+  );
+}
 
 describe('Camera Model Transform Matrix', () => {
   beforeEach(() => {
@@ -12,42 +27,54 @@ describe('Camera Model Transform Matrix', () => {
   });
 
   describe('getViewMatrix composition', () => {
-    it('applies the model transform in world space (modelTransform * viewMatrix), not camera space (viewMatrix * modelTransform)', () => {
-      camera.setPosition(5, 5, 5);
+    it('applies the model transform to world coordinates before the camera transform', () => {
+      camera.setPosition(0, 0, 10);
       camera.setFocalPoint(0, 0, 0);
       camera.setViewUp(0, 1, 0);
 
-      // A translation does not commute with the view rotation/translation, so
-      // this genuinely distinguishes the two multiplication orders.
+      // A translation is neither symmetric nor commuting with the view
+      // transform, so it distinguishes both the multiplication order and the
+      // row-major/column-major convention. A pure scale would not.
       const transform = vtkTransform.newInstance();
       transform.translate(1, 0, 0);
       const modelTransform = transform.getMatrix();
 
-      camera.setModelTransformMatrix(null);
-      const viewMatrix = camera.getViewMatrix();
-
       camera.setModelTransformMatrix(modelTransform);
-      const composed = camera.getViewMatrix();
 
-      const worldSpace = mat4.multiply(
-        mat4.create(),
-        modelTransform,
-        viewMatrix
-      );
-      const cameraSpace = mat4.multiply(
-        mat4.create(),
-        viewMatrix,
-        modelTransform
-      );
-
-      expect(areEquals(composed, worldSpace)).toBe(true);
-      expect(areEquals(composed, cameraSpace)).toBe(false);
+      // The world origin is moved to (1, 0, 0) by the model transform, so it
+      // must land one unit off the view axis rather than on it.
+      const eye = toEye(camera, [0, 0, 0]);
+      expect(eye[0]).toBeCloseTo(1, 10);
+      expect(eye[1]).toBeCloseTo(0, 10);
+      expect(eye[2]).toBeCloseTo(-10, 10);
 
       transform.delete();
     });
 
-    it('keeps the world-space transform consistent across camera orientations (vertical exaggeration)', () => {
-      // 2x vertical exaggeration: a non-uniform world-space Z scale.
+    it('matches view * modelTransform for a non-symmetric transform', () => {
+      camera.setPosition(5, 5, 5);
+      camera.setFocalPoint(0, 0, 0);
+      camera.setViewUp(0, 1, 0);
+
+      const transform = vtkTransform.newInstance();
+      transform.translate(1, 2, 3);
+      transform.rotateWXYZ(30, 0, 1, 0);
+      const modelTransform = transform.getMatrix();
+
+      camera.setModelTransformMatrix(null);
+      const view = asPointTransform(camera.getViewMatrix());
+
+      camera.setModelTransformMatrix(modelTransform);
+      const composed = asPointTransform(camera.getViewMatrix());
+
+      const expected = mat4.multiply(mat4.create(), view, modelTransform);
+      expect(areEquals(composed, expected)).toBe(true);
+
+      transform.delete();
+    });
+
+    it('keeps a vertical exaggeration world-space across camera orientations', () => {
+      // 2x exaggeration along world Z.
       const transform = vtkTransform.newInstance();
       transform.scale(1, 1, 2);
       const modelTransform = transform.getMatrix();
@@ -56,24 +83,18 @@ describe('Camera Model Transform Matrix', () => {
       camera.setFocalPoint(0, 0, 0);
       camera.setViewUp(0, 1, 0);
 
-      // The exaggeration must stay world-space (pre-multiplied), so model
-      // transforms must be applied before the view matrix for every orientation.
       [() => {}, () => camera.azimuth(37), () => camera.elevation(50)].forEach(
         (rotate) => {
           rotate();
 
           camera.setModelTransformMatrix(null);
-          const viewMatrix = camera.getViewMatrix();
+          const view = asPointTransform(camera.getViewMatrix());
 
           camera.setModelTransformMatrix(modelTransform);
-          const composed = camera.getViewMatrix();
+          const composed = asPointTransform(camera.getViewMatrix());
 
-          const worldSpace = mat4.multiply(
-            mat4.create(),
-            modelTransform,
-            viewMatrix
-          );
-          expect(areEquals(composed, worldSpace)).toBe(true);
+          const expected = mat4.multiply(mat4.create(), view, modelTransform);
+          expect(areEquals(composed, expected)).toBe(true);
         }
       );
 

--- a/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
+++ b/Sources/Rendering/Core/Camera/test/testModelTransformMatrix.js
@@ -1,10 +1,25 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mat4 } from 'gl-matrix';
-import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
+import { mat4, vec3 } from 'gl-matrix';
+import vtkMath from 'vtk.js/Sources/Common/Core/Math';
 import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
 import vtkTransform from 'vtk.js/Sources/Common/Transform/Transform';
 
 let camera;
+
+// getViewMatrix returns vtk's row-major order; transpose to get a matrix that
+// can be applied to points with gl-matrix.
+function asPointTransform(rowMajor) {
+  return mat4.transpose(mat4.create(), rowMajor);
+}
+
+// Where does world point p land in eye coordinates?
+function toEye(cam, p) {
+  return vec3.transformMat4(
+    new Float64Array(3),
+    p,
+    asPointTransform(cam.getViewMatrix())
+  );
+}
 
 describe('Camera Model Transform Matrix', () => {
   beforeEach(() => {
@@ -12,42 +27,52 @@ describe('Camera Model Transform Matrix', () => {
   });
 
   describe('getViewMatrix composition', () => {
-    it('applies the model transform in world space (modelTransform * viewMatrix), not camera space (viewMatrix * modelTransform)', () => {
-      camera.setPosition(5, 5, 5);
+    it('applies the model transform to world coordinates before the camera transform', () => {
+      camera.setPosition(0, 0, 10);
       camera.setFocalPoint(0, 0, 0);
       camera.setViewUp(0, 1, 0);
 
-      // A translation does not commute with the view rotation/translation, so
-      // this genuinely distinguishes the two multiplication orders.
+      // A translation is neither symmetric nor commuting with the view
+      // transform, so it distinguishes both the multiplication order and the
+      // row-major/column-major convention. A pure scale would not.
       const transform = vtkTransform.newInstance();
       transform.translate(1, 0, 0);
       const modelTransform = transform.getMatrix();
 
-      camera.setModelTransformMatrix(null);
-      const viewMatrix = camera.getViewMatrix();
-
       camera.setModelTransformMatrix(modelTransform);
-      const composed = camera.getViewMatrix();
 
-      const worldSpace = mat4.multiply(
-        mat4.create(),
-        modelTransform,
-        viewMatrix
-      );
-      const cameraSpace = mat4.multiply(
-        mat4.create(),
-        viewMatrix,
-        modelTransform
-      );
-
-      expect(areEquals(composed, worldSpace)).toBe(true);
-      expect(areEquals(composed, cameraSpace)).toBe(false);
+      // The world origin is moved to (1, 0, 0) by the model transform, so it
+      // must land one unit off the view axis rather than on it.
+      const eye = toEye(camera, [0, 0, 0]);
+      expect(vtkMath.areEquals(eye, [1, 0, -10])).toBe(true);
 
       transform.delete();
     });
 
-    it('keeps the world-space transform consistent across camera orientations (vertical exaggeration)', () => {
-      // 2x vertical exaggeration: a non-uniform world-space Z scale.
+    it('matches view * modelTransform for a non-symmetric transform', () => {
+      camera.setPosition(5, 5, 5);
+      camera.setFocalPoint(0, 0, 0);
+      camera.setViewUp(0, 1, 0);
+
+      const transform = vtkTransform.newInstance();
+      transform.translate(1, 2, 3);
+      transform.rotateWXYZ(30, 0, 1, 0);
+      const modelTransform = transform.getMatrix();
+
+      camera.setModelTransformMatrix(null);
+      const view = asPointTransform(camera.getViewMatrix());
+
+      camera.setModelTransformMatrix(modelTransform);
+      const composed = asPointTransform(camera.getViewMatrix());
+
+      const expected = mat4.multiply(mat4.create(), view, modelTransform);
+      expect(vtkMath.areEquals(composed, expected)).toBe(true);
+
+      transform.delete();
+    });
+
+    it('keeps a vertical exaggeration world-space across camera orientations', () => {
+      // 2x exaggeration along world Z.
       const transform = vtkTransform.newInstance();
       transform.scale(1, 1, 2);
       const modelTransform = transform.getMatrix();
@@ -56,24 +81,18 @@ describe('Camera Model Transform Matrix', () => {
       camera.setFocalPoint(0, 0, 0);
       camera.setViewUp(0, 1, 0);
 
-      // The exaggeration must stay world-space (pre-multiplied), so model
-      // transforms must be applied before the view matrix for every orientation.
       [() => {}, () => camera.azimuth(37), () => camera.elevation(50)].forEach(
         (rotate) => {
           rotate();
 
           camera.setModelTransformMatrix(null);
-          const viewMatrix = camera.getViewMatrix();
+          const view = asPointTransform(camera.getViewMatrix());
 
           camera.setModelTransformMatrix(modelTransform);
-          const composed = camera.getViewMatrix();
+          const composed = asPointTransform(camera.getViewMatrix());
 
-          const worldSpace = mat4.multiply(
-            mat4.create(),
-            modelTransform,
-            viewMatrix
-          );
-          expect(areEquals(composed, worldSpace)).toBe(true);
+          const expected = mat4.multiply(mat4.create(), view, modelTransform);
+          expect(vtkMath.areEquals(composed, expected)).toBe(true);
         }
       );
 
@@ -98,7 +117,7 @@ describe('Camera Model Transform Matrix', () => {
 
       const composite = camera.getCompositeProjectionMatrix(aspect, -1, 1);
 
-      expect(areEquals(composite, expected)).toBe(true);
+      expect(vtkMath.areEquals(composite, expected)).toBe(true);
     });
 
     it('returns a reusable copy when an explicit view matrix is set', () => {
@@ -116,7 +135,7 @@ describe('Camera Model Transform Matrix', () => {
       const view = camera.getViewMatrix(out);
 
       expect(view).toBe(out);
-      expect(areEquals(view, camera.getViewMatrix())).toBe(true);
+      expect(vtkMath.areEquals(view, camera.getViewMatrix())).toBe(true);
     });
   });
 });

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -35,22 +35,17 @@ function vtkRenderer(publicAPI, model) {
     renderer: publicAPI,
   };
 
-  // Scratch matrix for expandBounds
-  const tmpExpandBounds = new Float64Array(16);
-
   // Counterpart of vtkRenderer::ExpandBounds: transform the 8 corners of bounds
   // by matrix and take the axis-aligned bounds of the result.
-  // The matrix is row-major, matching the vtkMatrix4x4 convention used by the
-  // C++ version and by the camera's modelTransformMatrix, whereas
-  // vtkBoundingBox.transformBounds expects gl-matrix column-major.
+  // matrix is in gl-matrix column-major order, matching the camera's
+  // modelTransformMatrix and what vtkBoundingBox.transformBounds expects.
   // Unlike C++, where ModelTransformMatrix is always allocated, vtk-js leaves it
   // null by default, so a null matrix is a no-op rather than an error.
   function expandBounds(bounds, matrix) {
     if (!matrix) {
       return bounds;
     }
-    mat4.transpose(tmpExpandBounds, matrix);
-    return vtkBoundingBox.transformBounds(bounds, tmpExpandBounds, []);
+    return vtkBoundingBox.transformBounds(bounds, matrix, []);
   }
 
   publicAPI.updateCamera = () => {

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -35,6 +35,24 @@ function vtkRenderer(publicAPI, model) {
     renderer: publicAPI,
   };
 
+  // Scratch matrix for expandBounds
+  const tmpExpandBounds = new Float64Array(16);
+
+  // Counterpart of vtkRenderer::ExpandBounds: transform the 8 corners of bounds
+  // by matrix and take the axis-aligned bounds of the result.
+  // The matrix is row-major, matching the vtkMatrix4x4 convention used by the
+  // C++ version and by the camera's modelTransformMatrix, whereas
+  // vtkBoundingBox.transformBounds expects gl-matrix column-major.
+  // Unlike C++, where ModelTransformMatrix is always allocated, vtk-js leaves it
+  // null by default, so a null matrix is a no-op rather than an error.
+  function expandBounds(bounds, matrix) {
+    if (!matrix) {
+      return bounds;
+    }
+    mat4.transpose(tmpExpandBounds, matrix);
+    return vtkBoundingBox.transformBounds(bounds, tmpExpandBounds, []);
+  }
+
   publicAPI.updateCamera = () => {
     if (!model.activeCamera) {
       vtkDebugMacro('No cameras are on, creating one.');
@@ -392,13 +410,22 @@ function vtkRenderer(publicAPI, model) {
     // the view angle to become very small and cause bad depth sorting.
     model.activeCamera.setViewAngle(30.0);
 
-    center[0] = (boundsToUse[0] + boundsToUse[1]) / 2.0;
-    center[1] = (boundsToUse[2] + boundsToUse[3]) / 2.0;
-    center[2] = (boundsToUse[4] + boundsToUse[5]) / 2.0;
+    // The camera pose is consumed after the model transform (the view matrix is
+    // lookAt(position, focalPoint, viewUp) * modelTransformMatrix), so it lives
+    // in transformed space while prop bounds are in world space. Push the
+    // bounds through the transform before deriving the pose from them.
+    const expandedBounds = expandBounds(
+      boundsToUse,
+      model.activeCamera.getModelTransformMatrix()
+    );
 
-    let w1 = boundsToUse[1] - boundsToUse[0];
-    let w2 = boundsToUse[3] - boundsToUse[2];
-    let w3 = boundsToUse[5] - boundsToUse[4];
+    center[0] = (expandedBounds[0] + expandedBounds[1]) / 2.0;
+    center[1] = (expandedBounds[2] + expandedBounds[3]) / 2.0;
+    center[2] = (expandedBounds[4] + expandedBounds[5]) / 2.0;
+
+    let w1 = expandedBounds[1] - expandedBounds[0];
+    let w2 = expandedBounds[3] - expandedBounds[2];
+    let w3 = expandedBounds[5] - expandedBounds[4];
     w1 *= w1;
     w2 *= w2;
     w3 *= w3;
@@ -444,6 +471,8 @@ function vtkRenderer(publicAPI, model) {
       center[2] + distance * vn[2]
     );
 
+    // Pass the untransformed bounds: resetCameraClippingRange applies the model
+    // transform itself, so handing it expandedBounds would apply it twice.
     publicAPI.resetCameraClippingRange(boundsToUse);
 
     // setup default parallel scale
@@ -479,8 +508,12 @@ function vtkRenderer(publicAPI, model) {
       return false;
     }
 
-    // Get the exact range for the bounds
-    const range = model.activeCamera.computeClippingRange(boundsToUse);
+    // computeClippingRange measures along the camera's direction of projection,
+    // which is expressed in transformed space, so the world-space bounds have to
+    // be pushed through the model transform first.
+    const range = model.activeCamera.computeClippingRange(
+      expandBounds(boundsToUse, model.activeCamera.getModelTransformMatrix())
+    );
 
     // do not let far - near be less than 0.1 of the window height
     // this is for cases such as 2D images which may have zero range

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -35,18 +35,13 @@ function vtkRenderer(publicAPI, model) {
     renderer: publicAPI,
   };
 
-  // Scratch matrix for expandBounds
-  const tmpExpandBounds = new Float64Array(16);
-
   // Counterpart of vtkRenderer::ExpandBounds: the axis-aligned bounds of the 8
-  // corners of `bounds` transformed by the row-major `matrix`, which
-  // vtkBoundingBox.transformBounds needs column-major. Null is a no-op.
+  // corners of `bounds` transformed by `matrix`. A null matrix is a no-op.
   function expandBounds(bounds, matrix) {
     if (!matrix) {
       return bounds;
     }
-    mat4.transpose(tmpExpandBounds, matrix);
-    return vtkBoundingBox.transformBounds(bounds, tmpExpandBounds, []);
+    return vtkBoundingBox.transformBounds(bounds, matrix, []);
   }
 
   publicAPI.updateCamera = () => {

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -35,6 +35,20 @@ function vtkRenderer(publicAPI, model) {
     renderer: publicAPI,
   };
 
+  // Scratch matrix for expandBounds
+  const tmpExpandBounds = new Float64Array(16);
+
+  // Counterpart of vtkRenderer::ExpandBounds: the axis-aligned bounds of the 8
+  // corners of `bounds` transformed by the row-major `matrix`, which
+  // vtkBoundingBox.transformBounds needs column-major. Null is a no-op.
+  function expandBounds(bounds, matrix) {
+    if (!matrix) {
+      return bounds;
+    }
+    mat4.transpose(tmpExpandBounds, matrix);
+    return vtkBoundingBox.transformBounds(bounds, tmpExpandBounds, []);
+  }
+
   publicAPI.updateCamera = () => {
     if (!model.activeCamera) {
       vtkDebugMacro('No cameras are on, creating one.');
@@ -372,7 +386,6 @@ function vtkRenderer(publicAPI, model) {
 
   publicAPI.resetCamera = (bounds = null) => {
     const boundsToUse = bounds || publicAPI.computeVisiblePropBounds();
-    const center = [0, 0, 0];
 
     if (!vtkMath.areBoundsInitialized(boundsToUse)) {
       vtkDebugMacro('Cannot reset camera!');
@@ -392,13 +405,20 @@ function vtkRenderer(publicAPI, model) {
     // the view angle to become very small and cause bad depth sorting.
     model.activeCamera.setViewAngle(30.0);
 
-    center[0] = (boundsToUse[0] + boundsToUse[1]) / 2.0;
-    center[1] = (boundsToUse[2] + boundsToUse[3]) / 2.0;
-    center[2] = (boundsToUse[4] + boundsToUse[5]) / 2.0;
+    // The camera pose is consumed after the model transform (the view matrix is
+    // lookAt(position, focalPoint, viewUp) * modelTransformMatrix), so it lives
+    // in transformed space while prop bounds are in world space. Push the
+    // bounds through the transform before deriving the pose from them.
+    const expandedBounds = expandBounds(
+      boundsToUse,
+      model.activeCamera.getModelTransformMatrix()
+    );
 
-    let w1 = boundsToUse[1] - boundsToUse[0];
-    let w2 = boundsToUse[3] - boundsToUse[2];
-    let w3 = boundsToUse[5] - boundsToUse[4];
+    const center = vtkBoundingBox.getCenter(expandedBounds);
+
+    let w1 = vtkBoundingBox.getLength(expandedBounds, 0);
+    let w2 = vtkBoundingBox.getLength(expandedBounds, 1);
+    let w3 = vtkBoundingBox.getLength(expandedBounds, 2);
     w1 *= w1;
     w2 *= w2;
     w3 *= w3;
@@ -444,6 +464,8 @@ function vtkRenderer(publicAPI, model) {
       center[2] + distance * vn[2]
     );
 
+    // Pass the untransformed bounds: resetCameraClippingRange applies the model
+    // transform itself, so handing it expandedBounds would apply it twice.
     publicAPI.resetCameraClippingRange(boundsToUse);
 
     // setup default parallel scale
@@ -479,8 +501,12 @@ function vtkRenderer(publicAPI, model) {
       return false;
     }
 
-    // Get the exact range for the bounds
-    const range = model.activeCamera.computeClippingRange(boundsToUse);
+    // computeClippingRange measures along the camera's direction of projection,
+    // which is expressed in transformed space, so the world-space bounds have to
+    // be pushed through the model transform first.
+    const range = model.activeCamera.computeClippingRange(
+      expandBounds(boundsToUse, model.activeCamera.getModelTransformMatrix())
+    );
 
     // do not let far - near be less than 0.1 of the window height
     // this is for cases such as 2D images which may have zero range

--- a/Sources/Rendering/Core/Renderer/test/testResetCameraModelTransform.js
+++ b/Sources/Rendering/Core/Renderer/test/testResetCameraModelTransform.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mat4 } from 'gl-matrix';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
+
+// Bounds of a "geology-like" scene: kilometers in X/Y, meters in Z.
+const BOUNDS = [-1000, 1000, -1000, 1000, -10, 10];
+
+// 10x vertical exaggeration. The camera stores modelTransformMatrix row-major,
+// but a diagonal scale is symmetric so the two conventions coincide here.
+function zScale(factor) {
+  const m = new Float64Array(16);
+  mat4.identity(m);
+  m[10] = factor;
+  return m;
+}
+
+let renderer;
+let camera;
+
+describe('Renderer resetCamera with camera model transform', () => {
+  beforeEach(() => {
+    renderer = vtkRenderer.newInstance();
+    camera = vtkCamera.newInstance();
+    renderer.setActiveCamera(camera);
+    camera.setViewUp(0, 1, 0);
+  });
+
+  it('aims the camera at the transformed center, not the world center', () => {
+    // Off-center in Z so the transform actually moves the center.
+    const bounds = [-1000, 1000, -1000, 1000, 90, 110];
+    camera.setModelTransformMatrix(zScale(10));
+    renderer.resetCamera(bounds);
+
+    // World center Z is 100; after a 10x Z scale the scene center sits at 1000.
+    expect(camera.getFocalPoint()[2]).toBeCloseTo(1000, 6);
+  });
+
+  it('grows the fitted radius with the exaggeration factor', () => {
+    camera.setModelTransformMatrix(null);
+    renderer.resetCamera(BOUNDS);
+    const unscaled = camera.getParallelScale();
+
+    camera.setModelTransformMatrix(zScale(10));
+    renderer.resetCamera(BOUNDS);
+    const scaled = camera.getParallelScale();
+
+    // Z extent goes from 20 to 200, so the bounding sphere must grow.
+    expect(scaled).toBeGreaterThan(unscaled);
+  });
+
+  it('resetCameraClippingRange covers the transformed scene along the view axis', () => {
+    // Look straight down world -Z, so the exaggerated axis is the depth axis and
+    // the clipping range must stretch to match. This is the case that has no
+    // application-level call site to fix: interaction paths call
+    // resetCameraClippingRange() with no arguments.
+    camera.setPosition(0, 0, 5000);
+    camera.setFocalPoint(0, 0, 0);
+    // The factor has to be large enough that the error exceeds the minGap
+    // padding resetCameraClippingRange already applies, or the bug hides.
+    camera.setModelTransformMatrix(zScale(100));
+
+    renderer.resetCameraClippingRange(BOUNDS);
+    const [near, far] = camera.getClippingRange();
+
+    // Transformed Z extent is [-1000, 1000], so relative to the eye at z=5000
+    // the scene spans depths 4000..6000.
+    expect(near).toBeLessThanOrEqual(4000);
+    expect(far).toBeGreaterThanOrEqual(6000);
+  });
+
+  it('is unchanged when no model transform is set', () => {
+    camera.setModelTransformMatrix(null);
+    renderer.resetCamera(BOUNDS);
+    const focalPoint = [...camera.getFocalPoint()];
+    const position = [...camera.getPosition()];
+    const range = [...camera.getClippingRange()];
+
+    camera.setModelTransformMatrix(zScale(1));
+    renderer.resetCamera(BOUNDS);
+
+    expect(camera.getFocalPoint()).toEqual(focalPoint);
+    expect(camera.getPosition()).toEqual(position);
+    expect(camera.getClippingRange()).toEqual(range);
+  });
+});


### PR DESCRIPTION
### Context

#3538 fixed the composition order so the transform is applied in world space. But the camera pose is *consumed after* the transform: `getViewMatrix()` builds `lookAt(position, focalPoint, viewUp) · M`, so `position`/`focalPoint`/`clippingRange` are interpreted in transformed space, while prop bounds are in world space. Nothing bridged the two.

This is exactly how VTK C++ behaves — `vtkCamera.cxx` composes `ModelView = ViewTransform · ModelTransformMatrix`, and `vtkCamera.h` documents that "Clipping distance is measured in world coordinate unless a scale factor exists in camera's ModelTransformMatrix." The difference is that C++ has `vtkRenderer::ExpandBounds` (`vtkRenderer.cxx`), which pushes bounds through the transform before deriving the camera pose from them, called from `ResetCamera`, `ResetCameraClippingRange` and `ResetCameraScreenSpace`. vtk-js had no equivalent.

While adding it, I found a second, unrelated bug: the model transform was being applied transposed.

### Results

**`resetCamera` / `resetCameraClippingRange`.** Before, both derived the camera pose and clipping range from untransformed bounds. With a 10x Z exaggeration on bounds `[-1000, 1000, -1000, 1000, 90, 110]`, `resetCamera` aimed the camera at world Z 100 while the rendered scene center was at 1000 — the scene was mis-framed and clipped. The error is proportional to `(factor − 1)` and vanishes at 1x, which is why it went unnoticed. After, the camera is aimed at the transformed center and the clipping range covers the transformed scene.

**Transposed model transform.** `getViewMatrix` composed `view · Mᵀ` instead of `view · M`. Probing a camera at `(0,0,10)` looking at the origin, with `M = translate(1, 0, 0)` from `vtkTransform`:

```
eye of world origin, actual : [0, 0, -10]
                    view · M   : [1, 0, -10]
                    view · Mᵀ  : [0, 0, -10]   <- what we were producing
```

A pure scale is symmetric, so `M = Mᵀ` and vertical exaggeration worked either way — but rotations and translations were applied transposed.

### Changes

**Behavior change:** `setModelTransformMatrix` now interprets its argument as gl-matrix column-major, consistent with `vtkTransform`, `vtkMatrixBuilder` and `userMatrix` on `vtkProp3D` — and with what `index.d.ts` already declared (`mat4`). This is a silent change for anyone who passed a rotation or translation and pre-transposed to compensate; pure scales are unaffected.

- [x] Documentation and TypeScript definitions were updated to match those changes


### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code


- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Arch Linux
  - **Browser**: Chromium