### PR TITLE
chore(ImageMarchingCubes): fix example clipping

### DIFF
--- a/Sources/Filters/General/ImageMarchingCubes/example/index.js
+++ b/Sources/Filters/General/ImageMarchingCubes/example/index.js
@@ -45,10 +45,20 @@ mapper.setInputConnection(mCubes.getOutputPort());
 // ----------------------------------------------------------------------------
 // UI control handling
 // ----------------------------------------------------------------------------
+function updateSampleBounds() {
+  const radius = sphere.getRadius();
+  const iso = mCubes.getContourValue();
+
+  const margin = 0.1;
+  const extent = radius + iso + margin;
+
+  sample.setModelBounds(-extent, extent, -extent, extent, -extent, extent);
+}
+
 const gui = new GUI();
 const params = {
   VolumeResolution: 50,
-  Radius: 0.025,
+  Radius: 0.5,
   IsoValue: 0.0,
   ComputeNormals: false,
   MergePoints: false,
@@ -66,6 +76,7 @@ gui
   .name('Radius')
   .onChange((v) => {
     sphere.setRadius(Number(v));
+    updateSampleBounds();
     renderWindow.render();
   });
 gui
@@ -73,6 +84,7 @@ gui
   .name('Iso value')
   .onChange((v) => {
     mCubes.setContourValue(Number(v));
+    updateSampleBounds();
     renderWindow.render();
   });
 gui


### PR DESCRIPTION
### Context
The produces sphere in ImageMarchingCubes example can clip with the sampler bounds for a big enough radius or ISO value.

<img width="650" alt="image" src="https://github.com/user-attachments/assets/41bc810a-8987-47ab-bab3-656f0c5c9dd9" />

### Results
Bounds are updated when changing radius or ISO to prevent clipping.

### Changes
Update sample bounds on radius and iso value updates to avoid clipping of output with bounds

Set initial GUI radius to actual sphere's initial radius

### PR Checklist
<!--
NOTE: We will not merge if the following steps have not been completed!
-->
- [x] GitHub Actions CI passed: [semantic-release](https://github.com/semantic-release/semantic-release) commit messages, lint, and tests
- [x] Test coverage added
- [x] Documentation and TypeScript definitions are updated to match these changes
