### PR TITLE
fix(ResliceCursorWidget): add missing render in examples

### DIFF
--- a/Examples/Widgets/ResliceCursorWidgetLabelmap/index.js
+++ b/Examples/Widgets/ResliceCursorWidgetLabelmap/index.js
@@ -656,6 +656,7 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
 
     view3D.renderer.resetCamera();
     view3D.renderer.resetCameraClippingRange();
+    view3D.renderWindow.render();
   });
 });
 

--- a/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
+++ b/Sources/Widgets/Widgets3D/ResliceCursorWidget/example/index.js
@@ -462,6 +462,7 @@ reader.setUrl(`${__BASE_PATH__}/data/volume/LIDC2.vti`).then(() => {
 
     view3D.renderer.resetCamera();
     view3D.renderer.resetCameraClippingRange();
+    view3D.renderWindow.render();
 
     // set max number of slices to slider.
     const maxNumberOfSlices = vec3.length(image.getDimensions());


### PR DESCRIPTION
### Context
The 3D view in ResliceCursorWidget's and ResliceCursorWidgetLabelmap's examples is not rendered properly on first initialization.

### Results
3D views are properly rendered initially.

### Changes
Added a missing render call.