### PR TITLE
feat(RenderWindowInteractor): add optional mouseWheelSpinYBuffering

### DIFF
--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -58,10 +58,12 @@ export interface IRenderWindowInteractorInitialValues {
   recognizeGestures?: boolean;
   currentGesture?: string;
   lastFrameTime?: number;
-  wheelTimeoutID?: number;
   moveTimeoutID?: number;
   preventDefaultOnPointerDown?: boolean;
   preventDefaultOnPointerUp?: boolean;
+  /**
+   * @deprecated Use wheelEndDebounceDelay = 0 instead.
+   */
   mouseScrollDebounceByPass?: boolean;
   wheelEndDebounceDelay?: number;
   mouseWheelSpinYBuffering?: boolean;
@@ -189,13 +191,14 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 
   /**
    * @default false
+    * @deprecated Use getWheelEndDebounceDelay() instead.
    */
   getMouseScrollDebounceByPass(): boolean;
 
   /**
    * @default 200
    */
-  getWheelEndDebounceDelay(): number;
+    getWheelEndDebounceDelay(): number;
 
   /**
    * @default false
@@ -1079,8 +1082,8 @@ export interface vtkRenderWindowInteractor extends vtkObject {
   /**
    * Allow system to bypass scrolling debounce. This function must be called to allow the debounce to be bypassed
    * @param mouseScrollDebounceByPass
+    * @deprecated Use setWheelEndDebounceDelay(0) instead.
    */
-
   setMouseScrollDebounceByPass(mouseScrollDebounceByPass: boolean): boolean;
 
   /**

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -63,6 +63,8 @@ export interface IRenderWindowInteractorInitialValues {
   preventDefaultOnPointerDown?: boolean;
   preventDefaultOnPointerUp?: boolean;
   mouseScrollDebounceByPass?: boolean;
+  wheelEndDebounceDelay?: number;
+  mouseWheelSpinYBuffering?: boolean;
   longTapDuration?: number;
   longTapDistance?: number;
 }
@@ -189,6 +191,16 @@ export interface vtkRenderWindowInteractor extends vtkObject {
    * @default false
    */
   getMouseScrollDebounceByPass(): boolean;
+
+  /**
+   * @default 200
+   */
+  getWheelEndDebounceDelay(): number;
+
+  /**
+   * @default false
+   */
+  getMouseWheelSpinYBuffering(): boolean;
 
   /**
    * @default 500
@@ -1070,6 +1082,21 @@ export interface vtkRenderWindowInteractor extends vtkObject {
    */
 
   setMouseScrollDebounceByPass(mouseScrollDebounceByPass: boolean): boolean;
+
+  /**
+   * Set the delay (in ms) after the last wheel event before the wheel-end
+   * event is fired.
+   * @param wheelEndDebounceDelay
+   */
+  setWheelEndDebounceDelay(wheelEndDebounceDelay: number): boolean;
+
+  /**
+   * When enabled, fractional spinY deltas from high-frequency wheel events
+   * (e.g. trackpads) are accumulated and only dispatched once they add up to
+   * a full step, instead of firing a mouseWheelEvent for every wheel tick.
+   * @param mouseWheelSpinYBuffering
+   */
+  setMouseWheelSpinYBuffering(mouseWheelSpinYBuffering: boolean): boolean;
 
   /**
    *

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -61,10 +61,6 @@ export interface IRenderWindowInteractorInitialValues {
   moveTimeoutID?: number;
   preventDefaultOnPointerDown?: boolean;
   preventDefaultOnPointerUp?: boolean;
-  /**
-   * @deprecated Use wheelEndDebounceDelay = 0 instead.
-   */
-  mouseScrollDebounceByPass?: boolean;
   wheelEndDebounceDelay?: number;
   mouseWheelSpinYBuffering?: boolean;
   longTapDuration?: number;

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.d.ts
@@ -4,45 +4,45 @@ import vtkRenderer from '../Renderer';
 import { Axis, Device, Input, MouseButton } from './Constants';
 
 declare enum handledEvents {
-  'StartAnimation',
-  'Animation',
-  'EndAnimation',
-  'MouseEnter',
-  'MouseLeave',
-  'StartMouseMove',
-  'MouseMove',
-  'EndMouseMove',
-  'LeftButtonPress',
-  'LeftButtonRelease',
-  'MiddleButtonPress',
-  'MiddleButtonRelease',
-  'RightButtonPress',
-  'RightButtonRelease',
-  'KeyPress',
-  'KeyDown',
-  'KeyUp',
-  'StartMouseWheel',
-  'MouseWheel',
-  'EndMouseWheel',
-  'StartPinch',
-  'Pinch',
-  'EndPinch',
-  'StartPan',
-  'Pan',
-  'EndPan',
-  'Tap',
-  'LongTap',
-  'StartRotate',
-  'Rotate',
-  'EndRotate',
-  'Button3D',
-  'Move3D',
-  'StartPointerLock',
-  'EndPointerLock',
-  'StartInteraction',
-  'Interaction',
-  'EndInteraction',
-  'AnimationFrameRateUpdate',
+  StartAnimation,
+  Animation,
+  EndAnimation,
+  MouseEnter,
+  MouseLeave,
+  StartMouseMove,
+  MouseMove,
+  EndMouseMove,
+  LeftButtonPress,
+  LeftButtonRelease,
+  MiddleButtonPress,
+  MiddleButtonRelease,
+  RightButtonPress,
+  RightButtonRelease,
+  KeyPress,
+  KeyDown,
+  KeyUp,
+  StartMouseWheel,
+  MouseWheel,
+  EndMouseWheel,
+  StartPinch,
+  Pinch,
+  EndPinch,
+  StartPan,
+  Pan,
+  EndPan,
+  Tap,
+  LongTap,
+  StartRotate,
+  Rotate,
+  EndRotate,
+  Button3D,
+  Move3D,
+  StartPointerLock,
+  EndPointerLock,
+  StartInteraction,
+  Interaction,
+  EndInteraction,
+  AnimationFrameRateUpdate,
 }
 
 /**
@@ -191,14 +191,14 @@ export interface vtkRenderWindowInteractor extends vtkObject {
 
   /**
    * @default false
-    * @deprecated Use getWheelEndDebounceDelay() instead.
+   * @deprecated Use getWheelEndDebounceDelay() instead.
    */
   getMouseScrollDebounceByPass(): boolean;
 
   /**
    * @default 200
    */
-    getWheelEndDebounceDelay(): number;
+  getWheelEndDebounceDelay(): number;
 
   /**
    * @default false
@@ -1082,7 +1082,7 @@ export interface vtkRenderWindowInteractor extends vtkObject {
   /**
    * Allow system to bypass scrolling debounce. This function must be called to allow the debounce to be bypassed
    * @param mouseScrollDebounceByPass
-    * @deprecated Use setWheelEndDebounceDelay(0) instead.
+   * @deprecated Use setWheelEndDebounceDelay(0) instead.
    */
   setMouseScrollDebounceByPass(mouseScrollDebounceByPass: boolean): boolean;
 

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -116,6 +116,8 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   // Accumulates fractional spinY deltas when mouseWheelSpinYBuffering is enabled.
   let scrollBuffer = 0;
 
+  let wheelTimeoutID = 0;
+
   // Track mouse button bitmask for detecting chorded button interactions.
   // Per W3C Pointer Events spec §10, pointerdown/pointerup only fire for the
   // first press / last release. Chorded (additional) button changes while
@@ -326,9 +328,10 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   const _unbindEvents = () => {
     // Clear any previous timeouts and state variables that control mouse / touchpad behavior.
     clearTimeout(model.moveTimeoutID);
-    clearTimeout(model.wheelTimeoutID);
+    clearTimeout(wheelTimeoutID);
     model.moveTimeoutID = 0;
-    model.wheelTimeoutID = 0;
+    wheelTimeoutID = 0;
+    scrollBuffer = 0;
     wheelCoefficient = 1.0;
 
     const { container } = model;
@@ -879,7 +882,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     // mouse wheel events have absolute spin values higher than 1.
     // Here the first spin value is "recorded", and used to normalize
     // all the following mouse wheel events.
-    if (model.wheelTimeoutID === 0) {
+    if (wheelTimeoutID === 0) {
       // we attempt to distinguish between trackpads and mice
       // .3 will be larger than the first trackpad event,
       // but small enough to detect some common edge case mice
@@ -893,6 +896,12 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
     callData.spinY /= wheelCoefficient;
 
+    if (wheelTimeoutID === 0) {
+      publicAPI.startMouseWheelEvent(callData);
+    } else {
+      clearTimeout(wheelTimeoutID);
+    }
+
     if (model.mouseWheelSpinYBuffering) {
       // Reset the buffer when the scroll direction reverses so a direction
       // change is never delayed by leftover buffer from the previous one.
@@ -903,42 +912,27 @@ function vtkRenderWindowInteractor(publicAPI, model) {
         scrollBuffer = 0;
       }
       scrollBuffer += callData.spinY;
-    }
 
-    if (model.wheelTimeoutID === 0) {
-      publicAPI.startMouseWheelEvent(callData);
-      if (!model.mouseWheelSpinYBuffering) {
+      if (Math.abs(scrollBuffer) >= SCROLL_THRESHOLD) {
+        callData.spinY = Math.trunc(scrollBuffer);
+        scrollBuffer -= callData.spinY;
         publicAPI.mouseWheelEvent(callData);
       }
     } else {
-      if (!model.mouseWheelSpinYBuffering) {
-        publicAPI.mouseWheelEvent(callData);
-      }
-      clearTimeout(model.wheelTimeoutID);
-    }
-
-    // Only fire once the buffered spin reaches a full step, rounding fractional
-    // high-frequency deltas (e.g. trackpads) into a single integer-sized event.
-    if (
-      model.mouseWheelSpinYBuffering &&
-      Math.abs(scrollBuffer) >= SCROLL_THRESHOLD
-    ) {
-      callData.spinY = Math.sign(scrollBuffer);
-      scrollBuffer -= callData.spinY;
       publicAPI.mouseWheelEvent(callData);
     }
 
-    if (model.mouseScrollDebounceByPass) {
+    if (model.mouseScrollDebounceByPass || model.wheelEndDebounceDelay === 0) {
       publicAPI.extendAnimation(600);
       publicAPI.endMouseWheelEvent();
-      model.wheelTimeoutID = 0;
+      wheelTimeoutID = 0;
       scrollBuffer = 0;
     } else {
       // start a timer to keep us animating while we get wheel events
-      model.wheelTimeoutID = setTimeout(() => {
+      wheelTimeoutID = setTimeout(() => {
         publicAPI.extendAnimation(600);
         publicAPI.endMouseWheelEvent();
-        model.wheelTimeoutID = 0;
+        wheelTimeoutID = 0;
         scrollBuffer = 0;
       }, model.wheelEndDebounceDelay);
     }
@@ -1418,7 +1412,6 @@ const DEFAULT_VALUES = {
   animationRequest: null,
   lastFrameTime: 0.1,
   recentAnimationFrameRate: 10.0,
-  wheelTimeoutID: 0,
   moveTimeoutID: 0,
   lastGamepadValues: {},
   preventDefaultOnPointerDown: false,

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -11,6 +11,9 @@ const { vtkWarningMacro, vtkErrorMacro, normalizeWheel, vtkOnceErrorMacro } =
 // Global methods
 // ----------------------------------------------------------------------------
 
+// Spin amount (in normalized wheel units) needed to trigger a buffered wheel event.
+const SCROLL_THRESHOLD = 1;
+
 const EMPTY_MOUSE_EVENT = {
   ctrlKey: false,
   altKey: false,
@@ -109,6 +112,9 @@ function vtkRenderWindowInteractor(publicAPI, model) {
 
   // Factor to apply on wheel spin.
   let wheelCoefficient = 1;
+
+  // Accumulates fractional spinY deltas when mouseWheelSpinYBuffering is enabled.
+  let scrollBuffer = 0;
 
   // Track mouse button bitmask for detecting chorded button interactions.
   // Per W3C Pointer Events spec §10, pointerdown/pointerup only fire for the
@@ -887,25 +893,54 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
     callData.spinY /= wheelCoefficient;
 
+    if (model.mouseWheelSpinYBuffering) {
+      // Reset the buffer when the scroll direction reverses so a direction
+      // change is never delayed by leftover buffer from the previous one.
+      if (
+        scrollBuffer !== 0 &&
+        Math.sign(callData.spinY) !== Math.sign(scrollBuffer)
+      ) {
+        scrollBuffer = 0;
+      }
+      scrollBuffer += callData.spinY;
+    }
+
     if (model.wheelTimeoutID === 0) {
       publicAPI.startMouseWheelEvent(callData);
-      publicAPI.mouseWheelEvent(callData);
+      if (!model.mouseWheelSpinYBuffering) {
+        publicAPI.mouseWheelEvent(callData);
+      }
     } else {
-      publicAPI.mouseWheelEvent(callData);
+      if (!model.mouseWheelSpinYBuffering) {
+        publicAPI.mouseWheelEvent(callData);
+      }
       clearTimeout(model.wheelTimeoutID);
+    }
+
+    // Only fire once the buffered spin reaches a full step, rounding fractional
+    // high-frequency deltas (e.g. trackpads) into a single integer-sized event.
+    if (
+      model.mouseWheelSpinYBuffering &&
+      Math.abs(scrollBuffer) >= SCROLL_THRESHOLD
+    ) {
+      callData.spinY = Math.sign(scrollBuffer);
+      scrollBuffer -= callData.spinY;
+      publicAPI.mouseWheelEvent(callData);
     }
 
     if (model.mouseScrollDebounceByPass) {
       publicAPI.extendAnimation(600);
       publicAPI.endMouseWheelEvent();
       model.wheelTimeoutID = 0;
+      scrollBuffer = 0;
     } else {
       // start a timer to keep us animating while we get wheel events
       model.wheelTimeoutID = setTimeout(() => {
         publicAPI.extendAnimation(600);
         publicAPI.endMouseWheelEvent();
         model.wheelTimeoutID = 0;
-      }, 200);
+        scrollBuffer = 0;
+      }, model.wheelEndDebounceDelay);
     }
   };
 
@@ -1389,6 +1424,8 @@ const DEFAULT_VALUES = {
   preventDefaultOnPointerDown: false,
   preventDefaultOnPointerUp: false,
   mouseScrollDebounceByPass: false,
+  wheelEndDebounceDelay: 200,
+  mouseWheelSpinYBuffering: false,
   longTapDuration: 500,
   longTapMaximumDistance: 30,
 };
@@ -1431,6 +1468,8 @@ export function extend(publicAPI, model, initialValues = {}) {
     'preventDefaultOnPointerDown',
     'preventDefaultOnPointerUp',
     'mouseScrollDebounceByPass',
+    'wheelEndDebounceDelay',
+    'mouseWheelSpinYBuffering',
     'longTapDuration',
     'longTapMaximumDistance',
   ]);

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -902,7 +902,11 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       clearTimeout(wheelTimeoutID);
     }
 
+    let triggerMouseWheelEvent = true;
+
     if (model.mouseWheelSpinYBuffering) {
+      triggerMouseWheelEvent = false;
+
       // Reset the buffer when the scroll direction reverses so a direction
       // change is never delayed by leftover buffer from the previous one.
       if (
@@ -916,9 +920,11 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       if (Math.abs(scrollBuffer) >= SCROLL_THRESHOLD) {
         callData.spinY = Math.trunc(scrollBuffer);
         scrollBuffer -= callData.spinY;
-        publicAPI.mouseWheelEvent(callData);
+        triggerMouseWheelEvent = true;
       }
-    } else {
+    }
+
+    if (triggerMouseWheelEvent) {
       publicAPI.mouseWheelEvent(callData);
     }
 
@@ -1467,6 +1473,16 @@ export function extend(publicAPI, model, initialValues = {}) {
     'longTapMaximumDistance',
   ]);
   macro.moveToProtected(publicAPI, model, ['view']);
+
+  // mouseScrollDebounceByPass is deprecated; warn while preserving the
+  // original setter's boolean return value (macro.chain would return an array).
+  const setMouseScrollDebounceByPass = publicAPI.setMouseScrollDebounceByPass;
+  publicAPI.setMouseScrollDebounceByPass = (...args) => {
+    vtkWarningMacro(
+      'mouseScrollDebounceByPass is deprecated. Use wheelEndDebounceDelay instead.'
+    );
+    return setMouseScrollDebounceByPass(...args);
+  };
 
   // For more macro methods, see "Sources/macros.js"
 

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -928,7 +928,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
       publicAPI.mouseWheelEvent(callData);
     }
 
-    if (model.mouseScrollDebounceByPass || model.wheelEndDebounceDelay === 0) {
+    if (model.wheelEndDebounceDelay === 0) {
       publicAPI.extendAnimation(600);
       publicAPI.endMouseWheelEvent();
       wheelTimeoutID = 0;
@@ -1422,7 +1422,6 @@ const DEFAULT_VALUES = {
   lastGamepadValues: {},
   preventDefaultOnPointerDown: false,
   preventDefaultOnPointerUp: false,
-  mouseScrollDebounceByPass: false,
   wheelEndDebounceDelay: 200,
   mouseWheelSpinYBuffering: false,
   longTapDuration: 500,
@@ -1466,7 +1465,6 @@ export function extend(publicAPI, model, initialValues = {}) {
     'picker',
     'preventDefaultOnPointerDown',
     'preventDefaultOnPointerUp',
-    'mouseScrollDebounceByPass',
     'wheelEndDebounceDelay',
     'mouseWheelSpinYBuffering',
     'longTapDuration',
@@ -1474,14 +1472,16 @@ export function extend(publicAPI, model, initialValues = {}) {
   ]);
   macro.moveToProtected(publicAPI, model, ['view']);
 
-  // mouseScrollDebounceByPass is deprecated; warn while preserving the
-  // original setter's boolean return value (macro.chain would return an array).
-  const setMouseScrollDebounceByPass = publicAPI.setMouseScrollDebounceByPass;
-  publicAPI.setMouseScrollDebounceByPass = (...args) => {
+  // mouseScrollDebounceByPass is deprecated; delegate to wheelEndDebounceDelay.
+  publicAPI.getMouseScrollDebounceByPass = () =>
+    model.wheelEndDebounceDelay === 0;
+  publicAPI.setMouseScrollDebounceByPass = (byPass) => {
     vtkWarningMacro(
       'mouseScrollDebounceByPass is deprecated. Use wheelEndDebounceDelay instead.'
     );
-    return setMouseScrollDebounceByPass(...args);
+    return publicAPI.setWheelEndDebounceDelay(
+      byPass ? 0 : DEFAULT_VALUES.wheelEndDebounceDelay
+    );
   };
 
   // For more macro methods, see "Sources/macros.js"


### PR DESCRIPTION
## Motivation

High-frequency wheel input devices (e.g. trackpads) can emit many small fractional spinY deltas in quick succession. Consumers of tkRenderWindowInteractor that map wheel events directly to camera zoom/dolly can end up with jittery or overly sensitive interactions as a result.

## Change

- Adds an opt-in mouseWheelSpinYBuffering flag (default alse). When enabled, fractional spinY deltas are accumulated per interactor instance and a mouseWheelEvent is only dispatched once the buffered spin reaches a full step (rounded via Math.sign). The buffer resets when the scroll direction reverses and when the wheel-end debounce fires.
- Adds a configurable wheelEndDebounceDelay (default 200, matching the previous hardcoded value) so consumers can tune how long to wait after the last wheel event before the wheel-end event fires.
- Updates the corresponding TypeScript definitions (index.d.ts).

## Backward compatibility

Both new properties default to values that reproduce the current behavior exactly (mouseWheelSpinYBuffering: false disables buffering entirely; wheelEndDebounceDelay: 200 matches the previous hardcoded timeout), so no existing consumer behavior changes unless they opt in.

## Testing

- 
pm run reformat and lint (oxlint) pass with no issues.
- Manually verified against a downstream application that previously carried this behavior as a local patch; setting mouseWheelSpinYBuffering(true) reproduces that smoothing behavior.