### PR TITLE
perf(Renderer): accumulate actors and volumes without concat

### DIFF
--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -17,8 +17,8 @@ function notImplemented(method) {
 // Append array elements individually; append other values as one element.
 function collectFromProps(props, getFromProp) {
   const collected = [];
-  props.forEach((prop) => {
-    const items = getFromProp(prop);
+  for (let i = 0; i < props.length; i++) {
+    const items = getFromProp(props[i]);
     if (Array.isArray(items)) {
       for (let j = 0; j < items.length; j++) {
         collected.push(items[j]);
@@ -26,7 +26,7 @@ function collectFromProps(props, getFromProp) {
     } else {
       collected.push(items);
     }
-  });
+  }
   return collected;
 }
 

--- a/Sources/Rendering/Core/Renderer/index.js
+++ b/Sources/Rendering/Core/Renderer/index.js
@@ -13,6 +13,26 @@ function notImplemented(method) {
   return () => vtkErrorMacro(`vtkRenderer::${method} - NOT IMPLEMENTED`);
 }
 
+// Props may return an array or a single object (e.g. vtkImageSlice).
+// Append array elements individually; append other values as one element.
+function collectFromProps(props, getFromProp) {
+  const collected = [];
+  props.forEach((prop) => {
+    const items = getFromProp(prop);
+    if (Array.isArray(items)) {
+      for (let j = 0; j < items.length; j++) {
+        collected.push(items[j]);
+      }
+    } else {
+      collected.push(items);
+    }
+  });
+  return collected;
+}
+
+const getPropActors = (prop) => prop.getActors();
+const getPropVolumes = (prop) => prop.getVolumes();
+
 // ----------------------------------------------------------------------------
 // vtkRenderer methods
 // ----------------------------------------------------------------------------
@@ -138,10 +158,7 @@ function vtkRenderer(publicAPI, model) {
   };
 
   publicAPI.getActors = () => {
-    model.actors = [];
-    model.props.forEach((prop) => {
-      model.actors = model.actors.concat(prop.getActors());
-    });
+    model.actors = collectFromProps(model.props, getPropActors);
     return model.actors;
   };
   publicAPI.addActor = publicAPI.addViewProp;
@@ -160,10 +177,7 @@ function vtkRenderer(publicAPI, model) {
   };
 
   publicAPI.getVolumes = () => {
-    model.volumes = [];
-    model.props.forEach((prop) => {
-      model.volumes = model.volumes.concat(prop.getVolumes());
-    });
+    model.volumes = collectFromProps(model.props, getPropVolumes);
     return model.volumes;
   };
   publicAPI.addVolume = publicAPI.addViewProp;

--- a/Sources/Rendering/Core/Renderer/test/testPropCollection.js
+++ b/Sources/Rendering/Core/Renderer/test/testPropCollection.js
@@ -1,0 +1,35 @@
+import { expect, it } from 'vitest';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkVolume from 'vtk.js/Sources/Rendering/Core/Volume';
+
+it.each([
+  ['getActors', vtkActor, vtkImageSlice],
+  ['getVolumes', vtkVolume, vtkVolume],
+])('%s collects props into fresh snapshots', (method, type, singleType) => {
+  const gc = testUtils.createGarbageCollector();
+  const renderer = gc.registerResource(vtkRenderer.newInstance());
+  const first = gc.registerResource(type.newInstance());
+  const second = gc.registerResource(type.newInstance());
+  const single = gc.registerResource(singleType.newInstance());
+  const composite = { [method]: () => [first, second] };
+
+  renderer.addViewProp(composite);
+  renderer.addViewProp({ [method]: () => [] });
+  renderer.addViewProp({ [method]: () => single });
+  const snapshot = renderer[method]();
+  expect(snapshot).toEqual([first, second, single]);
+  expect(renderer[method]()).not.toBe(snapshot);
+
+  renderer.removeViewProp(composite);
+  renderer.addViewProp(first);
+  const current = renderer[method]();
+  expect(current).toEqual([single, first]);
+  expect(renderer[`${method}ByReference`]()).toBe(current);
+  expect(snapshot).toEqual([first, second, single]);
+
+  gc.releaseResources();
+});


### PR DESCRIPTION
### Context

`getActors()` and `getVolumes()` collect each prop's objects using repeated
`concat` calls. Each concat call copies the growing result array. 
This quadratic work repeats on every `getActors` call, including `getActors()`
during picking without an explicit pick list.

Batching geometry into fewer actors is the vtk.js way, but separate
actors are useful when datasets load and unload independently. This change came
out of loading tiled point clouds, where chunks of points are swapped in and out as the view changes.

### Results

Recorded headless Chromium medians per collection call, spanning actor and
volume results:

| Count | Before | After |
| ---: | ---: | ---: |
| 400 | 0.05–0.06 ms | 0.005–0.010 ms |
| 2,000 | 1.08–1.21 ms | 0.035–0.055 ms |

At 2,000 objects, this saves roughly 1 ms per call.

### Changes

- Use a shared `push` helper for linear collection, preserving array and
  non-array prop answers.
- Preserve order and fresh snapshots; by-reference getters return the latest
  snapshot.

### PR Checklist

- [x] GitHub Actions CI passed: [semantic-release](https://github.com/semantic-release/semantic-release) commit messages, lint, and tests
- [x] Test coverage added
- [x] Documentation and TypeScript definitions are updated to match these changes
