### PR TITLE
fix(RTAnalyticSource): match native VTK scalar output

### DIFF
--- a/Sources/Common/DataModel/ImageData/test/testImageData.js
+++ b/Sources/Common/DataModel/ImageData/test/testImageData.js
@@ -24,20 +24,20 @@ it('Test vtkImageData histogram', () => {
   const hist = image.computeHistogram(bounds);
 
   const baseline1 = {
-    minimum: 9,
-    maximum: 185,
-    average: 64.65,
-    variance: 782.87,
-    sigma: 27.98,
+    minimum: -29.26,
+    maximum: 272.73,
+    average: 53.95,
+    variance: 2824.76,
+    sigma: 53.15,
     count: 132651,
   };
 
   expect(
-    hist.minimum === baseline1.minimum,
+    compareFloat(hist.minimum.toFixed(2), baseline1.minimum),
     'computeHistogram return value test: minimum'
   ).toBeTruthy();
   expect(
-    hist.maximum === baseline1.maximum,
+    compareFloat(hist.maximum.toFixed(2), baseline1.maximum),
     'computeHistogram return value test: maximum'
   ).toBeTruthy();
   expect(
@@ -61,19 +61,19 @@ it('Test vtkImageData histogram', () => {
   const voxelFunc = (idx) => idx[0] > 9 && idx[0] < 40;
 
   const baseline2 = {
-    minimum: 9,
-    maximum: 173,
-    average: 65.29,
-    variance: 676.51,
-    sigma: 26.01,
+    minimum: -28.52,
+    maximum: 252.4,
+    average: 55.48,
+    variance: 2333.78,
+    sigma: 48.31,
     count: 78030,
   };
 
   const histWithMask = image.computeHistogram(bounds, voxelFunc);
 
   expect(
-    histWithMask.minimum === baseline2.minimum &&
-      histWithMask.maximum === baseline2.maximum &&
+    compareFloat(histWithMask.minimum.toFixed(2), baseline2.minimum) &&
+      compareFloat(histWithMask.maximum.toFixed(2), baseline2.maximum) &&
       compareFloat(histWithMask.average.toFixed(2), baseline2.average) &&
       compareFloat(histWithMask.variance.toFixed(2), baseline2.variance) &&
       compareFloat(histWithMask.sigma.toFixed(2), baseline2.sigma) &&

--- a/Sources/Filters/General/ImageDataOutlineFilter/test/testImageDataOutlineFilter.js
+++ b/Sources/Filters/General/ImageDataOutlineFilter/test/testImageDataOutlineFilter.js
@@ -55,6 +55,8 @@ it.skipIf(__VTK_TEST_NO_WEBGL__)('Test ImageDataOutlineFilter', () => {
 
   const rtSource = vtkRTAnalyticSource.newInstance({
     dataDirection,
+    maximum: 120,
+    offset: 40,
   });
   rtSource.setWholeExtent(0, 199, 0, 199, 0, 199);
   rtSource.setCenter(100, 100, 100);

--- a/Sources/Filters/General/PaintFilter/test/testPaintEllipse.js
+++ b/Sources/Filters/General/PaintFilter/test/testPaintEllipse.js
@@ -40,7 +40,7 @@ it.skipIf(__VTK_TEST_NO_WEBGL__)(
     renderer.setBackground(0.32, 0.34, 0.43);
 
     const backgroundSource = gc.registerResource(
-      vtkRTAnalyticSource.newInstance()
+      vtkRTAnalyticSource.newInstance({ maximum: 120, offset: 40 })
     );
     backgroundSource.setWholeExtent([0, size, 0, size, 0, size]);
     backgroundSource.update();

--- a/Sources/Filters/Sources/RTAnalyticSource/index.js
+++ b/Sources/Filters/Sources/RTAnalyticSource/index.js
@@ -42,7 +42,7 @@ function vtkRTAnalyticSource(publicAPI, model) {
       (_, i) => model.wholeExtent[i * 2 + 1] - model.wholeExtent[i * 2] + 1
     );
 
-    const newArray = new Uint8Array(dims[0] * dims[1] * dims[2]);
+    const newArray = new Float32Array(dims[0] * dims[1] * dims[2]);
     const temp2 =
       1.0 / (2.0 * model.standardDeviation * model.standardDeviation);
 
@@ -85,7 +85,7 @@ function vtkRTAnalyticSource(publicAPI, model) {
       numberOfComponents: 1,
       values: newArray,
     });
-    da.setName('scalars');
+    da.setName('RTData');
 
     const cpd = id.getPointData();
     cpd.setScalars(da);
@@ -100,8 +100,8 @@ function vtkRTAnalyticSource(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  offset: 40,
-  maximum: 120,
+  offset: 0,
+  maximum: 255,
   center: [0, 0, 0],
   frequency: [60, 30, 40],
   magnitude: [10, 18, 5],

--- a/Sources/Proxy/Core/View2DProxy/test/testView2DProxy.js
+++ b/Sources/Proxy/Core/View2DProxy/test/testView2DProxy.js
@@ -18,7 +18,9 @@ it.skipIf(__VTK_TEST_NO_WEBGL__)(
     const gc = testUtils.createGarbageCollector();
     expect('rendering', 'vtkView2DProxy Rendering').toBeTruthy();
 
-    const source = gc.registerResource(vtkRTAnalyticSource.newInstance());
+    const source = gc.registerResource(
+      vtkRTAnalyticSource.newInstance({ maximum: 120, offset: 40 })
+    );
     const size = 50;
     source.setWholeExtent([0, size, 0, size, 0, size]);
     source.update();

--- a/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapper.js
+++ b/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapper.js
@@ -41,7 +41,9 @@ it.skipIf(__VTK_TEST_NO_WEBGL__)('Test ImageResliceMapper', () => {
   // Test code
   // ----------------------------------------------------------------------------
 
-  const rtSource = gc.registerResource(vtkRTAnalyticSource.newInstance());
+  const rtSource = gc.registerResource(
+    vtkRTAnalyticSource.newInstance({ maximum: 120, offset: 40 })
+  );
   rtSource.setWholeExtent(0, 199, 0, 199, 0, 199);
   rtSource.setCenter(100, 100, 100);
 

--- a/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperPolyData.js
+++ b/Sources/Rendering/Core/ImageResliceMapper/test/testImageResliceMapperPolyData.js
@@ -41,7 +41,9 @@ it.skipIf(__VTK_TEST_NO_WEBGL__)('Test ImageResliceMapperPolyData', () => {
   // Test code
   // ----------------------------------------------------------------------------
 
-  const rtSource = gc.registerResource(vtkRTAnalyticSource.newInstance());
+  const rtSource = gc.registerResource(
+    vtkRTAnalyticSource.newInstance({ maximum: 120, offset: 40 })
+  );
   rtSource.setWholeExtent(0, 199, 0, 199, 0, 199);
   rtSource.setCenter(100, 100, 100);
 

--- a/Sources/Testing/testUtils.js
+++ b/Sources/Testing/testUtils.js
@@ -148,7 +148,10 @@ function createGarbageCollector() {
  * @returns Constructed image as vtkImageData
  */
 function createImage(size, spacing) {
-  const source = vtkRTAnalyticSource.newInstance();
+  const source = vtkRTAnalyticSource.newInstance({
+    maximum: 120,
+    offset: 40,
+  });
   source.setWholeExtent([0, size[0] - 1, 0, size[1] - 1, 0, size[2] - 1]);
   source.update();
   const image = source.getOutputData();


### PR DESCRIPTION
<!--
👋 Hello, and thank you for starting this contribution!
📖 Make sure you've read our [CONTRIBUTING.md](https://github.com/Kitware/vtk-js/blob/master/CONTRIBUTING.md) guide before submitting your pull request.
❗️ Please follow the template below to help other contributors review your work.
-->

### Context
<!--
Explain why this change is needed. Please include relevant links supporting this change, such as:
- fix #ISSUE_NUMBER (from issue tracker)
- discourse post thread, or any other existing references
- screenshot of the issue
- console log of error, callstack
-->
Fixes #3629

### Results
<!--
Describe or illustrate the effects of your contribution. Please include:
- comparisons of the behavior before vs after
- screenshots of new or changed visualizations if applicable
-->

### Changes
<!--
Please describe what is changing. Include:
- APIs added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or change to an API. Adequate documentation and TS definitions should also be added/updated.
-->
- [ ] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing
<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and the reasons why.
Tests should complete without errors. See CONTRIBUTING.md
-->
- [ ] This change adds or fixes unit tests <!-- Tests should be added for new functionality -->
- [ ] Tested environment:
  - **vtk.js**: <!-- ex: 14.0.0 (favor latest master) -->
  - **OS**: <!-- ex: Windows 10, iOS 13.6 -->
  - **Browser**: <!-- ex: Chrome 89.0.4389.128 -->

<!--
Edit and uncomment the section below if relevant

### Funding
This contribution is funded by [Example](https://example.com).

 -->
