### PR TITLE
chore(SphereWidget): add missing render in example

### DIFF
--- a/Sources/Widgets/Widgets3D/SphereWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/SphereWidget/example/index.js
@@ -44,6 +44,7 @@ let widget = null;
 let widgetHandle = null;
 
 renderer.resetCamera();
+renderWindow.render();
 
 // -----------------------------------------------------------
 // UI control handling


### PR DESCRIPTION
### Context
In SphereWidget example, the cube does not appear without interacting without moving the camera due to a missing render.

### Results
The scene is now correctly displayed on load.

### Changes
Added a missing render

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code