### PR TITLE
fix(RenderWindowInteractor): preserve first mouse move

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -756,9 +756,11 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     if (model.moveTimeoutID === 0) {
       publicAPI.startMouseMoveEvent(callData);
     } else {
-      publicAPI.mouseMoveEvent(callData);
       clearTimeout(model.moveTimeoutID);
     }
+    // StartMouseMove is only a burst marker; every move must also fire
+    // MouseMove or subscribers lose the first move of the burst.
+    publicAPI.mouseMoveEvent(callData);
 
     // start a timer to keep us animating while we get mouse move events
     model.moveTimeoutID = setTimeout(() => {

--- a/Sources/Rendering/Core/RenderWindowInteractor/test/testChordedButtons.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/test/testChordedButtons.js
@@ -144,6 +144,31 @@ it('Test RenderWindowInteractor single button (no false chorded events)', () => 
   teardown(env);
 });
 
+it('Test RenderWindowInteractor reports the first move of a burst', () => {
+  const env = setupInteractor();
+  const { container, interactor } = env;
+
+  const events = [];
+  const subs = [
+    interactor.onStartMouseMove(() => events.push('StartMouseMove')),
+    interactor.onMouseMove(() => events.push('MouseMove')),
+  ];
+
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 0 })
+  );
+  expect(events).toEqual(['StartMouseMove', 'MouseMove']);
+
+  events.length = 0;
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 0 })
+  );
+  expect(events).toEqual(['MouseMove']);
+
+  subs.forEach((subscription) => subscription.unsubscribe());
+  teardown(env);
+});
+
 it('Test RenderWindowInteractor three-button chord', () => {
   const env = setupInteractor();
   const { container, interactor } = env;


### PR DESCRIPTION
`handleMouseMove` groups pointer moves into bursts with a 200 ms timer. Since 0564e3d2 introduced the burst markers, the first move of a burst fired only `startMouseMoveEvent`, replacing the `mouseMoveEvent` that fired for every move before that change. `MouseMove` subscribers never see the first move after 200 ms of pointer rest:

- Camera styles diff against their stored previous position, so a drag picks the motion up one event late.
- Per-event consumers, such as `WidgetManager` hover picking, miss single moves entirely: one small pointer nudge after rest produces no `MouseMove` at all.

This change fires `mouseMoveEvent` for every move. `startMouseMoveEvent` still marks the burst boundary and the end timer is unchanged. Subscribers now receive both `StartMouseMove` and `MouseMove` for the first event of a burst.

Existing consumers that use `StartMouseMove`/`EndMouseMove` as animation-lifecycle markers keep working unchanged. Consumers of `MouseMove` (Camera styles, `WidgetManager` hover picking) now also see the first move.

A new test in `testChordedButtons.js` asserts the first move of a burst produces `StartMouseMove` then `MouseMove`, and a following move produces only `MouseMove`.