### PR TITLE
chore(Convolution2DPass): fix incorrect initial render in example

### DIFF
--- a/Sources/Rendering/OpenGL/Renderer/index.js
+++ b/Sources/Rendering/OpenGL/Renderer/index.js
@@ -21,6 +21,7 @@ function vtkOpenGLRenderer(publicAPI, model) {
         return;
       }
 
+      model.renderable.updateLightGeometry();
       publicAPI.updateLights();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.renderable.getActiveCamera());

--- a/Sources/Rendering/WebGPU/Renderer/index.js
+++ b/Sources/Rendering/WebGPU/Renderer/index.js
@@ -48,6 +48,7 @@ function vtkWebGPURenderer(publicAPI, model) {
 
       model.camera = model.renderable.getActiveCamera();
 
+      model.renderable.updateLightGeometry();
       publicAPI.updateLights();
       publicAPI.prepareNodes();
       publicAPI.addMissingNode(model.camera);


### PR DESCRIPTION
Add missing renderer.updateLightsGeometryToFollowCamera() to fix incorrect initial render and the first camera interaction changing the lighting of the scene

### Context
In Convolution2DPass example, the ligting of the scene changes after the first camera interaction (rotation or zoom).

<img width="400" height="360" alt="image" src="https://github.com/user-attachments/assets/2fba75da-5d06-4dfe-89f9-aaff9b7c72b4" />
<img width="400" height="360" alt="image" src="https://github.com/user-attachments/assets/ba02bfae-0a23-4272-a6ef-0e66971b0557" />


### Results
The lighting is correct at the first render.

### Changes
Added missing `renderer.updateLightsGeometryToFollowCamera();`