### PR TITLE
fix(renderwindowinteractor): do not trigger mouse press event for the…

### DIFF
--- a/Examples/Rendering/MouseEvents/index.js
+++ b/Examples/Rendering/MouseEvents/index.js
@@ -163,36 +163,42 @@ clearBtn.addEventListener('click', () => {
 // ----------------------------------------------------------------------------
 
 interactor.onLeftButtonPress(() => {
+  const inconsistent = buttonState.left;
   buttonState.left = true;
   updateIndicators();
-  logEvent('LeftButtonPress', '#53d769');
+  logEvent('LeftButtonPress', inconsistent ? 'orange' : 'green');
 });
 interactor.onLeftButtonRelease(() => {
+  const inconsistent = !buttonState.left;
   buttonState.left = false;
   updateIndicators();
-  logEvent('LeftButtonRelease', '#fc3d39');
+  logEvent('LeftButtonRelease', inconsistent ? 'orange' : 'red');
 });
 
 interactor.onMiddleButtonPress(() => {
+  const inconsistent = buttonState.middle;
   buttonState.middle = true;
   updateIndicators();
-  logEvent('MiddleButtonPress', '#53d769');
+  logEvent('MiddleButtonPress', inconsistent ? 'orange' : 'green');
 });
 interactor.onMiddleButtonRelease(() => {
+  const inconsistent = !buttonState.middle;
   buttonState.middle = false;
   updateIndicators();
-  logEvent('MiddleButtonRelease', '#fc3d39');
+  logEvent('MiddleButtonRelease', inconsistent ? 'orange' : 'red');
 });
 
 interactor.onRightButtonPress(() => {
+  const inconsistent = buttonState.right;
   buttonState.right = true;
   updateIndicators();
-  logEvent('RightButtonPress', '#53d769');
+  logEvent('RightButtonPress', inconsistent ? 'orange' : 'green');
 });
 interactor.onRightButtonRelease(() => {
+  const inconsistent = !buttonState.right;
   buttonState.right = false;
   updateIndicators();
-  logEvent('RightButtonRelease', '#fc3d39');
+  logEvent('RightButtonRelease', inconsistent ? 'orange' : 'red');
 });
 
 interactor.onMouseMove(() => {

--- a/Sources/Rendering/Core/RenderWindowInteractor/index.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/index.js
@@ -17,6 +17,14 @@ const EMPTY_MOUSE_EVENT = {
   shiftKey: false,
 };
 
+// Bitmask values used in PointerEvent.buttons.
+const MOUSE_BUTTON_BITMASK = {
+  NONE: 0,
+  LEFT: 1,
+  RIGHT: 2,
+  MIDDLE: 4,
+};
+
 const deviceInputMap = {
   'xr-standard': [
     Input.Trigger,
@@ -115,6 +123,7 @@ function vtkRenderWindowInteractor(publicAPI, model) {
   // first press / last release. Chorded (additional) button changes while
   // another button is held are signaled via pointermove with updated `buttons`.
   let previousMouseButtons = 0;
+  let externalButtons = 0;
 
   // Tap / LongTap gesture tracking for touch and pen pointers.
   let tapInformation = { timer: null, pointerId: null };
@@ -451,25 +460,35 @@ function vtkRenderWindowInteractor(publicAPI, model) {
     }
   };
 
-  function handleChordedButtons(callData, previous, current) {
+  function handleChordedButtons(callData, previous, current, ignore = 0) {
+    const { LEFT, MIDDLE, RIGHT } = MOUSE_BUTTON_BITMASK;
     /* eslint-disable no-bitwise */
-    if ((previous & ~current & 1) !== 0)
+    if ((previous & ~current & LEFT & ~ignore) !== 0)
       publicAPI.leftButtonReleaseEvent(callData);
-    if ((previous & ~current & 4) !== 0)
+    if ((previous & ~current & MIDDLE & ~ignore) !== 0)
       publicAPI.middleButtonReleaseEvent(callData);
-    if ((previous & ~current & 2) !== 0)
+    if ((previous & ~current & RIGHT & ~ignore) !== 0)
       publicAPI.rightButtonReleaseEvent(callData);
-    if ((~previous & current & 1) !== 0)
+    if ((~previous & current & LEFT & ~ignore) !== 0)
       publicAPI.leftButtonPressEvent(callData);
-    if ((~previous & current & 4) !== 0)
+    if ((~previous & current & MIDDLE & ~ignore) !== 0)
       publicAPI.middleButtonPressEvent(callData);
-    if ((~previous & current & 2) !== 0)
+    if ((~previous & current & RIGHT & ~ignore) !== 0)
       publicAPI.rightButtonPressEvent(callData);
     /* eslint-enable no-bitwise */
   }
 
   publicAPI.handlePointerUp = (event) => {
-    if (pointerCache.has(event.pointerId)) {
+    const buttonBitMap = [
+      MOUSE_BUTTON_BITMASK.LEFT,
+      MOUSE_BUTTON_BITMASK.MIDDLE,
+      MOUSE_BUTTON_BITMASK.RIGHT,
+    ];
+    const buttonBit = buttonBitMap[event.button] ?? MOUSE_BUTTON_BITMASK.NONE;
+
+    /* eslint-disable no-bitwise */
+    if (pointerCache.has(event.pointerId) || externalButtons & buttonBit) {
+      /* eslint-enable no-bitwise */
       if (model.preventDefaultOnPointerUp) {
         preventDefault(event);
       }
@@ -484,24 +503,21 @@ function vtkRenderWindowInteractor(publicAPI, model) {
           break;
         case 'mouse':
         default: {
-          // buttons bitmask: 1=left, 4=middle, 2=right
-          const buttonBitMap = [1, 4, 2];
-          const buttonBit = buttonBitMap[event.button] ?? 0;
           const callData = {
             ...getModifierKeysFor(event),
             position: getScreenEventPositionFor(event),
             deviceType: getDeviceTypeFor(event),
           };
           // Mask out the primary button — handleMouseUp handles it below.
-          /* eslint-disable no-bitwise */
           handleChordedButtons(
             callData,
-            previousMouseButtons & ~buttonBit,
-            event.buttons & ~buttonBit
+            previousMouseButtons,
+            event.buttons,
+            buttonBit
           );
-          /* eslint-enable no-bitwise */
           publicAPI.handleMouseUp(event);
           previousMouseButtons = event.buttons;
+          externalButtons &= ~buttonBit;
           break;
         }
       }
@@ -557,8 +573,22 @@ function vtkRenderWindowInteractor(publicAPI, model) {
             position: getScreenEventPositionFor(event),
             deviceType: getDeviceTypeFor(event),
           };
-          handleChordedButtons(callData, previousMouseButtons, currentButtons);
+          const mousePressOutsideRWI =
+            previousMouseButtons === MOUSE_BUTTON_BITMASK.NONE;
+          if (mousePressOutsideRWI) {
+            // The first button(s) press event was not caught by the RWI,
+            // hence no press/release events must be fired by the chorded button handler.
+            externalButtons = currentButtons;
+          }
+          handleChordedButtons(
+            callData,
+            previousMouseButtons,
+            currentButtons,
+            externalButtons
+          );
           previousMouseButtons = currentButtons;
+          // Stop ignoring the released button(s) if it was released
+          externalButtons &= currentButtons;
         }
         publicAPI.handleMouseMove(event);
         break;

--- a/Sources/Rendering/Core/RenderWindowInteractor/test/testChordedButtons.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/test/testChordedButtons.js
@@ -243,3 +243,117 @@ it('Test RenderWindowInteractor pointercancel releases all held buttons', () => 
   subs.forEach((s) => s.unsubscribe());
   teardown(env);
 });
+
+it('Test no chorded button press for first button', () => {
+  // This use-case happens when a user presses a button outside the render window
+  // and moves the pointer into the render window. The button press should not be triggered.
+  const env = setupInteractor();
+  const { container, interactor } = env;
+
+  const events = [];
+  const sub1 = interactor.onLeftButtonPress(() =>
+    events.push('LeftButtonPress')
+  );
+  const sub2 = interactor.onRightButtonPress(() =>
+    events.push('RightButtonPress')
+  );
+  const sub3 = interactor.onLeftButtonRelease(() =>
+    events.push('LeftButtonRelease')
+  );
+  const sub4 = interactor.onRightButtonRelease(() =>
+    events.push('RightButtonRelease')
+  );
+
+  // A.1. Miss left button press (outside the render window)
+  // A.2. Move mouse cursor into the render window
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 1 })
+  );
+  // A.3. Release left button inside the render window (pointerup fires)
+  console.log('now');
+  container.dispatchEvent(
+    makePointerEvent('pointerup', { button: 0, buttons: 0 })
+  );
+  expect(events).toEqual(['LeftButtonRelease']);
+  events.length = 0;
+
+  // B.1. Miss left button press outside the render window
+  // B.2. Move mouse cursor into the render window
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 1 })
+  );
+  // B.3. Miss left button release outside the render window
+  // B.4. Move mouse cursor into the render window
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 0 })
+  );
+  expect(events).toEqual([]);
+  events.length = 0;
+
+  // C.1. Miss left button press (outside the render window)
+  // C.2. Move mouse cursor into the render window
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 1 })
+  );
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 1 })
+  );
+  expect(events).toEqual([]);
+
+  // C.3. Press right while left held (pointermove with button change per spec §10)
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: 2, buttons: 3 })
+  );
+  expect(events).toEqual(['RightButtonPress']);
+
+  // C.4. Release right while left held (pointermove with button change per spec §10)
+  events.length = 0;
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: 2, buttons: 1 })
+  );
+  expect(events).toEqual(['RightButtonRelease']);
+
+  // C.5. Release left
+  events.length = 0;
+  container.dispatchEvent(
+    makePointerEvent('pointerup', { button: 0, buttons: 0 })
+  );
+  expect(events).toEqual(['LeftButtonRelease']);
+
+  // C.6. Move
+  events.length = 0;
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 0 })
+  );
+  expect(events).toEqual([]);
+
+  // D.1. Miss left button press
+  // D.2. Move mouse cursor into the render window
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 1 })
+  );
+  // D.3. Press right while left held (pointermove with button change per spec §10)
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: 2, buttons: 3 })
+  );
+  expect(events).toEqual(['RightButtonPress']);
+  events.length = 0;
+  // D.4. Release right while left held (pointermove with button change per spec §10)
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: 2, buttons: 1 })
+  );
+  expect(events).toEqual(['RightButtonRelease']);
+  events.length = 0;
+  // D.5. Miss release left (outside the render window)
+  // D.6. Move back into the render window (pointermove fires)
+  container.dispatchEvent(
+    makePointerEvent('pointermove', { button: -1, buttons: 0 })
+  );
+  expect(events).toEqual([]);
+
+  sub1.unsubscribe();
+  sub2.unsubscribe();
+  sub3.unsubscribe();
+  sub4.unsubscribe();
+  teardown(env);
+});

--- a/Sources/Rendering/Core/RenderWindowInteractor/test/testChordedButtons.js
+++ b/Sources/Rendering/Core/RenderWindowInteractor/test/testChordedButtons.js
@@ -1,4 +1,4 @@
-import { it, expect } from 'vitest';
+import { it, expect, describe, beforeEach, afterAll, afterEach } from 'vitest';
 
 import vtkRenderWindowInteractor from 'vtk.js/Sources/Rendering/Core/RenderWindowInteractor';
 
@@ -54,306 +54,243 @@ function teardown({ container, interactor }) {
 }
 
 // Tests ------------------------------------------------------------------
-
-it('Test RenderWindowInteractor chorded button press', () => {
+describe('Chorded buttons events', () => {
   const env = setupInteractor();
   const { container, interactor } = env;
 
   const events = [];
-  const sub1 = interactor.onLeftButtonPress(() =>
-    events.push('LeftButtonPress')
-  );
-  const sub2 = interactor.onRightButtonPress(() =>
-    events.push('RightButtonPress')
-  );
-  const sub3 = interactor.onLeftButtonRelease(() =>
-    events.push('LeftButtonRelease')
-  );
-  const sub4 = interactor.onRightButtonRelease(() =>
-    events.push('RightButtonRelease')
-  );
+  let subs;
 
-  // 1. Press left button (pointerdown fires for first button)
-  container.dispatchEvent(
-    makePointerEvent('pointerdown', { button: 0, buttons: 1 })
-  );
-  expect(events).toEqual(['LeftButtonPress']);
+  beforeEach(() => {
+    events.length = 0;
+    subs = [
+      interactor.onLeftButtonPress(() => events.push('LeftButtonPress')),
+      interactor.onMiddleButtonPress(() => events.push('MiddleButtonPress')),
+      interactor.onRightButtonPress(() => events.push('RightButtonPress')),
+      interactor.onLeftButtonRelease(() => events.push('LeftButtonRelease')),
+      interactor.onMiddleButtonRelease(() =>
+        events.push('MiddleButtonRelease')
+      ),
+      interactor.onRightButtonRelease(() => events.push('RightButtonRelease')),
+    ];
+  });
+  afterEach(() => {
+    subs.forEach((s) => s.unsubscribe());
+    interactor.unbindEvents(); // clear timeouts
+    interactor.setContainer(container);
+    interactor.initialize();
+  });
 
-  // 2. Press right while left held (pointermove with button change per spec §10)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 2, buttons: 3 })
-  );
-  expect(events.includes('RightButtonPress')).toBeTruthy();
+  it('Test RenderWindowInteractor chorded button press', () => {
+    // 1. Press left button (pointerdown fires for first button)
+    container.dispatchEvent(
+      makePointerEvent('pointerdown', { button: 0, buttons: 1 })
+    );
+    expect(events).toEqual(['LeftButtonPress']);
 
-  // 3. Release left while right held (pointermove with button change)
-  events.length = 0;
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 0, buttons: 2 })
-  );
-  expect(events).toEqual(['LeftButtonRelease']);
+    // 2. Press right while left held (pointermove with button change per spec §10)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 2, buttons: 3 })
+    );
+    expect(events.includes('RightButtonPress')).toBeTruthy();
 
-  // 4. Release right - last button (pointerup fires)
-  events.length = 0;
-  container.dispatchEvent(
-    makePointerEvent('pointerup', { button: 2, buttons: 0 })
-  );
-  expect(events).toEqual(['RightButtonRelease']);
+    // 3. Release left while right held (pointermove with button change)
+    events.length = 0;
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 0, buttons: 2 })
+    );
+    expect(events).toEqual(['LeftButtonRelease']);
 
-  sub1.unsubscribe();
-  sub2.unsubscribe();
-  sub3.unsubscribe();
-  sub4.unsubscribe();
-  teardown(env);
-});
+    // 4. Release right - last button (pointerup fires)
+    events.length = 0;
+    container.dispatchEvent(
+      makePointerEvent('pointerup', { button: 2, buttons: 0 })
+    );
+    expect(events).toEqual(['RightButtonRelease']);
+  });
 
-it('Test RenderWindowInteractor single button (no false chorded events)', () => {
-  const env = setupInteractor();
-  const { container, interactor } = env;
+  it('Test RenderWindowInteractor single button (no false chorded events)', () => {
+    // Normal left click cycle
+    container.dispatchEvent(
+      makePointerEvent('pointerdown', { button: 0, buttons: 1 })
+    );
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 1 })
+    );
+    container.dispatchEvent(
+      makePointerEvent('pointerup', { button: 0, buttons: 0 })
+    );
 
-  const events = [];
-  const sub1 = interactor.onLeftButtonPress(() =>
-    events.push('LeftButtonPress')
-  );
-  const sub2 = interactor.onLeftButtonRelease(() =>
-    events.push('LeftButtonRelease')
-  );
-  const sub3 = interactor.onRightButtonPress(() =>
-    events.push('RightButtonPress')
-  );
-  const sub4 = interactor.onRightButtonRelease(() =>
-    events.push('RightButtonRelease')
-  );
+    expect(events).toEqual(['LeftButtonPress', 'LeftButtonRelease']);
+  });
 
-  // Normal left click cycle
-  container.dispatchEvent(
-    makePointerEvent('pointerdown', { button: 0, buttons: 1 })
-  );
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 1 })
-  );
-  container.dispatchEvent(
-    makePointerEvent('pointerup', { button: 0, buttons: 0 })
-  );
+  it('Test RenderWindowInteractor reports the first move of a burst', () => {
+    const moveEvents = [];
+    const subs2 = [
+      interactor.onStartMouseMove(() => moveEvents.push('StartMouseMove')),
+      interactor.onMouseMove(() => moveEvents.push('MouseMove')),
+    ];
 
-  expect(events).toEqual(['LeftButtonPress', 'LeftButtonRelease']);
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 0 })
+    );
+    expect(moveEvents).toEqual(['StartMouseMove', 'MouseMove']);
 
-  sub1.unsubscribe();
-  sub2.unsubscribe();
-  sub3.unsubscribe();
-  sub4.unsubscribe();
-  teardown(env);
-});
+    moveEvents.length = 0;
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 0 })
+    );
+    expect(moveEvents).toEqual(['MouseMove']);
 
-it('Test RenderWindowInteractor reports the first move of a burst', () => {
-  const env = setupInteractor();
-  const { container, interactor } = env;
+    subs2.forEach((subscription) => subscription.unsubscribe());
+  });
 
-  const events = [];
-  const subs = [
-    interactor.onStartMouseMove(() => events.push('StartMouseMove')),
-    interactor.onMouseMove(() => events.push('MouseMove')),
-  ];
+  it('Test RenderWindowInteractor three-button chord', () => {
+    // Press left
+    container.dispatchEvent(
+      makePointerEvent('pointerdown', { button: 0, buttons: 1 })
+    );
+    // Press middle (chorded)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 1, buttons: 5 })
+    );
+    // Press right (chorded)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 2, buttons: 7 })
+    );
+    // Release all three simultaneously (only pointerup fires with buttons=0)
+    container.dispatchEvent(
+      makePointerEvent('pointerup', { button: 0, buttons: 0 })
+    );
 
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 0 })
-  );
-  expect(events).toEqual(['StartMouseMove', 'MouseMove']);
+    // Chorded releases (middle, right) fire before the primary button release
+    // (left) which is handled by handleMouseUp.
+    expect(events).toEqual([
+      'LeftButtonPress',
+      'MiddleButtonPress',
+      'RightButtonPress',
+      'MiddleButtonRelease',
+      'RightButtonRelease',
+      'LeftButtonRelease',
+    ]);
+  });
 
-  events.length = 0;
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 0 })
-  );
-  expect(events).toEqual(['MouseMove']);
+  it('Test RenderWindowInteractor pointercancel releases all held buttons', () => {
+    // Press left
+    container.dispatchEvent(
+      makePointerEvent('pointerdown', { button: 0, buttons: 1 })
+    );
+    // Press middle (chorded)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 1, buttons: 5 })
+    );
 
-  subs.forEach((subscription) => subscription.unsubscribe());
-  teardown(env);
-});
+    events.length = 0;
 
-it('Test RenderWindowInteractor three-button chord', () => {
-  const env = setupInteractor();
-  const { container, interactor } = env;
+    // Cancel the interaction — all held buttons should be released
+    container.dispatchEvent(
+      makePointerEvent('pointercancel', { button: 0, buttons: 0 })
+    );
 
-  const events = [];
-  const subs = [
-    interactor.onLeftButtonPress(() => events.push('LP')),
-    interactor.onMiddleButtonPress(() => events.push('MP')),
-    interactor.onRightButtonPress(() => events.push('RP')),
-    interactor.onLeftButtonRelease(() => events.push('LR')),
-    interactor.onMiddleButtonRelease(() => events.push('MR')),
-    interactor.onRightButtonRelease(() => events.push('RR')),
-  ];
+    expect(events).toEqual(['LeftButtonRelease', 'MiddleButtonRelease']);
+  });
 
-  // Press left
-  container.dispatchEvent(
-    makePointerEvent('pointerdown', { button: 0, buttons: 1 })
-  );
-  // Press middle (chorded)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 1, buttons: 5 })
-  );
-  // Press right (chorded)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 2, buttons: 7 })
-  );
-  // Release all three simultaneously (only pointerup fires with buttons=0)
-  container.dispatchEvent(
-    makePointerEvent('pointerup', { button: 0, buttons: 0 })
-  );
+  it('Test no button press when clicked outside the render window', () => {
+    // This use-case happens when a user presses a button outside the render window
+    // and moves the pointer into the render window. The button press should not be triggered.
 
-  // Chorded releases (middle, right) fire before the primary button release
-  // (left) which is handled by handleMouseUp.
-  expect(events).toEqual(['LP', 'MP', 'RP', 'MR', 'RR', 'LR']);
+    // 1. Miss left button press (outside the render window)
+    // 2. Move mouse cursor into the render window
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 1 })
+    );
+    // 3. Release left button inside the render window (pointerup fires)
+    container.dispatchEvent(
+      makePointerEvent('pointerup', { button: 0, buttons: 0 })
+    );
+    expect(events).toEqual(['LeftButtonRelease']);
+  });
 
-  subs.forEach((s) => s.unsubscribe());
-  teardown(env);
-});
+  it('Test no button release when first clicked outside the render window', () => {
+    // 1. Miss left button press outside the render window
+    // 2. Move mouse cursor into the render window
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 1 })
+    );
+    // 3. Miss left button release outside the render window
+    // 4. Move mouse cursor into the render window
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 0 })
+    );
+    expect(events).toEqual([]);
+  });
 
-it('Test RenderWindowInteractor pointercancel releases all held buttons', () => {
-  const env = setupInteractor();
-  const { container, interactor } = env;
+  it('Test release button with chorded events when first clicked outside the render window', () => {
+    // 1. Miss left button press (outside the render window)
+    // 2. Move mouse cursor into the render window
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 1 })
+    );
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 1 })
+    );
+    expect(events).toEqual([]);
 
-  const events = [];
-  const subs = [
-    interactor.onLeftButtonPress(() => events.push('LP')),
-    interactor.onMiddleButtonPress(() => events.push('MP')),
-    interactor.onRightButtonPress(() => events.push('RP')),
-    interactor.onLeftButtonRelease(() => events.push('LR')),
-    interactor.onMiddleButtonRelease(() => events.push('MR')),
-    interactor.onRightButtonRelease(() => events.push('RR')),
-  ];
+    // 3. Press right while left held (pointermove with button change per spec §10)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 2, buttons: 3 })
+    );
+    expect(events).toEqual(['RightButtonPress']);
 
-  // Press left
-  container.dispatchEvent(
-    makePointerEvent('pointerdown', { button: 0, buttons: 1 })
-  );
-  // Press middle (chorded)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 1, buttons: 5 })
-  );
+    // 4. Release right while left held (pointermove with button change per spec §10)
+    events.length = 0;
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 2, buttons: 1 })
+    );
+    expect(events).toEqual(['RightButtonRelease']);
 
-  events.length = 0;
+    // 5. Release left
+    events.length = 0;
+    container.dispatchEvent(
+      makePointerEvent('pointerup', { button: 0, buttons: 0 })
+    );
+    expect(events).toEqual(['LeftButtonRelease']);
 
-  // Cancel the interaction — all held buttons should be released
-  container.dispatchEvent(
-    makePointerEvent('pointercancel', { button: 0, buttons: 0 })
-  );
+    // 6. Move
+    events.length = 0;
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 0 })
+    );
+    expect(events).toEqual([]);
+  });
 
-  expect(events).toEqual(['LR', 'MR']);
+  it('Test release button with chorded events when pressed and released outside the render window', () => {
+    // 1. Miss left button press
+    // 2. Move mouse cursor into the render window
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 1 })
+    );
+    // 3. Press right while left held (pointermove with button change per spec §10)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 2, buttons: 3 })
+    );
+    expect(events).toEqual(['RightButtonPress']);
+    events.length = 0;
+    // 4. Release right while left held (pointermove with button change per spec §10)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: 2, buttons: 1 })
+    );
+    expect(events).toEqual(['RightButtonRelease']);
+    events.length = 0;
+    // 5. Miss release left (outside the render window)
+    // 6. Move back into the render window (pointermove fires)
+    container.dispatchEvent(
+      makePointerEvent('pointermove', { button: -1, buttons: 0 })
+    );
+    expect(events).toEqual([]);
+  });
 
-  subs.forEach((s) => s.unsubscribe());
-  teardown(env);
-});
-
-it('Test no chorded button press for first button', () => {
-  // This use-case happens when a user presses a button outside the render window
-  // and moves the pointer into the render window. The button press should not be triggered.
-  const env = setupInteractor();
-  const { container, interactor } = env;
-
-  const events = [];
-  const sub1 = interactor.onLeftButtonPress(() =>
-    events.push('LeftButtonPress')
-  );
-  const sub2 = interactor.onRightButtonPress(() =>
-    events.push('RightButtonPress')
-  );
-  const sub3 = interactor.onLeftButtonRelease(() =>
-    events.push('LeftButtonRelease')
-  );
-  const sub4 = interactor.onRightButtonRelease(() =>
-    events.push('RightButtonRelease')
-  );
-
-  // A.1. Miss left button press (outside the render window)
-  // A.2. Move mouse cursor into the render window
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 1 })
-  );
-  // A.3. Release left button inside the render window (pointerup fires)
-  console.log('now');
-  container.dispatchEvent(
-    makePointerEvent('pointerup', { button: 0, buttons: 0 })
-  );
-  expect(events).toEqual(['LeftButtonRelease']);
-  events.length = 0;
-
-  // B.1. Miss left button press outside the render window
-  // B.2. Move mouse cursor into the render window
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 1 })
-  );
-  // B.3. Miss left button release outside the render window
-  // B.4. Move mouse cursor into the render window
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 0 })
-  );
-  expect(events).toEqual([]);
-  events.length = 0;
-
-  // C.1. Miss left button press (outside the render window)
-  // C.2. Move mouse cursor into the render window
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 1 })
-  );
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 1 })
-  );
-  expect(events).toEqual([]);
-
-  // C.3. Press right while left held (pointermove with button change per spec §10)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 2, buttons: 3 })
-  );
-  expect(events).toEqual(['RightButtonPress']);
-
-  // C.4. Release right while left held (pointermove with button change per spec §10)
-  events.length = 0;
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 2, buttons: 1 })
-  );
-  expect(events).toEqual(['RightButtonRelease']);
-
-  // C.5. Release left
-  events.length = 0;
-  container.dispatchEvent(
-    makePointerEvent('pointerup', { button: 0, buttons: 0 })
-  );
-  expect(events).toEqual(['LeftButtonRelease']);
-
-  // C.6. Move
-  events.length = 0;
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 0 })
-  );
-  expect(events).toEqual([]);
-
-  // D.1. Miss left button press
-  // D.2. Move mouse cursor into the render window
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 1 })
-  );
-  // D.3. Press right while left held (pointermove with button change per spec §10)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 2, buttons: 3 })
-  );
-  expect(events).toEqual(['RightButtonPress']);
-  events.length = 0;
-  // D.4. Release right while left held (pointermove with button change per spec §10)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: 2, buttons: 1 })
-  );
-  expect(events).toEqual(['RightButtonRelease']);
-  events.length = 0;
-  // D.5. Miss release left (outside the render window)
-  // D.6. Move back into the render window (pointermove fires)
-  container.dispatchEvent(
-    makePointerEvent('pointermove', { button: -1, buttons: 0 })
-  );
-  expect(events).toEqual([]);
-
-  sub1.unsubscribe();
-  sub2.unsubscribe();
-  sub3.unsubscribe();
-  sub4.unsubscribe();
-  teardown(env);
+  afterAll(() => {
+    teardown(env);
+  });
 });


### PR DESCRIPTION
… first mouse down button

The RWI may not catch a mouse press event (e.g. because it was caught by a div over the RW), in that case the "chorded event" must not apply and moving the mouse over the RW must not trigger a mouse down event

### Context
If you add a slider over the RW, a click and drag on the slider may trigger some mouse move events on the RW if the mouse moves outside the slider. Currently, due to the chorded event mechanism, the first mouse move event was triggering a mouse press event that was then enabling the interactor style to rotate the camera while the slider was being interacted with.

### Results
The interactor style interaction use case described above no longer happens because the mouse press event is no longer triggered.

### Changes
The chorded event mechanism is not applied for the "first" button(s), only when there is at least one button down.

### PR Checklist
- [ ] GitHub Actions CI passed: [semantic-release](https://github.com/semantic-release/semantic-release) commit messages, lint, and tests
- [x] Test coverage added
- [x] Documentation and TypeScript definitions are updated to match these changes