### PR TITLE
fix(widgets): do not deactivate widgets when none consume events

### DIFF
--- a/Sources/Widgets/Core/WidgetManager/index.js
+++ b/Sources/Widgets/Core/WidgetManager/index.js
@@ -195,17 +195,16 @@ function vtkWidgetManager(publicAPI, model) {
   };
 
   const handleEvent = async (callData, fromTouchEvent = false) => {
-    if (
-      !model.isAnimating &&
-      model.pickingEnabled &&
-      callData.pokedRenderer === model._renderer
-    ) {
+    if (callData.pokedRenderer !== model._renderer) {
+      deactivateAllWidgets();
+      return macro.VOID;
+    }
+    if (!model.isAnimating && model.pickingEnabled) {
       const callID = Symbol('UpdateSelection');
       model._currentUpdateSelectionCallID = callID;
       await updateSelection(callData, fromTouchEvent, callID);
-    } else {
-      deactivateAllWidgets();
     }
+    return macro.VOID;
   };
 
   function updateWidgetForRender(w) {

--- a/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
+++ b/Sources/Widgets/Widgets3D/PaintWidget/behavior.js
@@ -76,6 +76,7 @@ export default function widgetBehavior(publicAPI, model) {
         model.activeState.get('origin', 'up', 'right', 'direction', 'scale1')
       );
     } else {
+      // Mouse cursor is just hovering, the circle representation was updated above
       return macro.VOID;
     }
 


### PR DESCRIPTION
Fixes the PaintWidget example where a mouse hover anywhere on the window was deactivating the widget. It still seems unclear whether widgets should be deactivated automatically in case of an event over a different renderer, but that behavior was kept.

### Context
See #3573

### Results
Closes #3573

### Changes
Because the "Animating" mode was on, the widgets were deactivated. That need was not expressively stated in https://github.com/Kitware/vtk-js/commit/1d56bbb02c947925c18fd74c0fbe632cc8ebcd80 
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
- [x] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: master
  - **OS**: Windows
  - **Browser**: Firefox
