### PR TITLE
chore(ImageResliceMapper): add missing resetCamera and render

### DIFF
--- a/Sources/Rendering/Core/ImageResliceMapper/example/index.js
+++ b/Sources/Rendering/Core/ImageResliceMapper/example/index.js
@@ -170,6 +170,8 @@ ppty.setPiecewiseFunction(ofun);
 ppty.setColorWindow(1400);
 ppty.setColorLevel(-500);
 actor.setProperty(ppty);
+renderer.resetCamera();
+renderWindow.render();
 
 const gui = new GUI();
 const params = {


### PR DESCRIPTION
### Context
In ImageResliceMapper's example, interacting with the scene before the data is loaded can prevent a proper display of the data.

Current initial render
<img width="1914" height="747" alt="image" src="https://github.com/user-attachments/assets/e5d5b531-f73f-4f8a-a55f-0b48d1c0e038" />

Current display after data is finished loading if we dezoom before it is finished
<img width="1918" height="744" alt="image" src="https://github.com/user-attachments/assets/ee6d91b2-258c-4527-8488-238f8fe00fea" />

Fixed initial display
<img width="1911" height="945" alt="image" src="https://github.com/user-attachments/assets/098a4179-3079-451d-8fd3-35e4b7eb7694" />

### Results
Camera is properly reset and data is loaded correctly.

### Changes
Added initial resetCamera and render calls.