### PR TITLE
fix(DiskSource): fix Uint8 overflow

### DIFF
--- a/Sources/Filters/Sources/DiskSource/index.js
+++ b/Sources/Filters/Sources/DiskSource/index.js
@@ -87,7 +87,7 @@ function vtkDiskSource(publicAPI, model) {
 
     // Generate cell connectivity (quads)
     const cellCount = radialResolution * circumferentialResolution;
-    const cellData = new Uint8Array(cellCount * 5);
+    const cellData = new Uint32Array(cellCount * 5);
     let offset = 0;
     for (let i = 0; i < model.circumferentialResolution; i++) {
       for (let j = 0; j < model.radialResolution; j++) {


### PR DESCRIPTION
### Context
For every circurmferential resolution (CR), there's a radial resolution (RR) past which the connectivity of the disk is wrong

<img width="300" alt="image" src="https://github.com/user-attachments/assets/7dd01d5c-9b68-4096-be4f-349f313bffde" />

(CR=6, RR=42)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0943943c-e6ec-4d98-acda-3b500cecc996" />

(CR=4, RR=64)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5a0015cd-4494-404b-9c08-b1a72a2fc9f3" />

(CR=10, RR=25)

### Results
The connectivity is correct for every combination of CR and RR.

### Changes
Replace Uint8Array by Uint32Array to fix overflow error with disks with more than 50 points

### PR Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] GitHub Actions CI passed: [semantic-release](https://github.com/semantic-release/semantic-release) commit messages, lint, and tests
- [x] Test coverage added
- [x] Documentation and TypeScript definitions are updated to match these changes
