### PR TITLE
perf(OpenGL/Helper): read the depth mask only for point picking

### DIFF
--- a/Sources/Rendering/OpenGL/Helper/index.js
+++ b/Sources/Rendering/OpenGL/Helper/index.js
@@ -44,8 +44,12 @@ function vtkOpenGLHelper(publicAPI, model) {
       const mode = publicAPI.getOpenGLMode(rep);
       const wideLines = publicAPI.haveWideLines(ren, actor);
       const gl = model.context;
-      const depthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
+      // Point picking temporarily disables depth writes. Save and restore the
+      // depth mask only for that case because gl.getParameter synchronizes the
+      // CPU and GPU, and that synchronization is slow.
+      let depthMask;
       if (model.pointPicking) {
+        depthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
         gl.depthMask(false);
       }
       const drawingLines = mode === gl.LINES;


### PR DESCRIPTION
`vtkOpenGLHelper` reads `DEPTH_WRITEMASK` before every draw. Normal draws do not change the depth mask, so that readback is unnecessary. The readback runs once per drawn polydata, so a 200-actor scene issues 200 of them per frame.

This change reads and restores the depth mask only for point picking, where vtk.js temporarily disables depth writes.

#### Why the readback is expensive

In a standalone vtk.js app the readback costs nothing measurable: Chromium answers `getParameter` from client-side state on an uncontended context. The stall appears when vtk.js draws inside another renderer's frame, for example a MapLibre custom layer:

1. The host renders first and leaves a deep queue of GPU commands (terrain, tiles).
2. The host calls the custom layer, and vtk.js draws into the same context.
3. The first draw calls `getParameter(DEPTH_WRITEMASK)`. With a deep queue, Chromium cannot answer from client-side state, so the query round-trips to the GPU process.
4. **Bottleneck:** the query cannot return until the GPU process works through every queued host command. The first query of the frame blocks the main thread for tens of milliseconds.
5. Every later draw repeats the query, and the draws themselves refill the queue, so per-draw queries keep re-paying smaller stalls (~0.2 ms each).

```text
host draws (deep GPU queue)
  └─ vtk.js draw #1 ─ getParameter ── waits for whole queue ← 20–140 ms
     vtk.js draw #2 ─ getParameter ── waits for draw #1     ← ~0.2 ms
     vtk.js draw #N ─ getParameter ── ...                   × N actors
```
