### PR TITLE
fix(WebGPU): apply camera physical scale to custom projection

### DIFF
--- a/Sources/Rendering/Core/Camera/index.d.ts
+++ b/Sources/Rendering/Core/Camera/index.d.ts
@@ -1,6 +1,6 @@
 import { mat4 } from 'gl-matrix';
 import { vtkObject } from '../../../interfaces';
-import { Bounds, Vector3, Range } from '../../../types';
+import { Bounds, Nullable, Vector3, Range } from '../../../types';
 
 /**
  *
@@ -141,6 +141,12 @@ export interface vtkCamera extends vtkObject {
   getDistance(): number;
 
   /**
+   * Get the explicit projection matrix, or null when the camera computes
+   * its projection from its standard parameters.
+   */
+  getExplicitProjectionMatrix(): Nullable<mat4>;
+
+  /**
    * Get the focal of the camera in world coordinates.
    */
   getFocalPoint(): Vector3;
@@ -241,8 +247,15 @@ export interface vtkCamera extends vtkObject {
    * @param {Number} aspect Camera frustum aspect ratio.
    * @param {Number} nearz Camera frustum near plane.
    * @param {Number} farz Camera frustum far plane.
+   * @param {mat4} [out] Optional output matrix to mutate and return, instead
+   * of allocating a new one.
    */
-  getProjectionMatrix(aspect: number, nearz: number, farz: number): mat4;
+  getProjectionMatrix(
+    aspect: number,
+    nearz: number,
+    farz: number,
+    out?: mat4
+  ): mat4;
 
   /**
    * Not implemented yet
@@ -566,10 +579,15 @@ export interface vtkCamera extends vtkObject {
   setPositionAndFocalPoint(position: number[], focalPoint: number[]): boolean;
 
   /**
-   *
-   * @param {mat4} mat
+   * Set the explicit projection matrix, or null to use a projection computed
+   * from the camera's standard parameters.
    */
-  setProjectionMatrix(mat: mat4): boolean;
+  setExplicitProjectionMatrix(mat: Nullable<mat4>): boolean;
+
+  /**
+   * @deprecated Use setExplicitProjectionMatrix instead.
+   */
+  setProjectionMatrix(mat: Nullable<mat4>): boolean;
 
   /**
    * Set the roll angle of the camera about the direction of projection.

--- a/Sources/Rendering/Core/Camera/index.js
+++ b/Sources/Rendering/Core/Camera/index.js
@@ -3,9 +3,13 @@ import { quat, vec3, vec4, mat4 } from 'gl-matrix';
 import macro from 'vtk.js/Sources/macros';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
 
-const { vtkDebugMacro } = macro;
+const { vtkDebugMacro, vtkWarningMacro } = macro;
 
 /* eslint-disable new-cap */
+
+// vtkWarningMacro doesn't dedupe; without this, callers such as the WebXR
+// frame loop would spam the console.
+let warned = false;
 
 /*
  * Convenience function to access elements of a gl-matrix.  If it turns
@@ -557,23 +561,34 @@ function vtkCamera(publicAPI, model) {
   };
 
   publicAPI.setProjectionMatrix = (mat) => {
-    model.projectionMatrix = mat;
+    if (!warned) {
+      warned = true;
+      vtkWarningMacro(
+        'setProjectionMatrix() is deprecated. Use setExplicitProjectionMatrix() instead.'
+      );
+    }
+    return publicAPI.setExplicitProjectionMatrix(mat);
   };
 
-  publicAPI.getProjectionMatrix = (aspect, nearz, farz) => {
-    const result = new Float64Array(16);
-    mat4.identity(result);
+  publicAPI.getProjectionMatrix = (
+    aspect,
+    nearz,
+    farz,
+    out = new Float64Array(16)
+  ) => {
+    const result = out;
 
-    if (model.projectionMatrix) {
+    if (model.explicitProjectionMatrix) {
       const scale = 1 / model.physicalScale;
       vec3.set(tmpvec1, scale, scale, scale);
 
-      mat4.copy(result, model.projectionMatrix);
+      mat4.copy(result, model.explicitProjectionMatrix);
       mat4.scale(result, result, tmpvec1);
       mat4.transpose(result, result);
       return result;
     }
 
+    mat4.identity(result);
     mat4.identity(tmpMatrix);
 
     // FIXME: Not sure what to do about adjust z buffer here
@@ -795,7 +810,7 @@ export const DEFAULT_VALUES = {
   screenBottomRight: [0.5, -0.5, -0.5],
   screenTopRight: [0.5, 0.5, -0.5],
   freezeFocalPoint: false,
-  projectionMatrix: null,
+  explicitProjectionMatrix: null,
   viewMatrix: null,
   modelTransformMatrix: null,
   cameraLightTransform: mat4.create(),
@@ -826,6 +841,7 @@ export function extend(publicAPI, model, initialValues = {}) {
     'freezeFocalPoint',
     'physicalScale',
     'modelTransformMatrix',
+    'explicitProjectionMatrix',
   ]);
 
   macro.getArray(publicAPI, model, [

--- a/Sources/Rendering/Core/Camera/test/testExplicitProjectionMatrix.js
+++ b/Sources/Rendering/Core/Camera/test/testExplicitProjectionMatrix.js
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mat4 } from 'gl-matrix';
+import macro from 'vtk.js/Sources/macros';
+import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
+import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
+
+let camera;
+
+describe('Camera Explicit Projection Matrix', () => {
+  beforeEach(() => {
+    camera = vtkCamera.newInstance();
+  });
+
+  describe('getProjectionMatrix with an explicit matrix', () => {
+    it('scales the explicit matrix by 1/physicalScale', () => {
+      // Stands in for a projection supplied by a caller, such as
+      // WebXR's XRView.projectionMatrix.
+      const explicit = mat4.perspective(
+        mat4.create(),
+        Math.PI / 3,
+        1.5,
+        0.5,
+        75
+      );
+      camera.setExplicitProjectionMatrix(explicit);
+      camera.setPhysicalScale(2.5);
+
+      const result = camera.getProjectionMatrix(1.5, -1, 1);
+
+      // Reimplemented independently, so this isn't a tautological test.
+      const scale = 1 / 2.5;
+      const expected = mat4.scale(mat4.create(), explicit, [
+        scale,
+        scale,
+        scale,
+      ]);
+      mat4.transpose(expected, expected);
+
+      expect(areEquals(result, expected)).toBe(true);
+      // Sanity: the scale must actually have an effect (not silently 1:1).
+      expect(areEquals(result, mat4.transpose(mat4.create(), explicit))).toBe(
+        false
+      );
+    });
+
+    it('leaves the explicit matrix unscaled at the default physicalScale of 1', () => {
+      const explicit = mat4.ortho(mat4.create(), -2, 2, -1, 1, 0.1, 50);
+      camera.setExplicitProjectionMatrix(explicit);
+
+      const result = camera.getProjectionMatrix(1.0, -1, 1);
+      const expected = mat4.transpose(mat4.create(), explicit);
+
+      expect(areEquals(result, expected)).toBe(true);
+    });
+
+    it('reverts to the computed projection once the explicit matrix is cleared', () => {
+      camera.setClippingRange(0.1, 100);
+      camera.setViewAngle(40);
+      const computed = camera.getProjectionMatrix(1.2, -1, 1);
+
+      camera.setExplicitProjectionMatrix(mat4.create());
+      expect(areEquals(camera.getProjectionMatrix(1.2, -1, 1), computed)).toBe(
+        false
+      );
+
+      camera.setExplicitProjectionMatrix(null);
+      expect(areEquals(camera.getProjectionMatrix(1.2, -1, 1), computed)).toBe(
+        true
+      );
+    });
+  });
+
+  describe('getProjectionMatrix out parameter', () => {
+    it('writes into an output buffer supplied by the caller and returns it', () => {
+      camera.setClippingRange(0.1, 100);
+      const out = new Float64Array(16);
+
+      const result = camera.getProjectionMatrix(1.33, -1, 1, out);
+
+      expect(result).toBe(out);
+      expect(areEquals(result, camera.getProjectionMatrix(1.33, -1, 1))).toBe(
+        true
+      );
+    });
+
+    it('writes an explicit matrix result into an output buffer supplied by the caller', () => {
+      const explicit = mat4.perspective(mat4.create(), Math.PI / 4, 1, 1, 10);
+      camera.setExplicitProjectionMatrix(explicit);
+      const out = new Float64Array(16);
+
+      const result = camera.getProjectionMatrix(1, -1, 1, out);
+
+      expect(result).toBe(out);
+      expect(areEquals(result, camera.getProjectionMatrix(1, -1, 1))).toBe(
+        true
+      );
+    });
+
+    it('still allocates its own buffer when no out is given (backward compatible)', () => {
+      camera.setClippingRange(0.1, 100);
+      const a = camera.getProjectionMatrix(1, -1, 1);
+      const b = camera.getProjectionMatrix(1, -1, 1);
+
+      expect(a).not.toBe(b);
+      expect(areEquals(a, b)).toBe(true);
+    });
+  });
+
+  describe('setProjectionMatrix (deprecated)', () => {
+    it('routes through to explicitProjectionMatrix', () => {
+      const explicit = mat4.perspective(mat4.create(), 1, 1, 1, 20);
+
+      camera.setProjectionMatrix(explicit);
+
+      // Plain setGet, no defensive copy: same reference back.
+      expect(camera.getExplicitProjectionMatrix()).toBe(explicit);
+      const expected = mat4.transpose(mat4.create(), explicit);
+      expect(areEquals(camera.getProjectionMatrix(1, -1, 1), expected)).toBe(
+        true
+      );
+    });
+
+    it('accepts null, matching WebXR frame loop teardown usage', () => {
+      camera.setProjectionMatrix(mat4.create());
+      expect(camera.getExplicitProjectionMatrix()).not.toBeNull();
+
+      camera.setProjectionMatrix(null);
+      expect(camera.getExplicitProjectionMatrix()).toBeNull();
+    });
+
+    it('warns at most once no matter how many times it is called', () => {
+      const warnings = [];
+      macro.setLoggerFunction('warn', (...args) =>
+        warnings.push(args.join(' '))
+      );
+      try {
+        camera.setProjectionMatrix(mat4.create());
+        const afterFirstCall = warnings.length;
+
+        // Called every frame by WebXR; repeated calls must not add further warnings.
+        camera.setProjectionMatrix(mat4.create());
+        camera.setProjectionMatrix(null);
+        camera.setProjectionMatrix(mat4.create());
+
+        expect(afterFirstCall).toBeLessThanOrEqual(1);
+        expect(warnings.length).toBe(afterFirstCall);
+      } finally {
+        macro.setLoggerFunction('warn', console.warn);
+      }
+    });
+  });
+});

--- a/Sources/Rendering/WebGPU/Camera/index.js
+++ b/Sources/Rendering/WebGPU/Camera/index.js
@@ -5,6 +5,12 @@ import vtkViewNode from 'vtk.js/Sources/Rendering/SceneGraph/ViewNode';
 
 import { registerOverride } from 'vtk.js/Sources/Rendering/WebGPU/ViewNodeFactory';
 
+// Reversed Z backend (see RenderEncoder) vs. Core/Camera's GL style output
+// (near/far -> -1/+1): z' = 0.5*w - 0.5*z remaps one into the other.
+const Z_REMAP = mat4.create();
+Z_REMAP[10] = -0.5;
+Z_REMAP[14] = 0.5;
+
 // ----------------------------------------------------------------------------
 // vtkWebGPUCamera methods
 // ----------------------------------------------------------------------------
@@ -14,6 +20,18 @@ function vtkWebGPUCamera(publicAPI, model) {
   model.classHierarchy.push('vtkWebGPUCamera');
 
   publicAPI.getProjectionMatrix = (outMat, aspect, cRange, windowCenter) => {
+    const explicitProjectionMatrix =
+      model.renderable.getExplicitProjectionMatrix?.();
+    if (explicitProjectionMatrix) {
+      // Delegate to Core rather than duplicate its copy + physicalScale
+      // scaling; the second transpose cancels Core's own (same trick
+      // WebGL/Camera uses).
+      model.renderable.getProjectionMatrix(aspect, -1, 1, outMat);
+      mat4.transpose(outMat, outMat);
+      mat4.multiply(outMat, Z_REMAP, outMat);
+      return;
+    }
+
     mat4.identity(outMat);
     if (model.renderable.getParallelProjection()) {
       // set up a rectangular parallelipiped
@@ -31,8 +49,10 @@ function vtkWebGPUCamera(publicAPI, model) {
       outMat[0] = 2.0 * xr;
       outMat[5] = 2.0 * yr;
       outMat[10] = 1.0 / (cRange[1] - cRange[0]);
-      outMat[12] = (xmax + xmin) * xr;
-      outMat[13] = (ymax + ymin) * yr;
+      // Sign matches gl-matrix's mat4.ortho and Core: positive windowCenter
+      // shifts NDC negative.
+      outMat[12] = -(xmax + xmin) * xr;
+      outMat[13] = -(ymax + ymin) * yr;
       outMat[14] = cRange[1] / (cRange[1] - cRange[0]);
     } else {
       const tmp = Math.tan((Math.PI * model.renderable.getViewAngle()) / 360.0);
@@ -63,7 +83,13 @@ function vtkWebGPUCamera(publicAPI, model) {
   };
 
   publicAPI.convertToOpenGLDepth = (val) => {
-    if (model.renderable.getParallelProjection()) {
+    // The remap above is affine in depth after division, so inverting it gives
+    // the same "1 - val" formula parallel projection uses for affine
+    // explicit matrices only (matches Core's oblique projection check).
+    if (
+      model.renderable.getParallelProjection() ||
+      model.renderable.getExplicitProjectionMatrix?.()
+    ) {
       return 1.0 - val;
     }
     const cRange = model.renderable.getClippingRangeByReference();

--- a/Sources/Rendering/WebGPU/Camera/test/testExplicitProjectionMatrix.js
+++ b/Sources/Rendering/WebGPU/Camera/test/testExplicitProjectionMatrix.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mat4, vec3, vec4 } from 'gl-matrix';
+import { areEquals } from 'vtk.js/Sources/Common/Core/Math';
+import vtkCamera from 'vtk.js/Sources/Rendering/Core/Camera';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkWebGPUCamera from 'vtk.js/Sources/Rendering/WebGPU/Camera';
+
+// Pure JS until a render is requested, so this can be tested directly
+// without a WebGPU adapter (contrast testImageMapperCameraProjection.js).
+
+const ASPECT = 1.3;
+
+// The matrix library defaults to Float32Array; use Float64Array here to match
+// production precision and avoid error during conversion in both directions.
+const vec3f64 = () => new Float64Array(3);
+const vec4f64 = () => new Float64Array(4);
+
+function makeWebGPUCamera(coreCamera) {
+  const webgpuCamera = vtkWebGPUCamera.newInstance();
+  webgpuCamera.setRenderable(coreCamera);
+  return webgpuCamera;
+}
+
+// Simulates this backend's projection (native or delegated) without a real GPU.
+function projectWithWebGPU(coreCamera, webgpuCamera, worldPoint) {
+  const view = coreCamera.getViewMatrix();
+  mat4.transpose(view, view); // Core's getViewMatrix is transposed once already
+  const viewSpace = vec3.transformMat4(vec3f64(), worldPoint, view);
+
+  const outMat = new Float64Array(16);
+  webgpuCamera.getProjectionMatrix(
+    outMat,
+    ASPECT,
+    coreCamera.getClippingRangeByReference(),
+    coreCamera.getWindowCenterByReference()
+  );
+  const clip = vec4.transformMat4(
+    vec4f64(),
+    [viewSpace[0], viewSpace[1], viewSpace[2], 1],
+    outMat
+  );
+  return {
+    hardwareDepth: clip[2] / clip[3],
+    ndcX: clip[0] / clip[3],
+    ndcY: clip[1] / clip[3],
+  };
+}
+
+// Backend independent half of picking, once handed standard 0=near,1=far
+// depth; z*2-1 below mirrors Viewport.normalizedViewportToProjection.
+function unproject(renderer, ndcX, ndcY, standardDepth) {
+  const glZ = standardDepth * 2.0 - 1.0;
+  const viewPos = renderer.projectionToView(ndcX, ndcY, glZ, ASPECT);
+  return renderer.viewToWorld(viewPos[0], viewPos[1], viewPos[2]);
+}
+
+// Mirrors WebGPU/HardwareSelector: project, read depth, convertToOpenGLDepth, unproject.
+function pickWorldPosition(renderer, webgpuCamera, worldPoint) {
+  const coreCamera = renderer.getActiveCamera();
+  const { hardwareDepth, ndcX, ndcY } = projectWithWebGPU(
+    coreCamera,
+    webgpuCamera,
+    worldPoint
+  );
+  const standardDepth = webgpuCamera.convertToOpenGLDepth(hardwareDepth);
+  return unproject(renderer, ndcX, ndcY, standardDepth);
+}
+
+describe('WebGPU Camera explicit projection matrix', () => {
+  let renderer;
+  let camera;
+  let webgpuCamera;
+
+  beforeEach(() => {
+    renderer = vtkRenderer.newInstance();
+    camera = vtkCamera.newInstance();
+    renderer.setActiveCamera(camera);
+    webgpuCamera = makeWebGPUCamera(camera);
+  });
+
+  describe.each([
+    ['perspective', false],
+    ['parallel', true],
+  ])('%s projection', (_label, parallelProjection) => {
+    beforeEach(() => {
+      camera.setPosition(0, 0, 10);
+      camera.setFocalPoint(0, 0, 0);
+      camera.setViewUp(0, 1, 0);
+      camera.setParallelProjection(parallelProjection);
+      camera.setParallelScale(3);
+      camera.setViewAngle(45);
+      camera.setClippingRange(1, 100);
+    });
+
+    it('maps the near clipping plane to reversed Z hardware depth 1, decreasing towards far', () => {
+      const [near, far] = camera.getClippingRangeByReference();
+      const nearWorld = [0, 0, 10 - near];
+      const farWorld = [0, 0, 10 - far];
+
+      const { hardwareDepth: nearDepth } = projectWithWebGPU(
+        camera,
+        webgpuCamera,
+        nearWorld
+      );
+      const { hardwareDepth: farDepth } = projectWithWebGPU(
+        camera,
+        webgpuCamera,
+        farWorld
+      );
+
+      // Reversed Z: near is always 1. Parallel far is 0; perspective's
+      // 1/depth parametrization only approaches 0 -- at far it's near/far.
+      expect(nearDepth).toBeCloseTo(1, 9);
+      const expectedFarDepth = parallelProjection ? 0 : near / far;
+      expect(farDepth).toBeCloseTo(expectedFarDepth, 9);
+      expect(farDepth).toBeLessThan(nearDepth);
+
+      // Both convertToOpenGLDepth branches must convert in both directions at the
+      // clipping planes.
+      expect(webgpuCamera.convertToOpenGLDepth(nearDepth)).toBeCloseTo(0, 9);
+      expect(webgpuCamera.convertToOpenGLDepth(farDepth)).toBeCloseTo(1, 9);
+    });
+
+    it('picks the same world position via the standard path and an equivalent explicit matrix override', () => {
+      const worldPoint = [0.6, -0.4, 2.5];
+
+      // Standard (native, untouched) path.
+      const standardWorld = pickWorldPosition(
+        renderer,
+        webgpuCamera,
+        worldPoint
+      );
+      expect(areEquals(standardWorld, worldPoint, 1e-6)).toBe(true);
+
+      // Explicit matrix equal to the standard path's own output: Core
+      // transposes first, so transposing again recovers the raw GL style matrix.
+      const raw = camera.getProjectionMatrix(ASPECT, -1, 1);
+      mat4.transpose(raw, raw);
+      camera.setExplicitProjectionMatrix(raw);
+
+      const explicitWorld = pickWorldPosition(
+        renderer,
+        webgpuCamera,
+        worldPoint
+      );
+      expect(areEquals(explicitWorld, worldPoint, 1e-6)).toBe(true);
+      expect(areEquals(explicitWorld, standardWorld, 1e-6)).toBe(true);
+    });
+  });
+
+  it('scales the explicit matrix projection by 1/physicalScale, matching Core', () => {
+    camera.setClippingRange(1, 100);
+    const raw = mat4.perspective(mat4.create(), Math.PI / 4, ASPECT, 1, 100);
+    camera.setExplicitProjectionMatrix(raw);
+    camera.setPhysicalScale(4);
+
+    const outMat = new Float64Array(16);
+    webgpuCamera.getProjectionMatrix(
+      outMat,
+      ASPECT,
+      camera.getClippingRangeByReference(),
+      camera.getWindowCenterByReference()
+    );
+
+    const expected = camera.getProjectionMatrix(ASPECT, -1, 1);
+    mat4.transpose(expected, expected);
+    const Z_REMAP = mat4.create();
+    Z_REMAP[10] = -0.5;
+    Z_REMAP[14] = 0.5;
+    mat4.multiply(expected, Z_REMAP, expected);
+
+    expect(areEquals(outMat, expected)).toBe(true);
+  });
+});

--- a/Sources/Rendering/WebXR/RenderWindowHelper/index.js
+++ b/Sources/Rendering/WebXR/RenderWindowHelper/index.js
@@ -202,7 +202,7 @@ function vtkWebXRRenderWindowHelper(publicAPI, model) {
       model.initBackground = null;
     }
 
-    ren.getActiveCamera().setProjectionMatrix(null);
+    ren.getActiveCamera().setExplicitProjectionMatrix(null);
     ren.resetCamera();
 
     ren.setViewport(0.0, 0, 1.0, 1.0);
@@ -345,7 +345,9 @@ function vtkWebXRRenderWindowHelper(publicAPI, model) {
           .computeViewParametersFromPhysicalMatrix(
             view.transform.inverse.matrix
           );
-        ren.getActiveCamera().setProjectionMatrix(view.projectionMatrix);
+        ren
+          .getActiveCamera()
+          .setExplicitProjectionMatrix(view.projectionMatrix);
 
         model.renderWindow.traverseAllPasses();
       });


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
WebGPU ignores both the explicit projection matrix and physicalScale. The matrix remains unchanged for every scale.

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [x] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
