### PR TITLE
chore(webgpu): run WebGPU tests in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,3 +69,38 @@ jobs:
           name: test-results-${{ matrix.os }}-node_${{ matrix.node }}-${{ matrix.browser }}
           path: Utilities/TestResults/
           retention-days: 15
+
+  webgpu-test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    name: ubuntu-24.04 / node 22 / chromium / WebGPU
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup project
+        uses: ./.github/actions/setup-node-project
+        with:
+          node-version: '22'
+      - name: Resolve Playwright version
+        id: playwright
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browser
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-ubuntu-24.04-chromium-${{ steps.playwright.outputs.version }}
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+      - name: Install Playwright system deps
+        run: sudo npx playwright install-deps chromium
+      - name: Tests
+        run: xvfb-run --auto-servernum npm run test:webgpu
+      - name: Archive test results
+        if: github.event_name != 'merge_group' && (success() || failure())
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: test-results-ubuntu-24.04-node_22-chromium-webgpu
+          path: Utilities/TestResults/
+          retention-days: 15

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -23,8 +23,10 @@ if (webGPU) {
   // Headless Chromium does not expose a WebGPU adapter by default.
   chromiumArgs.push('--enable-unsafe-webgpu');
   if (ci) {
-    // No real GPU on CI: use Dawn's software (SwiftShader) WebGPU adapter.
-    chromiumArgs.push('--use-webgpu-adapter=swiftshader');
+    chromiumArgs.push(
+      '--enable-features=Vulkan', // Use Vulkan for the compositor.
+      '--use-vulkan=swiftshader' // Back Vulkan with SwiftShader on GPU-less CI.
+    );
   }
 }
 


### PR DESCRIPTION
### Context

vtk.js provides a `test:webgpu` target, but the GitHub Actions workflow does not run it. The existing CI flags can create a SwiftShader WebGPU device, but WebGPU canvas presentation times out because headless Chromium's compositor is not using Vulkan SwiftShader.

### Results

WebGPU tests now run as a dedicated GitHub Actions job using Chromium and SwiftShader.

### Changes

- Add a dedicated WebGPU test job to the build/test workflow.
- Enable Chromium GPU compositing and route Vulkan through SwiftShader on CI.
- Keep the existing `npm run test:webgpu` entry point and full test discovery.

### PR Checklist

- [ ] GitHub Actions CI passed: [semantic-release](https://github.com/semantic-release/semantic-release) commit messages, lint, and tests
- [x] Test coverage added
- [x] Documentation and TypeScript definitions are updated to match these changes
