### PR TITLE
fix(camera): fix setPositionAndFocalPoint

### DIFF
--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -108,8 +108,9 @@ function vtkCamera(publicAPI, model) {
   };
 
   publicAPI.setPositionAndFocalPoint = (position, focalPoint) => {
-    if (setPosition(...position) || setFocalPoint(...focalPoint)) {
-      // recompute the focal distance
+    const modifiedPosition = setPosition(...position);
+    const modifiedFocalPoint = setFocalPoint(...focalPoint);
+    if (modifiedPosition || modifiedFocalPoint) {
       publicAPI.computeDistance();
       publicAPI.modified();
       return true;


### PR DESCRIPTION
### Context
vtkCamera's setPositionAndFocalPoint introduced in #3554 does not work as intended. setFocalPoint is not called if setPosition returns true, due to the if structure.

### Results
Both methods are now always called.

### Changes
Separated the calls from the if.