### PR TITLE
chore(VolumeContour): add missing listen to example GUI

### DIFF
--- a/Examples/Volume/VolumeContour/index.js
+++ b/Examples/Volume/VolumeContour/index.js
@@ -39,6 +39,7 @@ const params = { IsoValue: 0.0 };
 const isoCtrl = gui
   .add(params, 'IsoValue', 0.0, 1.0, 0.05)
   .name('Iso value')
+  .listen()
   .onChange((v) => {
     const isoValue = Number(v);
     marchingCube.setContourValue(isoValue);


### PR DESCRIPTION
### Context
In VolumeContour's example, the initial iso value is not updated when the data is finished loading.

### Results
ISO value is correctly initialized to 1308.6666666666667.

### Changes
Added a `.listen()` to the GUI element so that updating `params.IsoValue` updates the UI.