### PR TITLE
chore(examples): fix EventEmitter error in built examples

### DIFF
--- a/Documentation/scripts/build-examples.mjs
+++ b/Documentation/scripts/build-examples.mjs
@@ -2,6 +2,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import nodePolyfills from '@rolldown/plugin-node-polyfills';
 import { fileURLToPath } from 'url';
 import { build as viteBuild } from 'vite';
 
@@ -210,6 +211,7 @@ function createExamplePlugins() {
   return [
     ...createVtkPlugins({ includeCjson: true }),
     inlineExtractedCssPlugin(),
+    { ...nodePolyfills(), enforce: 'pre' },
   ];
 }
 


### PR DESCRIPTION
### Context
Some examples fail to load due to an EventEmitter heritage error.
This was supposed to fixed in 14028ec, but it only fixed it for examples ran with `npm run example` not in `build-examples` version.

### Results
The error is fixed in `build-examples` mode

### Changes
Added `nodePolyFills` to example plugins use in `viteBuild` in `build-examples.mjs`, mirroring `createEsmConfig` and `createUmdConfig`

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
