### PR TITLE
chore(WidgetRepresentation): fix example representations scale and initial render

### DIFF
--- a/Sources/Widgets/Representations/WidgetRepresentation/example/index.js
+++ b/Sources/Widgets/Representations/WidgetRepresentation/example/index.js
@@ -71,11 +71,13 @@ const compositeState = vtkStateBuilder
 const widgetSphereRep = vtkSphereHandleRepresentation.newInstance();
 widgetSphereRep.setInputData(compositeState);
 widgetSphereRep.setLabels(['all']);
+widgetSphereRep.setScaleInPixels(false);
 widgetSphereRep.getActors().forEach(renderer.addActor);
 
 const widgetCubeRep = vtkCubeHandleRepresentation.newInstance();
 widgetCubeRep.setInputData(compositeState);
 widgetCubeRep.setLabels('all');
+widgetCubeRep.setScaleInPixels(false);
 widgetCubeRep.getActors().forEach(renderer.addActor);
 
 const reps = { sphere: widgetSphereRep, cube: widgetCubeRep };
@@ -291,3 +293,7 @@ groupC
   .add(stateParams, 'COriginZ', -1, 1, 0.1)
   .name('Origin Z')
   .onChange(() => applyStateField('c', 'C'));
+
+applyStateField('a', 'A');
+applyStateField('b', 'B');
+applyStateField('c', 'C');


### PR DESCRIPTION
### Context
There are 2 issues in the example of WidgetRepresentation:

- The initial lil gui widgets state is not coherent with what is displayed in the scene (unchecking Active at first does nothing)
- The size of the representations is proportionnal to their Origin X

### Results
The scene is now initialized correctly with lil-gui widgets' state and representations' scale is only dictated by the Scale sliders.

### Changes
Calling applyStateField at initialization fixes the 1st point.

Setting scaleInPixels to false fixes the second.

This PR fixes #3582 
